### PR TITLE
feat: DeployGuard v1.0 — diff-aware scoring, custom rules, MCP tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,57 @@
+# Changelog
+
+All notable changes to DeployGuard will be documented in this file.
+
+## [1.0.0] - 2026-04-09
+
+### Added
+
+- **Diff-aware risk scoring** — Churn is weighted by file sensitivity: auth/payment files count 3x, infrastructure 2x, config 0.5x, tests 0.3x.
+- **PR split recommendations** — When a PR spans multiple areas (frontend, backend, migrations), the report suggests concrete split boundaries.
+- **Custom risk rules** — Drop a `.deployguard.yml` in your repo to define custom sensitivity patterns, factor weights, threshold overrides, and file ignores.
+- **Deployment correlation** — Track whether warned/blocked PRs caused post-deploy incidents via the deploy-event API. False positive and negative rates visible in trends.
+- **Trend dashboard** — Admin page in Komatik showing decision distribution, risk trends, top risk factors, and recent evaluations with Recharts visualizations.
+- **Slack/webhook notifications** — Configurable `webhook-url` and `webhook-events` inputs for real-time Slack or custom endpoint alerts on warn/block decisions.
+- **Evaluation history storage** — `evaluation-store-url` input to persist gate results for historical trend analysis.
+- **MCP tool server** — Standalone MCP server exposing health check and risk scoring functions for AI agent consumption.
+
+### Changed
+
+- `health-check-url` input deprecated in favor of `health-check-urls` (comma-separated, multiple URLs).
+- Code churn description changed from "Total lines changed" to "Sensitivity-weighted lines changed" for transparency.
+
+## [0.3.0] - 2026-04-09
+
+### Added
+
+- **Multi-URL health checks** — `health-check-urls` input accepts comma-separated URLs, all checked in parallel.
+- **Vercel deployment status check** — `checkVercelHealth()` queries the Vercel Deployments API when `VERCEL_TOKEN` and `VERCEL_PROJECT_ID` are set.
+- **Supabase REST check** — `checkSupabaseHealth()` pings the Supabase REST API when `SUPABASE_URL` and `SUPABASE_ANON_KEY` are set.
+- All health checks (HTTP, Vercel, Supabase, MCP) run in parallel via `Promise.all`.
+
+## [0.2.0] - 2026-04-09
+
+### Added
+
+- **GitHub Check Runs** — Creates a check run with pass/neutral/fail conclusion.
+- **PR risk labels** — Auto-applies `deployguard:low-risk`, `deployguard:medium-risk`, or `deployguard:high-risk` labels.
+- **Auto-request reviewers** — `reviewers-on-risk` input to request specific reviewers on warn/block.
+- **Webhook notifications** — Generic POST webhook with Slack-compatible payload.
+- **Actionable guidance** — PR comments include specific guidance based on risk factors.
+- **Job summary** — Rich Markdown summary in GitHub Actions job output.
+- **Visual score bar** — Risk score visualization in PR comments.
+- **Evaluation JSON output** — `evaluation-json` output for downstream workflow steps.
+
+## [0.1.0] - 2026-04-09
+
+### Added
+
+- Initial release with core gate evaluation logic.
+- HTTP health checks, MCP gateway health checks.
+- Risk scoring: file count (logarithmic), code churn (logarithmic), test file ratio, sensitive file detection, author history.
+- Decision logic: allow, warn, block based on configurable thresholds.
+- Self-healing test repair (Jest, Playwright, Cypress).
+- Fail-open error handling.
+- PR comment posting (sticky, idempotent updates).
+- Local simulation script (`scripts/simulate.ts`).
+- CI, dry-run, and self-test workflows.

--- a/README.md
+++ b/README.md
@@ -138,6 +138,49 @@ GitHub Action → Gate Evaluation
 
 ---
 
+## Per-Repo Configuration
+
+Drop a `.deployguard.yml` at your repo root to customize risk scoring:
+
+```yaml
+# .deployguard.yml
+sensitivity:
+  high:
+    - "src/auth/**"
+    - "src/payments/**"
+    - "infrastructure/**"
+  medium:
+    - "supabase/migrations/**"
+  low:
+    - "docs/**"
+    - "*.md"
+    - "*.css"
+weights:
+  code_churn: 3
+  test_coverage: 4
+  file_count: 1
+  sensitive_files: 5
+  author_history: 1
+thresholds:
+  risk: 65
+  warn: 45
+ignore:
+  - "package-lock.json"
+  - "*.generated.ts"
+```
+
+| Field                | Description                                                                                                         |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `sensitivity.high`   | Glob patterns for 3x churn weight                                                                                   |
+| `sensitivity.medium` | Glob patterns for 2x churn weight                                                                                   |
+| `sensitivity.low`    | Glob patterns for 0.5x churn weight                                                                                 |
+| `weights`            | Override factor weights (default: code_churn=3, test_coverage=2, file_count=2, sensitive_files=3, author_history=1) |
+| `thresholds.risk`    | Override the `risk-threshold` input                                                                                 |
+| `thresholds.warn`    | Override the `warn-threshold` input                                                                                 |
+| `ignore`             | Glob patterns for files to exclude from scoring entirely                                                            |
+
+---
+
 ## Development
 
 ```bash

--- a/dist/index.js
+++ b/dist/index.js
@@ -29922,6 +29922,170 @@ function wrappy (fn, cb) {
 
 /***/ }),
 
+/***/ 2973:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.loadRepoConfig = loadRepoConfig;
+exports.matchesGlobs = matchesGlobs;
+const core = __importStar(__nccwpck_require__(7484));
+const github = __importStar(__nccwpck_require__(3228));
+const types_js_1 = __nccwpck_require__(8522);
+let yamlParse = null;
+function parseYaml(input) {
+    if (yamlParse)
+        return yamlParse(input);
+    const lines = input.split("\n");
+    const result = {};
+    let currentKey = "";
+    let currentArray = null;
+    for (const raw of lines) {
+        const line = raw.replace(/\r$/, "");
+        if (line.trim() === "" || line.trim().startsWith("#"))
+            continue;
+        const topMatch = line.match(/^(\w[\w-]*):\s*(.*)$/);
+        if (topMatch) {
+            if (currentKey && currentArray) {
+                result[currentKey] = currentArray;
+                currentArray = null;
+            }
+            const [, key, val] = topMatch;
+            currentKey = key;
+            if (val && val.trim()) {
+                const numVal = Number(val.trim());
+                result[key] = isNaN(numVal) ? val.trim() : numVal;
+            }
+            continue;
+        }
+        const nestedObjMatch = line.match(/^\s{2}(\w[\w-]*):\s*(.*)$/);
+        if (nestedObjMatch) {
+            if (currentArray) {
+                result[currentKey] = currentArray;
+                currentArray = null;
+            }
+            const [, subKey, subVal] = nestedObjMatch;
+            if (typeof result[currentKey] !== "object" || Array.isArray(result[currentKey])) {
+                result[currentKey] = {};
+            }
+            const obj = result[currentKey];
+            if (subVal && subVal.trim()) {
+                const numVal = Number(subVal.trim());
+                obj[subKey] = isNaN(numVal) ? subVal.trim() : numVal;
+            }
+            else {
+                obj[subKey] = [];
+            }
+            continue;
+        }
+        const arrayItemMatch = line.match(/^\s+-\s+"?([^"]*)"?\s*$/);
+        if (arrayItemMatch) {
+            const val = arrayItemMatch[1];
+            if (currentKey &&
+                typeof result[currentKey] === "object" &&
+                !Array.isArray(result[currentKey])) {
+                const obj = result[currentKey];
+                const keys = Object.keys(obj);
+                const lastKey = keys[keys.length - 1];
+                if (lastKey && Array.isArray(obj[lastKey])) {
+                    obj[lastKey].push(val);
+                }
+            }
+            else {
+                if (!currentArray)
+                    currentArray = [];
+                currentArray.push(val);
+            }
+            continue;
+        }
+    }
+    if (currentKey && currentArray) {
+        result[currentKey] = currentArray;
+    }
+    return result;
+}
+async function loadRepoConfig(token) {
+    if (!token)
+        return null;
+    try {
+        const octokit = github.getOctokit(token);
+        const { owner, repo } = github.context.repo;
+        const { data } = await octokit.rest.repos.getContent({
+            owner,
+            repo,
+            path: ".deployguard.yml",
+        });
+        if (Array.isArray(data) || data.type !== "file" || !data.content) {
+            return null;
+        }
+        const content = Buffer.from(data.content, "base64").toString("utf-8");
+        const raw = parseYaml(content);
+        const parsed = types_js_1.RepoConfig.safeParse(raw);
+        if (!parsed.success) {
+            core.warning(`.deployguard.yml parse error: ${parsed.error.message} — using defaults`);
+            return null;
+        }
+        core.debug(`Loaded .deployguard.yml: ${JSON.stringify(parsed.data)}`);
+        return parsed.data;
+    }
+    catch (error) {
+        const msg = String(error);
+        if (!msg.includes("404") && !msg.includes("Not Found")) {
+            core.debug(`.deployguard.yml load failed: ${msg}`);
+        }
+        return null;
+    }
+}
+function globToRegex(pattern) {
+    const escaped = pattern
+        .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+        .replace(/\*\*/g, "<<GLOBSTAR>>")
+        .replace(/\*/g, "[^/]*")
+        .replace(/<<GLOBSTAR>>/g, ".*")
+        .replace(/\?/g, ".");
+    return new RegExp(`^${escaped}$`, "i");
+}
+function matchesGlobs(filename, patterns) {
+    return patterns.some((p) => globToRegex(p).test(filename));
+}
+
+
+/***/ }),
+
 /***/ 1956:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
@@ -29962,6 +30126,7 @@ var __importStar = (this && this.__importStar) || (function () {
 })();
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.isSensitiveFile = isSensitiveFile;
+exports.sensitivityWeight = sensitivityWeight;
 exports.computeRiskScore = computeRiskScore;
 exports.checkHealth = checkHealth;
 exports.checkMcpHealth = checkMcpHealth;
@@ -29973,10 +30138,12 @@ exports.postPrComment = postPrComment;
 exports.createCheckRun = createCheckRun;
 exports.managePrLabels = managePrLabels;
 exports.requestHighRiskReviewers = requestHighRiskReviewers;
+exports.suggestSplitBoundaries = suggestSplitBoundaries;
 exports.formatGateReport = formatGateReport;
 const core = __importStar(__nccwpck_require__(7484));
 const github = __importStar(__nccwpck_require__(3228));
 const types_js_1 = __nccwpck_require__(8522);
+const config_js_1 = __nccwpck_require__(2973);
 // ---------------------------------------------------------------------------
 // PR diff fetching via @actions/github
 // ---------------------------------------------------------------------------
@@ -30040,28 +30207,66 @@ function isNonSourceFile(filename) {
 function isSensitiveFile(filename) {
     return SENSITIVE_PATTERNS.some((p) => p.test(filename));
 }
-function computeRiskScore(files) {
+const HIGH_SENSITIVITY_PATTERN = /(?:^|\/)(?:auth|security|payment|billing|webhook)/i;
+const INFRA_SENSITIVITY_PATTERN = /(?:^|\/)(?:migrations|infrastructure|\.github\/workflows|secrets|\.env)/i;
+function sensitivityWeight(filename, repoConfig) {
+    if (repoConfig) {
+        if (repoConfig.ignore.length > 0 && (0, config_js_1.matchesGlobs)(filename, repoConfig.ignore))
+            return 0;
+        if (repoConfig.sensitivity.high.length > 0 &&
+            (0, config_js_1.matchesGlobs)(filename, repoConfig.sensitivity.high))
+            return 3;
+        if (repoConfig.sensitivity.medium.length > 0 &&
+            (0, config_js_1.matchesGlobs)(filename, repoConfig.sensitivity.medium))
+            return 2;
+        if (repoConfig.sensitivity.low.length > 0 &&
+            (0, config_js_1.matchesGlobs)(filename, repoConfig.sensitivity.low))
+            return 0.5;
+    }
+    if (isTestFile(filename))
+        return 0.3;
+    if (HIGH_SENSITIVITY_PATTERN.test(filename))
+        return 3;
+    if (INFRA_SENSITIVITY_PATTERN.test(filename))
+        return 2;
+    if (isNonSourceFile(filename))
+        return 0.5;
+    return 1;
+}
+function computeRiskScore(files, repoConfig) {
     if (files.length === 0) {
         return { score: 0, factors: [] };
     }
+    const effectiveFiles = repoConfig?.ignore.length
+        ? files.filter((f) => !(0, config_js_1.matchesGlobs)(f.filename, repoConfig.ignore))
+        : files;
+    if (effectiveFiles.length === 0) {
+        return { score: 0, factors: [] };
+    }
     const factors = [];
-    const fileCount = files.length;
+    const customWeights = repoConfig?.weights ?? {};
+    const fileCount = effectiveFiles.length;
     const fileCountScore = Math.min(100, Math.round(30 * Math.log2(1 + fileCount)));
     factors.push({
         type: "file_count",
         score: fileCountScore,
         detail: { fileCount, description: "Number of files changed" },
     });
-    const totalChanges = files.reduce((sum, f) => sum + f.changes, 0);
-    const churnScore = Math.min(100, Math.round(25 * Math.log2(1 + totalChanges / 50)));
+    const totalChanges = effectiveFiles.reduce((sum, f) => sum + f.changes, 0);
+    const weightedChanges = effectiveFiles.reduce((sum, f) => sum + f.changes * sensitivityWeight(f.filename, repoConfig), 0);
+    const churnScore = Math.min(100, Math.round(25 * Math.log2(1 + weightedChanges / 50)));
     factors.push({
         type: "code_churn",
         score: churnScore,
-        detail: { totalChanges, description: "Total lines changed" },
+        detail: {
+            totalChanges,
+            weightedChanges: Math.round(weightedChanges),
+            description: "Sensitivity-weighted lines changed",
+        },
     });
-    const testFileCount = files.filter((f) => isTestFile(f.filename)).length;
-    const nonSourceCount = files.filter((f) => !isTestFile(f.filename) && isNonSourceFile(f.filename)).length;
-    const sourceFileCount = files.length - testFileCount - nonSourceCount;
+    const testFileCount = effectiveFiles.filter((f) => isTestFile(f.filename)).length;
+    const nonSourceCount = effectiveFiles.filter((f) => !isTestFile(f.filename) && isNonSourceFile(f.filename)).length;
+    const sourceFileCount = effectiveFiles.length - testFileCount - nonSourceCount;
     if (sourceFileCount > 0) {
         const testRatio = testFileCount / sourceFileCount;
         const testCoverageScore = Math.round(Math.max(0, 100 - testRatio * 200));
@@ -30076,7 +30281,15 @@ function computeRiskScore(files) {
             },
         });
     }
-    const sensitiveFiles = files.filter((f) => isSensitiveFile(f.filename));
+    const sensitiveByConfig = repoConfig?.sensitivity.high.length
+        ? effectiveFiles.filter((f) => (0, config_js_1.matchesGlobs)(f.filename, repoConfig.sensitivity.high))
+        : [];
+    const sensitiveByDefault = effectiveFiles.filter((f) => isSensitiveFile(f.filename));
+    const sensitiveFilenames = new Set([
+        ...sensitiveByConfig.map((f) => f.filename),
+        ...sensitiveByDefault.map((f) => f.filename),
+    ]);
+    const sensitiveFiles = effectiveFiles.filter((f) => sensitiveFilenames.has(f.filename));
     if (sensitiveFiles.length > 0) {
         const sensitiveScore = Math.min(100, sensitiveFiles.length * 25);
         factors.push({
@@ -30089,15 +30302,15 @@ function computeRiskScore(files) {
             },
         });
     }
-    return { score: weightedAverageScores(factors), factors };
+    return { score: weightedAverageScores(factors, customWeights), factors };
 }
-function weightedAverageScores(factors) {
+function weightedAverageScores(factors, overrides) {
     if (factors.length === 0)
         return 0;
     let totalWeight = 0;
     let weightedSum = 0;
     for (const f of factors) {
-        const w = FACTOR_WEIGHTS[f.type] ?? 1;
+        const w = overrides?.[f.type] ?? FACTOR_WEIGHTS[f.type] ?? 1;
         weightedSum += f.score * w;
         totalWeight += w;
     }
@@ -30420,7 +30633,7 @@ async function callGateApi(config, localEvaluation) {
 // ---------------------------------------------------------------------------
 async function evaluateGate(config, commitSha, prNumber) {
     const start = Date.now();
-    const [files, authorFactor, httpHealthChecks, vercelCheck, supabaseCheck, mcpCheck] = await Promise.all([
+    const [files, authorFactor, httpHealthChecks, vercelCheck, supabaseCheck, mcpCheck, repoConfig,] = await Promise.all([
         prNumber ? fetchPrFiles(prNumber, config.githubToken) : Promise.resolve([]),
         prNumber && config.githubToken
             ? computeAuthorHistory(prNumber, config.githubToken)
@@ -30431,12 +30644,18 @@ async function evaluateGate(config, commitSha, prNumber) {
         checkVercelHealth(),
         checkSupabaseHealth(),
         checkMcpHealth(),
+        (0, config_js_1.loadRepoConfig)(config.githubToken),
     ]);
-    const { score: localRiskScore, factors: riskFactors } = computeRiskScore(files);
+    const effectiveRiskThreshold = repoConfig?.thresholds.risk ?? config.riskThreshold;
+    const effectiveWarnThreshold = repoConfig?.thresholds.warn ?? config.warnThreshold;
+    const { score: localRiskScore, factors: riskFactors } = computeRiskScore(files, repoConfig);
     if (authorFactor) {
         riskFactors.push(authorFactor);
     }
-    const riskScore = riskFactors.length > 0 ? weightedAverageScores(riskFactors) : localRiskScore;
+    const customWeights = repoConfig?.weights ?? {};
+    const riskScore = riskFactors.length > 0
+        ? weightedAverageScores(riskFactors, customWeights)
+        : localRiskScore;
     const healthChecks = [...httpHealthChecks];
     if (vercelCheck)
         healthChecks.push(vercelCheck);
@@ -30445,7 +30664,7 @@ async function evaluateGate(config, commitSha, prNumber) {
     if (mcpCheck)
         healthChecks.push(mcpCheck);
     const healthScore = aggregateHealthScore(healthChecks);
-    const gateDecision = decideGate(riskScore, healthScore, config.riskThreshold, config.warnThreshold);
+    const gateDecision = decideGate(riskScore, healthScore, effectiveRiskThreshold, effectiveWarnThreshold);
     const fileNames = files.map((f) => f.filename);
     let localEvaluation = {
         id: `dg-${commitSha.substring(0, 7)}-${Date.now()}`,
@@ -30654,6 +30873,44 @@ function buildScoreBar(score, threshold) {
     const bar = "█".repeat(filled) + "░".repeat(width - filled);
     return `\`${bar}\` ${score}/100 (threshold: ${threshold})`;
 }
+function suggestSplitBoundaries(files) {
+    if (files.length < 5)
+        return [];
+    const groups = {};
+    for (const f of files) {
+        const parts = f.replace(/\\/g, "/").split("/");
+        let bucket;
+        if (parts[0] === ".github") {
+            bucket = "CI/workflow";
+        }
+        else if (/^(migrations?|supabase)/i.test(parts[0])) {
+            bucket = "database/migrations";
+        }
+        else if (parts.length >= 2) {
+            bucket = parts.slice(0, 2).join("/");
+        }
+        else {
+            bucket = parts[0];
+        }
+        (groups[bucket] ??= []).push(f);
+    }
+    const sorted = Object.entries(groups)
+        .filter(([, v]) => v.length >= 2)
+        .sort((a, b) => b[1].length - a[1].length);
+    if (sorted.length < 2)
+        return [];
+    const suggestions = [];
+    const [first, second] = sorted;
+    suggestions.push(`- **Suggested split:** \`${first[0]}/\` changes (${first[1].length} files) ` +
+        `could be a separate PR from \`${second[0]}/\` changes (${second[1].length} files).`);
+    if (sorted.length > 2) {
+        const rest = sorted.slice(2);
+        const restTotal = rest.reduce((sum, [, v]) => sum + v.length, 0);
+        suggestions.push(`- ${rest.length} other group${rest.length > 1 ? "s" : ""} (${restTotal} files) ` +
+            `may also be separable: ${rest.map(([k, v]) => `\`${k}/\` (${v.length})`).join(", ")}.`);
+    }
+    return suggestions;
+}
 function buildGuidance(evaluation) {
     if (evaluation.gateDecision === "allow")
         return [];
@@ -30680,8 +30937,16 @@ function buildGuidance(evaluation) {
         }
     }
     const fileCountFactor = evaluation.riskFactors.find((f) => f.type === "file_count");
+    const shouldSuggestSplit = (fileCountFactor && fileCountFactor.score >= 70) ||
+        (churnFactor && churnFactor.score >= 70);
     if (fileCountFactor && fileCountFactor.score >= 80) {
         lines.push(`- **Many files changed**. Large PRs are harder to review thoroughly — consider splitting.`);
+    }
+    if (shouldSuggestSplit && evaluation.files && evaluation.files.length >= 5) {
+        const splits = suggestSplitBoundaries(evaluation.files);
+        if (splits.length > 0) {
+            lines.push(...splits);
+        }
     }
     if (lines.length === 2) {
         lines.push(`- Risk score exceeds threshold. Review the risk factors above before proceeding.`);
@@ -31444,7 +31709,7 @@ async function storeEvaluation(url, evaluation) {
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.GateApiResponse = exports.GateEvaluation = exports.RiskFactor = exports.HealthCheckResult = exports.GateDecision = void 0;
+exports.RepoConfig = exports.GateApiResponse = exports.GateEvaluation = exports.RiskFactor = exports.HealthCheckResult = exports.GateDecision = void 0;
 const zod_1 = __nccwpck_require__(924);
 exports.GateDecision = zod_1.z.enum(["allow", "warn", "block"]);
 exports.HealthCheckResult = zod_1.z.object({
@@ -31486,6 +31751,23 @@ exports.GateApiResponse = zod_1.z.object({
     gateDecision: exports.GateDecision.optional(),
     healthChecks: zod_1.z.array(exports.HealthCheckResult).optional(),
     riskFactors: zod_1.z.array(exports.RiskFactor).optional(),
+});
+exports.RepoConfig = zod_1.z.object({
+    sensitivity: zod_1.z
+        .object({
+        high: zod_1.z.array(zod_1.z.string()).default([]),
+        medium: zod_1.z.array(zod_1.z.string()).default([]),
+        low: zod_1.z.array(zod_1.z.string()).default([]),
+    })
+        .default({}),
+    weights: zod_1.z.record(zod_1.z.number().min(0).max(10)).default({}),
+    thresholds: zod_1.z
+        .object({
+        risk: zod_1.z.number().min(0).max(100).optional(),
+        warn: zod_1.z.number().min(0).max(100).optional(),
+    })
+        .default({}),
+    ignore: zod_1.z.array(zod_1.z.string()).default([]),
 });
 
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -29966,7 +29966,7 @@ exports.matchesGlobs = matchesGlobs;
 const core = __importStar(__nccwpck_require__(7484));
 const github = __importStar(__nccwpck_require__(3228));
 const types_js_1 = __nccwpck_require__(8522);
-let yamlParse = null;
+const yamlParse = null;
 function parseYaml(input) {
     if (yamlParse)
         return yamlParse(input);

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -29,6 +29,6 @@ export default tseslint.config(
     },
   },
   {
-    ignores: ["dist/", "node_modules/", "coverage/", "scripts/"],
+    ignores: ["dist/", "node_modules/", "coverage/", "scripts/", "mcp/"],
   },
 );

--- a/mcp/dist/server.d.ts
+++ b/mcp/dist/server.d.ts
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+export {};

--- a/mcp/dist/server.js
+++ b/mcp/dist/server.js
@@ -1,0 +1,368 @@
+#!/usr/bin/env node
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+const HEALTH_CHECK_TIMEOUT_MS = 10_000;
+const VERCEL_TIMEOUT_MS = 10_000;
+const SUPABASE_TIMEOUT_MS = 10_000;
+const server = new McpServer({
+    name: "deployguard",
+    version: "1.0.0",
+});
+server.tool("check-http-health", "Check the health of an HTTP endpoint by sending a GET request and evaluating the response status", {
+    url: z.string().url().describe("The URL to check"),
+}, async ({ url }) => {
+    const start = Date.now();
+    try {
+        const response = await fetch(url, {
+            method: "GET",
+            signal: AbortSignal.timeout(HEALTH_CHECK_TIMEOUT_MS),
+        });
+        const latencyMs = Date.now() - start;
+        let status;
+        if (response.ok)
+            status = "healthy";
+        else if (response.status < 500)
+            status = "degraded";
+        else
+            status = "down";
+        const result = {
+            target: url,
+            status,
+            latencyMs,
+            detail: { httpStatus: response.status },
+        };
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    }
+    catch (error) {
+        const result = {
+            target: url,
+            status: "down",
+            latencyMs: Date.now() - start,
+            detail: { error: String(error) },
+        };
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    }
+});
+server.tool("check-vercel-health", "Check the latest Vercel production deployment status. Requires VERCEL_TOKEN and VERCEL_PROJECT_ID environment variables.", {}, async () => {
+    const token = process.env.VERCEL_TOKEN;
+    const projectId = process.env.VERCEL_PROJECT_ID;
+    if (!token || !projectId) {
+        return {
+            content: [
+                {
+                    type: "text",
+                    text: JSON.stringify({
+                        error: "Missing VERCEL_TOKEN or VERCEL_PROJECT_ID environment variables",
+                    }),
+                },
+            ],
+        };
+    }
+    const start = Date.now();
+    try {
+        const url = `https://api.vercel.com/v6/deployments?projectId=${encodeURIComponent(projectId)}&target=production&limit=1`;
+        const response = await fetch(url, {
+            method: "GET",
+            headers: { Authorization: `Bearer ${token}` },
+            signal: AbortSignal.timeout(VERCEL_TIMEOUT_MS),
+        });
+        const latencyMs = Date.now() - start;
+        if (!response.ok) {
+            return {
+                content: [
+                    {
+                        type: "text",
+                        text: JSON.stringify({
+                            target: "vercel:production",
+                            status: "degraded",
+                            latencyMs,
+                            detail: { httpStatus: response.status },
+                        }),
+                    },
+                ],
+            };
+        }
+        const body = (await response.json());
+        const deployment = body?.deployments?.[0];
+        const result = {
+            target: "vercel:production",
+            status: deployment?.readyState === "READY" ? "healthy" : "degraded",
+            latencyMs,
+            detail: {
+                readyState: deployment?.readyState ?? "unknown",
+                url: deployment?.url,
+                createdAt: deployment?.createdAt
+                    ? new Date(deployment.createdAt).toISOString()
+                    : undefined,
+            },
+        };
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    }
+    catch (error) {
+        return {
+            content: [
+                {
+                    type: "text",
+                    text: JSON.stringify({
+                        target: "vercel:production",
+                        status: "down",
+                        latencyMs: Date.now() - start,
+                        detail: { error: String(error) },
+                    }),
+                },
+            ],
+        };
+    }
+});
+server.tool("check-supabase-health", "Check the health of a Supabase project by pinging its REST API. Requires SUPABASE_URL and SUPABASE_ANON_KEY environment variables.", {}, async () => {
+    const supabaseUrl = process.env.SUPABASE_URL;
+    const anonKey = process.env.SUPABASE_ANON_KEY;
+    if (!supabaseUrl || !anonKey) {
+        return {
+            content: [
+                {
+                    type: "text",
+                    text: JSON.stringify({
+                        error: "Missing SUPABASE_URL or SUPABASE_ANON_KEY environment variables",
+                    }),
+                },
+            ],
+        };
+    }
+    const start = Date.now();
+    try {
+        const response = await fetch(`${supabaseUrl}/rest/v1/`, {
+            method: "GET",
+            headers: { apikey: anonKey, Authorization: `Bearer ${anonKey}` },
+            signal: AbortSignal.timeout(SUPABASE_TIMEOUT_MS),
+        });
+        const latencyMs = Date.now() - start;
+        const result = {
+            target: "supabase:rest",
+            status: response.ok ? "healthy" : "degraded",
+            latencyMs,
+            detail: { httpStatus: response.status },
+        };
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    }
+    catch (error) {
+        return {
+            content: [
+                {
+                    type: "text",
+                    text: JSON.stringify({
+                        target: "supabase:rest",
+                        status: "down",
+                        latencyMs: Date.now() - start,
+                        detail: { error: String(error) },
+                    }),
+                },
+            ],
+        };
+    }
+});
+const TEST_FILE_PATTERN = /\.(test|spec)\.(ts|tsx|js|jsx)$|__tests__\/|\.cy\.(ts|js)$/;
+const NON_SOURCE_PATTERN = /\.(sql|ya?ml|json|md|css|svg|lock|txt|env|png|jpg|gif)$/i;
+const SENSITIVE_PATTERNS = [
+    /(?:^|\/)migrations\//i,
+    /(?:^|\/)auth/i,
+    /(?:^|\/)security/i,
+    /(?:^|\/)payment/i,
+    /(?:^|\/)billing/i,
+    /(?:^|\/)webhook/i,
+    /(?:^|\/)infrastructure\//i,
+    /(?:^|\/)\.github\/workflows\//i,
+    /(?:^|\/)secrets/i,
+    /(?:^|\/)\.env/i,
+];
+const HIGH_SENSITIVITY = /(?:^|\/)(?:auth|security|payment|billing|webhook)/i;
+const INFRA_SENSITIVITY = /(?:^|\/)(?:migrations|infrastructure|\.github\/workflows|secrets|\.env)/i;
+function sensitivityWeight(filename) {
+    if (TEST_FILE_PATTERN.test(filename))
+        return 0.3;
+    if (HIGH_SENSITIVITY.test(filename))
+        return 3;
+    if (INFRA_SENSITIVITY.test(filename))
+        return 2;
+    if (NON_SOURCE_PATTERN.test(filename))
+        return 0.5;
+    return 1;
+}
+const FACTOR_WEIGHTS = {
+    code_churn: 3,
+    test_coverage: 2,
+    file_count: 2,
+    sensitive_files: 3,
+};
+server.tool("compute-risk-score", "Compute a deployment risk score for a set of changed files. Provide file names and their change counts.", {
+    files: z
+        .array(z.object({
+        filename: z.string(),
+        changes: z.number().int().min(0),
+    }))
+        .describe("Array of changed files with their line change counts"),
+}, async ({ files, }) => {
+    if (files.length === 0) {
+        return {
+            content: [
+                {
+                    type: "text",
+                    text: JSON.stringify({ score: 0, factors: [], decision: "allow" }),
+                },
+            ],
+        };
+    }
+    const factors = [];
+    const fileCountScore = Math.min(100, Math.round(30 * Math.log2(1 + files.length)));
+    factors.push({
+        type: "file_count",
+        score: fileCountScore,
+        detail: { fileCount: files.length },
+    });
+    const totalChanges = files.reduce((s, f) => s + f.changes, 0);
+    const weightedChanges = files.reduce((s, f) => s + f.changes * sensitivityWeight(f.filename), 0);
+    const churnScore = Math.min(100, Math.round(25 * Math.log2(1 + weightedChanges / 50)));
+    factors.push({
+        type: "code_churn",
+        score: churnScore,
+        detail: { totalChanges, weightedChanges: Math.round(weightedChanges) },
+    });
+    const testFiles = files.filter((f) => TEST_FILE_PATTERN.test(f.filename));
+    const nonSource = files.filter((f) => !TEST_FILE_PATTERN.test(f.filename) &&
+        NON_SOURCE_PATTERN.test(f.filename));
+    const sourceCount = files.length - testFiles.length - nonSource.length;
+    if (sourceCount > 0) {
+        const ratio = testFiles.length / sourceCount;
+        factors.push({
+            type: "test_coverage",
+            score: Math.round(Math.max(0, 100 - ratio * 200)),
+            detail: { testFiles: testFiles.length, sourceFiles: sourceCount },
+        });
+    }
+    const sensitive = files.filter((f) => SENSITIVE_PATTERNS.some((p) => p.test(f.filename)));
+    if (sensitive.length > 0) {
+        factors.push({
+            type: "sensitive_files",
+            score: Math.min(100, sensitive.length * 25),
+            detail: {
+                count: sensitive.length,
+                files: sensitive.map((f) => f.filename),
+            },
+        });
+    }
+    let totalWeight = 0;
+    let weightedSum = 0;
+    for (const f of factors) {
+        const w = FACTOR_WEIGHTS[f.type] ?? 1;
+        weightedSum += f.score * w;
+        totalWeight += w;
+    }
+    const score = Math.min(100, Math.max(0, Math.round(weightedSum / totalWeight)));
+    const decision = score > 70 ? "block" : score > 55 ? "warn" : "allow";
+    return {
+        content: [
+            {
+                type: "text",
+                text: JSON.stringify({ score, factors, decision }, null, 2),
+            },
+        ],
+    };
+});
+server.tool("evaluate-deployment", "Run a full DeployGuard evaluation including health checks and risk scoring. Provide the target URLs and file changes.", {
+    healthUrls: z
+        .array(z.string().url())
+        .default([])
+        .describe("URLs to health-check before scoring"),
+    files: z
+        .array(z.object({
+        filename: z.string(),
+        changes: z.number().int().min(0),
+    }))
+        .default([])
+        .describe("Changed files with line counts"),
+}, async ({ healthUrls, files, }) => {
+    const healthChecks = [];
+    const httpChecks = await Promise.all(healthUrls.map(async (url) => {
+        const start = Date.now();
+        try {
+            const res = await fetch(url, {
+                method: "GET",
+                signal: AbortSignal.timeout(HEALTH_CHECK_TIMEOUT_MS),
+            });
+            return {
+                target: url,
+                status: (res.ok ? "healthy" : res.status < 500 ? "degraded" : "down"),
+                latencyMs: Date.now() - start,
+                detail: { httpStatus: res.status },
+            };
+        }
+        catch (err) {
+            return {
+                target: url,
+                status: "down",
+                latencyMs: Date.now() - start,
+                detail: { error: String(err) },
+            };
+        }
+    }));
+    healthChecks.push(...httpChecks);
+    const healthScore = healthChecks.length > 0
+        ? Math.round(healthChecks.reduce((sum, c) => sum +
+            (c.status === "healthy" ? 100 : c.status === "degraded" ? 50 : 0), 0) / healthChecks.length)
+        : 100;
+    let riskScore = 0;
+    let factors = [];
+    if (files.length > 0) {
+        const fileCountScore = Math.min(100, Math.round(30 * Math.log2(1 + files.length)));
+        factors.push({
+            type: "file_count",
+            score: fileCountScore,
+            detail: { fileCount: files.length },
+        });
+        const weightedChanges = files.reduce((s, f) => s + f.changes * sensitivityWeight(f.filename), 0);
+        factors.push({
+            type: "code_churn",
+            score: Math.min(100, Math.round(25 * Math.log2(1 + weightedChanges / 50))),
+            detail: {
+                totalChanges: files.reduce((s, f) => s + f.changes, 0),
+                weightedChanges: Math.round(weightedChanges),
+            },
+        });
+        let totalW = 0;
+        let wSum = 0;
+        for (const f of factors) {
+            const w = FACTOR_WEIGHTS[f.type] ?? 1;
+            wSum += f.score * w;
+            totalW += w;
+        }
+        riskScore = Math.min(100, Math.max(0, Math.round(wSum / totalW)));
+    }
+    const decision = riskScore > 70
+        ? "block"
+        : riskScore > 55 || healthScore < 50
+            ? "warn"
+            : "allow";
+    return {
+        content: [
+            {
+                type: "text",
+                text: JSON.stringify({
+                    healthScore,
+                    riskScore,
+                    decision,
+                    healthChecks,
+                    riskFactors: factors,
+                }, null, 2),
+            },
+        ],
+    };
+});
+async function main() {
+    const transport = new StdioServerTransport();
+    await server.connect(transport);
+}
+main().catch((err) => {
+    console.error("MCP server failed:", err);
+    process.exit(1);
+});

--- a/mcp/dist/server.js
+++ b/mcp/dist/server.js
@@ -202,7 +202,7 @@ server.tool("compute-risk-score", "Compute a deployment risk score for a set of 
         changes: z.number().int().min(0),
     }))
         .describe("Array of changed files with their line change counts"),
-}, async ({ files, }) => {
+}, async ({ files }) => {
     if (files.length === 0) {
         return {
             content: [
@@ -229,8 +229,7 @@ server.tool("compute-risk-score", "Compute a deployment risk score for a set of 
         detail: { totalChanges, weightedChanges: Math.round(weightedChanges) },
     });
     const testFiles = files.filter((f) => TEST_FILE_PATTERN.test(f.filename));
-    const nonSource = files.filter((f) => !TEST_FILE_PATTERN.test(f.filename) &&
-        NON_SOURCE_PATTERN.test(f.filename));
+    const nonSource = files.filter((f) => !TEST_FILE_PATTERN.test(f.filename) && NON_SOURCE_PATTERN.test(f.filename));
     const sourceCount = files.length - testFiles.length - nonSource.length;
     if (sourceCount > 0) {
         const ratio = testFiles.length / sourceCount;
@@ -308,11 +307,10 @@ server.tool("evaluate-deployment", "Run a full DeployGuard evaluation including 
     }));
     healthChecks.push(...httpChecks);
     const healthScore = healthChecks.length > 0
-        ? Math.round(healthChecks.reduce((sum, c) => sum +
-            (c.status === "healthy" ? 100 : c.status === "degraded" ? 50 : 0), 0) / healthChecks.length)
+        ? Math.round(healthChecks.reduce((sum, c) => sum + (c.status === "healthy" ? 100 : c.status === "degraded" ? 50 : 0), 0) / healthChecks.length)
         : 100;
     let riskScore = 0;
-    let factors = [];
+    const factors = [];
     if (files.length > 0) {
         const fileCountScore = Math.min(100, Math.round(30 * Math.log2(1 + files.length)));
         factors.push({
@@ -338,11 +336,7 @@ server.tool("evaluate-deployment", "Run a full DeployGuard evaluation including 
         }
         riskScore = Math.min(100, Math.max(0, Math.round(wSum / totalW)));
     }
-    const decision = riskScore > 70
-        ? "block"
-        : riskScore > 55 || healthScore < 50
-            ? "warn"
-            : "allow";
+    const decision = riskScore > 70 ? "block" : riskScore > 55 || healthScore < 50 ? "warn" : "allow";
     return {
         content: [
             {

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,0 +1,1177 @@
+{
+  "name": "@deployguard/mcp-server",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@deployguard/mcp-server",
+      "version": "1.0.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.12.1",
+        "zod": "^3.24.0"
+      },
+      "bin": {
+        "deployguard-mcp": "dist/server.js"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "typescript": "^5.7.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.13",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
+      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.12",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
+      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@deployguard/mcp-server",
+  "version": "1.0.0",
+  "private": true,
+  "description": "MCP server exposing DeployGuard health checks and risk scoring as tools",
+  "type": "module",
+  "main": "dist/server.js",
+  "bin": {
+    "deployguard-mcp": "dist/server.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/server.js"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.1",
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -398,7 +398,7 @@ server.tool(
         : 100;
 
     let riskScore = 0;
-    let factors: RiskFactor[] = [];
+    const factors: RiskFactor[] = [];
     if (files.length > 0) {
       const fileCountScore = Math.min(100, Math.round(30 * Math.log2(1 + files.length)));
       factors.push({

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -1,0 +1,465 @@
+#!/usr/bin/env node
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+
+const HEALTH_CHECK_TIMEOUT_MS = 10_000;
+const VERCEL_TIMEOUT_MS = 10_000;
+const SUPABASE_TIMEOUT_MS = 10_000;
+
+interface HealthResult {
+  target: string;
+  status: "healthy" | "degraded" | "down";
+  latencyMs: number;
+  detail: Record<string, unknown>;
+}
+
+interface RiskFactor {
+  type: string;
+  score: number;
+  detail: Record<string, unknown>;
+}
+
+const server = new McpServer({
+  name: "deployguard",
+  version: "1.0.0",
+});
+
+server.tool(
+  "check-http-health",
+  "Check the health of an HTTP endpoint by sending a GET request and evaluating the response status",
+  {
+    url: z.string().url().describe("The URL to check"),
+  },
+  async ({ url }): Promise<{ content: Array<{ type: "text"; text: string }> }> => {
+    const start = Date.now();
+    try {
+      const response = await fetch(url, {
+        method: "GET",
+        signal: AbortSignal.timeout(HEALTH_CHECK_TIMEOUT_MS),
+      });
+      const latencyMs = Date.now() - start;
+      let status: "healthy" | "degraded" | "down";
+      if (response.ok) status = "healthy";
+      else if (response.status < 500) status = "degraded";
+      else status = "down";
+
+      const result: HealthResult = {
+        target: url,
+        status,
+        latencyMs,
+        detail: { httpStatus: response.status },
+      };
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    } catch (error) {
+      const result: HealthResult = {
+        target: url,
+        status: "down",
+        latencyMs: Date.now() - start,
+        detail: { error: String(error) },
+      };
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    }
+  },
+);
+
+server.tool(
+  "check-vercel-health",
+  "Check the latest Vercel production deployment status. Requires VERCEL_TOKEN and VERCEL_PROJECT_ID environment variables.",
+  {},
+  async (): Promise<{ content: Array<{ type: "text"; text: string }> }> => {
+    const token = process.env.VERCEL_TOKEN;
+    const projectId = process.env.VERCEL_PROJECT_ID;
+    if (!token || !projectId) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              error: "Missing VERCEL_TOKEN or VERCEL_PROJECT_ID environment variables",
+            }),
+          },
+        ],
+      };
+    }
+
+    const start = Date.now();
+    try {
+      const url = `https://api.vercel.com/v6/deployments?projectId=${encodeURIComponent(projectId)}&target=production&limit=1`;
+      const response = await fetch(url, {
+        method: "GET",
+        headers: { Authorization: `Bearer ${token}` },
+        signal: AbortSignal.timeout(VERCEL_TIMEOUT_MS),
+      });
+      const latencyMs = Date.now() - start;
+
+      if (!response.ok) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                target: "vercel:production",
+                status: "degraded",
+                latencyMs,
+                detail: { httpStatus: response.status },
+              }),
+            },
+          ],
+        };
+      }
+
+      const body = (await response.json()) as {
+        deployments?: Array<{ readyState?: string; url?: string; createdAt?: number }>;
+      };
+      const deployment = body?.deployments?.[0];
+
+      const result: HealthResult = {
+        target: "vercel:production",
+        status: deployment?.readyState === "READY" ? "healthy" : "degraded",
+        latencyMs,
+        detail: {
+          readyState: deployment?.readyState ?? "unknown",
+          url: deployment?.url,
+          createdAt: deployment?.createdAt
+            ? new Date(deployment.createdAt).toISOString()
+            : undefined,
+        },
+      };
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              target: "vercel:production",
+              status: "down",
+              latencyMs: Date.now() - start,
+              detail: { error: String(error) },
+            }),
+          },
+        ],
+      };
+    }
+  },
+);
+
+server.tool(
+  "check-supabase-health",
+  "Check the health of a Supabase project by pinging its REST API. Requires SUPABASE_URL and SUPABASE_ANON_KEY environment variables.",
+  {},
+  async (): Promise<{ content: Array<{ type: "text"; text: string }> }> => {
+    const supabaseUrl = process.env.SUPABASE_URL;
+    const anonKey = process.env.SUPABASE_ANON_KEY;
+    if (!supabaseUrl || !anonKey) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              error: "Missing SUPABASE_URL or SUPABASE_ANON_KEY environment variables",
+            }),
+          },
+        ],
+      };
+    }
+
+    const start = Date.now();
+    try {
+      const response = await fetch(`${supabaseUrl}/rest/v1/`, {
+        method: "GET",
+        headers: { apikey: anonKey, Authorization: `Bearer ${anonKey}` },
+        signal: AbortSignal.timeout(SUPABASE_TIMEOUT_MS),
+      });
+      const latencyMs = Date.now() - start;
+
+      const result: HealthResult = {
+        target: "supabase:rest",
+        status: response.ok ? "healthy" : "degraded",
+        latencyMs,
+        detail: { httpStatus: response.status },
+      };
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              target: "supabase:rest",
+              status: "down",
+              latencyMs: Date.now() - start,
+              detail: { error: String(error) },
+            }),
+          },
+        ],
+      };
+    }
+  },
+);
+
+const TEST_FILE_PATTERN = /\.(test|spec)\.(ts|tsx|js|jsx)$|__tests__\/|\.cy\.(ts|js)$/;
+const NON_SOURCE_PATTERN = /\.(sql|ya?ml|json|md|css|svg|lock|txt|env|png|jpg|gif)$/i;
+const SENSITIVE_PATTERNS = [
+  /(?:^|\/)migrations\//i,
+  /(?:^|\/)auth/i,
+  /(?:^|\/)security/i,
+  /(?:^|\/)payment/i,
+  /(?:^|\/)billing/i,
+  /(?:^|\/)webhook/i,
+  /(?:^|\/)infrastructure\//i,
+  /(?:^|\/)\.github\/workflows\//i,
+  /(?:^|\/)secrets/i,
+  /(?:^|\/)\.env/i,
+];
+
+const HIGH_SENSITIVITY = /(?:^|\/)(?:auth|security|payment|billing|webhook)/i;
+const INFRA_SENSITIVITY =
+  /(?:^|\/)(?:migrations|infrastructure|\.github\/workflows|secrets|\.env)/i;
+
+function sensitivityWeight(filename: string): number {
+  if (TEST_FILE_PATTERN.test(filename)) return 0.3;
+  if (HIGH_SENSITIVITY.test(filename)) return 3;
+  if (INFRA_SENSITIVITY.test(filename)) return 2;
+  if (NON_SOURCE_PATTERN.test(filename)) return 0.5;
+  return 1;
+}
+
+const FACTOR_WEIGHTS: Record<string, number> = {
+  code_churn: 3,
+  test_coverage: 2,
+  file_count: 2,
+  sensitive_files: 3,
+};
+
+server.tool(
+  "compute-risk-score",
+  "Compute a deployment risk score for a set of changed files. Provide file names and their change counts.",
+  {
+    files: z
+      .array(
+        z.object({
+          filename: z.string(),
+          changes: z.number().int().min(0),
+        }),
+      )
+      .describe("Array of changed files with their line change counts"),
+  },
+  async ({ files }): Promise<{ content: Array<{ type: "text"; text: string }> }> => {
+    if (files.length === 0) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({ score: 0, factors: [], decision: "allow" }),
+          },
+        ],
+      };
+    }
+
+    const factors: RiskFactor[] = [];
+
+    const fileCountScore = Math.min(100, Math.round(30 * Math.log2(1 + files.length)));
+    factors.push({
+      type: "file_count",
+      score: fileCountScore,
+      detail: { fileCount: files.length },
+    });
+
+    const totalChanges = files.reduce((s, f) => s + f.changes, 0);
+    const weightedChanges = files.reduce(
+      (s, f) => s + f.changes * sensitivityWeight(f.filename),
+      0,
+    );
+    const churnScore = Math.min(
+      100,
+      Math.round(25 * Math.log2(1 + weightedChanges / 50)),
+    );
+    factors.push({
+      type: "code_churn",
+      score: churnScore,
+      detail: { totalChanges, weightedChanges: Math.round(weightedChanges) },
+    });
+
+    const testFiles = files.filter((f) => TEST_FILE_PATTERN.test(f.filename));
+    const nonSource = files.filter(
+      (f) => !TEST_FILE_PATTERN.test(f.filename) && NON_SOURCE_PATTERN.test(f.filename),
+    );
+    const sourceCount = files.length - testFiles.length - nonSource.length;
+    if (sourceCount > 0) {
+      const ratio = testFiles.length / sourceCount;
+      factors.push({
+        type: "test_coverage",
+        score: Math.round(Math.max(0, 100 - ratio * 200)),
+        detail: { testFiles: testFiles.length, sourceFiles: sourceCount },
+      });
+    }
+
+    const sensitive = files.filter((f) =>
+      SENSITIVE_PATTERNS.some((p) => p.test(f.filename)),
+    );
+    if (sensitive.length > 0) {
+      factors.push({
+        type: "sensitive_files",
+        score: Math.min(100, sensitive.length * 25),
+        detail: {
+          count: sensitive.length,
+          files: sensitive.map((f) => f.filename),
+        },
+      });
+    }
+
+    let totalWeight = 0;
+    let weightedSum = 0;
+    for (const f of factors) {
+      const w = FACTOR_WEIGHTS[f.type] ?? 1;
+      weightedSum += f.score * w;
+      totalWeight += w;
+    }
+    const score = Math.min(100, Math.max(0, Math.round(weightedSum / totalWeight)));
+
+    const decision = score > 70 ? "block" : score > 55 ? "warn" : "allow";
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({ score, factors, decision }, null, 2),
+        },
+      ],
+    };
+  },
+);
+
+server.tool(
+  "evaluate-deployment",
+  "Run a full DeployGuard evaluation including health checks and risk scoring. Provide the target URLs and file changes.",
+  {
+    healthUrls: z
+      .array(z.string().url())
+      .default([])
+      .describe("URLs to health-check before scoring"),
+    files: z
+      .array(
+        z.object({
+          filename: z.string(),
+          changes: z.number().int().min(0),
+        }),
+      )
+      .default([])
+      .describe("Changed files with line counts"),
+  },
+  async ({
+    healthUrls,
+    files,
+  }): Promise<{ content: Array<{ type: "text"; text: string }> }> => {
+    const healthChecks: HealthResult[] = [];
+
+    const httpChecks = await Promise.all(
+      healthUrls.map(async (url) => {
+        const start = Date.now();
+        try {
+          const res = await fetch(url, {
+            method: "GET",
+            signal: AbortSignal.timeout(HEALTH_CHECK_TIMEOUT_MS),
+          });
+          return {
+            target: url,
+            status: (res.ok ? "healthy" : res.status < 500 ? "degraded" : "down") as
+              | "healthy"
+              | "degraded"
+              | "down",
+            latencyMs: Date.now() - start,
+            detail: { httpStatus: res.status },
+          };
+        } catch (err) {
+          return {
+            target: url,
+            status: "down" as const,
+            latencyMs: Date.now() - start,
+            detail: { error: String(err) },
+          };
+        }
+      }),
+    );
+    healthChecks.push(...httpChecks);
+
+    const healthScore =
+      healthChecks.length > 0
+        ? Math.round(
+            healthChecks.reduce(
+              (sum, c) =>
+                sum + (c.status === "healthy" ? 100 : c.status === "degraded" ? 50 : 0),
+              0,
+            ) / healthChecks.length,
+          )
+        : 100;
+
+    let riskScore = 0;
+    let factors: RiskFactor[] = [];
+    if (files.length > 0) {
+      const fileCountScore = Math.min(100, Math.round(30 * Math.log2(1 + files.length)));
+      factors.push({
+        type: "file_count",
+        score: fileCountScore,
+        detail: { fileCount: files.length },
+      });
+
+      const weightedChanges = files.reduce(
+        (s, f) => s + f.changes * sensitivityWeight(f.filename),
+        0,
+      );
+      factors.push({
+        type: "code_churn",
+        score: Math.min(100, Math.round(25 * Math.log2(1 + weightedChanges / 50))),
+        detail: {
+          totalChanges: files.reduce((s, f) => s + f.changes, 0),
+          weightedChanges: Math.round(weightedChanges),
+        },
+      });
+
+      let totalW = 0;
+      let wSum = 0;
+      for (const f of factors) {
+        const w = FACTOR_WEIGHTS[f.type] ?? 1;
+        wSum += f.score * w;
+        totalW += w;
+      }
+      riskScore = Math.min(100, Math.max(0, Math.round(wSum / totalW)));
+    }
+
+    const decision =
+      riskScore > 70 ? "block" : riskScore > 55 || healthScore < 50 ? "warn" : "allow";
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(
+            {
+              healthScore,
+              riskScore,
+              decision,
+              healthChecks,
+              riskFactors: factors,
+            },
+            null,
+            2,
+          ),
+        },
+      ],
+    };
+  },
+);
+
+async function main() {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch((err) => {
+  console.error("MCP server failed:", err);
+  process.exit(1);
+});

--- a/mcp/tsconfig.json
+++ b/mcp/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true
+  },
+  "include": ["src"]
+}

--- a/src/__tests__/gate.test.ts
+++ b/src/__tests__/gate.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   computeRiskScore,
   isSensitiveFile,
+  sensitivityWeight,
+  suggestSplitBoundaries,
   decideGate,
   checkHealth,
   checkVercelHealth,
@@ -235,6 +237,171 @@ describe("computeRiskScore", () => {
     expect(sensitiveF!.score).toBe(100);
     expect(result.score).toBeGreaterThanOrEqual(60);
   });
+
+  it("weights auth file churn at 3x (diff-aware scoring)", () => {
+    const normal = computeRiskScore([
+      { filename: "src/utils.ts", additions: 100, deletions: 0, changes: 100 },
+    ]);
+    const auth = computeRiskScore([
+      { filename: "src/auth/login.ts", additions: 100, deletions: 0, changes: 100 },
+    ]);
+    const normalChurn = normal.factors.find((f) => f.type === "code_churn")!;
+    const authChurn = auth.factors.find((f) => f.type === "code_churn")!;
+    expect(authChurn.score).toBeGreaterThan(normalChurn.score);
+    const authDetail = authChurn.detail as { weightedChanges: number };
+    expect(authDetail.weightedChanges).toBe(300);
+  });
+
+  it("weights test file churn at 0.3x (diff-aware scoring)", () => {
+    const result = computeRiskScore([
+      {
+        filename: "src/__tests__/app.test.ts",
+        additions: 500,
+        deletions: 0,
+        changes: 500,
+      },
+    ]);
+    const churn = result.factors.find((f) => f.type === "code_churn")!;
+    const detail = churn.detail as { weightedChanges: number };
+    expect(detail.weightedChanges).toBe(150);
+  });
+
+  it("weights config/non-source file churn at 0.5x", () => {
+    const result = computeRiskScore([
+      { filename: "README.md", additions: 200, deletions: 0, changes: 200 },
+    ]);
+    const churn = result.factors.find((f) => f.type === "code_churn")!;
+    const detail = churn.detail as { weightedChanges: number };
+    expect(detail.weightedChanges).toBe(100);
+  });
+
+  it("weights infrastructure file churn at 2x", () => {
+    const result = computeRiskScore([
+      { filename: ".github/workflows/ci.yml", additions: 50, deletions: 0, changes: 50 },
+    ]);
+    const churn = result.factors.find((f) => f.type === "code_churn")!;
+    const detail = churn.detail as { weightedChanges: number };
+    expect(detail.weightedChanges).toBe(100);
+  });
+
+  it("includes both totalChanges and weightedChanges in churn detail", () => {
+    const result = computeRiskScore([
+      { filename: "src/auth/login.ts", additions: 50, deletions: 0, changes: 50 },
+      { filename: "src/utils.ts", additions: 50, deletions: 0, changes: 50 },
+    ]);
+    const churn = result.factors.find((f) => f.type === "code_churn")!;
+    const detail = churn.detail as {
+      totalChanges: number;
+      weightedChanges: number;
+    };
+    expect(detail.totalChanges).toBe(100);
+    expect(detail.weightedChanges).toBe(200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sensitivityWeight
+// ---------------------------------------------------------------------------
+
+describe("sensitivityWeight", () => {
+  it("returns 3 for auth files", () => {
+    expect(sensitivityWeight("src/auth/login.ts")).toBe(3);
+  });
+  it("returns 3 for payment files", () => {
+    expect(sensitivityWeight("src/payment/checkout.ts")).toBe(3);
+  });
+  it("returns 3 for security files", () => {
+    expect(sensitivityWeight("lib/security/validate.ts")).toBe(3);
+  });
+  it("returns 3 for billing files", () => {
+    expect(sensitivityWeight("billing/invoice.ts")).toBe(3);
+  });
+  it("returns 3 for webhook files", () => {
+    expect(sensitivityWeight("src/webhook/stripe.ts")).toBe(3);
+  });
+  it("returns 2 for migration files", () => {
+    expect(sensitivityWeight("supabase/migrations/001.sql")).toBe(2);
+  });
+  it("returns 2 for workflow files", () => {
+    expect(sensitivityWeight(".github/workflows/ci.yml")).toBe(2);
+  });
+  it("returns 2 for .env files", () => {
+    expect(sensitivityWeight(".env.production")).toBe(2);
+  });
+  it("returns 0.3 for test files", () => {
+    expect(sensitivityWeight("src/__tests__/utils.test.ts")).toBe(0.3);
+  });
+  it("returns 0.5 for non-source files", () => {
+    expect(sensitivityWeight("README.md")).toBe(0.5);
+    expect(sensitivityWeight("package.json")).toBe(0.5);
+    expect(sensitivityWeight("styles/main.css")).toBe(0.5);
+  });
+  it("returns 1 for regular source files", () => {
+    expect(sensitivityWeight("src/utils.ts")).toBe(1);
+    expect(sensitivityWeight("lib/helpers.js")).toBe(1);
+  });
+  it("prioritizes test detection over non-source for .test.ts files", () => {
+    expect(sensitivityWeight("src/auth.test.ts")).toBe(0.3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// suggestSplitBoundaries
+// ---------------------------------------------------------------------------
+
+describe("suggestSplitBoundaries", () => {
+  it("returns empty for fewer than 5 files", () => {
+    expect(
+      suggestSplitBoundaries(["src/a.ts", "src/b.ts", "lib/c.ts", "lib/d.ts"]),
+    ).toEqual([]);
+  });
+
+  it("returns empty when all files are in the same group", () => {
+    const files = Array.from({ length: 10 }, (_, i) => `src/components/c${i}.tsx`);
+    expect(suggestSplitBoundaries(files)).toEqual([]);
+  });
+
+  it("suggests splitting two clear groups", () => {
+    const files = [
+      "src/components/Header.tsx",
+      "src/components/Footer.tsx",
+      "src/components/Nav.tsx",
+      "supabase/migrations/001.sql",
+      "supabase/migrations/002.sql",
+    ];
+    const suggestions = suggestSplitBoundaries(files);
+    expect(suggestions.length).toBeGreaterThanOrEqual(1);
+    expect(suggestions[0]).toContain("src/components/");
+    expect(suggestions[0]).toContain("separate PR");
+  });
+
+  it("groups .github files under CI/workflow", () => {
+    const files = [
+      ".github/workflows/ci.yml",
+      ".github/workflows/deploy.yml",
+      "src/app/page.tsx",
+      "src/app/layout.tsx",
+      "src/app/globals.css",
+    ];
+    const suggestions = suggestSplitBoundaries(files);
+    expect(suggestions.length).toBeGreaterThanOrEqual(1);
+    expect(suggestions[0]).toContain("CI/workflow");
+  });
+
+  it("reports additional groups when more than 2 exist", () => {
+    const files = [
+      "src/auth/login.ts",
+      "src/auth/signup.ts",
+      "src/auth/oauth.ts",
+      "lib/utils/format.ts",
+      "lib/utils/parse.ts",
+      "supabase/migrations/001.sql",
+      "supabase/migrations/002.sql",
+    ];
+    const suggestions = suggestSplitBoundaries(files);
+    expect(suggestions.length).toBe(2);
+    expect(suggestions[1]).toContain("also be separable");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -363,7 +530,11 @@ describe("formatGateReport", () => {
       {
         type: "code_churn",
         score: 30,
-        detail: { totalChanges: 150, description: "Total lines changed" },
+        detail: {
+          totalChanges: 150,
+          weightedChanges: 150,
+          description: "Sensitivity-weighted lines changed",
+        },
       },
     ],
     evaluationMs: 42,
@@ -391,7 +562,7 @@ describe("formatGateReport", () => {
   it("lists risk factors when present", () => {
     const report = formatGateReport(baseEvaluation);
     expect(report).toContain("code_churn");
-    expect(report).toContain("Total lines changed");
+    expect(report).toContain("Sensitivity-weighted lines changed");
   });
 
   it("lists health checks when present", () => {
@@ -486,7 +657,11 @@ describe("formatGateReport", () => {
         {
           type: "code_churn",
           score: 80,
-          detail: { totalChanges: 2000, description: "Total lines changed" },
+          detail: {
+            totalChanges: 2000,
+            weightedChanges: 2000,
+            description: "Sensitivity-weighted lines changed",
+          },
         },
       ],
     };
@@ -563,6 +738,35 @@ describe("formatGateReport", () => {
   it("omits guidance for allow decision", () => {
     const report = formatGateReport(baseEvaluation);
     expect(report).not.toContain("### Guidance");
+  });
+
+  it("includes split boundary suggestions when churn is high and files span multiple directories", () => {
+    const evaluation: GateEvaluation = {
+      ...baseEvaluation,
+      gateDecision: "warn",
+      riskScore: 60,
+      riskFactors: [
+        {
+          type: "code_churn",
+          score: 80,
+          detail: {
+            totalChanges: 2000,
+            weightedChanges: 2000,
+            description: "Sensitivity-weighted lines changed",
+          },
+        },
+      ],
+      files: [
+        "src/components/Header.tsx",
+        "src/components/Footer.tsx",
+        "src/components/Nav.tsx",
+        "supabase/migrations/001.sql",
+        "supabase/migrations/002.sql",
+      ],
+    };
+    const report = formatGateReport(evaluation);
+    expect(report).toContain("Suggested split");
+    expect(report).toContain("separate PR");
   });
 });
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,7 +3,7 @@ import * as github from "@actions/github";
 import { RepoConfig } from "./types.js";
 import type { RepoConfig as RepoConfigType } from "./types.js";
 
-let yamlParse: ((input: string) => unknown) | null = null;
+const yamlParse: ((input: string) => unknown) | null = null;
 
 function parseYaml(input: string): unknown {
   if (yamlParse) return yamlParse(input);

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,135 @@
+import * as core from "@actions/core";
+import * as github from "@actions/github";
+import { RepoConfig } from "./types.js";
+import type { RepoConfig as RepoConfigType } from "./types.js";
+
+let yamlParse: ((input: string) => unknown) | null = null;
+
+function parseYaml(input: string): unknown {
+  if (yamlParse) return yamlParse(input);
+
+  const lines = input.split("\n");
+  const result: Record<string, unknown> = {};
+  let currentKey = "";
+  let currentArray: string[] | null = null;
+
+  for (const raw of lines) {
+    const line = raw.replace(/\r$/, "");
+    if (line.trim() === "" || line.trim().startsWith("#")) continue;
+
+    const topMatch = line.match(/^(\w[\w-]*):\s*(.*)$/);
+    if (topMatch) {
+      if (currentKey && currentArray) {
+        result[currentKey] = currentArray;
+        currentArray = null;
+      }
+      const [, key, val] = topMatch;
+      currentKey = key;
+      if (val && val.trim()) {
+        const numVal = Number(val.trim());
+        result[key] = isNaN(numVal) ? val.trim() : numVal;
+      }
+      continue;
+    }
+
+    const nestedObjMatch = line.match(/^\s{2}(\w[\w-]*):\s*(.*)$/);
+    if (nestedObjMatch) {
+      if (currentArray) {
+        result[currentKey] = currentArray;
+        currentArray = null;
+      }
+      const [, subKey, subVal] = nestedObjMatch;
+      if (typeof result[currentKey] !== "object" || Array.isArray(result[currentKey])) {
+        result[currentKey] = {};
+      }
+      const obj = result[currentKey] as Record<string, unknown>;
+      if (subVal && subVal.trim()) {
+        const numVal = Number(subVal.trim());
+        obj[subKey] = isNaN(numVal) ? subVal.trim() : numVal;
+      } else {
+        obj[subKey] = [];
+      }
+      continue;
+    }
+
+    const arrayItemMatch = line.match(/^\s+-\s+"?([^"]*)"?\s*$/);
+    if (arrayItemMatch) {
+      const val = arrayItemMatch[1];
+      if (
+        currentKey &&
+        typeof result[currentKey] === "object" &&
+        !Array.isArray(result[currentKey])
+      ) {
+        const obj = result[currentKey] as Record<string, unknown>;
+        const keys = Object.keys(obj);
+        const lastKey = keys[keys.length - 1];
+        if (lastKey && Array.isArray(obj[lastKey])) {
+          (obj[lastKey] as string[]).push(val);
+        }
+      } else {
+        if (!currentArray) currentArray = [];
+        currentArray.push(val);
+      }
+      continue;
+    }
+  }
+
+  if (currentKey && currentArray) {
+    result[currentKey] = currentArray;
+  }
+
+  return result;
+}
+
+export async function loadRepoConfig(token?: string): Promise<RepoConfigType | null> {
+  if (!token) return null;
+
+  try {
+    const octokit = github.getOctokit(token);
+    const { owner, repo } = github.context.repo;
+
+    const { data } = await octokit.rest.repos.getContent({
+      owner,
+      repo,
+      path: ".deployguard.yml",
+    });
+
+    if (Array.isArray(data) || data.type !== "file" || !data.content) {
+      return null;
+    }
+
+    const content = Buffer.from(data.content, "base64").toString("utf-8");
+    const raw = parseYaml(content);
+    const parsed = RepoConfig.safeParse(raw);
+
+    if (!parsed.success) {
+      core.warning(
+        `.deployguard.yml parse error: ${parsed.error.message} — using defaults`,
+      );
+      return null;
+    }
+
+    core.debug(`Loaded .deployguard.yml: ${JSON.stringify(parsed.data)}`);
+    return parsed.data;
+  } catch (error) {
+    const msg = String(error);
+    if (!msg.includes("404") && !msg.includes("Not Found")) {
+      core.debug(`.deployguard.yml load failed: ${msg}`);
+    }
+    return null;
+  }
+}
+
+function globToRegex(pattern: string): RegExp {
+  const escaped = pattern
+    .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+    .replace(/\*\*/g, "<<GLOBSTAR>>")
+    .replace(/\*/g, "[^/]*")
+    .replace(/<<GLOBSTAR>>/g, ".*")
+    .replace(/\?/g, ".");
+  return new RegExp(`^${escaped}$`, "i");
+}
+
+export function matchesGlobs(filename: string, patterns: string[]): boolean {
+  return patterns.some((p) => globToRegex(p).test(filename));
+}

--- a/src/gate.ts
+++ b/src/gate.ts
@@ -7,8 +7,10 @@ import type {
   GateDecision,
   GateEvaluation,
   HealthCheckResult,
+  RepoConfig,
   RiskFactor,
 } from "./types.js";
+import { loadRepoConfig, matchesGlobs } from "./config.js";
 
 // ---------------------------------------------------------------------------
 // PR file metadata used for risk heuristics
@@ -96,7 +98,45 @@ export function isSensitiveFile(filename: string): boolean {
   return SENSITIVE_PATTERNS.some((p) => p.test(filename));
 }
 
-export function computeRiskScore(files: PrFileInfo[]): {
+const HIGH_SENSITIVITY_PATTERN = /(?:^|\/)(?:auth|security|payment|billing|webhook)/i;
+const INFRA_SENSITIVITY_PATTERN =
+  /(?:^|\/)(?:migrations|infrastructure|\.github\/workflows|secrets|\.env)/i;
+
+export function sensitivityWeight(
+  filename: string,
+  repoConfig?: RepoConfig | null,
+): number {
+  if (repoConfig) {
+    if (repoConfig.ignore.length > 0 && matchesGlobs(filename, repoConfig.ignore))
+      return 0;
+    if (
+      repoConfig.sensitivity.high.length > 0 &&
+      matchesGlobs(filename, repoConfig.sensitivity.high)
+    )
+      return 3;
+    if (
+      repoConfig.sensitivity.medium.length > 0 &&
+      matchesGlobs(filename, repoConfig.sensitivity.medium)
+    )
+      return 2;
+    if (
+      repoConfig.sensitivity.low.length > 0 &&
+      matchesGlobs(filename, repoConfig.sensitivity.low)
+    )
+      return 0.5;
+  }
+
+  if (isTestFile(filename)) return 0.3;
+  if (HIGH_SENSITIVITY_PATTERN.test(filename)) return 3;
+  if (INFRA_SENSITIVITY_PATTERN.test(filename)) return 2;
+  if (isNonSourceFile(filename)) return 0.5;
+  return 1;
+}
+
+export function computeRiskScore(
+  files: PrFileInfo[],
+  repoConfig?: RepoConfig | null,
+): {
   score: number;
   factors: RiskFactor[];
 } {
@@ -104,9 +144,19 @@ export function computeRiskScore(files: PrFileInfo[]): {
     return { score: 0, factors: [] };
   }
 
+  const effectiveFiles = repoConfig?.ignore.length
+    ? files.filter((f) => !matchesGlobs(f.filename, repoConfig.ignore))
+    : files;
+
+  if (effectiveFiles.length === 0) {
+    return { score: 0, factors: [] };
+  }
+
   const factors: RiskFactor[] = [];
 
-  const fileCount = files.length;
+  const customWeights = repoConfig?.weights ?? {};
+
+  const fileCount = effectiveFiles.length;
   const fileCountScore = Math.min(100, Math.round(30 * Math.log2(1 + fileCount)));
   factors.push({
     type: "file_count",
@@ -114,19 +164,27 @@ export function computeRiskScore(files: PrFileInfo[]): {
     detail: { fileCount, description: "Number of files changed" },
   });
 
-  const totalChanges = files.reduce((sum, f) => sum + f.changes, 0);
-  const churnScore = Math.min(100, Math.round(25 * Math.log2(1 + totalChanges / 50)));
+  const totalChanges = effectiveFiles.reduce((sum, f) => sum + f.changes, 0);
+  const weightedChanges = effectiveFiles.reduce(
+    (sum, f) => sum + f.changes * sensitivityWeight(f.filename, repoConfig),
+    0,
+  );
+  const churnScore = Math.min(100, Math.round(25 * Math.log2(1 + weightedChanges / 50)));
   factors.push({
     type: "code_churn",
     score: churnScore,
-    detail: { totalChanges, description: "Total lines changed" },
+    detail: {
+      totalChanges,
+      weightedChanges: Math.round(weightedChanges),
+      description: "Sensitivity-weighted lines changed",
+    },
   });
 
-  const testFileCount = files.filter((f) => isTestFile(f.filename)).length;
-  const nonSourceCount = files.filter(
+  const testFileCount = effectiveFiles.filter((f) => isTestFile(f.filename)).length;
+  const nonSourceCount = effectiveFiles.filter(
     (f) => !isTestFile(f.filename) && isNonSourceFile(f.filename),
   ).length;
-  const sourceFileCount = files.length - testFileCount - nonSourceCount;
+  const sourceFileCount = effectiveFiles.length - testFileCount - nonSourceCount;
   if (sourceFileCount > 0) {
     const testRatio = testFileCount / sourceFileCount;
     const testCoverageScore = Math.round(Math.max(0, 100 - testRatio * 200));
@@ -142,7 +200,16 @@ export function computeRiskScore(files: PrFileInfo[]): {
     });
   }
 
-  const sensitiveFiles = files.filter((f) => isSensitiveFile(f.filename));
+  const sensitiveByConfig = repoConfig?.sensitivity.high.length
+    ? effectiveFiles.filter((f) => matchesGlobs(f.filename, repoConfig.sensitivity.high))
+    : [];
+  const sensitiveByDefault = effectiveFiles.filter((f) => isSensitiveFile(f.filename));
+  const sensitiveFilenames = new Set([
+    ...sensitiveByConfig.map((f) => f.filename),
+    ...sensitiveByDefault.map((f) => f.filename),
+  ]);
+  const sensitiveFiles = effectiveFiles.filter((f) => sensitiveFilenames.has(f.filename));
+
   if (sensitiveFiles.length > 0) {
     const sensitiveScore = Math.min(100, sensitiveFiles.length * 25);
     factors.push({
@@ -156,15 +223,18 @@ export function computeRiskScore(files: PrFileInfo[]): {
     });
   }
 
-  return { score: weightedAverageScores(factors), factors };
+  return { score: weightedAverageScores(factors, customWeights), factors };
 }
 
-function weightedAverageScores(factors: RiskFactor[]): number {
+function weightedAverageScores(
+  factors: RiskFactor[],
+  overrides?: Record<string, number>,
+): number {
   if (factors.length === 0) return 0;
   let totalWeight = 0;
   let weightedSum = 0;
   for (const f of factors) {
-    const w = FACTOR_WEIGHTS[f.type] ?? 1;
+    const w = overrides?.[f.type] ?? FACTOR_WEIGHTS[f.type] ?? 1;
     weightedSum += f.score * w;
     totalWeight += w;
   }
@@ -536,28 +606,45 @@ export async function evaluateGate(
 ): Promise<GateEvaluation> {
   const start = Date.now();
 
-  const [files, authorFactor, httpHealthChecks, vercelCheck, supabaseCheck, mcpCheck] =
-    await Promise.all([
-      prNumber ? fetchPrFiles(prNumber, config.githubToken) : Promise.resolve([]),
-      prNumber && config.githubToken
-        ? computeAuthorHistory(prNumber, config.githubToken)
-        : Promise.resolve(null),
-      config.healthCheckUrls.length > 0
-        ? Promise.all(config.healthCheckUrls.map((url) => checkHealth(url)))
-        : Promise.resolve([]),
-      checkVercelHealth(),
-      checkSupabaseHealth(),
-      checkMcpHealth(),
-    ]);
+  const [
+    files,
+    authorFactor,
+    httpHealthChecks,
+    vercelCheck,
+    supabaseCheck,
+    mcpCheck,
+    repoConfig,
+  ] = await Promise.all([
+    prNumber ? fetchPrFiles(prNumber, config.githubToken) : Promise.resolve([]),
+    prNumber && config.githubToken
+      ? computeAuthorHistory(prNumber, config.githubToken)
+      : Promise.resolve(null),
+    config.healthCheckUrls.length > 0
+      ? Promise.all(config.healthCheckUrls.map((url) => checkHealth(url)))
+      : Promise.resolve([]),
+    checkVercelHealth(),
+    checkSupabaseHealth(),
+    checkMcpHealth(),
+    loadRepoConfig(config.githubToken),
+  ]);
 
-  const { score: localRiskScore, factors: riskFactors } = computeRiskScore(files);
+  const effectiveRiskThreshold = repoConfig?.thresholds.risk ?? config.riskThreshold;
+  const effectiveWarnThreshold = repoConfig?.thresholds.warn ?? config.warnThreshold;
+
+  const { score: localRiskScore, factors: riskFactors } = computeRiskScore(
+    files,
+    repoConfig,
+  );
 
   if (authorFactor) {
     riskFactors.push(authorFactor);
   }
 
+  const customWeights = repoConfig?.weights ?? {};
   const riskScore =
-    riskFactors.length > 0 ? weightedAverageScores(riskFactors) : localRiskScore;
+    riskFactors.length > 0
+      ? weightedAverageScores(riskFactors, customWeights)
+      : localRiskScore;
 
   const healthChecks: HealthCheckResult[] = [...httpHealthChecks];
   if (vercelCheck) healthChecks.push(vercelCheck);
@@ -568,8 +655,8 @@ export async function evaluateGate(
   const gateDecision = decideGate(
     riskScore,
     healthScore,
-    config.riskThreshold,
-    config.warnThreshold,
+    effectiveRiskThreshold,
+    effectiveWarnThreshold,
   );
 
   const fileNames = files.map((f) => f.filename);
@@ -820,6 +907,53 @@ function buildScoreBar(score: number, threshold: number): string {
   return `\`${bar}\` ${score}/100 (threshold: ${threshold})`;
 }
 
+export function suggestSplitBoundaries(files: string[]): string[] {
+  if (files.length < 5) return [];
+
+  const groups: Record<string, string[]> = {};
+  for (const f of files) {
+    const parts = f.replace(/\\/g, "/").split("/");
+    let bucket: string;
+
+    if (parts[0] === ".github") {
+      bucket = "CI/workflow";
+    } else if (/^(migrations?|supabase)/i.test(parts[0])) {
+      bucket = "database/migrations";
+    } else if (parts.length >= 2) {
+      bucket = parts.slice(0, 2).join("/");
+    } else {
+      bucket = parts[0];
+    }
+
+    (groups[bucket] ??= []).push(f);
+  }
+
+  const sorted = Object.entries(groups)
+    .filter(([, v]) => v.length >= 2)
+    .sort((a, b) => b[1].length - a[1].length);
+
+  if (sorted.length < 2) return [];
+
+  const suggestions: string[] = [];
+  const [first, second] = sorted;
+
+  suggestions.push(
+    `- **Suggested split:** \`${first[0]}/\` changes (${first[1].length} files) ` +
+      `could be a separate PR from \`${second[0]}/\` changes (${second[1].length} files).`,
+  );
+
+  if (sorted.length > 2) {
+    const rest = sorted.slice(2);
+    const restTotal = rest.reduce((sum, [, v]) => sum + v.length, 0);
+    suggestions.push(
+      `- ${rest.length} other group${rest.length > 1 ? "s" : ""} (${restTotal} files) ` +
+        `may also be separable: ${rest.map(([k, v]) => `\`${k}/\` (${v.length})`).join(", ")}.`,
+    );
+  }
+
+  return suggestions;
+}
+
 function buildGuidance(evaluation: GateEvaluation): string[] {
   if (evaluation.gateDecision === "allow") return [];
 
@@ -857,10 +991,21 @@ function buildGuidance(evaluation: GateEvaluation): string[] {
   }
 
   const fileCountFactor = evaluation.riskFactors.find((f) => f.type === "file_count");
+  const shouldSuggestSplit =
+    (fileCountFactor && fileCountFactor.score >= 70) ||
+    (churnFactor && churnFactor.score >= 70);
+
   if (fileCountFactor && fileCountFactor.score >= 80) {
     lines.push(
       `- **Many files changed**. Large PRs are harder to review thoroughly — consider splitting.`,
     );
+  }
+
+  if (shouldSuggestSplit && evaluation.files && evaluation.files.length >= 5) {
+    const splits = suggestSplitBoundaries(evaluation.files);
+    if (splits.length > 0) {
+      lines.push(...splits);
+    }
   }
 
   if (lines.length === 2) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,8 @@ export {
   formatGateReport,
   computeRiskScore,
   isSensitiveFile,
+  sensitivityWeight,
+  suggestSplitBoundaries,
   checkHealth,
   checkVercelHealth,
   checkSupabaseHealth,
@@ -23,12 +25,14 @@ export {
 export { jestHealer } from "./healers/jest.js";
 export { playwrightHealer } from "./healers/playwright.js";
 export { cypressHealer } from "./healers/cypress.js";
+export { loadRepoConfig, matchesGlobs } from "./config.js";
 export type {
   GateEvaluation,
   GateDecision,
   GateApiResponse,
   HealthCheckResult,
   RiskFactor,
+  RepoConfig,
   DeployGuardConfig,
   TestRepairResult,
 } from "./types.js";

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,6 +51,25 @@ export const GateApiResponse = z.object({
 });
 export type GateApiResponse = z.infer<typeof GateApiResponse>;
 
+export const RepoConfig = z.object({
+  sensitivity: z
+    .object({
+      high: z.array(z.string()).default([]),
+      medium: z.array(z.string()).default([]),
+      low: z.array(z.string()).default([]),
+    })
+    .default({}),
+  weights: z.record(z.number().min(0).max(10)).default({}),
+  thresholds: z
+    .object({
+      risk: z.number().min(0).max(100).optional(),
+      warn: z.number().min(0).max(100).optional(),
+    })
+    .default({}),
+  ignore: z.array(z.string()).default([]),
+});
+export type RepoConfig = z.infer<typeof RepoConfig>;
+
 export interface DeployGuardConfig {
   apiKey: string;
   apiUrl: string;


### PR DESCRIPTION
## Summary

- **Diff-aware risk scoring**: Code churn now weighted by file sensitivity (auth 3x, infra 2x, config 0.5x, tests 0.3x)
- **PR split recommendations**: Concrete boundary suggestions based on file path grouping when PRs are large
- **Per-repo `.deployguard.yml`**: Custom sensitivity patterns, factor weights, thresholds, and ignore globs
- **Standalone MCP server**: 5 tools exposing health checks and risk scoring for AI agent consumption
- **Marketplace preparation**: CHANGELOG.md, README config docs

## Test plan

- [x] 193 unit tests passing (`npm test`)
- [x] `ncc build` compiles cleanly
- [x] Local simulation against PR #640 (UI changes) → ALLOW at 47/100
- [x] Local simulation against PR #641 (infra changes) → BLOCK at 75/100, split reco fires
- [x] MCP server responds to `initialize`, `tools/list`, `tools/call` (compute-risk-score)
- [ ] CI workflow passes on this PR
- [ ] End-to-end test on a Komatik PR after both PRs merge


Made with [Cursor](https://cursor.com)