### PR TITLE
chore: add Trailhead generated artifact policy

### DIFF
--- a/.trailhead.yml
+++ b/.trailhead.yml
@@ -1,0 +1,9 @@
+# Trailhead repository policy.
+#
+# The MCP package copies shared source during prebuild and commits selected
+# runtime artifacts. Score the canonical source files, not their generated copies.
+ignore:
+  - "mcp/src/risk-engine.ts"
+  - "mcp/src/adapters/**"
+  - "mcp/dist/risk-engine.*"
+  - "mcp/dist/adapters/**"


### PR DESCRIPTION
## Summary
- Add `.trailhead.yml` so Trailhead ignores MCP generated source copies and committed runtime artifacts during risk scoring.
- Keep the canonical source files as the review signal while allowing generated artifact PRs to pass the self-test gate.

## Test plan
- npm test -- src/__tests__/config.test.ts
- git diff --check

Made with [Cursor](https://cursor.com)