### PR TITLE
feat(policy): enforce governed overrides and publish rollout packs

### DIFF
--- a/.agents/skills/trailhead/SKILL.md
+++ b/.agents/skills/trailhead/SKILL.md
@@ -106,7 +106,7 @@ Trailhead also runs as a GitHub Action (`KomatikAI/trailhead@v3`). The MCP tools
 
 ## Repository Maintenance Notes
 
-- `main` is the active/default branch. `dev` and `staging` are compatibility mirrors and should stay fast-forwarded to `main`.
+- `dev` is the active/default branch. `main` and `staging` are compatibility mirrors and should stay fast-forwarded to `dev`.
 - MCP prebuild copies `src/risk-engine.ts` and `src/adapters/*` into `mcp/src/`; matching `mcp/dist/risk-engine.*` and `mcp/dist/adapters/*` are intentionally committed runtime artifacts.
 - If `src/risk-engine.ts` imports another local module, update the `app/` and `mcp/` prebuild scripts and committed dist artifacts in the same change.
 - `origin/experiment/rd-satellite/deployguard-supply-chain-risk` is not promotion-ready until app and MCP builds pass with the new `supply-chain` module.

--- a/.trailhead.yml
+++ b/.trailhead.yml
@@ -3,6 +3,8 @@
 # The MCP package copies shared source during prebuild and commits selected
 # runtime artifacts. Score the canonical source files, not their generated copies.
 ignore:
+  - "dist/index.js"
+  - "dist/index.js.map"
   - "mcp/src/risk-engine.ts"
   - "mcp/src/adapters/**"
   - "mcp/dist/risk-engine.*"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to Trailhead will be documented in this file.
 
 - **Trailhead canonical naming** — Completed the DeployGuard-to-Trailhead migration across action metadata, docs, examples, package metadata, telemetry attributes, risk labels, and persisted evaluation targets.
 - **Compatibility preserved** — `.deployguard.yml` and shipped `DEPLOYGUARD_*` environment variables remain supported as legacy fallbacks.
-- **Repository branch sync** — `main` is the active/default branch; `dev` and `staging` are kept fast-forwarded to `main`.
+- **Repository branch sync** — `dev` is the active/default branch; `main` and `staging` are kept fast-forwarded to `dev`.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -69,28 +69,35 @@ The weighted average determines the decision:
 
 ## Inputs
 
-| Input                     | Required | Default               | Description                                                      |
-| ------------------------- | -------- | --------------------- | ---------------------------------------------------------------- |
-| `github-token`            | No       | `${{ github.token }}` | GitHub token for PR analysis and comments                        |
-| `risk-threshold`          | No       | `70`                  | Block the PR above this risk score (0-100)                       |
-| `warn-threshold`          | No       | risk - 15             | Warn above this risk score (0-100)                               |
-| `health-check-urls`       | No       | —                     | Comma-separated URLs to health-check before scoring              |
-| `fail-mode`               | No       | `open`                | What happens when Trailhead errors: `open` or `closed`           |
-| `self-heal`               | No       | `false`               | Auto-repair failing tests (needs `TRAILHEAD_TEST_FAILURES` env)  |
-| `add-risk-labels`         | No       | `true`                | Add `trailhead:low-risk` / `warn` / `high-risk` labels to the PR |
-| `reviewers-on-risk`       | No       | —                     | Comma-separated usernames to request review on warn/block        |
-| `webhook-url`             | No       | —                     | URL to POST results to (Slack, Discord, custom)                  |
-| `webhook-events`          | No       | `warn,block`          | Which decisions trigger the webhook                              |
-| `evaluation-store-url`    | No       | —                     | URL to POST evaluations for trend dashboards                     |
-| `evaluation-store-secret` | No       | —                     | Bearer token for `evaluation-store-url`                          |
-| `dora-metrics`            | No       | `false`               | Compute DORA-5 metrics alongside the gate evaluation             |
-| `dora-environment`        | No       | —                     | Filter DORA metrics to a specific deployment environment         |
-| `environment`             | No       | —                     | Target deployment environment (for per-env threshold overrides)  |
-| `security-gate`           | No       | `true`                | Enable Code Scanning alerts as a risk factor                     |
-| `canary-webhook-secret`   | No       | —                     | HMAC secret for deploy outcome webhooks                          |
-| `otel-endpoint`           | No       | —                     | OTLP HTTP endpoint for exporting evaluation spans                |
-| `otel-headers`            | No       | —                     | Auth headers for the OTLP endpoint (key=value, comma-separated)  |
-| `api-key`                 | No       | —                     | API key for remote enrichment (omit for local-only)              |
+| Input                     | Required | Default               | Description                                                                            |
+| ------------------------- | -------- | --------------------- | -------------------------------------------------------------------------------------- |
+| `github-token`            | No       | `${{ github.token }}` | GitHub token for PR analysis and comments                                              |
+| `risk-threshold`          | No       | `70`                  | Block the PR above this risk score (0-100)                                             |
+| `warn-threshold`          | No       | risk - 15             | Warn above this risk score (0-100)                                                     |
+| `health-check-urls`       | No       | —                     | Comma-separated URLs to health-check before scoring                                    |
+| `fail-mode`               | No       | env-aware             | Error policy: explicit `open`/`closed`, or auto (`production`=`closed`, others=`open`) |
+| `override-fail-mode`      | No       | —                     | Governed temporary override for fail mode (requires override metadata)                 |
+| `override-risk-threshold` | No       | —                     | Governed temporary risk threshold override (0-100)                                     |
+| `override-warn-threshold` | No       | —                     | Governed temporary warn threshold override (0-100)                                     |
+| `override-reason`         | No       | —                     | Required when any override is set                                                      |
+| `override-owner`          | No       | —                     | Required when any override is set                                                      |
+| `override-ticket`         | No       | —                     | Required when any override is set                                                      |
+| `override-expires-at`     | No       | —                     | Required when any override is set (ISO-8601)                                           |
+| `self-heal`               | No       | `false`               | Auto-repair failing tests (needs `TRAILHEAD_TEST_FAILURES` env)                        |
+| `add-risk-labels`         | No       | `true`                | Add `trailhead:low-risk` / `warn` / `high-risk` labels to the PR                       |
+| `reviewers-on-risk`       | No       | —                     | Comma-separated usernames to request review on warn/block                              |
+| `webhook-url`             | No       | —                     | URL to POST results to (Slack, Discord, custom)                                        |
+| `webhook-events`          | No       | `warn,block`          | Which decisions trigger the webhook                                                    |
+| `evaluation-store-url`    | No       | —                     | URL to POST evaluations for trend dashboards                                           |
+| `evaluation-store-secret` | No       | —                     | Bearer token for `evaluation-store-url`                                                |
+| `dora-metrics`            | No       | `false`               | Compute DORA-5 metrics alongside the gate evaluation                                   |
+| `dora-environment`        | No       | —                     | Filter DORA metrics to a specific deployment environment                               |
+| `environment`             | No       | —                     | Target deployment environment (for per-env threshold overrides)                        |
+| `security-gate`           | No       | `true`                | Enable Code Scanning alerts as a risk factor                                           |
+| `canary-webhook-secret`   | No       | —                     | HMAC secret for deploy outcome webhooks                                                |
+| `otel-endpoint`           | No       | —                     | OTLP HTTP endpoint for exporting evaluation spans                                      |
+| `otel-headers`            | No       | —                     | Auth headers for the OTLP endpoint (key=value, comma-separated)                        |
+| `api-key`                 | No       | —                     | API key for remote enrichment (omit for local-only)                                    |
 
 ## Outputs
 
@@ -228,6 +235,24 @@ Compatibility remains for shipped surfaces:
 - Old `deployguard:*` risk labels are removed when Trailhead applies the new
   `trailhead:*` risk label.
 
+## Policy Profiles and Overrides
+
+Trailhead now supports environment-aware defaults out of the box:
+
+- `production` defaults to fail-closed when `fail-mode` is not set.
+- `staging`, `dev`, and other environments default to fail-open with warning visibility.
+
+Temporary overrides are supported but governed. If any override input is set (`override-*`),
+Trailhead requires:
+
+- `override-reason`
+- `override-owner`
+- `override-ticket`
+- `override-expires-at` (future ISO-8601 timestamp)
+
+Applied overrides are attached to `evaluation-json`, included in PR reports, and carried through
+evaluation storage/webhooks for auditability.
+
 ---
 
 ## GitHub App
@@ -326,6 +351,7 @@ Interactive wizard that generates `.trailhead.yml` and the workflow YAML with al
 - [Multi-CI templates](examples/) — GitLab CI and CircleCI configurations
 - [Observability dashboards](examples/observability/) — Grafana and Datadog dashboard imports
 - [Auto-rollback workflow](examples/github-actions/) — automated rollback on deployment failure
+- [Policy rollout pack](examples/policy-pack/) — Phase 1 and Phase 2 governance/enforcement templates
 
 ---
 

--- a/action.yml
+++ b/action.yml
@@ -24,9 +24,37 @@ inputs:
     required: false
     default: ""
   fail-mode:
-    description: "What to do when Trailhead itself errors: 'open' allows the deploy, 'closed' blocks it."
+    description: "Error mode when Trailhead fails. Default is env-aware: production=closed, others=open."
     required: false
-    default: "open"
+    default: ""
+  override-fail-mode:
+    description: "Governed override for fail-mode (open|closed). Requires reason/owner/ticket/expiry inputs."
+    required: false
+    default: ""
+  override-risk-threshold:
+    description: "Governed override for risk-threshold (0-100). Requires reason/owner/ticket/expiry inputs."
+    required: false
+    default: ""
+  override-warn-threshold:
+    description: "Governed override for warn-threshold (0-100). Requires reason/owner/ticket/expiry inputs."
+    required: false
+    default: ""
+  override-reason:
+    description: "Required when any override is set. Human-readable reason for temporary policy override."
+    required: false
+    default: ""
+  override-owner:
+    description: "Required when any override is set. Owner accountable for the override."
+    required: false
+    default: ""
+  override-ticket:
+    description: "Required when any override is set. Linked change ticket (Jira/GitHub issue/etc.)."
+    required: false
+    default: ""
+  override-expires-at:
+    description: "Required when any override is set. ISO-8601 expiry timestamp for the override."
+    required: false
+    default: ""
   self-heal:
     description: "Attempt to auto-repair failing tests before blocking (requires TRAILHEAD_TEST_FAILURES env)."
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -40310,6 +40310,20 @@ const GateEvaluation = objectType({
     reportUrl: stringType().url().optional(),
     environment: stringType().optional(),
     service: stringType().optional(),
+    policyOverride: objectType({
+        owner: stringType(),
+        reason: stringType(),
+        linkedTicket: stringType(),
+        expiresAt: stringType(),
+        appliedAt: stringType(),
+        changes: objectType({
+            failMode: enumType(["open", "closed"]).optional(),
+            riskThreshold: numberType().min(0).max(100).optional(),
+            warnThreshold: numberType().min(0).max(100).optional(),
+        })
+            .default({}),
+    })
+        .optional(),
 });
 const GateApiResponse = objectType({
     id: stringType().optional(),
@@ -41900,6 +41914,19 @@ function formatGateReport(evaluation, riskThreshold) {
     if (riskThreshold !== undefined) {
         lines.push(`**Risk:** ${buildScoreBar(evaluation.riskScore, riskThreshold)}`, ``);
     }
+    if (evaluation.policyOverride) {
+        const override = evaluation.policyOverride;
+        const changes = [];
+        if (override.changes.failMode)
+            changes.push(`fail-mode=${override.changes.failMode}`);
+        if (override.changes.riskThreshold !== undefined) {
+            changes.push(`risk-threshold=${override.changes.riskThreshold}`);
+        }
+        if (override.changes.warnThreshold !== undefined) {
+            changes.push(`warn-threshold=${override.changes.warnThreshold}`);
+        }
+        lines.push(`### Policy Override`, ``, `- Owner: \`${override.owner}\``, `- Ticket: \`${override.linkedTicket}\``, `- Reason: ${override.reason}`, `- Expires: \`${override.expiresAt}\``, `- Changes: ${changes.length > 0 ? changes.join(", ") : "none"}`, ``);
+    }
     if (evaluation.riskFactors.length > 0) {
         lines.push(`<details><summary><strong>Risk Factor Breakdown</strong> (${evaluation.riskFactors.length} factors)</summary>`, ``);
         const chart = buildFactorChart(evaluation.riskFactors);
@@ -43044,6 +43071,12 @@ const cypressHealer = {
 
 
 
+class PolicyOverrideError extends Error {
+    constructor(message) {
+        super(message);
+        this.name = "PolicyOverrideError";
+    }
+}
 function initHealers() {
     registerHealer(jestHealer);
     registerHealer(playwrightHealer);
@@ -43051,6 +43084,62 @@ function initHealers() {
 }
 function readEnv(primary, legacy) {
     return process.env[primary] ?? (legacy ? process.env[legacy] : undefined);
+}
+function parseThresholdInput(name) {
+    const value = core.getInput(name);
+    if (!value)
+        return undefined;
+    const parsed = parseInt(value, 10);
+    if (Number.isNaN(parsed) || parsed < 0 || parsed > 100) {
+        throw new PolicyOverrideError(`${name} must be an integer between 0 and 100`);
+    }
+    return parsed;
+}
+function resolveFailMode(failModeInput, environment) {
+    const explicitFailMode = failModeInput;
+    if (explicitFailMode === "open" || explicitFailMode === "closed") {
+        return explicitFailMode;
+    }
+    return environment === "production" ? "closed" : "open";
+}
+function resolvePolicyOverride() {
+    const overrideFailModeRaw = core.getInput("override-fail-mode");
+    const overrideFailMode = overrideFailModeRaw === "open" || overrideFailModeRaw === "closed"
+        ? overrideFailModeRaw
+        : undefined;
+    const overrideRiskThreshold = parseThresholdInput("override-risk-threshold");
+    const overrideWarnThreshold = parseThresholdInput("override-warn-threshold");
+    const hasOverride = overrideFailMode !== undefined ||
+        overrideRiskThreshold !== undefined ||
+        overrideWarnThreshold !== undefined;
+    if (!hasOverride)
+        return null;
+    const reason = core.getInput("override-reason").trim();
+    const owner = core.getInput("override-owner").trim();
+    const linkedTicket = core.getInput("override-ticket").trim();
+    const expiresAt = core.getInput("override-expires-at").trim();
+    if (!reason || !owner || !linkedTicket || !expiresAt) {
+        throw new PolicyOverrideError("Overrides require override-reason, override-owner, override-ticket, and override-expires-at");
+    }
+    const expiresMs = Date.parse(expiresAt);
+    if (Number.isNaN(expiresMs)) {
+        throw new PolicyOverrideError("override-expires-at must be a valid ISO-8601 datetime");
+    }
+    if (expiresMs <= Date.now()) {
+        throw new PolicyOverrideError(`Override expired at ${expiresAt}. Extend expiry before applying.`);
+    }
+    return {
+        owner,
+        reason,
+        linkedTicket,
+        expiresAt: new Date(expiresMs).toISOString(),
+        appliedAt: new Date().toISOString(),
+        changes: {
+            failMode: overrideFailMode,
+            riskThreshold: overrideRiskThreshold,
+            warnThreshold: overrideWarnThreshold,
+        },
+    };
 }
 async function runSelfHeal(config, prNumber) {
     const results = [];
@@ -43103,6 +43192,9 @@ async function runSelfHeal(config, prNumber) {
 async function run() {
     try {
         initHealers();
+        const environment = core.getInput("environment") || undefined;
+        const policyOverride = resolvePolicyOverride();
+        const failMode = resolveFailMode(core.getInput("fail-mode"), environment);
         const config = {
             apiKey: core.getInput("api-key") || "",
             apiUrl: readEnv("TRAILHEAD_API_URL", "DEPLOYGUARD_API_URL") || "",
@@ -43115,7 +43207,7 @@ async function run() {
             warnThreshold: core.getInput("warn-threshold")
                 ? parseInt(core.getInput("warn-threshold"), 10)
                 : undefined,
-            failMode: core.getInput("fail-mode") || "open",
+            failMode,
             selfHeal: core.getInput("self-heal") !== "false",
             addRiskLabels: core.getInput("add-risk-labels") !== "false",
             reviewersOnRisk: core.getInput("reviewers-on-risk")
@@ -43130,14 +43222,29 @@ async function run() {
                 .map((s) => s.trim())
                 .filter(Boolean),
             evaluationStoreUrl: core.getInput("evaluation-store-url") || undefined,
-            environment: core.getInput("environment") || undefined,
+            environment,
             securityGate: core.getInput("security-gate") !== "false",
         };
+        if (policyOverride?.changes.riskThreshold !== undefined) {
+            config.riskThreshold = policyOverride.changes.riskThreshold;
+        }
+        if (policyOverride?.changes.warnThreshold !== undefined) {
+            config.warnThreshold = policyOverride.changes.warnThreshold;
+        }
+        if (policyOverride?.changes.failMode !== undefined) {
+            config.failMode = policyOverride.changes.failMode;
+        }
+        if (policyOverride) {
+            core.warning(`Governed override active (${policyOverride.linkedTicket}) by ${policyOverride.owner}; expires ${policyOverride.expiresAt}.`);
+        }
         const context = github_context;
         const commitSha = context.sha;
         const prNumber = context.payload.pull_request?.number;
         core.info(`Evaluating deployment gate for ${commitSha.substring(0, 7)}`);
         const evaluation = await evaluateGate(config, commitSha, prNumber);
+        if (policyOverride) {
+            evaluation.policyOverride = policyOverride;
+        }
         core.setOutput("health-score", evaluation.healthScore.toString());
         core.setOutput("risk-score", evaluation.riskScore.toString());
         core.setOutput("gate-decision", evaluation.gateDecision);
@@ -43265,7 +43372,12 @@ async function run() {
         }
     }
     catch (error) {
-        const failMode = core.getInput("fail-mode") || "open";
+        if (error instanceof PolicyOverrideError) {
+            core.setFailed(`Invalid policy override: ${error.message}`);
+            return;
+        }
+        const environment = core.getInput("environment") || undefined;
+        const failMode = resolveFailMode(core.getInput("fail-mode"), environment);
         if (failMode === "open") {
             core.warning(`Trailhead evaluation failed — proceeding with deployment (fail-open). Error: ${error}`);
         }

--- a/docs/README.md
+++ b/docs/README.md
@@ -134,6 +134,28 @@ legacy `.deployguard.yml` is still accepted when `.trailhead.yml` is absent.
 This repository's `.trailhead.yml` ignores generated MCP copy/artifact paths so risk scores
 reflect canonical source changes instead of prebuild output.
 
+## Policy Profiles and Governed Overrides
+
+Trailhead ships an environment-aware fail policy by default:
+
+- `production` defaults to fail-closed (blocks when Trailhead itself fails)
+- all other environments default to fail-open with visible warnings
+
+You can still override policy settings temporarily, but overrides are enforceable and auditable.
+Any `override-*` input requires:
+
+- owner
+- reason
+- linked ticket
+- expiry timestamp
+
+Active overrides are included in the gate report and evaluation payload.
+
+For reusable starter packs and governance templates, use `examples/policy-pack/`.
+
+For Phase 2 (enforcement, canary-first promotion, and unblock operations), use
+`examples/policy-pack/phase-2/`.
+
 ## Monorepo Service Boundaries
 
 Define independent services for monorepos — each gets its own risk evaluation:

--- a/docs/README.md
+++ b/docs/README.md
@@ -184,9 +184,9 @@ The current fallback table is `trailhead_evaluations`.
 
 ## Branch and Release Context
 
-This repository uses `main` as the active/default branch. `dev` and `staging` are kept
-fast-forwarded to `main` for compatibility with older automation, and open PRs should target
-`main`.
+This repository uses `dev` as the active/default branch. `main` and `staging` are kept
+fast-forwarded to `dev` for compatibility with older automation, and open PRs should target
+`dev`.
 
 The unmerged branch `origin/experiment/rd-satellite/deployguard-supply-chain-risk` is known
 not to be promotion-ready: its targeted tests pass, but `app` and `mcp` builds fail until

--- a/examples/policy-pack/README.md
+++ b/examples/policy-pack/README.md
@@ -1,0 +1,28 @@
+# Trailhead Policy Pack
+
+This pack provides Phase 1 baseline artifacts for consistent org rollout:
+
+- Starter `.trailhead.yml` configs
+- Branch strategy variants (`main` only, or `dev`/`staging`/`main`)
+- GitHub ruleset templates for enforcement
+- Pilot baseline capture template
+- Phase 2 enforcement and promotion rollout kit
+
+## Files
+
+- `trailhead-starter.main-only.yml`
+- `trailhead-starter.progressive.yml`
+- `github-ruleset.main-only.json`
+- `github-ruleset.progressive.json`
+- `enforcement-guidelines.md`
+- `pilot-baseline-template.md`
+- `phase-2/`
+  - includes `phase-2/pilots/` concrete repo bundles
+
+## Usage
+
+1. Pick the starter config that matches your branch model.
+2. Apply the matching ruleset template in your GitHub org/repo settings.
+3. Run the pilot baseline template before switching from advisory to enforcement.
+4. Track override and rollback trend lines at each phase boundary.
+5. Use `phase-2/` to move pilot repos from advisory to enforced operation.

--- a/examples/policy-pack/enforcement-guidelines.md
+++ b/examples/policy-pack/enforcement-guidelines.md
@@ -1,0 +1,26 @@
+# GitHub Enforcement Guidelines
+
+Use these conventions with the ruleset JSON templates.
+
+## Required Check Naming
+
+- Use stable, explicit check names:
+  - `Trailhead`
+  - `CI / lint`
+  - `CI / test`
+  - `Deploy / staging`
+  - `Deploy / production`
+- Do not use ambiguous names like `build`, `checks`, or `pipeline`.
+- Keep one logical concern per check context so required checks stay meaningful.
+
+## Required Deployments
+
+- `main`-only flow: require `production`.
+- progressive flow: require `staging` and `production` at their respective gates.
+
+## Restricted Bypass Pattern
+
+- Allow bypass for as few actors as possible.
+- Prefer PR-only bypass mode over always bypass.
+- Require ticketed override metadata in workflow inputs when any policy override is used.
+- Review override age weekly; auto-expire with `override-expires-at`.

--- a/examples/policy-pack/github-ruleset.main-only.json
+++ b/examples/policy-pack/github-ruleset.main-only.json
@@ -1,0 +1,51 @@
+{
+  "name": "trailhead-main-enforcement",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/main"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": true,
+        "require_last_push_approval": true
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "required_status_checks": [
+          {
+            "context": "Trailhead",
+            "integration_id": null
+          },
+          {
+            "context": "CI / test",
+            "integration_id": null
+          }
+        ]
+      }
+    },
+    {
+      "type": "required_deployments",
+      "parameters": {
+        "required_deployment_environments": ["production"]
+      }
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": 1,
+      "actor_type": "OrganizationAdmin",
+      "bypass_mode": "pull_request"
+    }
+  ]
+}

--- a/examples/policy-pack/github-ruleset.progressive.json
+++ b/examples/policy-pack/github-ruleset.progressive.json
@@ -1,0 +1,55 @@
+{
+  "name": "trailhead-progressive-enforcement",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/dev", "refs/heads/staging", "refs/heads/main"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": true,
+        "require_last_push_approval": true
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "required_status_checks": [
+          {
+            "context": "Trailhead",
+            "integration_id": null
+          },
+          {
+            "context": "CI / test",
+            "integration_id": null
+          },
+          {
+            "context": "CI / lint",
+            "integration_id": null
+          }
+        ]
+      }
+    },
+    {
+      "type": "required_deployments",
+      "parameters": {
+        "required_deployment_environments": ["staging", "production"]
+      }
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": 1,
+      "actor_type": "OrganizationAdmin",
+      "bypass_mode": "pull_request"
+    }
+  ]
+}

--- a/examples/policy-pack/phase-2/README.md
+++ b/examples/policy-pack/phase-2/README.md
@@ -1,0 +1,25 @@
+# Phase 2 Rollout Kit
+
+This pack operationalizes policy into enforced merge and promotion controls.
+
+## Included Artifacts
+
+- `pilot-enforcement-checklist.md` - checklist for moving pilot repos from advisory to enforced mode
+- `required-checks-and-deployments.md` - branch/ruleset wiring guidance for required checks and required deployments
+- `trailhead-enforced-workflow.yml` - template workflow with stable check naming and deployment gates
+- `canary-promotion-runbook.md` - canary-first promotion flow, criteria, and rollback triggers
+- `blocked-to-green-runbook.md` - common failure modes and remediation flow
+- `threshold-archetypes.yml` - risk threshold presets by repo archetype
+- `pilots/` - concrete low/medium/high pilot bundles with per-repo rulesets/workflows/baselines
+- `pilots-renamed/` - renamed-repo scope pack with wave plan and baseline targets
+
+## How to Use
+
+1. Pick pilot repos and complete `pilot-enforcement-checklist.md`.
+2. Apply branch/ruleset controls from `required-checks-and-deployments.md`.
+3. Add `trailhead-enforced-workflow.yml` and map it to your deployment system.
+4. Adopt canary and rollback decisions from `canary-promotion-runbook.md`.
+5. Train teams on `blocked-to-green-runbook.md`.
+6. Calibrate with `threshold-archetypes.yml` after 2-4 weeks of pilot data.
+7. Apply repo-specific assets from `pilots/` to start the first enforced cohort.
+8. For renamed repos, execute rollout waves from `pilots-renamed/waves.yml`.

--- a/examples/policy-pack/phase-2/blocked-to-green-runbook.md
+++ b/examples/policy-pack/phase-2/blocked-to-green-runbook.md
@@ -1,0 +1,42 @@
+# Blocked-to-Green Runbook
+
+Use this when a PR is blocked or repeatedly warning.
+
+## Top Failure Modes
+
+- Sensitive file churn pushes risk score above threshold
+- Missing or weak tests on changed source files
+- Open security alerts (critical/high)
+- Deployment instability signals from recent outcomes
+- Freeze window policy violations
+
+## Remediation Flow
+
+1. Identify dominant risk factors from Trailhead report.
+2. Apply targeted fix:
+   - add tests
+   - split PR
+   - resolve security alerts
+   - reduce change blast radius
+3. Re-run checks and confirm score moved below block threshold.
+4. If still blocked, involve repo owner and security/release owners.
+
+## Suspected False Positive Escalation
+
+Escalate when both are true:
+
+- dominant factors do not reflect real release risk
+- remediation does not materially change score
+
+Escalation path:
+
+1. Open linked ticket with evidence and risk rationale.
+2. Apply governed temporary override (`override-*` + required metadata).
+3. Set short expiry and assign accountable owner.
+4. Add calibration task for threshold/pattern tuning.
+
+## Success Criteria
+
+- PR reaches `allow` or justified governed `warn`
+- override (if used) has owner, reason, ticket, and expiry
+- follow-up calibration task is logged

--- a/examples/policy-pack/phase-2/canary-promotion-runbook.md
+++ b/examples/policy-pack/phase-2/canary-promotion-runbook.md
@@ -1,0 +1,40 @@
+# Canary-First Promotion Runbook
+
+Standard promotion path:
+
+1. small exposure
+2. medium exposure
+3. full production
+
+## Stage Progression
+
+Use a fixed progression for each production change:
+
+- Stage A (small): 5-10% traffic or one shard/region
+- Stage B (medium): 25-50% traffic or half of target shards/regions
+- Stage C (full): 100% production
+
+## Promotion Criteria
+
+Promote to next stage only when all are true for the current stage window:
+
+- Health checks are passing (`check-http-health` and provider checks)
+- No sustained error spike against baseline
+- No severe security alerts introduced for the deployed revision
+- Trailhead decision is not `block` for the release PR
+
+## Rollback Triggers
+
+Rollback immediately if any condition is met:
+
+- Critical endpoint health is `down`
+- Error rate exceeds 2x baseline for 5+ minutes
+- Successful synthetic checks drop below 98%
+- New critical security alert tied to deployed change
+
+## Rollback Actions
+
+1. Trigger rollback strategy (`vercel`, `github-deployment`, or `workflow-dispatch`).
+2. Announce rollback in incident channel and PR thread.
+3. Freeze further promotions until root cause triage is complete.
+4. Capture CFR impact and recovery time for DORA review.

--- a/examples/policy-pack/phase-2/pilot-enforcement-checklist.md
+++ b/examples/policy-pack/phase-2/pilot-enforcement-checklist.md
@@ -1,0 +1,38 @@
+# Pilot Enforcement Checklist
+
+Use this before turning on hard enforcement in pilot repositories.
+
+## Scope and Ownership
+
+- [ ] Pilot repos selected across criticality tiers (low/medium/high).
+- [ ] Repo owners assigned for each pilot repository.
+- [ ] Escalation owner assigned for suspected Trailhead false positives.
+
+## Branch Protection and Rulesets
+
+- [ ] Protected branches configured for pilot merge paths.
+- [ ] Required status check includes `Trailhead`.
+- [ ] Required CI checks use stable names (`CI / lint`, `CI / test`).
+- [ ] Required deployments configured where merge must imply deploy readiness.
+- [ ] Bypass actors restricted to minimal approved set.
+- [ ] Merge queue enabled on high-traffic pilot branches.
+
+## Gate and Promotion Operations
+
+- [ ] `environment` is set consistently in workflow inputs.
+- [ ] Canary-first progression is documented and active.
+- [ ] Rollback trigger conditions are documented and tested.
+- [ ] Auto-rollback workflow is wired and dry-run validated.
+
+## Runbook Readiness
+
+- [ ] Team can execute blocked-to-green flow in under 30 minutes.
+- [ ] Top 5 block causes have known remediations.
+- [ ] False-positive escalation path is tested end-to-end.
+
+## Calibration and Exit
+
+- [ ] Threshold preset chosen from archetype baseline.
+- [ ] 2-4 weeks of block/noise data collected.
+- [ ] Advisory to enforced decision logged with rationale.
+- [ ] Phase 2 exit criteria reviewed and signed off.

--- a/examples/policy-pack/phase-2/pilots-renamed/README.md
+++ b/examples/policy-pack/phase-2/pilots-renamed/README.md
@@ -1,0 +1,44 @@
+# Renamed Repo Pilot Scope
+
+This pack captures the renamed Base Camp repo set you referenced and prepares
+parallel rollout waves for Phase 2.
+
+## Included Repos
+
+- `cairn`
+- `gtm`
+- `kindling`
+- `komatik-vector`
+- `lodge`
+- `pack`
+- `sundog`
+- `trace-floe`
+- `trace-triage`
+- `trace-watchtower`
+- `traverse`
+
+## Execution Defaults
+
+- wave size: 3 repos per wave
+- branch model default: `dev/staging/main` (progressive)
+- required check contexts:
+  - `Trailhead`
+  - `CI / lint`
+  - `CI / test`
+  - `Deploy / staging`
+  - `Deploy / production`
+
+Use the existing templates in `examples/policy-pack/phase-2/`:
+
+- `required-checks-and-deployments.md`
+- `trailhead-enforced-workflow.yml`
+- `threshold-archetypes.yml`
+- `canary-promotion-runbook.md`
+- `blocked-to-green-runbook.md`
+
+## Files in This Folder
+
+- `repos.yml` - repo metadata and criticality assumptions
+- `waves.yml` - parallel execution waves (3 repos each)
+- `baseline-targets.md` - prefilled per-repo baseline target sheet
+- `org-rollout-checklist.md` - centralized rollout tracker for all waves

--- a/examples/policy-pack/phase-2/pilots-renamed/baseline-targets.md
+++ b/examples/policy-pack/phase-2/pilots-renamed/baseline-targets.md
@@ -1,0 +1,23 @@
+# Baseline Targets - Renamed Repos
+
+Populate current values from last 30 days before enabling full enforcement.
+
+| Repo             | Criticality | Block Rate Target | Rollback Rate Target | CFR Target | Median Unblock Target |
+| ---------------- | ----------- | ----------------- | -------------------- | ---------- | --------------------- |
+| cairn            | medium      | 15-25%            | <= 4%                | <= 8%      | <= 3h                 |
+| gtm              | medium      | 15-25%            | <= 4%                | <= 8%      | <= 3h                 |
+| kindling         | medium      | 15-25%            | <= 4%                | <= 8%      | <= 3h                 |
+| komatik-vector   | high        | 20-30%            | <= 3%                | <= 6%      | <= 2h                 |
+| lodge            | medium      | 15-25%            | <= 4%                | <= 8%      | <= 3h                 |
+| pack             | medium      | 15-25%            | <= 4%                | <= 8%      | <= 3h                 |
+| sundog           | medium      | 15-25%            | <= 4%                | <= 8%      | <= 3h                 |
+| trace-floe       | high        | 20-30%            | <= 3%                | <= 6%      | <= 2h                 |
+| trace-triage     | high        | 20-30%            | <= 3%                | <= 6%      | <= 2h                 |
+| trace-watchtower | high        | 20-30%            | <= 3%                | <= 6%      | <= 2h                 |
+| traverse         | medium      | 15-25%            | <= 4%                | <= 8%      | <= 3h                 |
+
+## Notes
+
+- These are starting targets for Phase 2, not hard quotas.
+- Calibrate after each wave based on false-positive and false-negative trends.
+- For any governed override, require owner, reason, ticket, and expiry.

--- a/examples/policy-pack/phase-2/pilots-renamed/org-rollout-checklist.md
+++ b/examples/policy-pack/phase-2/pilots-renamed/org-rollout-checklist.md
@@ -1,0 +1,42 @@
+# Org Rollout Checklist (Renamed Repos)
+
+Track Phase 2 rollout completion across all renamed repos.
+
+## Status Legend
+
+- `not-started`
+- `in-progress`
+- `done`
+- `blocked`
+
+## Repo Rollout Matrix
+
+| Wave    | Repo             | Criticality | Ruleset Applied | Workflow Merged | Baseline Captured | Week-1 Review Completed | Owner | Last Updated | Notes |
+| ------- | ---------------- | ----------- | --------------- | --------------- | ----------------- | ----------------------- | ----- | ------------ | ----- |
+| wave-01 | cairn            | medium      | not-started     | not-started     | not-started       | not-started             | tbd   | tbd          |       |
+| wave-01 | gtm              | medium      | not-started     | not-started     | not-started       | not-started             | tbd   | tbd          |       |
+| wave-01 | kindling         | medium      | not-started     | not-started     | not-started       | not-started             | tbd   | tbd          |       |
+| wave-02 | komatik-vector   | high        | not-started     | not-started     | not-started       | not-started             | tbd   | tbd          |       |
+| wave-02 | lodge            | medium      | not-started     | not-started     | not-started       | not-started             | tbd   | tbd          |       |
+| wave-02 | pack             | medium      | not-started     | not-started     | not-started       | not-started             | tbd   | tbd          |       |
+| wave-03 | sundog           | medium      | not-started     | not-started     | not-started       | not-started             | tbd   | tbd          |       |
+| wave-03 | traverse         | medium      | not-started     | not-started     | not-started       | not-started             | tbd   | tbd          |       |
+| wave-03 | trace-floe       | high        | not-started     | not-started     | not-started       | not-started             | tbd   | tbd          |       |
+| wave-04 | trace-triage     | high        | not-started     | not-started     | not-started       | not-started             | tbd   | tbd          |       |
+| wave-04 | trace-watchtower | high        | not-started     | not-started     | not-started       | not-started             | tbd   | tbd          |       |
+
+## Global Exit Checklist (Phase 2)
+
+- [ ] All repos have `Ruleset Applied = done`.
+- [ ] All repos have `Workflow Merged = done`.
+- [ ] All repos have `Baseline Captured = done`.
+- [ ] All repos completed one enforced week review.
+- [ ] Top failure modes documented and linked per repo.
+- [ ] Escalation owner confirmed for every high-criticality repo.
+- [ ] Threshold adjustments logged where noise exceeded target bands.
+
+## Weekly Ops Cadence
+
+- Monday: update status matrix + blockers.
+- Wednesday: review block/noise trends and override usage.
+- Friday: close week review notes and decide next-wave readiness.

--- a/examples/policy-pack/phase-2/pilots-renamed/repos.yml
+++ b/examples/policy-pack/phase-2/pilots-renamed/repos.yml
@@ -1,0 +1,67 @@
+repos:
+  - name: cairn
+    branch_strategy: progressive
+    criticality: medium
+    archetype: application
+    required_deployments: [staging, production]
+    notes: "Verify service boundaries and deployment environment names."
+  - name: gtm
+    branch_strategy: progressive
+    criticality: medium
+    archetype: application
+    required_deployments: [staging, production]
+    notes: "Growth/marketing workflow changes may need lower warn noise."
+  - name: kindling
+    branch_strategy: progressive
+    criticality: medium
+    archetype: monorepo-component
+    required_deployments: [staging, production]
+    notes: "Confirm component ownership and codeowner coverage."
+  - name: komatik-vector
+    branch_strategy: progressive
+    criticality: high
+    archetype: infrastructure
+    required_deployments: [staging, production]
+    notes: "Vector/data infrastructure can have high blast radius."
+  - name: lodge
+    branch_strategy: progressive
+    criticality: medium
+    archetype: application
+    required_deployments: [staging, production]
+    notes: "Validate release cadence before tightening thresholds."
+  - name: pack
+    branch_strategy: progressive
+    criticality: medium
+    archetype: monorepo-component
+    required_deployments: [staging, production]
+    notes: "Check if monorepo service map is required."
+  - name: sundog
+    branch_strategy: progressive
+    criticality: medium
+    archetype: application
+    required_deployments: [staging, production]
+    notes: "Confirm health endpoints for promotion criteria."
+  - name: trace-floe
+    branch_strategy: progressive
+    criticality: high
+    archetype: infrastructure
+    required_deployments: [staging, production]
+    notes: "Security-adjacent signal path; treat as high criticality."
+  - name: trace-triage
+    branch_strategy: progressive
+    criticality: high
+    archetype: infrastructure
+    required_deployments: [staging, production]
+    notes: "Incident/rescue flow; prioritize rollback readiness."
+  - name: trace-watchtower
+    branch_strategy: progressive
+    criticality: high
+    archetype: infrastructure
+    required_deployments: [staging, production]
+    notes: "Governance/security visibility; ensure low false-negative risk."
+  - name: traverse
+    branch_strategy: progressive
+    criticality: medium
+    archetype: application
+    required_deployments: [staging, production]
+    notes: "Reviewflow lineage likely needs balanced warn tuning."

--- a/examples/policy-pack/phase-2/pilots-renamed/wave-01/README.md
+++ b/examples/policy-pack/phase-2/pilots-renamed/wave-01/README.md
@@ -1,0 +1,20 @@
+# Wave 01 - Execution Bundle
+
+Repos in this wave:
+
+- `cairn`
+- `gtm`
+- `kindling`
+
+Each repo folder contains:
+
+- `ruleset.json`
+- `trailhead-enforced-workflow.yml`
+- `baseline.md`
+
+## Apply Order
+
+1. Review and apply `ruleset.json` in GitHub rulesets.
+2. Add `trailhead-enforced-workflow.yml` to `.github/workflows/`.
+3. Fill `baseline.md` current values from last 30 days.
+4. Run one week in enforced mode and review noise before Wave 2.

--- a/examples/policy-pack/phase-2/pilots-renamed/wave-01/cairn/baseline.md
+++ b/examples/policy-pack/phase-2/pilots-renamed/wave-01/cairn/baseline.md
@@ -1,0 +1,23 @@
+# Baseline - cairn (Wave 01)
+
+## Scope
+
+- Repository: `cairn`
+- Criticality: medium
+- Branch strategy: progressive (`dev/staging/main`)
+- Evaluation window: last 30 days
+
+## Metrics
+
+| Metric              | Current | Target | Notes                                             |
+| ------------------- | ------- | ------ | ------------------------------------------------- |
+| Block rate          | tbd     | 15-25% | Keep signal useful without blocking routine flow. |
+| Rollback rate       | tbd     | <= 4%  | Production rollbacks only.                        |
+| CFR                 | tbd     | <= 8%  | Track trend and incident context.                 |
+| Median unblock time | tbd     | <= 3h  | First block to fully green checks.                |
+
+## Owners
+
+- Repo owner: `tbd`
+- Release owner: `tbd`
+- Escalation owner: `tbd`

--- a/examples/policy-pack/phase-2/pilots-renamed/wave-01/cairn/ruleset.json
+++ b/examples/policy-pack/phase-2/pilots-renamed/wave-01/cairn/ruleset.json
@@ -1,0 +1,63 @@
+{
+  "name": "trailhead-wave01-cairn",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/dev", "refs/heads/staging", "refs/heads/main"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": true,
+        "require_last_push_approval": true
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "required_status_checks": [
+          {
+            "context": "Trailhead",
+            "integration_id": null
+          },
+          {
+            "context": "CI / lint",
+            "integration_id": null
+          },
+          {
+            "context": "CI / test",
+            "integration_id": null
+          },
+          {
+            "context": "Deploy / staging",
+            "integration_id": null
+          },
+          {
+            "context": "Deploy / production",
+            "integration_id": null
+          }
+        ]
+      }
+    },
+    {
+      "type": "required_deployments",
+      "parameters": {
+        "required_deployment_environments": ["staging", "production"]
+      }
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": 1,
+      "actor_type": "OrganizationAdmin",
+      "bypass_mode": "pull_request"
+    }
+  ]
+}

--- a/examples/policy-pack/phase-2/pilots-renamed/wave-01/cairn/trailhead-enforced-workflow.yml
+++ b/examples/policy-pack/phase-2/pilots-renamed/wave-01/cairn/trailhead-enforced-workflow.yml
@@ -1,0 +1,59 @@
+name: Trailhead enforced gate (cairn)
+
+on:
+  pull_request:
+    branches:
+      - dev
+      - staging
+      - main
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+  security-events: read
+  deployments: read
+
+jobs:
+  trailhead:
+    name: Trailhead
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: KomatikAI/trailhead@v3
+        with:
+          environment: ${{ github.base_ref == 'main' && 'production' || github.base_ref == 'staging' && 'staging' || 'dev' }}
+          dora-metrics: "true"
+          security-gate: "true"
+
+  ci-lint:
+    name: CI / lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "Replace with lint command"
+
+  ci-test:
+    name: CI / test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "Replace with test command"
+
+  deploy-staging:
+    name: Deploy / staging
+    if: github.base_ref == 'staging'
+    needs: [trailhead, ci-lint, ci-test]
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      - run: echo "Replace with staging deployment validation check"
+
+  deploy-production:
+    name: Deploy / production
+    if: github.base_ref == 'main'
+    needs: [trailhead, ci-lint, ci-test]
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - run: echo "Replace with production deployment validation check"

--- a/examples/policy-pack/phase-2/pilots-renamed/wave-01/gtm/baseline.md
+++ b/examples/policy-pack/phase-2/pilots-renamed/wave-01/gtm/baseline.md
@@ -1,0 +1,23 @@
+# Baseline - gtm (Wave 01)
+
+## Scope
+
+- Repository: `gtm`
+- Criticality: medium
+- Branch strategy: progressive (`dev/staging/main`)
+- Evaluation window: last 30 days
+
+## Metrics
+
+| Metric              | Current | Target | Notes                                              |
+| ------------------- | ------- | ------ | -------------------------------------------------- |
+| Block rate          | tbd     | 15-25% | Tune warn noise for marketing-heavy repo patterns. |
+| Rollback rate       | tbd     | <= 4%  | Production rollbacks only.                         |
+| CFR                 | tbd     | <= 8%  | Correlate with promotion and deployment checks.    |
+| Median unblock time | tbd     | <= 3h  | First block to fully green checks.                 |
+
+## Owners
+
+- Repo owner: `tbd`
+- Release owner: `tbd`
+- Escalation owner: `tbd`

--- a/examples/policy-pack/phase-2/pilots-renamed/wave-01/gtm/ruleset.json
+++ b/examples/policy-pack/phase-2/pilots-renamed/wave-01/gtm/ruleset.json
@@ -1,0 +1,63 @@
+{
+  "name": "trailhead-wave01-gtm",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/dev", "refs/heads/staging", "refs/heads/main"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": true,
+        "require_last_push_approval": true
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "required_status_checks": [
+          {
+            "context": "Trailhead",
+            "integration_id": null
+          },
+          {
+            "context": "CI / lint",
+            "integration_id": null
+          },
+          {
+            "context": "CI / test",
+            "integration_id": null
+          },
+          {
+            "context": "Deploy / staging",
+            "integration_id": null
+          },
+          {
+            "context": "Deploy / production",
+            "integration_id": null
+          }
+        ]
+      }
+    },
+    {
+      "type": "required_deployments",
+      "parameters": {
+        "required_deployment_environments": ["staging", "production"]
+      }
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": 1,
+      "actor_type": "OrganizationAdmin",
+      "bypass_mode": "pull_request"
+    }
+  ]
+}

--- a/examples/policy-pack/phase-2/pilots-renamed/wave-01/gtm/trailhead-enforced-workflow.yml
+++ b/examples/policy-pack/phase-2/pilots-renamed/wave-01/gtm/trailhead-enforced-workflow.yml
@@ -1,0 +1,59 @@
+name: Trailhead enforced gate (gtm)
+
+on:
+  pull_request:
+    branches:
+      - dev
+      - staging
+      - main
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+  security-events: read
+  deployments: read
+
+jobs:
+  trailhead:
+    name: Trailhead
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: KomatikAI/trailhead@v3
+        with:
+          environment: ${{ github.base_ref == 'main' && 'production' || github.base_ref == 'staging' && 'staging' || 'dev' }}
+          dora-metrics: "true"
+          security-gate: "true"
+
+  ci-lint:
+    name: CI / lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "Replace with lint command"
+
+  ci-test:
+    name: CI / test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "Replace with test command"
+
+  deploy-staging:
+    name: Deploy / staging
+    if: github.base_ref == 'staging'
+    needs: [trailhead, ci-lint, ci-test]
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      - run: echo "Replace with staging deployment validation check"
+
+  deploy-production:
+    name: Deploy / production
+    if: github.base_ref == 'main'
+    needs: [trailhead, ci-lint, ci-test]
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - run: echo "Replace with production deployment validation check"

--- a/examples/policy-pack/phase-2/pilots-renamed/wave-01/kindling/baseline.md
+++ b/examples/policy-pack/phase-2/pilots-renamed/wave-01/kindling/baseline.md
@@ -1,0 +1,23 @@
+# Baseline - kindling (Wave 01)
+
+## Scope
+
+- Repository: `kindling`
+- Criticality: medium
+- Branch strategy: progressive (`dev/staging/main`)
+- Evaluation window: last 30 days
+
+## Metrics
+
+| Metric              | Current | Target | Notes                                                |
+| ------------------- | ------- | ------ | ---------------------------------------------------- |
+| Block rate          | tbd     | 15-25% | Validate component-level sensitivity patterns.       |
+| Rollback rate       | tbd     | <= 4%  | Production rollbacks only.                           |
+| CFR                 | tbd     | <= 8%  | Track against canary failures and incident outcomes. |
+| Median unblock time | tbd     | <= 3h  | First block to fully green checks.                   |
+
+## Owners
+
+- Repo owner: `tbd`
+- Release owner: `tbd`
+- Escalation owner: `tbd`

--- a/examples/policy-pack/phase-2/pilots-renamed/wave-01/kindling/ruleset.json
+++ b/examples/policy-pack/phase-2/pilots-renamed/wave-01/kindling/ruleset.json
@@ -1,0 +1,63 @@
+{
+  "name": "trailhead-wave01-kindling",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/dev", "refs/heads/staging", "refs/heads/main"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": true,
+        "require_last_push_approval": true
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "required_status_checks": [
+          {
+            "context": "Trailhead",
+            "integration_id": null
+          },
+          {
+            "context": "CI / lint",
+            "integration_id": null
+          },
+          {
+            "context": "CI / test",
+            "integration_id": null
+          },
+          {
+            "context": "Deploy / staging",
+            "integration_id": null
+          },
+          {
+            "context": "Deploy / production",
+            "integration_id": null
+          }
+        ]
+      }
+    },
+    {
+      "type": "required_deployments",
+      "parameters": {
+        "required_deployment_environments": ["staging", "production"]
+      }
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": 1,
+      "actor_type": "OrganizationAdmin",
+      "bypass_mode": "pull_request"
+    }
+  ]
+}

--- a/examples/policy-pack/phase-2/pilots-renamed/wave-01/kindling/trailhead-enforced-workflow.yml
+++ b/examples/policy-pack/phase-2/pilots-renamed/wave-01/kindling/trailhead-enforced-workflow.yml
@@ -1,0 +1,59 @@
+name: Trailhead enforced gate (kindling)
+
+on:
+  pull_request:
+    branches:
+      - dev
+      - staging
+      - main
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+  security-events: read
+  deployments: read
+
+jobs:
+  trailhead:
+    name: Trailhead
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: KomatikAI/trailhead@v3
+        with:
+          environment: ${{ github.base_ref == 'main' && 'production' || github.base_ref == 'staging' && 'staging' || 'dev' }}
+          dora-metrics: "true"
+          security-gate: "true"
+
+  ci-lint:
+    name: CI / lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "Replace with lint command"
+
+  ci-test:
+    name: CI / test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "Replace with test command"
+
+  deploy-staging:
+    name: Deploy / staging
+    if: github.base_ref == 'staging'
+    needs: [trailhead, ci-lint, ci-test]
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      - run: echo "Replace with staging deployment validation check"
+
+  deploy-production:
+    name: Deploy / production
+    if: github.base_ref == 'main'
+    needs: [trailhead, ci-lint, ci-test]
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - run: echo "Replace with production deployment validation check"

--- a/examples/policy-pack/phase-2/pilots-renamed/wave-02/README.md
+++ b/examples/policy-pack/phase-2/pilots-renamed/wave-02/README.md
@@ -1,0 +1,20 @@
+# Wave 02 - Execution Bundle
+
+Repos in this wave:
+
+- `komatik-vector`
+- `lodge`
+- `pack`
+
+Each repo folder contains:
+
+- `ruleset.json`
+- `trailhead-enforced-workflow.yml`
+- `baseline.md`
+
+## Apply Order
+
+1. Review and apply `ruleset.json` in GitHub rulesets.
+2. Add `trailhead-enforced-workflow.yml` to `.github/workflows/`.
+3. Fill `baseline.md` current values from last 30 days.
+4. Run one week in enforced mode and compare noise against Wave 01.

--- a/examples/policy-pack/phase-2/pilots-renamed/wave-02/komatik-vector/baseline.md
+++ b/examples/policy-pack/phase-2/pilots-renamed/wave-02/komatik-vector/baseline.md
@@ -1,0 +1,23 @@
+# Baseline - komatik-vector (Wave 02)
+
+## Scope
+
+- Repository: `komatik-vector`
+- Criticality: high
+- Branch strategy: progressive (`dev/staging/main`)
+- Evaluation window: last 30 days
+
+## Metrics
+
+| Metric              | Current | Target | Notes                                           |
+| ------------------- | ------- | ------ | ----------------------------------------------- |
+| Block rate          | tbd     | 20-30% | Higher guardrails expected for infra/data risk. |
+| Rollback rate       | tbd     | <= 3%  | Production rollbacks only.                      |
+| CFR                 | tbd     | <= 6%  | Track by incident class and deployment stage.   |
+| Median unblock time | tbd     | <= 2h  | Fast high-severity triage expectation.          |
+
+## Owners
+
+- Repo owner: `tbd`
+- Release owner: `tbd`
+- Escalation owner: `tbd`

--- a/examples/policy-pack/phase-2/pilots-renamed/wave-02/komatik-vector/ruleset.json
+++ b/examples/policy-pack/phase-2/pilots-renamed/wave-02/komatik-vector/ruleset.json
@@ -1,0 +1,63 @@
+{
+  "name": "trailhead-wave02-komatik-vector",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/dev", "refs/heads/staging", "refs/heads/main"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": true,
+        "require_last_push_approval": true
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "required_status_checks": [
+          {
+            "context": "Trailhead",
+            "integration_id": null
+          },
+          {
+            "context": "CI / lint",
+            "integration_id": null
+          },
+          {
+            "context": "CI / test",
+            "integration_id": null
+          },
+          {
+            "context": "Deploy / staging",
+            "integration_id": null
+          },
+          {
+            "context": "Deploy / production",
+            "integration_id": null
+          }
+        ]
+      }
+    },
+    {
+      "type": "required_deployments",
+      "parameters": {
+        "required_deployment_environments": ["staging", "production"]
+      }
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": 1,
+      "actor_type": "OrganizationAdmin",
+      "bypass_mode": "pull_request"
+    }
+  ]
+}

--- a/examples/policy-pack/phase-2/pilots-renamed/wave-02/komatik-vector/trailhead-enforced-workflow.yml
+++ b/examples/policy-pack/phase-2/pilots-renamed/wave-02/komatik-vector/trailhead-enforced-workflow.yml
@@ -1,0 +1,59 @@
+name: Trailhead enforced gate (komatik-vector)
+
+on:
+  pull_request:
+    branches:
+      - dev
+      - staging
+      - main
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+  security-events: read
+  deployments: read
+
+jobs:
+  trailhead:
+    name: Trailhead
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: KomatikAI/trailhead@v3
+        with:
+          environment: ${{ github.base_ref == 'main' && 'production' || github.base_ref == 'staging' && 'staging' || 'dev' }}
+          dora-metrics: "true"
+          security-gate: "true"
+
+  ci-lint:
+    name: CI / lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "Replace with lint command"
+
+  ci-test:
+    name: CI / test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "Replace with test command"
+
+  deploy-staging:
+    name: Deploy / staging
+    if: github.base_ref == 'staging'
+    needs: [trailhead, ci-lint, ci-test]
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      - run: echo "Replace with staging deployment validation check"
+
+  deploy-production:
+    name: Deploy / production
+    if: github.base_ref == 'main'
+    needs: [trailhead, ci-lint, ci-test]
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - run: echo "Replace with production deployment validation check"

--- a/examples/policy-pack/phase-2/pilots-renamed/wave-02/lodge/baseline.md
+++ b/examples/policy-pack/phase-2/pilots-renamed/wave-02/lodge/baseline.md
@@ -1,0 +1,23 @@
+# Baseline - lodge (Wave 02)
+
+## Scope
+
+- Repository: `lodge`
+- Criticality: medium
+- Branch strategy: progressive (`dev/staging/main`)
+- Evaluation window: last 30 days
+
+## Metrics
+
+| Metric              | Current | Target | Notes                                                   |
+| ------------------- | ------- | ------ | ------------------------------------------------------- |
+| Block rate          | tbd     | 15-25% | Tune threshold noise after first enforced week.         |
+| Rollback rate       | tbd     | <= 4%  | Production rollbacks only.                              |
+| CFR                 | tbd     | <= 8%  | Use trend and release context, not single-point values. |
+| Median unblock time | tbd     | <= 3h  | First block to fully green checks.                      |
+
+## Owners
+
+- Repo owner: `tbd`
+- Release owner: `tbd`
+- Escalation owner: `tbd`

--- a/examples/policy-pack/phase-2/pilots-renamed/wave-02/lodge/ruleset.json
+++ b/examples/policy-pack/phase-2/pilots-renamed/wave-02/lodge/ruleset.json
@@ -1,0 +1,63 @@
+{
+  "name": "trailhead-wave02-lodge",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/dev", "refs/heads/staging", "refs/heads/main"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": true,
+        "require_last_push_approval": true
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "required_status_checks": [
+          {
+            "context": "Trailhead",
+            "integration_id": null
+          },
+          {
+            "context": "CI / lint",
+            "integration_id": null
+          },
+          {
+            "context": "CI / test",
+            "integration_id": null
+          },
+          {
+            "context": "Deploy / staging",
+            "integration_id": null
+          },
+          {
+            "context": "Deploy / production",
+            "integration_id": null
+          }
+        ]
+      }
+    },
+    {
+      "type": "required_deployments",
+      "parameters": {
+        "required_deployment_environments": ["staging", "production"]
+      }
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": 1,
+      "actor_type": "OrganizationAdmin",
+      "bypass_mode": "pull_request"
+    }
+  ]
+}

--- a/examples/policy-pack/phase-2/pilots-renamed/wave-02/lodge/trailhead-enforced-workflow.yml
+++ b/examples/policy-pack/phase-2/pilots-renamed/wave-02/lodge/trailhead-enforced-workflow.yml
@@ -1,0 +1,59 @@
+name: Trailhead enforced gate (lodge)
+
+on:
+  pull_request:
+    branches:
+      - dev
+      - staging
+      - main
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+  security-events: read
+  deployments: read
+
+jobs:
+  trailhead:
+    name: Trailhead
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: KomatikAI/trailhead@v3
+        with:
+          environment: ${{ github.base_ref == 'main' && 'production' || github.base_ref == 'staging' && 'staging' || 'dev' }}
+          dora-metrics: "true"
+          security-gate: "true"
+
+  ci-lint:
+    name: CI / lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "Replace with lint command"
+
+  ci-test:
+    name: CI / test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "Replace with test command"
+
+  deploy-staging:
+    name: Deploy / staging
+    if: github.base_ref == 'staging'
+    needs: [trailhead, ci-lint, ci-test]
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      - run: echo "Replace with staging deployment validation check"
+
+  deploy-production:
+    name: Deploy / production
+    if: github.base_ref == 'main'
+    needs: [trailhead, ci-lint, ci-test]
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - run: echo "Replace with production deployment validation check"

--- a/examples/policy-pack/phase-2/pilots-renamed/wave-02/pack/baseline.md
+++ b/examples/policy-pack/phase-2/pilots-renamed/wave-02/pack/baseline.md
@@ -1,0 +1,23 @@
+# Baseline - pack (Wave 02)
+
+## Scope
+
+- Repository: `pack`
+- Criticality: medium
+- Branch strategy: progressive (`dev/staging/main`)
+- Evaluation window: last 30 days
+
+## Metrics
+
+| Metric              | Current | Target | Notes                                                   |
+| ------------------- | ------- | ------ | ------------------------------------------------------- |
+| Block rate          | tbd     | 15-25% | Validate component-level checks and service boundaries. |
+| Rollback rate       | tbd     | <= 4%  | Production rollbacks only.                              |
+| CFR                 | tbd     | <= 8%  | Track by component area where possible.                 |
+| Median unblock time | tbd     | <= 3h  | First block to fully green checks.                      |
+
+## Owners
+
+- Repo owner: `tbd`
+- Release owner: `tbd`
+- Escalation owner: `tbd`

--- a/examples/policy-pack/phase-2/pilots-renamed/wave-02/pack/ruleset.json
+++ b/examples/policy-pack/phase-2/pilots-renamed/wave-02/pack/ruleset.json
@@ -1,0 +1,63 @@
+{
+  "name": "trailhead-wave02-pack",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/dev", "refs/heads/staging", "refs/heads/main"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": true,
+        "require_last_push_approval": true
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "required_status_checks": [
+          {
+            "context": "Trailhead",
+            "integration_id": null
+          },
+          {
+            "context": "CI / lint",
+            "integration_id": null
+          },
+          {
+            "context": "CI / test",
+            "integration_id": null
+          },
+          {
+            "context": "Deploy / staging",
+            "integration_id": null
+          },
+          {
+            "context": "Deploy / production",
+            "integration_id": null
+          }
+        ]
+      }
+    },
+    {
+      "type": "required_deployments",
+      "parameters": {
+        "required_deployment_environments": ["staging", "production"]
+      }
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": 1,
+      "actor_type": "OrganizationAdmin",
+      "bypass_mode": "pull_request"
+    }
+  ]
+}

--- a/examples/policy-pack/phase-2/pilots-renamed/wave-02/pack/trailhead-enforced-workflow.yml
+++ b/examples/policy-pack/phase-2/pilots-renamed/wave-02/pack/trailhead-enforced-workflow.yml
@@ -1,0 +1,59 @@
+name: Trailhead enforced gate (pack)
+
+on:
+  pull_request:
+    branches:
+      - dev
+      - staging
+      - main
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+  security-events: read
+  deployments: read
+
+jobs:
+  trailhead:
+    name: Trailhead
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: KomatikAI/trailhead@v3
+        with:
+          environment: ${{ github.base_ref == 'main' && 'production' || github.base_ref == 'staging' && 'staging' || 'dev' }}
+          dora-metrics: "true"
+          security-gate: "true"
+
+  ci-lint:
+    name: CI / lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "Replace with lint command"
+
+  ci-test:
+    name: CI / test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "Replace with test command"
+
+  deploy-staging:
+    name: Deploy / staging
+    if: github.base_ref == 'staging'
+    needs: [trailhead, ci-lint, ci-test]
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      - run: echo "Replace with staging deployment validation check"
+
+  deploy-production:
+    name: Deploy / production
+    if: github.base_ref == 'main'
+    needs: [trailhead, ci-lint, ci-test]
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - run: echo "Replace with production deployment validation check"

--- a/examples/policy-pack/phase-2/pilots-renamed/wave-03/README.md
+++ b/examples/policy-pack/phase-2/pilots-renamed/wave-03/README.md
@@ -1,0 +1,20 @@
+# Wave 03 - Execution Bundle
+
+Repos in this wave:
+
+- `sundog`
+- `traverse`
+- `trace-floe`
+
+Each repo folder contains:
+
+- `ruleset.json`
+- `trailhead-enforced-workflow.yml`
+- `baseline.md`
+
+## Apply Order
+
+1. Review and apply `ruleset.json` in GitHub rulesets.
+2. Add `trailhead-enforced-workflow.yml` to `.github/workflows/`.
+3. Fill `baseline.md` current values from last 30 days.
+4. Run one week in enforced mode and compare to prior waves.

--- a/examples/policy-pack/phase-2/pilots-renamed/wave-03/sundog/baseline.md
+++ b/examples/policy-pack/phase-2/pilots-renamed/wave-03/sundog/baseline.md
@@ -1,0 +1,23 @@
+# Baseline - sundog (Wave 03)
+
+## Scope
+
+- Repository: `sundog`
+- Criticality: medium
+- Branch strategy: progressive (`dev/staging/main`)
+- Evaluation window: last 30 days
+
+## Metrics
+
+| Metric              | Current | Target | Notes                                              |
+| ------------------- | ------- | ------ | -------------------------------------------------- |
+| Block rate          | tbd     | 15-25% | Balance meaningful signal with routine throughput. |
+| Rollback rate       | tbd     | <= 4%  | Production rollbacks only.                         |
+| CFR                 | tbd     | <= 8%  | Track trend and correlate to deployment stage.     |
+| Median unblock time | tbd     | <= 3h  | First block to fully green checks.                 |
+
+## Owners
+
+- Repo owner: `tbd`
+- Release owner: `tbd`
+- Escalation owner: `tbd`

--- a/examples/policy-pack/phase-2/pilots-renamed/wave-03/sundog/ruleset.json
+++ b/examples/policy-pack/phase-2/pilots-renamed/wave-03/sundog/ruleset.json
@@ -1,0 +1,63 @@
+{
+  "name": "trailhead-wave03-sundog",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/dev", "refs/heads/staging", "refs/heads/main"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": true,
+        "require_last_push_approval": true
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "required_status_checks": [
+          {
+            "context": "Trailhead",
+            "integration_id": null
+          },
+          {
+            "context": "CI / lint",
+            "integration_id": null
+          },
+          {
+            "context": "CI / test",
+            "integration_id": null
+          },
+          {
+            "context": "Deploy / staging",
+            "integration_id": null
+          },
+          {
+            "context": "Deploy / production",
+            "integration_id": null
+          }
+        ]
+      }
+    },
+    {
+      "type": "required_deployments",
+      "parameters": {
+        "required_deployment_environments": ["staging", "production"]
+      }
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": 1,
+      "actor_type": "OrganizationAdmin",
+      "bypass_mode": "pull_request"
+    }
+  ]
+}

--- a/examples/policy-pack/phase-2/pilots-renamed/wave-03/sundog/trailhead-enforced-workflow.yml
+++ b/examples/policy-pack/phase-2/pilots-renamed/wave-03/sundog/trailhead-enforced-workflow.yml
@@ -1,0 +1,59 @@
+name: Trailhead enforced gate (sundog)
+
+on:
+  pull_request:
+    branches:
+      - dev
+      - staging
+      - main
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+  security-events: read
+  deployments: read
+
+jobs:
+  trailhead:
+    name: Trailhead
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: KomatikAI/trailhead@v3
+        with:
+          environment: ${{ github.base_ref == 'main' && 'production' || github.base_ref == 'staging' && 'staging' || 'dev' }}
+          dora-metrics: "true"
+          security-gate: "true"
+
+  ci-lint:
+    name: CI / lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "Replace with lint command"
+
+  ci-test:
+    name: CI / test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "Replace with test command"
+
+  deploy-staging:
+    name: Deploy / staging
+    if: github.base_ref == 'staging'
+    needs: [trailhead, ci-lint, ci-test]
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      - run: echo "Replace with staging deployment validation check"
+
+  deploy-production:
+    name: Deploy / production
+    if: github.base_ref == 'main'
+    needs: [trailhead, ci-lint, ci-test]
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - run: echo "Replace with production deployment validation check"

--- a/examples/policy-pack/phase-2/pilots-renamed/wave-03/trace-floe/baseline.md
+++ b/examples/policy-pack/phase-2/pilots-renamed/wave-03/trace-floe/baseline.md
@@ -1,0 +1,23 @@
+# Baseline - trace-floe (Wave 03)
+
+## Scope
+
+- Repository: `trace-floe`
+- Criticality: high
+- Branch strategy: progressive (`dev/staging/main`)
+- Evaluation window: last 30 days
+
+## Metrics
+
+| Metric              | Current | Target | Notes                                              |
+| ------------------- | ------- | ------ | -------------------------------------------------- |
+| Block rate          | tbd     | 20-30% | Security-adjacent path merits stronger guardrails. |
+| Rollback rate       | tbd     | <= 3%  | Production rollbacks only.                         |
+| CFR                 | tbd     | <= 6%  | Track with incident severity and recovery context. |
+| Median unblock time | tbd     | <= 2h  | Fast high-criticality remediation target.          |
+
+## Owners
+
+- Repo owner: `tbd`
+- Release owner: `tbd`
+- Escalation owner: `tbd`

--- a/examples/policy-pack/phase-2/pilots-renamed/wave-03/trace-floe/ruleset.json
+++ b/examples/policy-pack/phase-2/pilots-renamed/wave-03/trace-floe/ruleset.json
@@ -1,0 +1,63 @@
+{
+  "name": "trailhead-wave03-trace-floe",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/dev", "refs/heads/staging", "refs/heads/main"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": true,
+        "require_last_push_approval": true
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "required_status_checks": [
+          {
+            "context": "Trailhead",
+            "integration_id": null
+          },
+          {
+            "context": "CI / lint",
+            "integration_id": null
+          },
+          {
+            "context": "CI / test",
+            "integration_id": null
+          },
+          {
+            "context": "Deploy / staging",
+            "integration_id": null
+          },
+          {
+            "context": "Deploy / production",
+            "integration_id": null
+          }
+        ]
+      }
+    },
+    {
+      "type": "required_deployments",
+      "parameters": {
+        "required_deployment_environments": ["staging", "production"]
+      }
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": 1,
+      "actor_type": "OrganizationAdmin",
+      "bypass_mode": "pull_request"
+    }
+  ]
+}

--- a/examples/policy-pack/phase-2/pilots-renamed/wave-03/trace-floe/trailhead-enforced-workflow.yml
+++ b/examples/policy-pack/phase-2/pilots-renamed/wave-03/trace-floe/trailhead-enforced-workflow.yml
@@ -1,0 +1,59 @@
+name: Trailhead enforced gate (trace-floe)
+
+on:
+  pull_request:
+    branches:
+      - dev
+      - staging
+      - main
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+  security-events: read
+  deployments: read
+
+jobs:
+  trailhead:
+    name: Trailhead
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: KomatikAI/trailhead@v3
+        with:
+          environment: ${{ github.base_ref == 'main' && 'production' || github.base_ref == 'staging' && 'staging' || 'dev' }}
+          dora-metrics: "true"
+          security-gate: "true"
+
+  ci-lint:
+    name: CI / lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "Replace with lint command"
+
+  ci-test:
+    name: CI / test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "Replace with test command"
+
+  deploy-staging:
+    name: Deploy / staging
+    if: github.base_ref == 'staging'
+    needs: [trailhead, ci-lint, ci-test]
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      - run: echo "Replace with staging deployment validation check"
+
+  deploy-production:
+    name: Deploy / production
+    if: github.base_ref == 'main'
+    needs: [trailhead, ci-lint, ci-test]
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - run: echo "Replace with production deployment validation check"

--- a/examples/policy-pack/phase-2/pilots-renamed/wave-03/traverse/baseline.md
+++ b/examples/policy-pack/phase-2/pilots-renamed/wave-03/traverse/baseline.md
@@ -1,0 +1,23 @@
+# Baseline - traverse (Wave 03)
+
+## Scope
+
+- Repository: `traverse`
+- Criticality: medium
+- Branch strategy: progressive (`dev/staging/main`)
+- Evaluation window: last 30 days
+
+## Metrics
+
+| Metric              | Current | Target | Notes                                       |
+| ------------------- | ------- | ------ | ------------------------------------------- |
+| Block rate          | tbd     | 15-25% | Balance risk gating with delivery velocity. |
+| Rollback rate       | tbd     | <= 4%  | Production rollbacks only.                  |
+| CFR                 | tbd     | <= 8%  | Track alongside canary outcomes.            |
+| Median unblock time | tbd     | <= 3h  | First block to fully green checks.          |
+
+## Owners
+
+- Repo owner: `tbd`
+- Release owner: `tbd`
+- Escalation owner: `tbd`

--- a/examples/policy-pack/phase-2/pilots-renamed/wave-03/traverse/ruleset.json
+++ b/examples/policy-pack/phase-2/pilots-renamed/wave-03/traverse/ruleset.json
@@ -1,0 +1,63 @@
+{
+  "name": "trailhead-wave03-traverse",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/dev", "refs/heads/staging", "refs/heads/main"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": true,
+        "require_last_push_approval": true
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "required_status_checks": [
+          {
+            "context": "Trailhead",
+            "integration_id": null
+          },
+          {
+            "context": "CI / lint",
+            "integration_id": null
+          },
+          {
+            "context": "CI / test",
+            "integration_id": null
+          },
+          {
+            "context": "Deploy / staging",
+            "integration_id": null
+          },
+          {
+            "context": "Deploy / production",
+            "integration_id": null
+          }
+        ]
+      }
+    },
+    {
+      "type": "required_deployments",
+      "parameters": {
+        "required_deployment_environments": ["staging", "production"]
+      }
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": 1,
+      "actor_type": "OrganizationAdmin",
+      "bypass_mode": "pull_request"
+    }
+  ]
+}

--- a/examples/policy-pack/phase-2/pilots-renamed/wave-03/traverse/trailhead-enforced-workflow.yml
+++ b/examples/policy-pack/phase-2/pilots-renamed/wave-03/traverse/trailhead-enforced-workflow.yml
@@ -1,0 +1,59 @@
+name: Trailhead enforced gate (traverse)
+
+on:
+  pull_request:
+    branches:
+      - dev
+      - staging
+      - main
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+  security-events: read
+  deployments: read
+
+jobs:
+  trailhead:
+    name: Trailhead
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: KomatikAI/trailhead@v3
+        with:
+          environment: ${{ github.base_ref == 'main' && 'production' || github.base_ref == 'staging' && 'staging' || 'dev' }}
+          dora-metrics: "true"
+          security-gate: "true"
+
+  ci-lint:
+    name: CI / lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "Replace with lint command"
+
+  ci-test:
+    name: CI / test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "Replace with test command"
+
+  deploy-staging:
+    name: Deploy / staging
+    if: github.base_ref == 'staging'
+    needs: [trailhead, ci-lint, ci-test]
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      - run: echo "Replace with staging deployment validation check"
+
+  deploy-production:
+    name: Deploy / production
+    if: github.base_ref == 'main'
+    needs: [trailhead, ci-lint, ci-test]
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - run: echo "Replace with production deployment validation check"

--- a/examples/policy-pack/phase-2/pilots-renamed/wave-04/README.md
+++ b/examples/policy-pack/phase-2/pilots-renamed/wave-04/README.md
@@ -1,0 +1,19 @@
+# Wave 04 - Execution Bundle
+
+Repos in this wave:
+
+- `trace-triage`
+- `trace-watchtower`
+
+Each repo folder contains:
+
+- `ruleset.json`
+- `trailhead-enforced-workflow.yml`
+- `baseline.md`
+
+## Apply Order
+
+1. Review and apply `ruleset.json` in GitHub rulesets.
+2. Add `trailhead-enforced-workflow.yml` to `.github/workflows/`.
+3. Fill `baseline.md` current values from last 30 days.
+4. Run one week in enforced mode and perform Phase 2 exit review.

--- a/examples/policy-pack/phase-2/pilots-renamed/wave-04/trace-triage/baseline.md
+++ b/examples/policy-pack/phase-2/pilots-renamed/wave-04/trace-triage/baseline.md
@@ -1,0 +1,23 @@
+# Baseline - trace-triage (Wave 04)
+
+## Scope
+
+- Repository: `trace-triage`
+- Criticality: high
+- Branch strategy: progressive (`dev/staging/main`)
+- Evaluation window: last 30 days
+
+## Metrics
+
+| Metric              | Current | Target | Notes                                                  |
+| ------------------- | ------- | ------ | ------------------------------------------------------ |
+| Block rate          | tbd     | 20-30% | Rescue/incident flow warrants strict release controls. |
+| Rollback rate       | tbd     | <= 3%  | Production rollbacks only.                             |
+| CFR                 | tbd     | <= 6%  | Track with incident classification and recovery trend. |
+| Median unblock time | tbd     | <= 2h  | High-criticality fast remediation expectation.         |
+
+## Owners
+
+- Repo owner: `tbd`
+- Release owner: `tbd`
+- Escalation owner: `tbd`

--- a/examples/policy-pack/phase-2/pilots-renamed/wave-04/trace-triage/ruleset.json
+++ b/examples/policy-pack/phase-2/pilots-renamed/wave-04/trace-triage/ruleset.json
@@ -1,0 +1,63 @@
+{
+  "name": "trailhead-wave04-trace-triage",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/dev", "refs/heads/staging", "refs/heads/main"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": true,
+        "require_last_push_approval": true
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "required_status_checks": [
+          {
+            "context": "Trailhead",
+            "integration_id": null
+          },
+          {
+            "context": "CI / lint",
+            "integration_id": null
+          },
+          {
+            "context": "CI / test",
+            "integration_id": null
+          },
+          {
+            "context": "Deploy / staging",
+            "integration_id": null
+          },
+          {
+            "context": "Deploy / production",
+            "integration_id": null
+          }
+        ]
+      }
+    },
+    {
+      "type": "required_deployments",
+      "parameters": {
+        "required_deployment_environments": ["staging", "production"]
+      }
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": 1,
+      "actor_type": "OrganizationAdmin",
+      "bypass_mode": "pull_request"
+    }
+  ]
+}

--- a/examples/policy-pack/phase-2/pilots-renamed/wave-04/trace-triage/trailhead-enforced-workflow.yml
+++ b/examples/policy-pack/phase-2/pilots-renamed/wave-04/trace-triage/trailhead-enforced-workflow.yml
@@ -1,0 +1,59 @@
+name: Trailhead enforced gate (trace-triage)
+
+on:
+  pull_request:
+    branches:
+      - dev
+      - staging
+      - main
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+  security-events: read
+  deployments: read
+
+jobs:
+  trailhead:
+    name: Trailhead
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: KomatikAI/trailhead@v3
+        with:
+          environment: ${{ github.base_ref == 'main' && 'production' || github.base_ref == 'staging' && 'staging' || 'dev' }}
+          dora-metrics: "true"
+          security-gate: "true"
+
+  ci-lint:
+    name: CI / lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "Replace with lint command"
+
+  ci-test:
+    name: CI / test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "Replace with test command"
+
+  deploy-staging:
+    name: Deploy / staging
+    if: github.base_ref == 'staging'
+    needs: [trailhead, ci-lint, ci-test]
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      - run: echo "Replace with staging deployment validation check"
+
+  deploy-production:
+    name: Deploy / production
+    if: github.base_ref == 'main'
+    needs: [trailhead, ci-lint, ci-test]
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - run: echo "Replace with production deployment validation check"

--- a/examples/policy-pack/phase-2/pilots-renamed/wave-04/trace-watchtower/baseline.md
+++ b/examples/policy-pack/phase-2/pilots-renamed/wave-04/trace-watchtower/baseline.md
@@ -1,0 +1,23 @@
+# Baseline - trace-watchtower (Wave 04)
+
+## Scope
+
+- Repository: `trace-watchtower`
+- Criticality: high
+- Branch strategy: progressive (`dev/staging/main`)
+- Evaluation window: last 30 days
+
+## Metrics
+
+| Metric              | Current | Target | Notes                                                    |
+| ------------------- | ------- | ------ | -------------------------------------------------------- |
+| Block rate          | tbd     | 20-30% | Governance/security visibility path needs strict gating. |
+| Rollback rate       | tbd     | <= 3%  | Production rollbacks only.                               |
+| CFR                 | tbd     | <= 6%  | Track with incident and policy-change context.           |
+| Median unblock time | tbd     | <= 2h  | High-criticality remediation speed target.               |
+
+## Owners
+
+- Repo owner: `tbd`
+- Release owner: `tbd`
+- Escalation owner: `tbd`

--- a/examples/policy-pack/phase-2/pilots-renamed/wave-04/trace-watchtower/ruleset.json
+++ b/examples/policy-pack/phase-2/pilots-renamed/wave-04/trace-watchtower/ruleset.json
@@ -1,0 +1,63 @@
+{
+  "name": "trailhead-wave04-trace-watchtower",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/dev", "refs/heads/staging", "refs/heads/main"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": true,
+        "require_last_push_approval": true
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "required_status_checks": [
+          {
+            "context": "Trailhead",
+            "integration_id": null
+          },
+          {
+            "context": "CI / lint",
+            "integration_id": null
+          },
+          {
+            "context": "CI / test",
+            "integration_id": null
+          },
+          {
+            "context": "Deploy / staging",
+            "integration_id": null
+          },
+          {
+            "context": "Deploy / production",
+            "integration_id": null
+          }
+        ]
+      }
+    },
+    {
+      "type": "required_deployments",
+      "parameters": {
+        "required_deployment_environments": ["staging", "production"]
+      }
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": 1,
+      "actor_type": "OrganizationAdmin",
+      "bypass_mode": "pull_request"
+    }
+  ]
+}

--- a/examples/policy-pack/phase-2/pilots-renamed/wave-04/trace-watchtower/trailhead-enforced-workflow.yml
+++ b/examples/policy-pack/phase-2/pilots-renamed/wave-04/trace-watchtower/trailhead-enforced-workflow.yml
@@ -1,0 +1,59 @@
+name: Trailhead enforced gate (trace-watchtower)
+
+on:
+  pull_request:
+    branches:
+      - dev
+      - staging
+      - main
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+  security-events: read
+  deployments: read
+
+jobs:
+  trailhead:
+    name: Trailhead
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: KomatikAI/trailhead@v3
+        with:
+          environment: ${{ github.base_ref == 'main' && 'production' || github.base_ref == 'staging' && 'staging' || 'dev' }}
+          dora-metrics: "true"
+          security-gate: "true"
+
+  ci-lint:
+    name: CI / lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "Replace with lint command"
+
+  ci-test:
+    name: CI / test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "Replace with test command"
+
+  deploy-staging:
+    name: Deploy / staging
+    if: github.base_ref == 'staging'
+    needs: [trailhead, ci-lint, ci-test]
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      - run: echo "Replace with staging deployment validation check"
+
+  deploy-production:
+    name: Deploy / production
+    if: github.base_ref == 'main'
+    needs: [trailhead, ci-lint, ci-test]
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - run: echo "Replace with production deployment validation check"

--- a/examples/policy-pack/phase-2/pilots-renamed/waves.yml
+++ b/examples/policy-pack/phase-2/pilots-renamed/waves.yml
@@ -1,0 +1,23 @@
+wave_defaults:
+  repos_per_wave: 3
+  branch_strategy_default: progressive
+  template_ruleset: examples/policy-pack/github-ruleset.progressive.json
+  template_workflow: examples/policy-pack/phase-2/trailhead-enforced-workflow.yml
+
+waves:
+  - id: wave-01
+    repos: [cairn, gtm, kindling]
+    priority: medium
+    objective: "Establish first stable enforced cohort."
+  - id: wave-02
+    repos: [komatik-vector, lodge, pack]
+    priority: high
+    objective: "Expand to infra + component mix and validate noise profile."
+  - id: wave-03
+    repos: [sundog, traverse, trace-floe]
+    priority: high
+    objective: "Include one high-criticality trace repo with two medium peers."
+  - id: wave-04
+    repos: [trace-triage, trace-watchtower]
+    priority: critical
+    objective: "Finish highest-criticality governance and rescue paths."

--- a/examples/policy-pack/phase-2/pilots/README.md
+++ b/examples/policy-pack/phase-2/pilots/README.md
@@ -1,0 +1,24 @@
+# Pilot Repo Pack
+
+This folder contains a concrete Phase 2 pilot rollout for three repositories:
+
+- low criticality: `komatik-base-camp`
+- medium criticality: `trailhead`
+- high criticality: `komatik`
+
+## What Is Included Per Repo
+
+- `ruleset.json` - GitHub ruleset template for required checks/deployments
+- `trailhead-enforced-workflow.yml` - workflow template with stable check names
+- `baseline.md` - prefilled baseline worksheet for block rate, rollback rate, CFR, and unblock time
+
+## Assumptions to Verify
+
+- branch strategy:
+  - `komatik-base-camp`: main-only
+  - `trailhead`: main-only
+  - `komatik`: dev/staging/main
+- deployment environments:
+  - `staging`, `production`
+
+If your repo settings differ, adjust branch names and required deployment environments in each file.

--- a/examples/policy-pack/phase-2/pilots/komatik-base-camp/baseline.md
+++ b/examples/policy-pack/phase-2/pilots/komatik-base-camp/baseline.md
@@ -1,0 +1,31 @@
+# Pilot Baseline - komatik-base-camp (Low)
+
+## Scope
+
+- Repository: `komatik-base-camp`
+- Criticality: low
+- Branch strategy: main-only
+- Evaluation window: last 30 days
+
+## Baseline Metrics
+
+| Metric                    | Current | Target (Phase 2) | Notes                                     |
+| ------------------------- | ------- | ---------------- | ----------------------------------------- |
+| Block rate                | tbd     | <= 20%           | Keep noise manageable while enforcing.    |
+| Rollback rate             | tbd     | <= 5%            | Track production reversals only.          |
+| Change failure rate (CFR) | tbd     | <= 10%           | Diagnose with trends, not quota pressure. |
+| Median unblock time       | tbd     | <= 4h            | Time from first block to green checks.    |
+
+## Common Block Categories
+
+- [ ] Missing tests
+- [ ] Security alerts
+- [ ] Sensitive file churn
+- [ ] Deployment instability
+- [ ] Freeze window violation
+
+## Owners
+
+- Repo owner: `tbd`
+- Release owner: `tbd`
+- Escalation owner: `tbd`

--- a/examples/policy-pack/phase-2/pilots/komatik-base-camp/ruleset.json
+++ b/examples/policy-pack/phase-2/pilots/komatik-base-camp/ruleset.json
@@ -1,0 +1,59 @@
+{
+  "name": "trailhead-pilot-low-komatik-base-camp",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/main"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": true,
+        "require_last_push_approval": true
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "required_status_checks": [
+          {
+            "context": "Trailhead",
+            "integration_id": null
+          },
+          {
+            "context": "CI / lint",
+            "integration_id": null
+          },
+          {
+            "context": "CI / test",
+            "integration_id": null
+          },
+          {
+            "context": "Deploy / production",
+            "integration_id": null
+          }
+        ]
+      }
+    },
+    {
+      "type": "required_deployments",
+      "parameters": {
+        "required_deployment_environments": ["production"]
+      }
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": 1,
+      "actor_type": "OrganizationAdmin",
+      "bypass_mode": "pull_request"
+    }
+  ]
+}

--- a/examples/policy-pack/phase-2/pilots/komatik-base-camp/trailhead-enforced-workflow.yml
+++ b/examples/policy-pack/phase-2/pilots/komatik-base-camp/trailhead-enforced-workflow.yml
@@ -1,0 +1,47 @@
+name: Trailhead enforced gate (komatik-base-camp)
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+  security-events: read
+  deployments: read
+
+jobs:
+  trailhead:
+    name: Trailhead
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: KomatikAI/trailhead@v3
+        with:
+          environment: production
+          dora-metrics: "true"
+          security-gate: "true"
+
+  ci-lint:
+    name: CI / lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "Replace with lint command"
+
+  ci-test:
+    name: CI / test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "Replace with test command"
+
+  deploy-production:
+    name: Deploy / production
+    needs: [trailhead, ci-lint, ci-test]
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - run: echo "Replace with production deployment validation check"

--- a/examples/policy-pack/phase-2/pilots/komatik/baseline.md
+++ b/examples/policy-pack/phase-2/pilots/komatik/baseline.md
@@ -1,0 +1,31 @@
+# Pilot Baseline - komatik (High)
+
+## Scope
+
+- Repository: `komatik`
+- Criticality: high
+- Branch strategy: dev/staging/main
+- Evaluation window: last 30 days
+
+## Baseline Metrics
+
+| Metric                    | Current | Target (Phase 2) | Notes                                                |
+| ------------------------- | ------- | ---------------- | ---------------------------------------------------- |
+| Block rate                | tbd     | 20-30%           | Higher guardrail sensitivity is expected.            |
+| Rollback rate             | tbd     | <= 3%            | Prioritize rollback prevention in production.        |
+| Change failure rate (CFR) | tbd     | <= 6%            | Track trend and correlate to high-risk categories.   |
+| Median unblock time       | tbd     | <= 2h            | Fast response expectation for high-criticality path. |
+
+## Common Block Categories
+
+- [ ] Missing tests
+- [ ] Security alerts
+- [ ] Sensitive file churn
+- [ ] Deployment instability
+- [ ] Freeze window violation
+
+## Owners
+
+- Repo owner: `tbd`
+- Release owner: `tbd`
+- Escalation owner: `tbd`

--- a/examples/policy-pack/phase-2/pilots/komatik/ruleset.json
+++ b/examples/policy-pack/phase-2/pilots/komatik/ruleset.json
@@ -1,0 +1,63 @@
+{
+  "name": "trailhead-pilot-high-komatik",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/dev", "refs/heads/staging", "refs/heads/main"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": true,
+        "require_last_push_approval": true
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "required_status_checks": [
+          {
+            "context": "Trailhead",
+            "integration_id": null
+          },
+          {
+            "context": "CI / lint",
+            "integration_id": null
+          },
+          {
+            "context": "CI / test",
+            "integration_id": null
+          },
+          {
+            "context": "Deploy / staging",
+            "integration_id": null
+          },
+          {
+            "context": "Deploy / production",
+            "integration_id": null
+          }
+        ]
+      }
+    },
+    {
+      "type": "required_deployments",
+      "parameters": {
+        "required_deployment_environments": ["staging", "production"]
+      }
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": 1,
+      "actor_type": "OrganizationAdmin",
+      "bypass_mode": "pull_request"
+    }
+  ]
+}

--- a/examples/policy-pack/phase-2/pilots/komatik/trailhead-enforced-workflow.yml
+++ b/examples/policy-pack/phase-2/pilots/komatik/trailhead-enforced-workflow.yml
@@ -1,0 +1,59 @@
+name: Trailhead enforced gate (komatik)
+
+on:
+  pull_request:
+    branches:
+      - dev
+      - staging
+      - main
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+  security-events: read
+  deployments: read
+
+jobs:
+  trailhead:
+    name: Trailhead
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: KomatikAI/trailhead@v3
+        with:
+          environment: ${{ github.base_ref == 'main' && 'production' || github.base_ref == 'staging' && 'staging' || 'dev' }}
+          dora-metrics: "true"
+          security-gate: "true"
+
+  ci-lint:
+    name: CI / lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "Replace with lint command"
+
+  ci-test:
+    name: CI / test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "Replace with test command"
+
+  deploy-staging:
+    name: Deploy / staging
+    if: github.base_ref == 'staging'
+    needs: [trailhead, ci-lint, ci-test]
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      - run: echo "Replace with staging deployment validation check"
+
+  deploy-production:
+    name: Deploy / production
+    if: github.base_ref == 'main'
+    needs: [trailhead, ci-lint, ci-test]
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - run: echo "Replace with production deployment validation check"

--- a/examples/policy-pack/phase-2/pilots/repos.yml
+++ b/examples/policy-pack/phase-2/pilots/repos.yml
@@ -1,0 +1,29 @@
+pilot_repos:
+  - name: komatik-base-camp
+    criticality: low
+    branch_strategy: main-only
+    default_branch: main
+    required_deployments:
+      - production
+    owners:
+      - tbd
+    notes: "Dashboard and coordination surface; lower direct production blast radius."
+  - name: trailhead
+    criticality: medium
+    branch_strategy: main-only
+    default_branch: main
+    required_deployments:
+      - production
+    owners:
+      - tbd
+    notes: "Deployment-control layer; medium platform-wide operational risk."
+  - name: komatik
+    criticality: high
+    branch_strategy: progressive
+    default_branch: dev
+    required_deployments:
+      - staging
+      - production
+    owners:
+      - tbd
+    notes: "Core platform with auth/payments and highest customer impact."

--- a/examples/policy-pack/phase-2/pilots/trailhead/baseline.md
+++ b/examples/policy-pack/phase-2/pilots/trailhead/baseline.md
@@ -1,0 +1,31 @@
+# Pilot Baseline - trailhead (Medium)
+
+## Scope
+
+- Repository: `trailhead`
+- Criticality: medium
+- Branch strategy: main-only
+- Evaluation window: last 30 days
+
+## Baseline Metrics
+
+| Metric                    | Current | Target (Phase 2) | Notes                                                   |
+| ------------------------- | ------- | ---------------- | ------------------------------------------------------- |
+| Block rate                | tbd     | 15-25%           | Expect stronger enforcement than low-criticality repos. |
+| Rollback rate             | tbd     | <= 4%            | Focus on production release reversals.                  |
+| Change failure rate (CFR) | tbd     | <= 8%            | Use trend over single-window variance.                  |
+| Median unblock time       | tbd     | <= 3h            | Time to resolve from blocked to green.                  |
+
+## Common Block Categories
+
+- [ ] Missing tests
+- [ ] Security alerts
+- [ ] Sensitive file churn
+- [ ] Deployment instability
+- [ ] Freeze window violation
+
+## Owners
+
+- Repo owner: `tbd`
+- Release owner: `tbd`
+- Escalation owner: `tbd`

--- a/examples/policy-pack/phase-2/pilots/trailhead/ruleset.json
+++ b/examples/policy-pack/phase-2/pilots/trailhead/ruleset.json
@@ -1,0 +1,59 @@
+{
+  "name": "trailhead-pilot-medium-trailhead",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/main"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": true,
+        "require_last_push_approval": true
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "required_status_checks": [
+          {
+            "context": "Trailhead",
+            "integration_id": null
+          },
+          {
+            "context": "CI / lint",
+            "integration_id": null
+          },
+          {
+            "context": "CI / test",
+            "integration_id": null
+          },
+          {
+            "context": "Deploy / production",
+            "integration_id": null
+          }
+        ]
+      }
+    },
+    {
+      "type": "required_deployments",
+      "parameters": {
+        "required_deployment_environments": ["production"]
+      }
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": 1,
+      "actor_type": "OrganizationAdmin",
+      "bypass_mode": "pull_request"
+    }
+  ]
+}

--- a/examples/policy-pack/phase-2/pilots/trailhead/trailhead-enforced-workflow.yml
+++ b/examples/policy-pack/phase-2/pilots/trailhead/trailhead-enforced-workflow.yml
@@ -1,0 +1,47 @@
+name: Trailhead enforced gate (trailhead)
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+  security-events: read
+  deployments: read
+
+jobs:
+  trailhead:
+    name: Trailhead
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: KomatikAI/trailhead@v3
+        with:
+          environment: production
+          dora-metrics: "true"
+          security-gate: "true"
+
+  ci-lint:
+    name: CI / lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "Replace with lint command"
+
+  ci-test:
+    name: CI / test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "Replace with test command"
+
+  deploy-production:
+    name: Deploy / production
+    needs: [trailhead, ci-lint, ci-test]
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - run: echo "Replace with production deployment validation check"

--- a/examples/policy-pack/phase-2/required-checks-and-deployments.md
+++ b/examples/policy-pack/phase-2/required-checks-and-deployments.md
@@ -1,0 +1,41 @@
+# Required Checks and Deployments
+
+Use this to wire Trailhead as an enforced control (not advisory).
+
+## Required Status Checks
+
+Configure required checks with explicit, non-ambiguous names:
+
+- `Trailhead`
+- `CI / lint`
+- `CI / test`
+- `Deploy / staging` (when applicable)
+- `Deploy / production` (when applicable)
+
+Avoid contexts like `build`, `checks`, or `pipeline`.
+
+## Required Deployments
+
+Choose per branch model:
+
+- main-only model:
+  - require deployment to `production` for merges to `main`
+- progressive model:
+  - require deployment to `staging` for merges to `staging`
+  - require deployment to `production` for merges to `main`
+
+## Merge Queue Guidance
+
+Enable merge queue on branches with high PR throughput to reduce flaky rebase races.
+
+Suggested trigger:
+
+- more than 15 PR merges/week on a branch
+- or repeated merge conflict churn in queue-free mode
+
+## Restricted Bypass
+
+- Restrict bypass actors to approved release admins only.
+- Prefer PR-scoped bypass mode over global bypass mode.
+- Require ticketed override metadata when any `override-*` input is set.
+- Review all bypass activity weekly.

--- a/examples/policy-pack/phase-2/threshold-archetypes.yml
+++ b/examples/policy-pack/phase-2/threshold-archetypes.yml
@@ -1,0 +1,49 @@
+# Suggested threshold baselines by repository archetype.
+# Calibrate after collecting at least 2-4 weeks of pilot signals.
+
+archetypes:
+  application:
+    description: "Customer-facing app repos with frequent releases."
+    thresholds:
+      risk: 72
+      warn: 52
+    environments:
+      production:
+        risk: 65
+        warn: 45
+      staging:
+        risk: 75
+        warn: 55
+      dev:
+        risk: 82
+        warn: 62
+  infrastructure:
+    description: "Infra/platform repos with higher blast radius."
+    thresholds:
+      risk: 68
+      warn: 48
+    environments:
+      production:
+        risk: 60
+        warn: 40
+      staging:
+        risk: 70
+        warn: 50
+      dev:
+        risk: 78
+        warn: 58
+  monorepo-component:
+    description: "Monorepos with service/component boundaries."
+    thresholds:
+      risk: 75
+      warn: 55
+    environments:
+      production:
+        risk: 66
+        warn: 46
+      staging:
+        risk: 76
+        warn: 56
+      dev:
+        risk: 84
+        warn: 64

--- a/examples/policy-pack/phase-2/trailhead-enforced-workflow.yml
+++ b/examples/policy-pack/phase-2/trailhead-enforced-workflow.yml
@@ -1,0 +1,59 @@
+name: Trailhead enforced gate
+
+on:
+  pull_request:
+    branches:
+      - main
+      - staging
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+  security-events: read
+  deployments: read
+
+jobs:
+  trailhead:
+    name: Trailhead
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: KomatikAI/trailhead@v3
+        id: trailhead
+        with:
+          environment: ${{ github.base_ref == 'main' && 'production' || 'staging' }}
+          dora-metrics: "true"
+          security-gate: "true"
+
+  ci-lint:
+    name: CI / lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "Replace with lint command"
+
+  ci-test:
+    name: CI / test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "Replace with test command"
+
+  deploy-staging:
+    name: Deploy / staging
+    if: github.base_ref == 'staging'
+    needs: [trailhead, ci-lint, ci-test]
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      - run: echo "Replace with staging deployment validation check"
+
+  deploy-production:
+    name: Deploy / production
+    if: github.base_ref == 'main'
+    needs: [trailhead, ci-lint, ci-test]
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - run: echo "Replace with production deployment validation check"

--- a/examples/policy-pack/pilot-baseline-template.md
+++ b/examples/policy-pack/pilot-baseline-template.md
@@ -1,0 +1,43 @@
+# Trailhead Pilot Baseline
+
+Use this before enabling hard enforcement.
+
+## Pilot Scope
+
+| Criticality | Repository | Branch Strategy | Owner | Start Date |
+| ----------- | ---------- | --------------- | ----- | ---------- |
+| Low         |            |                 |       |            |
+| Medium      |            |                 |       |            |
+| High        |            |                 |       |            |
+
+## Baseline Metrics (Last 30 Days)
+
+| Repository | Block Rate | Rollback Rate | Change Failure Rate (CFR) | Median Unblock Time |
+| ---------- | ---------- | ------------- | ------------------------- | ------------------- |
+|            |            |               |                           |                     |
+|            |            |               |                           |                     |
+|            |            |               |                           |                     |
+
+## Common Block Causes
+
+- [ ] Missing tests
+- [ ] Sensitive file churn
+- [ ] Security alerts
+- [ ] Deployment instability
+- [ ] Freeze window violation
+- [ ] Other:
+
+## Override Baseline
+
+| Repository | Override Count | Expired Overrides | Avg Override Age | Top Owner |
+| ---------- | -------------- | ----------------- | ---------------- | --------- |
+|            |                |                   |                  |           |
+|            |                |                   |                  |           |
+|            |                |                   |                  |           |
+
+## Exit Check (Phase 1 -> Phase 2)
+
+- [ ] Environment-aware defaults are active.
+- [ ] Override metadata is required and auditable.
+- [ ] Starter config + enforcement templates are adopted in pilot repos.
+- [ ] Baseline metrics are captured and shared.

--- a/examples/policy-pack/trailhead-starter.main-only.yml
+++ b/examples/policy-pack/trailhead-starter.main-only.yml
@@ -1,0 +1,26 @@
+# Starter policy for repositories using main only.
+
+thresholds:
+  risk: 75
+  warn: 55
+
+environments:
+  production:
+    risk: 65
+    warn: 45
+    require_security_clear: true
+  dev:
+    risk: 80
+    warn: 60
+
+security:
+  severity_threshold: warning
+  block_on_critical: true
+
+freeze:
+  - days: ["friday", "saturday"]
+    afterHour: 15
+    message: "Release freeze window in effect"
+
+ignore:
+  - "*.generated.ts"

--- a/examples/policy-pack/trailhead-starter.progressive.yml
+++ b/examples/policy-pack/trailhead-starter.progressive.yml
@@ -1,0 +1,29 @@
+# Starter policy for repositories using dev -> staging -> main promotion.
+
+thresholds:
+  risk: 80
+  warn: 60
+
+environments:
+  dev:
+    risk: 85
+    warn: 65
+  staging:
+    risk: 75
+    warn: 55
+  production:
+    risk: 65
+    warn: 45
+    require_security_clear: true
+
+security:
+  severity_threshold: warning
+  block_on_critical: true
+
+canary:
+  webhook_type: generic
+
+freeze:
+  - days: ["friday"]
+    afterHour: 15
+    message: "No Friday afternoon promotions"

--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -405,6 +405,53 @@ describe("run (main entrypoint)", () => {
     expect(mockSetFailed).not.toHaveBeenCalled();
   });
 
+  it("defaults to fail-closed for production when fail-mode input is empty", async () => {
+    setupInputs({ "api-key": "test-key", environment: "production" });
+    mockEvaluateGate.mockRejectedValue(new Error("boom"));
+    await runMain();
+
+    expect(mockSetFailed).toHaveBeenCalledWith(expect.stringContaining("fail-closed"));
+  });
+
+  it("applies governed overrides when metadata is complete", async () => {
+    setupInputs({
+      "api-key": "test-key",
+      "override-risk-threshold": "62",
+      "override-warn-threshold": "42",
+      "override-fail-mode": "closed",
+      "override-reason": "Hotfix release window",
+      "override-owner": "release-manager",
+      "override-ticket": "OPS-1234",
+      "override-expires-at": "2099-01-01T00:00:00Z",
+    });
+    mockEvaluateGate.mockResolvedValue(makeEvaluation());
+    await runMain();
+
+    expect(mockEvaluateGate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        riskThreshold: 62,
+        warnThreshold: 42,
+        failMode: "closed",
+      }),
+      "abc1234567890",
+      42,
+    );
+  });
+
+  it("fails when override metadata is incomplete", async () => {
+    setupInputs({
+      "api-key": "test-key",
+      "override-risk-threshold": "62",
+      "override-owner": "release-manager",
+    });
+    await runMain();
+
+    expect(mockSetFailed).toHaveBeenCalledWith(
+      expect.stringContaining("Invalid policy override"),
+    );
+    expect(mockEvaluateGate).not.toHaveBeenCalled();
+  });
+
   it("runs self-heal on warn when enabled with test failures", async () => {
     setupInputs({ "api-key": "test-key", "github-token": "ghp_test" });
     mockEvaluateGate.mockResolvedValue(

--- a/src/gate.ts
+++ b/src/gate.ts
@@ -1159,6 +1159,28 @@ export function formatGateReport(
     lines.push(`**Risk:** ${buildScoreBar(evaluation.riskScore, riskThreshold)}`, ``);
   }
 
+  if (evaluation.policyOverride) {
+    const override = evaluation.policyOverride;
+    const changes: string[] = [];
+    if (override.changes.failMode) changes.push(`fail-mode=${override.changes.failMode}`);
+    if (override.changes.riskThreshold !== undefined) {
+      changes.push(`risk-threshold=${override.changes.riskThreshold}`);
+    }
+    if (override.changes.warnThreshold !== undefined) {
+      changes.push(`warn-threshold=${override.changes.warnThreshold}`);
+    }
+    lines.push(
+      `### Policy Override`,
+      ``,
+      `- Owner: \`${override.owner}\``,
+      `- Ticket: \`${override.linkedTicket}\``,
+      `- Reason: ${override.reason}`,
+      `- Expires: \`${override.expiresAt}\``,
+      `- Changes: ${changes.length > 0 ? changes.join(", ") : "none"}`,
+      ``,
+    );
+  }
+
   if (evaluation.riskFactors.length > 0) {
     lines.push(
       `<details><summary><strong>Risk Factor Breakdown</strong> (${evaluation.riskFactors.length} factors)</summary>`,

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,6 +22,26 @@ import { cypressHealer } from "./healers/cypress.js";
 import { fetchCodeScanningAlerts, formatSecuritySection } from "./security.js";
 import type { TrailheadConfig, TestRepairResult } from "./types.js";
 
+class PolicyOverrideError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PolicyOverrideError";
+  }
+}
+
+interface PolicyOverrideAudit {
+  owner: string;
+  reason: string;
+  linkedTicket: string;
+  expiresAt: string;
+  appliedAt: string;
+  changes: {
+    failMode?: "open" | "closed";
+    riskThreshold?: number;
+    warnThreshold?: number;
+  };
+}
+
 function initHealers(): void {
   registerHealer(jestHealer);
   registerHealer(playwrightHealer);
@@ -30,6 +50,79 @@ function initHealers(): void {
 
 function readEnv(primary: string, legacy?: string): string | undefined {
   return process.env[primary] ?? (legacy ? process.env[legacy] : undefined);
+}
+
+function parseThresholdInput(name: string): number | undefined {
+  const value = core.getInput(name);
+  if (!value) return undefined;
+  const parsed = parseInt(value, 10);
+  if (Number.isNaN(parsed) || parsed < 0 || parsed > 100) {
+    throw new PolicyOverrideError(`${name} must be an integer between 0 and 100`);
+  }
+  return parsed;
+}
+
+function resolveFailMode(
+  failModeInput: string,
+  environment: string | undefined,
+): "open" | "closed" {
+  const explicitFailMode = failModeInput as "open" | "closed" | "";
+  if (explicitFailMode === "open" || explicitFailMode === "closed") {
+    return explicitFailMode;
+  }
+  return environment === "production" ? "closed" : "open";
+}
+
+function resolvePolicyOverride(): PolicyOverrideAudit | null {
+  const overrideFailModeRaw = core.getInput("override-fail-mode");
+  const overrideFailMode =
+    overrideFailModeRaw === "open" || overrideFailModeRaw === "closed"
+      ? overrideFailModeRaw
+      : undefined;
+  const overrideRiskThreshold = parseThresholdInput("override-risk-threshold");
+  const overrideWarnThreshold = parseThresholdInput("override-warn-threshold");
+  const hasOverride =
+    overrideFailMode !== undefined ||
+    overrideRiskThreshold !== undefined ||
+    overrideWarnThreshold !== undefined;
+
+  if (!hasOverride) return null;
+
+  const reason = core.getInput("override-reason").trim();
+  const owner = core.getInput("override-owner").trim();
+  const linkedTicket = core.getInput("override-ticket").trim();
+  const expiresAt = core.getInput("override-expires-at").trim();
+
+  if (!reason || !owner || !linkedTicket || !expiresAt) {
+    throw new PolicyOverrideError(
+      "Overrides require override-reason, override-owner, override-ticket, and override-expires-at",
+    );
+  }
+
+  const expiresMs = Date.parse(expiresAt);
+  if (Number.isNaN(expiresMs)) {
+    throw new PolicyOverrideError(
+      "override-expires-at must be a valid ISO-8601 datetime",
+    );
+  }
+  if (expiresMs <= Date.now()) {
+    throw new PolicyOverrideError(
+      `Override expired at ${expiresAt}. Extend expiry before applying.`,
+    );
+  }
+
+  return {
+    owner,
+    reason,
+    linkedTicket,
+    expiresAt: new Date(expiresMs).toISOString(),
+    appliedAt: new Date().toISOString(),
+    changes: {
+      failMode: overrideFailMode,
+      riskThreshold: overrideRiskThreshold,
+      warnThreshold: overrideWarnThreshold,
+    },
+  };
 }
 
 async function runSelfHeal(
@@ -87,6 +180,9 @@ async function runSelfHeal(
 async function run(): Promise<void> {
   try {
     initHealers();
+    const environment = core.getInput("environment") || undefined;
+    const policyOverride = resolvePolicyOverride();
+    const failMode = resolveFailMode(core.getInput("fail-mode"), environment);
 
     const config: TrailheadConfig = {
       apiKey: core.getInput("api-key") || "",
@@ -100,7 +196,7 @@ async function run(): Promise<void> {
       warnThreshold: core.getInput("warn-threshold")
         ? parseInt(core.getInput("warn-threshold"), 10)
         : undefined,
-      failMode: (core.getInput("fail-mode") as "open" | "closed") || "open",
+      failMode,
       selfHeal: core.getInput("self-heal") !== "false",
       addRiskLabels: core.getInput("add-risk-labels") !== "false",
       reviewersOnRisk: core.getInput("reviewers-on-risk")
@@ -116,9 +212,25 @@ async function run(): Promise<void> {
         .map((s) => s.trim())
         .filter(Boolean),
       evaluationStoreUrl: core.getInput("evaluation-store-url") || undefined,
-      environment: core.getInput("environment") || undefined,
+      environment,
       securityGate: core.getInput("security-gate") !== "false",
     };
+
+    if (policyOverride?.changes.riskThreshold !== undefined) {
+      config.riskThreshold = policyOverride.changes.riskThreshold;
+    }
+    if (policyOverride?.changes.warnThreshold !== undefined) {
+      config.warnThreshold = policyOverride.changes.warnThreshold;
+    }
+    if (policyOverride?.changes.failMode !== undefined) {
+      config.failMode = policyOverride.changes.failMode;
+    }
+
+    if (policyOverride) {
+      core.warning(
+        `Governed override active (${policyOverride.linkedTicket}) by ${policyOverride.owner}; expires ${policyOverride.expiresAt}.`,
+      );
+    }
 
     const context = github.context;
     const commitSha = context.sha;
@@ -127,6 +239,9 @@ async function run(): Promise<void> {
     core.info(`Evaluating deployment gate for ${commitSha.substring(0, 7)}`);
 
     const evaluation = await evaluateGate(config, commitSha, prNumber);
+    if (policyOverride) {
+      evaluation.policyOverride = policyOverride;
+    }
 
     core.setOutput("health-score", evaluation.healthScore.toString());
     core.setOutput("risk-score", evaluation.riskScore.toString());
@@ -287,7 +402,13 @@ async function run(): Promise<void> {
       }
     }
   } catch (error) {
-    const failMode = core.getInput("fail-mode") || "open";
+    if (error instanceof PolicyOverrideError) {
+      core.setFailed(`Invalid policy override: ${error.message}`);
+      return;
+    }
+
+    const environment = core.getInput("environment") || undefined;
+    const failMode = resolveFailMode(core.getInput("fail-mode"), environment);
     if (failMode === "open") {
       core.warning(
         `Trailhead evaluation failed — proceeding with deployment (fail-open). Error: ${error}`,

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,6 +44,22 @@ export const GateEvaluation = z.object({
   reportUrl: z.string().url().optional(),
   environment: z.string().optional(),
   service: z.string().optional(),
+  policyOverride: z
+    .object({
+      owner: z.string(),
+      reason: z.string(),
+      linkedTicket: z.string(),
+      expiresAt: z.string(),
+      appliedAt: z.string(),
+      changes: z
+        .object({
+          failMode: z.enum(["open", "closed"]).optional(),
+          riskThreshold: z.number().min(0).max(100).optional(),
+          warnThreshold: z.number().min(0).max(100).optional(),
+        })
+        .default({}),
+    })
+    .optional(),
 });
 export type GateEvaluation = z.infer<typeof GateEvaluation>;
 


### PR DESCRIPTION
## Summary
- enforce environment-aware fail behavior in Trailhead runtime and add governed override controls that require owner, reason, ticket, and expiry metadata
- attach override audit metadata to evaluations/reports and cover the behavior with new main-entry tests
- publish Phase 1 and Phase 2 policy packs including starter configs, ruleset templates, canary/unblock runbooks, pilot bundles, renamed-repo wave artifacts, and an org-level rollout checklist
- align repository branch guidance docs to the current dev-default workflow

## Test plan
- [x] `npm run format:check`
- [x] `npm run lint`


Made with [Cursor](https://cursor.com)