### PR TITLE
chore: upgrade GitHub Action runtime from node20 to node24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - run: npm ci

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - run: npm ci
@@ -60,7 +60,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           registry-url: "https://registry.npmjs.org"
 
       - name: Build CLI

--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - run: npm ci

--- a/action.yml
+++ b/action.yml
@@ -119,5 +119,5 @@ outputs:
     description: "The deployment environment used for this evaluation."
 
 runs:
-  using: "node20"
+  using: "node24"
   main: "dist/index.js"


### PR DESCRIPTION
## Summary

Proactively upgrade the action runtime before the GitHub-enforced deadline.

**Warning from forge CI logs:**
> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: `dschirmer-shiftkey/deployguard@v3`. Actions will be forced to run with Node.js 24 by default starting **June 2nd, 2026**. Node.js 20 will be removed from the runner on **September 16th, 2026**.

## Changes

- `action.yml`: `runs.using: "node20"` → `runs.using: "node24"`
- `.github/workflows/ci.yml`: `node-version: 20` → `24`
- `.github/workflows/release.yml`: both setup-node steps `20` → `24`
- `.github/workflows/self-test.yml`: `node-version: 20` → `24`
- `.github/workflows/dry-run.yml`: `node-version: 20` → `24`

## Compatibility

The compiled `dist/index.js` bundle (produced by `@vercel/ncc`) is runtime-agnostic ES2022 and is fully compatible with Node.js 24. No source changes required.

## Deadline

- **June 2, 2026** — GitHub forces node24 by default
- **September 16, 2026** — Node.js 20 removed from runner entirely

Fixes: INFRA task 4232be9a