### PR TITLE
chore(ci): skip CI on doc-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,10 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore: ['**/*.md', '**/*.mdx', 'docs/**', 'LICENSE', '.gitignore']
   pull_request:
     branches: [main]
+    paths-ignore: ['**/*.md', '**/*.mdx', 'docs/**', 'LICENSE', '.gitignore']
 
 permissions:
   contents: read


### PR DESCRIPTION
Adds `paths-ignore` (markdown/docs/LICENSE/.gitignore) to `ci.yml` so doc-only PRs don't trigger CI. Safe — no required status checks on this repo. Part of the fleet-wide smart-CI rollout. 🤖 Generated with [Claude Code](https://claude.com/claude-code)