### PR TITLE
fix: dry-run cross-repo evaluation via --repo CLI arg

### DIFF
--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -44,10 +44,10 @@ jobs:
         id: gate
         env:
           GITHUB_TOKEN: ${{ secrets[inputs.token-secret] || secrets.GITHUB_TOKEN }}
-          GITHUB_REPOSITORY: ${{ inputs.target-repo }}
         run: |
           set +e
           OUTPUT=$(npx tsx scripts/simulate.ts \
+            --repo "${{ inputs.target-repo }}" \
             --pr "${{ inputs.pr-number }}" \
             --threshold "${{ inputs.risk-threshold }}" \
             ${{ inputs.health-check-url && format('--health-url {0}', inputs.health-check-url) || '' }} \

--- a/scripts/simulate.ts
+++ b/scripts/simulate.ts
@@ -4,12 +4,12 @@
  *
  * Usage:
  *   npx tsx scripts/simulate.ts
+ *   npx tsx scripts/simulate.ts --repo dschirmer-shiftkey/Komatik --pr 625
  *   npx tsx scripts/simulate.ts --health-url https://api.example.com/health
  *   npx tsx scripts/simulate.ts --threshold 50
  *
  * Environment variables (optional):
  *   GITHUB_TOKEN       — enables PR file fetching
- *   GITHUB_REPOSITORY  — owner/repo (default: dschirmer-shiftkey/deployguard)
  *   PR_NUMBER          — pull request number to evaluate
  */
 
@@ -27,9 +27,13 @@ function parseArgs() {
 async function main() {
   const flags = parseArgs();
 
-  const [owner, repo] = (
-    process.env.GITHUB_REPOSITORY ?? "dschirmer-shiftkey/deployguard"
-  ).split("/");
+  const targetRepo =
+    flags["repo"] ??
+    process.env.DEPLOYGUARD_TARGET_REPO ??
+    process.env.GITHUB_REPOSITORY ??
+    "dschirmer-shiftkey/deployguard";
+
+  const [owner, repo] = targetRepo.split("/");
 
   process.env.GITHUB_REPOSITORY = `${owner}/${repo}`;
 
@@ -41,7 +45,6 @@ async function main() {
   }
 
   const { evaluateGate, formatGateReport } = await import("../src/gate.js");
-  const { DeployGuardConfig } = await import("../src/types.js");
 
   type DeployGuardConfig = import("../src/types.js").DeployGuardConfig;
 


### PR DESCRIPTION
## Summary

- Fixes the dry-run workflow failing with 404 when evaluating PRs on other repos (e.g. Komatik)
- Root cause: GitHub Actions locks `GITHUB_REPOSITORY` env var to the hosting repo at the runner level — step-level `env` overrides don't propagate to the Node process
- Fix: pass target repo as `--repo` CLI argument to `simulate.ts`, which sets `process.env.GITHUB_REPOSITORY` before any `@actions/github` modules are imported

## Test plan

- [x] Local simulation with `--repo dschirmer-shiftkey/Komatik --pr 633` returns correct Komatik data
- [x] 47/47 tests pass
- [ ] Re-trigger dry-run workflow after merge to verify CI fix


Made with [Cursor](https://cursor.com)