### PR TITLE
fix: fetchPrFiles fail-open on token permission errors

### DIFF
--- a/src/gate.ts
+++ b/src/gate.ts
@@ -30,22 +30,27 @@ interface PrFileInfo {
 async function fetchPrFiles(prNumber: number, token?: string): Promise<PrFileInfo[]> {
   if (!token) return [];
 
-  const octokit = github.getOctokit(token);
-  const { owner, repo } = github.context.repo;
+  try {
+    const octokit = github.getOctokit(token);
+    const { owner, repo } = github.context.repo;
 
-  const { data: files } = await octokit.rest.pulls.listFiles({
-    owner,
-    repo,
-    pull_number: prNumber,
-    per_page: 300,
-  });
+    const { data: files } = await octokit.rest.pulls.listFiles({
+      owner,
+      repo,
+      pull_number: prNumber,
+      per_page: 300,
+    });
 
-  return files.map((f) => ({
-    filename: f.filename,
-    additions: f.additions,
-    deletions: f.deletions,
-    changes: f.changes,
-  }));
+    return files.map((f) => ({
+      filename: f.filename,
+      additions: f.additions,
+      deletions: f.deletions,
+      changes: f.changes,
+    }));
+  } catch (error) {
+    core.debug(`Failed to fetch PR files: ${error}`);
+    return [];
+  }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Wraps `fetchPrFiles` in try-catch so a 404 (missing token scope) returns an empty file list instead of crashing the simulation
- Aligns with DeployGuard's fail-open contract — missing PR data results in zero risk score, not a hard failure

## Context

The dry-run workflow crashed with exit code 2 when the `KOMATIK_PAT` lacked `pull_requests:read` scope. This fix ensures the gate evaluation still runs (with degraded risk scoring) rather than failing entirely.

## Test plan

- [x] 47/47 tests pass
- [ ] Re-trigger dry-run to confirm graceful degradation


Made with [Cursor](https://cursor.com)