### PR TITLE
ci: opt into Node.js 24 for GitHub Actions runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
   check:
     name: Lint, Test & Build
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -29,6 +29,8 @@ jobs:
   evaluate:
     name: "Evaluate PR #${{ inputs.pr-number }} on ${{ inputs.target-repo }}"
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -14,6 +14,9 @@ jobs:
     name: "DeployGuard Self-Test"
     runs-on: ubuntu-latest
 
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

- Set `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` on CI, self-test, and dry-run workflows
- Silences the Node.js 20 deprecation warning from GitHub Actions

Also serves as a small PR to validate the full DeployGuard self-test pipeline (check run, labels, guidance, score bar, job summary).

## Test plan

- [ ] CI passes (lint, test, build)
- [ ] Self-test runs and posts PR comment with gate evaluation
- [ ] Check run appears in Checks tab
- [ ] Risk label applied to this PR

Made with [Cursor](https://cursor.com)