### PR TITLE
feat: dry-run workflow for cross-repo gate evaluation

### DIFF
--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -1,0 +1,112 @@
+name: "Dry-Run Gate Evaluation"
+
+on:
+  workflow_dispatch:
+    inputs:
+      target-repo:
+        description: "Target repository (owner/repo)"
+        required: true
+        default: "dschirmer-shiftkey/Komatik"
+      pr-number:
+        description: "PR number to evaluate"
+        required: true
+      risk-threshold:
+        description: "Risk threshold (0-100)"
+        required: false
+        default: "70"
+      health-check-url:
+        description: "Health check URL (optional)"
+        required: false
+      token-secret:
+        description: "Name of the secret holding a PAT with target repo access (default: KOMATIK_PAT)"
+        required: false
+        default: "KOMATIK_PAT"
+
+permissions:
+  contents: read
+
+jobs:
+  evaluate:
+    name: "Evaluate PR #${{ inputs.pr-number }} on ${{ inputs.target-repo }}"
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - name: Run gate evaluation
+        id: gate
+        env:
+          GITHUB_TOKEN: ${{ secrets[inputs.token-secret] || secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ inputs.target-repo }}
+        run: |
+          set +e
+          OUTPUT=$(npx tsx scripts/simulate.ts \
+            --pr "${{ inputs.pr-number }}" \
+            --threshold "${{ inputs.risk-threshold }}" \
+            ${{ inputs.health-check-url && format('--health-url {0}', inputs.health-check-url) || '' }} \
+            2>&1)
+          EXIT_CODE=$?
+          set -e
+
+          echo "$OUTPUT"
+
+          echo "exit_code=$EXIT_CODE" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "report<<REPORT_EOF"
+            echo "$OUTPUT" | sed -n '/^## DeployGuard/,/^Raw evaluation/{ /^Raw evaluation/d; p; }'
+            echo "REPORT_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "raw<<RAW_EOF"
+            echo "$OUTPUT" | sed -n '/^Raw evaluation/,$ p'
+            echo "RAW_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Write job summary
+        env:
+          REPORT: ${{ steps.gate.outputs.report }}
+          RAW: ${{ steps.gate.outputs.raw }}
+          EXIT_CODE: ${{ steps.gate.outputs.exit_code }}
+        run: |
+          {
+            echo "# DeployGuard Dry-Run"
+            echo ""
+            echo "**Target:** \`${{ inputs.target-repo }}#${{ inputs.pr-number }}\`"
+            echo "**Threshold:** ${{ inputs.risk-threshold }}"
+            echo "**Health URL:** ${{ inputs.health-check-url || '(none)' }}"
+            echo ""
+            echo "---"
+            echo ""
+            echo "$REPORT"
+            echo ""
+            echo "---"
+            echo ""
+            echo "<details><summary>Raw evaluation JSON</summary>"
+            echo ""
+            echo '```json'
+            echo "$RAW"
+            echo '```'
+            echo "</details>"
+            echo ""
+            if [ "$EXIT_CODE" = "0" ]; then
+              echo "> ✅ **Gate would ALLOW this deployment**"
+            elif [ "$EXIT_CODE" = "1" ]; then
+              echo "> 🚫 **Gate would BLOCK this deployment**"
+            else
+              echo "> ⚠️ **Simulation encountered an error (exit $EXIT_CODE)**"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Fail on block (informational only)
+        if: steps.gate.outputs.exit_code == '1'
+        run: |
+          echo "::warning::Gate would BLOCK PR #${{ inputs.pr-number }} on ${{ inputs.target-repo }} (risk exceeded threshold ${{ inputs.risk-threshold }})"


### PR DESCRIPTION
## Summary

- Adds a `workflow_dispatch` dry-run workflow that evaluates any repo/PR without modifying the target
- Results are rendered as a GitHub Actions job summary with gate report + raw JSON
- Supports a configurable PAT secret (`KOMATIK_PAT` by default) for access to private repos
- Intentionally does **not** fail the workflow on `block` — just emits a warning annotation

## How to use

1. Add a `KOMATIK_PAT` secret to the DeployGuard repo (fine-grained PAT with read access to Komatik)
2. Go to Actions → "Dry-Run Gate Evaluation" → Run workflow
3. Enter target repo (`dschirmer-shiftkey/Komatik`), PR number, and threshold
4. Check the job summary for the full gate report

## Local simulation results (validated before this PR)

| Komatik PR | Files | Churn | Risk | Decision |
|-----------|-------|-------|------|----------|
| #633 (font lazy-load) | 6 | 119 | 39/100 | **ALLOW** |
| #625 (App Store) | 14 | 957 | 68/100 | **WARN** |
| #628 (staging→master) | 51 | 4911 | 75/100 | **BLOCK** |

## Test plan

- [x] Local simulation against 3 real Komatik PRs with varying sizes
- [ ] Add `KOMATIK_PAT` secret and trigger dry-run from Actions UI
- [ ] Verify job summary renders correctly


Made with [Cursor](https://cursor.com)