### PR TITLE
feat: add evaluation-store-url for historical trend analysis

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -54,6 +54,10 @@ inputs:
     description: "Comma-separated decisions that trigger the webhook (e.g. warn,block)"
     required: false
     default: "warn,block"
+  evaluation-store-url:
+    description: "URL to POST evaluation results for historical trend analysis"
+    required: false
+    default: ""
 
 outputs:
   health-score:

--- a/dist/index.js
+++ b/dist/index.js
@@ -31235,6 +31235,7 @@ async function run() {
                 .split(",")
                 .map((s) => s.trim())
                 .filter(Boolean),
+            evaluationStoreUrl: core.getInput("evaluation-store-url") || undefined,
         };
         const context = github.context;
         const commitSha = context.sha;
@@ -31261,6 +31262,9 @@ async function run() {
         }
         if (config.webhookUrl && config.webhookEvents.includes(evaluation.gateDecision)) {
             await (0, notify_js_1.sendWebhook)(config.webhookUrl, evaluation);
+        }
+        if (config.evaluationStoreUrl) {
+            await (0, notify_js_1.storeEvaluation)(config.evaluationStoreUrl, evaluation);
         }
         switch (evaluation.gateDecision) {
             case "allow":
@@ -31355,9 +31359,11 @@ var __importStar = (this && this.__importStar) || (function () {
 })();
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.sendWebhook = sendWebhook;
+exports.storeEvaluation = storeEvaluation;
 const core = __importStar(__nccwpck_require__(7484));
 const github = __importStar(__nccwpck_require__(3228));
 const WEBHOOK_TIMEOUT_MS = 10_000;
+const STORE_TIMEOUT_MS = 10_000;
 async function sendWebhook(url, evaluation) {
     const { owner, repo } = github.context.repo;
     const prUrl = evaluation.prNumber
@@ -31402,6 +31408,30 @@ async function sendWebhook(url, evaluation) {
     }
     catch (error) {
         core.debug(`Webhook delivery failed: ${error}`);
+    }
+}
+async function storeEvaluation(url, evaluation) {
+    try {
+        const storeSecret = process.env.EVALUATION_STORE_SECRET;
+        const headers = { "Content-Type": "application/json" };
+        if (storeSecret) {
+            headers["Authorization"] = `Bearer ${storeSecret}`;
+        }
+        const response = await fetch(url, {
+            method: "POST",
+            headers,
+            body: JSON.stringify(evaluation),
+            signal: AbortSignal.timeout(STORE_TIMEOUT_MS),
+        });
+        if (response.ok) {
+            core.debug(`Evaluation stored successfully at ${url}`);
+        }
+        else {
+            core.debug(`Evaluation store returned ${response.status} — data may not be persisted`);
+        }
+    }
+    catch (error) {
+        core.debug(`Evaluation store failed (non-blocking): ${error}`);
     }
 }
 

--- a/scripts/simulate.ts
+++ b/scripts/simulate.ts
@@ -62,6 +62,7 @@ async function main() {
     addRiskLabels: false,
     reviewersOnRisk: [],
     webhookEvents: [],
+    evaluationStoreUrl: flags["store-url"] || undefined,
   };
 
   const commitSha = flags["sha"] ?? "0000000000000000000000000000000000000000";

--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -11,6 +11,7 @@ const {
   mockRegisterHealer,
   mockAttemptRepair,
   mockSendWebhook,
+  mockStoreEvaluation,
   mockGetInput,
   mockInfo,
   mockWarning,
@@ -34,6 +35,7 @@ const {
     mockRegisterHealer: vi.fn(),
     mockAttemptRepair: vi.fn(),
     mockSendWebhook: vi.fn(),
+    mockStoreEvaluation: vi.fn(),
     mockGetInput: vi.fn(),
     mockInfo: vi.fn(),
     mockWarning: vi.fn(),
@@ -82,6 +84,7 @@ vi.mock("../gate.js", () => ({
 
 vi.mock("../notify.js", () => ({
   sendWebhook: mockSendWebhook,
+  storeEvaluation: mockStoreEvaluation,
 }));
 
 vi.mock("../healers/index.js", () => ({
@@ -131,6 +134,7 @@ describe("run (main entrypoint)", () => {
     mockManagePrLabels.mockReset().mockResolvedValue(undefined);
     mockRequestHighRiskReviewers.mockReset().mockResolvedValue(undefined);
     mockSendWebhook.mockReset().mockResolvedValue(undefined);
+    mockStoreEvaluation.mockReset().mockResolvedValue(undefined);
     mockRegisterHealer.mockReset();
     mockAttemptRepair.mockReset();
     mockGetInput.mockReset();
@@ -350,6 +354,29 @@ describe("run (main entrypoint)", () => {
     await runMain();
 
     expect(mockSendWebhook).not.toHaveBeenCalled();
+  });
+
+  it("stores evaluation when evaluation-store-url is set", async () => {
+    setupInputs({
+      "api-key": "test-key",
+      "evaluation-store-url": "https://komatik.ai/api/deployguard/store",
+    });
+    const eval_ = makeEvaluation();
+    mockEvaluateGate.mockResolvedValue(eval_);
+    await runMain();
+
+    expect(mockStoreEvaluation).toHaveBeenCalledWith(
+      "https://komatik.ai/api/deployguard/store",
+      eval_,
+    );
+  });
+
+  it("does not store evaluation when evaluation-store-url is not set", async () => {
+    setupInputs({ "api-key": "test-key" });
+    mockEvaluateGate.mockResolvedValue(makeEvaluation());
+    await runMain();
+
+    expect(mockStoreEvaluation).not.toHaveBeenCalled();
   });
 
   it("proceeds with warning on fail-open when evaluateGate throws", async () => {

--- a/src/__tests__/notify.test.ts
+++ b/src/__tests__/notify.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { sendWebhook } from "../notify.js";
+import { sendWebhook, storeEvaluation } from "../notify.js";
 import type { GateEvaluation } from "../types.js";
 
 vi.mock("@actions/core", () => ({
@@ -95,6 +95,70 @@ describe("sendWebhook", () => {
     vi.mocked(fetch).mockRejectedValueOnce(new Error("ECONNREFUSED"));
     await expect(
       sendWebhook("https://hooks.slack.com/test", makeEvaluation()),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("storeEvaluation", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+    delete process.env.EVALUATION_STORE_SECRET;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete process.env.EVALUATION_STORE_SECRET;
+  });
+
+  it("sends evaluation as POST body", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response('{"stored":true}', { status: 200 }),
+    );
+    const eval_ = makeEvaluation();
+    await storeEvaluation("https://komatik.ai/api/deployguard/store", eval_);
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://komatik.ai/api/deployguard/store",
+      expect.objectContaining({ method: "POST" }),
+    );
+    const body = JSON.parse(vi.mocked(fetch).mock.calls[0][1]!.body as string);
+    expect(body.id).toBe("dg-test");
+    expect(body.riskScore).toBe(85);
+    expect(body.gateDecision).toBe("block");
+  });
+
+  it("includes Authorization header when EVALUATION_STORE_SECRET is set", async () => {
+    process.env.EVALUATION_STORE_SECRET = "my-secret";
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response('{"stored":true}', { status: 200 }),
+    );
+    await storeEvaluation("https://komatik.ai/api/deployguard/store", makeEvaluation());
+
+    const headers = vi.mocked(fetch).mock.calls[0][1]!.headers as Record<string, string>;
+    expect(headers["Authorization"]).toBe("Bearer my-secret");
+  });
+
+  it("omits Authorization header when no secret is set", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response('{"stored":true}', { status: 200 }),
+    );
+    await storeEvaluation("https://komatik.ai/api/deployguard/store", makeEvaluation());
+
+    const headers = vi.mocked(fetch).mock.calls[0][1]!.headers as Record<string, string>;
+    expect(headers["Authorization"]).toBeUndefined();
+  });
+
+  it("handles non-200 response gracefully (fail-open)", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(new Response("error", { status: 500 }));
+    await expect(
+      storeEvaluation("https://komatik.ai/api/deployguard/store", makeEvaluation()),
+    ).resolves.toBeUndefined();
+  });
+
+  it("handles network error gracefully (fail-open)", async () => {
+    vi.mocked(fetch).mockRejectedValueOnce(new Error("ECONNREFUSED"));
+    await expect(
+      storeEvaluation("https://komatik.ai/api/deployguard/store", makeEvaluation()),
     ).resolves.toBeUndefined();
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ export {
   managePrLabels,
   requestHighRiskReviewers,
 } from "./gate.js";
-export { sendWebhook } from "./notify.js";
+export { sendWebhook, storeEvaluation } from "./notify.js";
 export {
   attemptRepair,
   registerHealer,

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,7 +8,7 @@ import {
   managePrLabels,
   requestHighRiskReviewers,
 } from "./gate.js";
-import { sendWebhook } from "./notify.js";
+import { sendWebhook, storeEvaluation } from "./notify.js";
 import { registerHealer, attemptRepair } from "./healers/index.js";
 import { jestHealer } from "./healers/jest.js";
 import { playwrightHealer } from "./healers/playwright.js";
@@ -111,6 +111,7 @@ async function run(): Promise<void> {
         .split(",")
         .map((s) => s.trim())
         .filter(Boolean),
+      evaluationStoreUrl: core.getInput("evaluation-store-url") || undefined,
     };
 
     const context = github.context;
@@ -145,6 +146,10 @@ async function run(): Promise<void> {
 
     if (config.webhookUrl && config.webhookEvents.includes(evaluation.gateDecision)) {
       await sendWebhook(config.webhookUrl, evaluation);
+    }
+
+    if (config.evaluationStoreUrl) {
+      await storeEvaluation(config.evaluationStoreUrl, evaluation);
     }
 
     switch (evaluation.gateDecision) {

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -3,6 +3,7 @@ import * as github from "@actions/github";
 import type { GateEvaluation } from "./types.js";
 
 const WEBHOOK_TIMEOUT_MS = 10_000;
+const STORE_TIMEOUT_MS = 10_000;
 
 export async function sendWebhook(
   url: string,
@@ -58,5 +59,35 @@ export async function sendWebhook(
     }
   } catch (error) {
     core.debug(`Webhook delivery failed: ${error}`);
+  }
+}
+
+export async function storeEvaluation(
+  url: string,
+  evaluation: GateEvaluation,
+): Promise<void> {
+  try {
+    const storeSecret = process.env.EVALUATION_STORE_SECRET;
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    if (storeSecret) {
+      headers["Authorization"] = `Bearer ${storeSecret}`;
+    }
+
+    const response = await fetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(evaluation),
+      signal: AbortSignal.timeout(STORE_TIMEOUT_MS),
+    });
+
+    if (response.ok) {
+      core.debug(`Evaluation stored successfully at ${url}`);
+    } else {
+      core.debug(
+        `Evaluation store returned ${response.status} — data may not be persisted`,
+      );
+    }
+  } catch (error) {
+    core.debug(`Evaluation store failed (non-blocking): ${error}`);
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,6 +64,7 @@ export interface DeployGuardConfig {
   reviewersOnRisk: string[];
   webhookUrl?: string;
   webhookEvents: string[];
+  evaluationStoreUrl?: string;
 }
 
 export interface TestRepairResult {


### PR DESCRIPTION
## Summary

- **New input `evaluation-store-url`**: optional URL to POST full evaluation JSON after every gate run, enabling historical trend analysis
- **`storeEvaluation()` function**: sends evaluation via `EVALUATION_STORE_SECRET` Bearer auth, fully fail-open (never blocks gate)
- **7 new tests**: auth header, payload correctness, fail-open on errors
- **Pairs with Komatik PR #641**: which adds `/api/deployguard/store` (receives evaluations) and `/api/deployguard/trends` (queries history with decision counts, average scores, top risk factors)

### Usage in Komatik

```yaml
- uses: dschirmer-shiftkey/deployguard@main
  with:
    evaluation-store-url: "https://komatik.ai/api/deployguard/store"
  env:
    EVALUATION_STORE_SECRET: ${{ secrets.INTERNAL_API_SECRET }}
```

### Trends API Response (from Komatik)

```json
{
  "repo": "dschirmer-shiftkey/Komatik",
  "period": { "days": 30, "evaluations": 47 },
  "decisions": { "allow": 35, "warn": 10, "block": 2 },
  "averages": { "riskScore": 42, "healthScore": 98 },
  "topRiskFactors": [
    { "type": "test_coverage", "occurrences": 28, "rate": 60 },
    { "type": "file_count", "occurrences": 12, "rate": 26 }
  ]
}
```

## Test plan

- [x] 170 unit tests pass (7 new for storeEvaluation)
- [x] ESLint + Prettier clean
- [x] TypeScript compiles without errors
- [x] `npm run build` succeeds
- [ ] CI workflow validates on GitHub
- [ ] Self-test workflow runs against this PR


Made with [Cursor](https://cursor.com)