### PR TITLE
feat(policy): E16 cross-repo impact registry and satellite webhooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to Trailhead will be documented in this file.
 ### Added
 
 - **CI manifest (E15)** — `ci-manifest.json` schema, `ci-manifest-path` action input, and orchestrator merge so path-filter job skips do not count as missing required checks. See [docs/ci-manifest.md](docs/ci-manifest.md).
+- **Cross-repo impact (E16)** — external consumer registry, satellite webhooks on contract changes, and Cross-Repo Impact section in Release Ready comments. See [docs/cross-repo-impact.md](docs/cross-repo-impact.md).
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -481,6 +481,7 @@ Interactive wizard that generates v2 `.trailhead.yml` and a `@v4` workflow with 
 | [docs/evaluation-storage.md](docs/evaluation-storage.md) | Cloud vs bring-your-own-store             |
 | [docs/marketplace-tiers.md](docs/marketplace-tiers.md)   | Free / Pro / Team plans                   |
 | [docs/ci-manifest.md](docs/ci-manifest.md)               | Path-filter CI manifest (v4.2)            |
+| [docs/cross-repo-impact.md](docs/cross-repo-impact.md)   | Consumer registry + satellite webhooks    |
 | [cloud/README.md](cloud/README.md)                       | Cloud API and local dev                   |
 
 - [Multi-CI templates](examples/) — GitLab CI and CircleCI configurations

--- a/dist/index.js
+++ b/dist/index.js
@@ -40687,6 +40687,19 @@ const GateEvaluation = objectType({
     context: MatchedContext.optional(),
     gateMode: GateMode.optional(),
     storePersisted: booleanType().optional(),
+    cross_repo_impact: objectType({
+        services: arrayType(objectType({
+            serviceName: stringType(),
+            touchedFiles: arrayType(stringType()),
+            consumers: arrayType(objectType({
+                id: stringType(),
+                repo: stringType().optional(),
+                branch: stringType().optional(),
+            })),
+            notify_webhook: stringType().url().optional(),
+        })),
+    })
+        .optional(),
 });
 const GateApiResponse = objectType({
     id: stringType().optional(),
@@ -40709,11 +40722,20 @@ const EnvironmentConfig = objectType({
     warn: numberType().min(0).max(100).optional(),
     require_security_clear: booleanType().optional(),
 });
+const ServiceConsumerRef = objectType({
+    repo: stringType().min(1),
+    name: stringType().optional(),
+    branch: stringType().optional(),
+    notify_webhook: stringType().url().optional(),
+});
+const ServiceConsumer = unionType([stringType(), ServiceConsumerRef]);
+const ConsumerRegistry = recordType(stringType(), ServiceConsumerRef);
 const ServiceMapping = objectType({
     paths: arrayType(stringType()),
     environment: stringType().optional(),
-    consumers: arrayType(stringType()).default([]),
+    consumers: arrayType(ServiceConsumer).default([]),
     contracts: arrayType(stringType()).default([]),
+    notify_webhook: stringType().url().optional(),
 });
 const SecurityConfig = objectType({
     severity_threshold: enumType(["error", "warning", "note", "none"]).default("warning"),
@@ -40782,6 +40804,7 @@ const RepoConfig = objectType({
     freeze: arrayType(FreezeWindow).default([]),
     environments: recordType(EnvironmentConfig).default({}),
     services: recordType(ServiceMapping).default({}),
+    consumer_registry: recordType(ServiceConsumerRef).default({}),
     security: SecurityConfig.default({}),
     canary: CanaryConfig.optional(),
     escalation: objectType({
@@ -40846,6 +40869,7 @@ const RepoConfig = objectType({
         cross_repo_impact: objectType({
             enabled: booleanType().default(true),
             mode: enumType(["warn", "block"]).default("warn"),
+            consumer_registry_path: stringType().optional(),
         })
             .default({}),
     })
@@ -41368,6 +41392,7 @@ const KNOWN_TOP_LEVEL_KEYS = new Set([
     "profiles",
     "thresholds",
     "ignore",
+    "consumer_registry",
     "freeze",
     "environments",
     "services",
@@ -41540,6 +41565,207 @@ function resolveGateMode(repoGateMode, schemaVersion, inputGateMode) {
         return repoGateMode;
     }
     return schemaVersion >= 2 ? "release-ready" : "risk-only";
+}
+
+;// CONCATENATED MODULE: external "node:fs"
+const external_node_fs_namespaceObject = require("node:fs");
+var external_node_fs_default = /*#__PURE__*/__nccwpck_require__.n(external_node_fs_namespaceObject);
+;// CONCATENATED MODULE: ./src/cross-repo-impact.ts
+
+
+
+
+function parseConsumerRegistry(raw) {
+    return ConsumerRegistry.parse(raw);
+}
+function loadConsumerRegistryFile(filePath) {
+    try {
+        const resolved = external_node_path_default().resolve(filePath);
+        const contents = external_node_fs_default().readFileSync(resolved, "utf8");
+        return parseConsumerRegistry(JSON.parse(contents));
+    }
+    catch {
+        return null;
+    }
+}
+function mergeConsumerRegistries(...registries) {
+    const merged = {};
+    for (const registry of registries) {
+        if (!registry)
+            continue;
+        Object.assign(merged, registry);
+    }
+    return merged;
+}
+function formatConsumerLabel(consumer) {
+    if (consumer.repo) {
+        const branch = consumer.branch ? `@${consumer.branch}` : "";
+        return `\`${consumer.repo}${branch}\``;
+    }
+    return `\`${consumer.id}\``;
+}
+function resolveConsumer(consumer, registry) {
+    if (typeof consumer === "string") {
+        const entry = registry[consumer];
+        if (entry) {
+            return {
+                id: entry.name ?? consumer,
+                repo: entry.repo,
+                branch: entry.branch,
+                notify_webhook: entry.notify_webhook,
+            };
+        }
+        return { id: consumer };
+    }
+    return {
+        id: consumer.name ?? consumer.repo,
+        repo: consumer.repo,
+        branch: consumer.branch,
+        notify_webhook: consumer.notify_webhook,
+    };
+}
+function detectCrossRepoImpact(files, repoConfig, externalRegistry) {
+    const cfg = repoConfig?.policies?.cross_repo_impact;
+    const empty = {
+        factor: null,
+        findings: [],
+        affectedConsumers: [],
+        services: [],
+    };
+    if (!cfg?.enabled)
+        return empty;
+    const registry = mergeConsumerRegistries(externalRegistry, repoConfig?.consumer_registry);
+    const affectedConsumers = new Set();
+    const findings = [];
+    const services = [];
+    for (const [serviceName, service] of Object.entries(repoConfig?.services ?? {})) {
+        const contractPatterns = service.contracts ?? [];
+        if (contractPatterns.length === 0)
+            continue;
+        const touchedFiles = files
+            .filter((f) => matchesGlobs(f.filename, contractPatterns))
+            .map((f) => f.filename);
+        if (touchedFiles.length === 0)
+            continue;
+        const resolvedConsumers = (service.consumers ?? []).map((consumer) => resolveConsumer(consumer, registry));
+        for (const consumer of resolvedConsumers) {
+            affectedConsumers.add(consumer.repo
+                ? `${consumer.repo}${consumer.branch ? `@${consumer.branch}` : ""}`
+                : consumer.id);
+        }
+        services.push({
+            serviceName,
+            touchedFiles,
+            consumers: resolvedConsumers,
+            notify_webhook: service.notify_webhook,
+        });
+        findings.push(`Contract surface changed for service "${serviceName}" (${touchedFiles.length} file(s)).`);
+    }
+    if (findings.length === 0)
+        return empty;
+    const consumerLabels = [...affectedConsumers];
+    return {
+        factor: {
+            type: "cross_repo_impact",
+            score: Math.min(100, 30 + consumerLabels.length * 15),
+            detail: {
+                findings,
+                affectedConsumers: consumerLabels,
+                services: services.map((service) => ({
+                    service: service.serviceName,
+                    touchedFiles: service.touchedFiles,
+                    consumers: service.consumers.map((consumer) => ({
+                        id: consumer.id,
+                        repo: consumer.repo,
+                        branch: consumer.branch,
+                    })),
+                })),
+                description: "Potential downstream consumer impact from contract changes",
+            },
+        },
+        findings,
+        affectedConsumers: consumerLabels,
+        services,
+    };
+}
+function collectCrossRepoWebhookDeliveries(impact) {
+    const deliveries = [];
+    const seen = new Set();
+    for (const service of impact.services) {
+        if (service.notify_webhook && !seen.has(service.notify_webhook)) {
+            seen.add(service.notify_webhook);
+            deliveries.push({ url: service.notify_webhook, serviceName: service.serviceName });
+        }
+        for (const consumer of service.consumers) {
+            if (!consumer.notify_webhook || seen.has(consumer.notify_webhook))
+                continue;
+            seen.add(consumer.notify_webhook);
+            deliveries.push({
+                url: consumer.notify_webhook,
+                serviceName: service.serviceName,
+                consumer,
+            });
+        }
+    }
+    return deliveries;
+}
+async function sendCrossRepoImpactWebhooks(impact, context, fetchImpl = fetch) {
+    const deliveries = collectCrossRepoWebhookDeliveries(impact);
+    if (deliveries.length === 0)
+        return;
+    await Promise.all(deliveries.map(async (delivery) => {
+        const service = impact.services.find((item) => item.serviceName === delivery.serviceName);
+        if (!service)
+            return;
+        const payload = {
+            event: "contract_change",
+            source_repo: context.repoId,
+            commit_sha: context.commitSha,
+            pr_number: context.prNumber,
+            service: delivery.serviceName,
+            touched_files: service.touchedFiles,
+            consumers: service.consumers.map((consumer) => ({
+                id: consumer.id,
+                repo: consumer.repo,
+                branch: consumer.branch,
+            })),
+            target_consumer: delivery.consumer
+                ? {
+                    id: delivery.consumer.id,
+                    repo: delivery.consumer.repo,
+                    branch: delivery.consumer.branch,
+                }
+                : undefined,
+            timestamp: new Date().toISOString(),
+        };
+        try {
+            await fetchImpl(delivery.url, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(payload),
+                signal: AbortSignal.timeout(10_000),
+            });
+        }
+        catch {
+            // fail-open: satellite notification must not block merge gate
+        }
+    }));
+}
+function formatCrossRepoImpactSection(impact) {
+    if (!impact || impact.services.length === 0)
+        return [];
+    const lines = [`### Cross-Repo Impact`, ``];
+    for (const service of impact.services) {
+        lines.push(`**${service.serviceName}** — ${service.touchedFiles.length} contract file(s) changed`);
+        if (service.consumers.length > 0) {
+            lines.push(`- Downstream: ${service.consumers.map((consumer) => formatConsumerLabel(consumer)).join(", ")}`);
+        }
+        if (service.notify_webhook) {
+            lines.push(`- Satellite webhook configured for this service`);
+        }
+        lines.push(``);
+    }
+    return lines;
 }
 
 ;// CONCATENATED MODULE: ./src/ci-core.ts
@@ -42050,6 +42276,7 @@ function formatSecuritySection(alerts) {
 }
 
 ;// CONCATENATED MODULE: ./src/gate.ts
+
 
 
 
@@ -42671,43 +42898,6 @@ function detectDuplicateLogicRisk(files) {
         findings,
     };
 }
-function detectCrossRepoImpact(files, repoConfig) {
-    const cfg = repoConfig?.policies?.cross_repo_impact;
-    if (!cfg?.enabled)
-        return { factor: null, findings: [], affectedConsumers: [] };
-    const affectedConsumers = new Set();
-    const findings = [];
-    for (const [serviceName, service] of Object.entries(repoConfig?.services ?? {})) {
-        const contractPatterns = service.contracts ?? [];
-        if (contractPatterns.length === 0)
-            continue;
-        const touchedContracts = files
-            .filter((f) => matchesGlobs(f.filename, contractPatterns))
-            .map((f) => f.filename);
-        if (touchedContracts.length === 0)
-            continue;
-        for (const consumer of service.consumers ?? []) {
-            affectedConsumers.add(consumer);
-        }
-        findings.push(`Contract surface changed for service "${serviceName}" (${touchedContracts.length} file(s)).`);
-    }
-    if (findings.length === 0) {
-        return { factor: null, findings: [], affectedConsumers: [] };
-    }
-    return {
-        factor: {
-            type: "cross_repo_impact",
-            score: Math.min(100, 30 + affectedConsumers.size * 15),
-            detail: {
-                findings,
-                affectedConsumers: [...affectedConsumers],
-                description: "Potential downstream consumer impact from contract changes",
-            },
-        },
-        findings,
-        affectedConsumers: [...affectedConsumers],
-    };
-}
 async function detectSessionCorrelation(params) {
     const cfg = params.repoConfig?.policies?.session_correlation;
     if (!cfg?.enabled || !params.prNumber || !params.token || !params.provenance)
@@ -43228,7 +43418,11 @@ async function evaluateGate(config, commitSha, prNumber) {
     if (duplicateLogic.factor) {
         riskFactors.push(duplicateLogic.factor);
     }
-    const crossRepoImpact = detectCrossRepoImpact(files, repoConfig);
+    const crossRepoRegistryPath = repoConfig?.policies?.cross_repo_impact?.consumer_registry_path;
+    const externalConsumerRegistry = crossRepoRegistryPath
+        ? loadConsumerRegistryFile(crossRepoRegistryPath)
+        : null;
+    const crossRepoImpact = detectCrossRepoImpact(files, repoConfig, externalConsumerRegistry);
     if (crossRepoImpact.factor) {
         riskFactors.push(crossRepoImpact.factor);
     }
@@ -43389,6 +43583,20 @@ async function evaluateGate(config, commitSha, prNumber) {
         trust_profile: trustProfile,
         gateMode,
         context: matchedContext?.matched,
+        cross_repo_impact: crossRepoImpact.services.length > 0
+            ? {
+                services: crossRepoImpact.services.map((service) => ({
+                    serviceName: service.serviceName,
+                    touchedFiles: service.touchedFiles,
+                    consumers: service.consumers.map((consumer) => ({
+                        id: consumer.id,
+                        repo: consumer.repo,
+                        branch: consumer.branch,
+                    })),
+                    notify_webhook: service.notify_webhook,
+                })),
+            }
+            : undefined,
     };
     let ciSummary = null;
     if (gateMode !== "risk-only" && config.githubToken) {
@@ -43462,6 +43670,13 @@ async function evaluateGate(config, commitSha, prNumber) {
                 evaluationMs: Date.now() - start,
             };
         }
+    }
+    if (crossRepoImpact.services.length > 0) {
+        await sendCrossRepoImpactWebhooks(crossRepoImpact, {
+            repoId: localEvaluation.repoId,
+            commitSha: localEvaluation.commitSha,
+            prNumber: localEvaluation.prNumber,
+        });
     }
     return localEvaluation;
 }
@@ -43839,6 +44054,23 @@ function formatGateReport(evaluation, riskThreshold) {
                 lines.push(`- ${reason}`);
             }
             lines.push(``);
+        }
+        if (evaluation.cross_repo_impact) {
+            lines.push(...formatCrossRepoImpactSection({
+                factor: null,
+                findings: [],
+                affectedConsumers: [],
+                services: evaluation.cross_repo_impact.services.map((service) => ({
+                    serviceName: service.serviceName,
+                    touchedFiles: service.touchedFiles,
+                    notify_webhook: service.notify_webhook,
+                    consumers: service.consumers.map((consumer) => ({
+                        id: consumer.id,
+                        repo: consumer.repo,
+                        branch: consumer.branch,
+                    })),
+                })),
+            }));
         }
     }
     else {
@@ -45097,9 +45329,6 @@ function resolveDeployEventsUrl(evaluationStoreUrl) {
     return evaluationStoreUrl.replace(/\/store\/?$/, "/deploy-event");
 }
 
-;// CONCATENATED MODULE: external "node:fs"
-const external_node_fs_namespaceObject = require("node:fs");
-var external_node_fs_default = /*#__PURE__*/__nccwpck_require__.n(external_node_fs_namespaceObject);
 ;// CONCATENATED MODULE: ./src/ci-manifest.ts
 
 

--- a/docs/cross-repo-impact.md
+++ b/docs/cross-repo-impact.md
@@ -1,0 +1,90 @@
+# Cross-Repo Impact (E16)
+
+Trailhead detects when a PR touches **contract surfaces** and resolves **downstream consumer repos** from your config. Affected consumers appear in the Release Ready PR comment; optional satellite webhooks notify downstream teams.
+
+## Configuration
+
+```yaml
+schema_version: 2
+
+# Alias → external repo mapping
+consumer_registry:
+  web:
+    repo: KomatikAI/frontend
+    branch: main
+  mobile:
+    repo: KomatikAI/mobile-app
+
+services:
+  api:
+    paths:
+      - "src/api/**"
+    contracts:
+      - "src/api/contracts/**"
+      - "openapi/**"
+    consumers:
+      - web # resolves via consumer_registry
+      - repo: KomatikAI/worker # inline external ref
+        branch: main
+    notify_webhook: https://hooks.example.com/api-contract-change
+
+policies:
+  cross_repo_impact:
+    enabled: true
+    mode: warn
+    consumer_registry_path: .trailhead/consumers.json # optional external file
+```
+
+### Consumer formats
+
+| Form                 | Example                                           | Use case                         |
+| -------------------- | ------------------------------------------------- | -------------------------------- |
+| Alias string         | `web`                                             | Resolved via `consumer_registry` |
+| Inline repo ref      | `{ repo: org/repo, branch: main }`                | External satellite repo          |
+| Per-consumer webhook | `{ repo: org/repo, notify_webhook: https://... }` | Notify one downstream            |
+
+### External registry file
+
+`.trailhead/consumers.json`:
+
+```json
+{
+  "billing-ui": {
+    "repo": "KomatikAI/billing-portal",
+    "branch": "main",
+    "notify_webhook": "https://hooks.example.com/billing"
+  }
+}
+```
+
+Set `policies.cross_repo_impact.consumer_registry_path` to load it. Inline `consumer_registry` in `.trailhead.yml` takes precedence on key collision.
+
+## Satellite webhooks
+
+When contract files change, Trailhead POSTs a `contract_change` event to:
+
+1. Each affected service's `notify_webhook`
+2. Each resolved consumer's `notify_webhook` (if set)
+
+Payload shape:
+
+```json
+{
+  "event": "contract_change",
+  "source_repo": "KomatikAI/platform",
+  "commit_sha": "abc123",
+  "pr_number": 42,
+  "service": "api",
+  "touched_files": ["src/api/contracts/users.json"],
+  "consumers": [{ "id": "web", "repo": "KomatikAI/frontend", "branch": "main" }],
+  "timestamp": "2026-05-24T12:00:00Z"
+}
+```
+
+Delivery is **fail-open** — webhook errors never block the merge gate.
+
+## PR comment
+
+Release-ready mode adds a **Cross-Repo Impact** section listing each affected service, changed contract files, and downstream repos.
+
+See [`examples/policy-pack/cross-repo-impact.example.yml`](../examples/policy-pack/cross-repo-impact.example.yml).

--- a/docs/roadmap-v4.md
+++ b/docs/roadmap-v4.md
@@ -40,11 +40,11 @@ Transform Trailhead from a risk-scoring sidecar into a **Release Readiness Gate*
 
 ## v4.2 Epics (next — Advanced CI)
 
-| Epic | Status         | Description                                                                     | Issues    |
-| ---- | -------------- | ------------------------------------------------------------------------------- | --------- |
-| E15  | 🔶 In progress | `ci-manifest.json` schema + Action input; merge with Checks API                 | #203–#206 |
-| E16  | ⏳             | External consumer registry, satellite webhooks, cross-repo impact in PR comment | #207–#209 |
-| E17  | ⏳             | GitLab, CircleCI, generic webhook CI adapters                                   | #210–#212 |
+| Epic | Status         | Description                                                           | Issues    |
+| ---- | -------------- | --------------------------------------------------------------------- | --------- |
+| E15  | ✅ Done        | `ci-manifest.json` schema + Action input; merge with Checks API       | #203–#206 |
+| E16  | 🔶 In progress | External consumer registry, satellite webhooks, cross-repo PR comment | #207–#209 |
+| E17  | ⏳             | GitLab, CircleCI, generic webhook CI adapters                         | #210–#212 |
 
 ### E15 preview
 

--- a/examples/policy-pack/README.md
+++ b/examples/policy-pack/README.md
@@ -18,6 +18,8 @@ This pack provides Phase 1 baseline artifacts for consistent org rollout:
 - `pilot-baseline-template.md`
 - `ci-manifest.example.json` — sample path-filter manifest (v4.2)
 - `ci-manifest-workflow.snippet.yml` — emit manifest + gate job pattern
+- `cross-repo-impact.example.yml` — consumer registry + satellite webhooks (v4.2)
+- `consumers.example.json` — external consumer registry file
 - `phase-2/`
   - includes `phase-2/pilots/` concrete repo bundles
 

--- a/examples/policy-pack/consumers.example.json
+++ b/examples/policy-pack/consumers.example.json
@@ -1,0 +1,11 @@
+{
+  "traverse": {
+    "repo": "KomatikAI/traverse",
+    "branch": "main"
+  },
+  "floe": {
+    "repo": "KomatikAI/shieldcheck",
+    "branch": "main",
+    "notify_webhook": "https://hooks.example.com/floe-contract"
+  }
+}

--- a/examples/policy-pack/cross-repo-impact.example.yml
+++ b/examples/policy-pack/cross-repo-impact.example.yml
@@ -1,0 +1,26 @@
+schema_version: 2
+
+consumer_registry:
+  dashboard:
+    repo: KomatikAI/komatik-base-camp
+    branch: main
+
+services:
+  api:
+    paths:
+      - "src/api/**"
+    contracts:
+      - "openapi/**"
+      - "src/api/contracts/**"
+    consumers:
+      - dashboard
+      - repo: KomatikAI/traverse
+        branch: main
+        notify_webhook: https://hooks.example.com/traverse-contract
+    notify_webhook: https://hooks.example.com/platform-api-contract
+
+policies:
+  cross_repo_impact:
+    enabled: true
+    mode: warn
+    consumer_registry_path: .trailhead/consumers.json

--- a/src/__tests__/cross-repo-impact.test.ts
+++ b/src/__tests__/cross-repo-impact.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  collectCrossRepoWebhookDeliveries,
+  detectCrossRepoImpact,
+  formatCrossRepoImpactSection,
+  loadConsumerRegistryFile,
+  mergeConsumerRegistries,
+  parseConsumerRegistry,
+  sendCrossRepoImpactWebhooks,
+} from "../cross-repo-impact.js";
+import type { RepoConfig } from "../types.js";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const baseConfig = {
+  schema_version: 2 as const,
+  gate: { mode: "release-ready" as const, check_name: "Trailhead — Release Ready" },
+  contexts: [],
+  sensitivity: { high: [], medium: [], low: [] },
+  weights: {},
+  profiles: [],
+  thresholds: {},
+  ignore: [],
+  freeze: [],
+  environments: {},
+  services: {
+    api: {
+      paths: ["src/api/**"],
+      contracts: ["src/api/contracts/**"],
+      consumers: ["web", { repo: "KomatikAI/frontend", branch: "main" }],
+      notify_webhook: "https://hooks.example.com/api-contract",
+    },
+  },
+  consumer_registry: {
+    web: { repo: "KomatikAI/web-app", branch: "main" },
+  },
+  security: {
+    severity_threshold: "warning",
+    block_on_critical: true,
+    ignore_rules: [],
+  },
+  escalation: {
+    targets: [],
+    acknowledge_sla_minutes: 30,
+    resolve_sla_minutes: 240,
+  },
+  policies: {
+    agent_prs: {
+      enabled: false,
+      required_approvals: 1,
+      require_code_owner_approval: false,
+      code_owner_reviewers: [],
+      sensitive_paths: [],
+      strict_on_unknown_provenance: true,
+    },
+    session_correlation: { enabled: false, threshold: 3, mode: "warn" as const, window_minutes: 60 },
+    ci_integrity: { enabled: true, mode: "block" },
+    workflow_security: {
+      enabled: true,
+      mode: "block",
+      allow_unpinned_actions: [],
+    },
+    prompt_injection: { enabled: true, mode: "warn" },
+    supply_chain: { enabled: true, mode: "warn" as const, force_score_on_critical: 80 },
+    pr_scope: {
+      enabled: true,
+      max_files: 50,
+      max_changes: 2000,
+      mode: "warn",
+      require_plan_for_agent_prs: false,
+    },
+    duplicate_logic: { enabled: true, mode: "warn" },
+    cross_repo_impact: { enabled: true, mode: "warn" as const },
+  },
+} satisfies RepoConfig;
+
+describe("detectCrossRepoImpact", () => {
+  it("resolves alias and external repo consumers when contracts change", () => {
+    const impact = detectCrossRepoImpact(
+      [{ filename: "src/api/contracts/users.json" }],
+      baseConfig,
+    );
+
+    expect(impact.factor).not.toBeNull();
+    expect(impact.services).toHaveLength(1);
+    expect(impact.services[0]?.consumers.map((c) => c.repo)).toEqual([
+      "KomatikAI/web-app",
+      "KomatikAI/frontend",
+    ]);
+    expect(impact.affectedConsumers).toContain("KomatikAI/web-app@main");
+    expect(impact.affectedConsumers).toContain("KomatikAI/frontend@main");
+  });
+
+  it("merges external registry file entries", () => {
+    const impact = detectCrossRepoImpact(
+      [{ filename: "src/api/contracts/users.json" }],
+      {
+        ...baseConfig,
+        services: {
+          api: {
+            paths: [],
+            contracts: ["src/api/contracts/**"],
+            consumers: ["worker"],
+          },
+        },
+        consumer_registry: {},
+      },
+      { worker: { repo: "KomatikAI/worker" } },
+    );
+
+    expect(impact.affectedConsumers).toContain("KomatikAI/worker");
+  });
+
+  it("returns empty result when policy disabled", () => {
+    const impact = detectCrossRepoImpact([{ filename: "src/api/contracts/users.json" }], {
+      ...baseConfig,
+      policies: {
+        ...baseConfig.policies,
+        cross_repo_impact: { enabled: false, mode: "warn" },
+      },
+    });
+    expect(impact.factor).toBeNull();
+  });
+});
+
+describe("consumer registry file", () => {
+  it("loads JSON registry from disk", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "th-registry-"));
+    const file = path.join(dir, "consumers.json");
+    fs.writeFileSync(
+      file,
+      JSON.stringify({ mobile: { repo: "KomatikAI/mobile", branch: "main" } }),
+    );
+    const registry = loadConsumerRegistryFile(file);
+    expect(registry?.mobile?.repo).toBe("KomatikAI/mobile");
+  });
+
+  it("parses inline registry records", () => {
+    const registry = parseConsumerRegistry({
+      api: { repo: "KomatikAI/api-client" },
+    });
+    expect(mergeConsumerRegistries(registry).api.repo).toBe("KomatikAI/api-client");
+  });
+});
+
+describe("satellite webhooks", () => {
+  it("collects service and consumer webhook URLs", () => {
+    const impact = detectCrossRepoImpact(
+      [{ filename: "src/api/contracts/users.json" }],
+      baseConfig,
+    );
+    const deliveries = collectCrossRepoWebhookDeliveries(impact);
+    expect(
+      deliveries.some((d) => d.url === "https://hooks.example.com/api-contract"),
+    ).toBe(true);
+  });
+
+  it("posts contract_change payloads fail-open", async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error("network"));
+    const impact = detectCrossRepoImpact(
+      [{ filename: "src/api/contracts/users.json" }],
+      baseConfig,
+    );
+
+    await expect(
+      sendCrossRepoImpactWebhooks(
+        impact,
+        { repoId: "KomatikAI/trailhead", commitSha: "abc1234", prNumber: 42 },
+        fetchMock,
+      ),
+    ).resolves.toBeUndefined();
+    expect(fetchMock).toHaveBeenCalled();
+  });
+});
+
+describe("formatCrossRepoImpactSection", () => {
+  it("lists downstream repos in markdown", () => {
+    const impact = detectCrossRepoImpact(
+      [{ filename: "src/api/contracts/users.json" }],
+      baseConfig,
+    );
+    const section = formatCrossRepoImpactSection(impact).join("\n");
+    expect(section).toContain("### Cross-Repo Impact");
+    expect(section).toContain("KomatikAI/frontend@main");
+    expect(section).toContain("Satellite webhook configured");
+  });
+});

--- a/src/__tests__/cross-repo-impact.test.ts
+++ b/src/__tests__/cross-repo-impact.test.ts
@@ -54,7 +54,12 @@ const baseConfig = {
       sensitive_paths: [],
       strict_on_unknown_provenance: true,
     },
-    session_correlation: { enabled: false, threshold: 3, mode: "warn" as const, window_minutes: 60 },
+    session_correlation: {
+      enabled: false,
+      threshold: 3,
+      mode: "warn" as const,
+      window_minutes: 60,
+    },
     ci_integrity: { enabled: true, mode: "block" },
     workflow_security: {
       enabled: true,

--- a/src/__tests__/gate.test.ts
+++ b/src/__tests__/gate.test.ts
@@ -627,6 +627,27 @@ describe("formatGateReport", () => {
     expect(report).toContain("`0.88`");
   });
 
+  it("includes cross-repo impact section in release-ready mode", () => {
+    const evaluation: GateEvaluation = {
+      ...baseEvaluation,
+      gateMode: "release-ready",
+      releaseReady: true,
+      cross_repo_impact: {
+        services: [
+          {
+            serviceName: "api",
+            touchedFiles: ["src/api/contracts/users.json"],
+            consumers: [{ id: "web", repo: "KomatikAI/frontend", branch: "main" }],
+            notify_webhook: "https://hooks.example.com/api",
+          },
+        ],
+      },
+    };
+    const report = formatGateReport(evaluation);
+    expect(report).toContain("Cross-Repo Impact");
+    expect(report).toContain("KomatikAI/frontend@main");
+  });
+
   it("includes policy findings when present", () => {
     const evaluation: GateEvaluation = {
       ...baseEvaluation,

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,6 +21,7 @@ const KNOWN_TOP_LEVEL_KEYS = new Set([
   "profiles",
   "thresholds",
   "ignore",
+  "consumer_registry",
   "freeze",
   "environments",
   "services",

--- a/src/cross-repo-impact.ts
+++ b/src/cross-repo-impact.ts
@@ -1,0 +1,283 @@
+import fs from "node:fs";
+import path from "node:path";
+import { matchesGlobs } from "./risk-engine.js";
+import type { ConsumerRegistry, RepoConfig, RiskFactor, ServiceConsumer } from "./types.js";
+import { ConsumerRegistry as ConsumerRegistrySchema } from "./types.js";
+
+export type { ServiceConsumer, ServiceConsumerRef, ConsumerRegistry } from "./types.js";
+
+export interface FileChange {
+  filename: string;
+}
+
+export interface ResolvedConsumer {
+  id: string;
+  repo?: string;
+  branch?: string;
+  notify_webhook?: string;
+}
+
+export interface CrossRepoServiceImpact {
+  serviceName: string;
+  touchedFiles: string[];
+  consumers: ResolvedConsumer[];
+  notify_webhook?: string;
+}
+
+export interface CrossRepoImpactResult {
+  factor: RiskFactor | null;
+  findings: string[];
+  affectedConsumers: string[];
+  services: CrossRepoServiceImpact[];
+}
+
+export function parseConsumerRegistry(raw: unknown): ConsumerRegistry {
+  return ConsumerRegistrySchema.parse(raw);
+}
+
+export function loadConsumerRegistryFile(filePath: string): ConsumerRegistry | null {
+  try {
+    const resolved = path.resolve(filePath);
+    const contents = fs.readFileSync(resolved, "utf8");
+    return parseConsumerRegistry(JSON.parse(contents));
+  } catch {
+    return null;
+  }
+}
+
+export function mergeConsumerRegistries(
+  ...registries: Array<ConsumerRegistry | null | undefined>
+): ConsumerRegistry {
+  const merged: ConsumerRegistry = {};
+  for (const registry of registries) {
+    if (!registry) continue;
+    Object.assign(merged, registry);
+  }
+  return merged;
+}
+
+export function formatConsumerLabel(consumer: ResolvedConsumer): string {
+  if (consumer.repo) {
+    const branch = consumer.branch ? `@${consumer.branch}` : "";
+    return `\`${consumer.repo}${branch}\``;
+  }
+  return `\`${consumer.id}\``;
+}
+
+function resolveConsumer(
+  consumer: ServiceConsumer,
+  registry: ConsumerRegistry,
+): ResolvedConsumer {
+  if (typeof consumer === "string") {
+    const entry = registry[consumer];
+    if (entry) {
+      return {
+        id: entry.name ?? consumer,
+        repo: entry.repo,
+        branch: entry.branch,
+        notify_webhook: entry.notify_webhook,
+      };
+    }
+    return { id: consumer };
+  }
+
+  return {
+    id: consumer.name ?? consumer.repo,
+    repo: consumer.repo,
+    branch: consumer.branch,
+    notify_webhook: consumer.notify_webhook,
+  };
+}
+
+export function detectCrossRepoImpact(
+  files: FileChange[],
+  repoConfig: RepoConfig | null,
+  externalRegistry?: ConsumerRegistry | null,
+): CrossRepoImpactResult {
+  const cfg = repoConfig?.policies?.cross_repo_impact;
+  const empty: CrossRepoImpactResult = {
+    factor: null,
+    findings: [],
+    affectedConsumers: [],
+    services: [],
+  };
+  if (!cfg?.enabled) return empty;
+
+  const registry = mergeConsumerRegistries(
+    externalRegistry,
+    repoConfig?.consumer_registry,
+  );
+  const affectedConsumers = new Set<string>();
+  const findings: string[] = [];
+  const services: CrossRepoServiceImpact[] = [];
+
+  for (const [serviceName, service] of Object.entries(repoConfig?.services ?? {})) {
+    const contractPatterns = service.contracts ?? [];
+    if (contractPatterns.length === 0) continue;
+
+    const touchedFiles = files
+      .filter((f) => matchesGlobs(f.filename, contractPatterns))
+      .map((f) => f.filename);
+    if (touchedFiles.length === 0) continue;
+
+    const resolvedConsumers = (service.consumers ?? []).map((consumer) =>
+      resolveConsumer(consumer, registry),
+    );
+    for (const consumer of resolvedConsumers) {
+      affectedConsumers.add(
+        consumer.repo
+          ? `${consumer.repo}${consumer.branch ? `@${consumer.branch}` : ""}`
+          : consumer.id,
+      );
+    }
+
+    services.push({
+      serviceName,
+      touchedFiles,
+      consumers: resolvedConsumers,
+      notify_webhook: service.notify_webhook,
+    });
+
+    findings.push(
+      `Contract surface changed for service "${serviceName}" (${touchedFiles.length} file(s)).`,
+    );
+  }
+
+  if (findings.length === 0) return empty;
+
+  const consumerLabels = [...affectedConsumers];
+  return {
+    factor: {
+      type: "cross_repo_impact",
+      score: Math.min(100, 30 + consumerLabels.length * 15),
+      detail: {
+        findings,
+        affectedConsumers: consumerLabels,
+        services: services.map((service) => ({
+          service: service.serviceName,
+          touchedFiles: service.touchedFiles,
+          consumers: service.consumers.map((consumer) => ({
+            id: consumer.id,
+            repo: consumer.repo,
+            branch: consumer.branch,
+          })),
+        })),
+        description: "Potential downstream consumer impact from contract changes",
+      },
+    },
+    findings,
+    affectedConsumers: consumerLabels,
+    services,
+  };
+}
+
+export interface CrossRepoWebhookContext {
+  repoId: string;
+  commitSha: string;
+  prNumber?: number;
+}
+
+export interface CrossRepoWebhookDelivery {
+  url: string;
+  serviceName: string;
+  consumer?: ResolvedConsumer;
+}
+
+export function collectCrossRepoWebhookDeliveries(
+  impact: CrossRepoImpactResult,
+): CrossRepoWebhookDelivery[] {
+  const deliveries: CrossRepoWebhookDelivery[] = [];
+  const seen = new Set<string>();
+
+  for (const service of impact.services) {
+    if (service.notify_webhook && !seen.has(service.notify_webhook)) {
+      seen.add(service.notify_webhook);
+      deliveries.push({ url: service.notify_webhook, serviceName: service.serviceName });
+    }
+    for (const consumer of service.consumers) {
+      if (!consumer.notify_webhook || seen.has(consumer.notify_webhook)) continue;
+      seen.add(consumer.notify_webhook);
+      deliveries.push({
+        url: consumer.notify_webhook,
+        serviceName: service.serviceName,
+        consumer,
+      });
+    }
+  }
+
+  return deliveries;
+}
+
+export async function sendCrossRepoImpactWebhooks(
+  impact: CrossRepoImpactResult,
+  context: CrossRepoWebhookContext,
+  fetchImpl: typeof fetch = fetch,
+): Promise<void> {
+  const deliveries = collectCrossRepoWebhookDeliveries(impact);
+  if (deliveries.length === 0) return;
+
+  await Promise.all(
+    deliveries.map(async (delivery) => {
+      const service = impact.services.find(
+        (item) => item.serviceName === delivery.serviceName,
+      );
+      if (!service) return;
+
+      const payload = {
+        event: "contract_change",
+        source_repo: context.repoId,
+        commit_sha: context.commitSha,
+        pr_number: context.prNumber,
+        service: delivery.serviceName,
+        touched_files: service.touchedFiles,
+        consumers: service.consumers.map((consumer) => ({
+          id: consumer.id,
+          repo: consumer.repo,
+          branch: consumer.branch,
+        })),
+        target_consumer: delivery.consumer
+          ? {
+              id: delivery.consumer.id,
+              repo: delivery.consumer.repo,
+              branch: delivery.consumer.branch,
+            }
+          : undefined,
+        timestamp: new Date().toISOString(),
+      };
+
+      try {
+        await fetchImpl(delivery.url, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+          signal: AbortSignal.timeout(10_000),
+        });
+      } catch {
+        // fail-open: satellite notification must not block merge gate
+      }
+    }),
+  );
+}
+
+export function formatCrossRepoImpactSection(
+  impact: CrossRepoImpactResult | undefined,
+): string[] {
+  if (!impact || impact.services.length === 0) return [];
+
+  const lines = [`### Cross-Repo Impact`, ``];
+  for (const service of impact.services) {
+    lines.push(
+      `**${service.serviceName}** — ${service.touchedFiles.length} contract file(s) changed`,
+    );
+    if (service.consumers.length > 0) {
+      lines.push(
+        `- Downstream: ${service.consumers.map((consumer) => formatConsumerLabel(consumer)).join(", ")}`,
+      );
+    }
+    if (service.notify_webhook) {
+      lines.push(`- Satellite webhook configured for this service`);
+    }
+    lines.push(``);
+  }
+  return lines;
+}

--- a/src/cross-repo-impact.ts
+++ b/src/cross-repo-impact.ts
@@ -1,7 +1,12 @@
 import fs from "node:fs";
 import path from "node:path";
 import { matchesGlobs } from "./risk-engine.js";
-import type { ConsumerRegistry, RepoConfig, RiskFactor, ServiceConsumer } from "./types.js";
+import type {
+  ConsumerRegistry,
+  RepoConfig,
+  RiskFactor,
+  ServiceConsumer,
+} from "./types.js";
 import { ConsumerRegistry as ConsumerRegistrySchema } from "./types.js";
 
 export type { ServiceConsumer, ServiceConsumerRef, ConsumerRegistry } from "./types.js";

--- a/src/gate.ts
+++ b/src/gate.ts
@@ -17,6 +17,12 @@ import { loadRepoConfig } from "./config.js";
 import { matchContext, resolveGateMode } from "./context-matcher.js";
 import type { PrMatchContext } from "./context-matcher.js";
 import {
+  detectCrossRepoImpact,
+  formatCrossRepoImpactSection,
+  loadConsumerRegistryFile,
+  sendCrossRepoImpactWebhooks,
+} from "./cross-repo-impact.js";
+import {
   evaluateRequiredChecks,
   fetchCheckRuns,
   formatCiStatusIcon,
@@ -891,58 +897,6 @@ function detectDuplicateLogicRisk(files: PrFileInfo[]): DuplicateLogicDetection 
   };
 }
 
-interface CrossRepoImpactDetection {
-  factor: RiskFactor | null;
-  findings: string[];
-  affectedConsumers: string[];
-}
-
-function detectCrossRepoImpact(
-  files: PrFileInfo[],
-  repoConfig: RepoConfig | null,
-): CrossRepoImpactDetection {
-  const cfg = repoConfig?.policies?.cross_repo_impact;
-  if (!cfg?.enabled) return { factor: null, findings: [], affectedConsumers: [] };
-
-  const affectedConsumers = new Set<string>();
-  const findings: string[] = [];
-
-  for (const [serviceName, service] of Object.entries(repoConfig?.services ?? {})) {
-    const contractPatterns = service.contracts ?? [];
-    if (contractPatterns.length === 0) continue;
-
-    const touchedContracts = files
-      .filter((f) => matchesGlobs(f.filename, contractPatterns))
-      .map((f) => f.filename);
-    if (touchedContracts.length === 0) continue;
-
-    for (const consumer of service.consumers ?? []) {
-      affectedConsumers.add(consumer);
-    }
-    findings.push(
-      `Contract surface changed for service "${serviceName}" (${touchedContracts.length} file(s)).`,
-    );
-  }
-
-  if (findings.length === 0) {
-    return { factor: null, findings: [], affectedConsumers: [] };
-  }
-
-  return {
-    factor: {
-      type: "cross_repo_impact",
-      score: Math.min(100, 30 + affectedConsumers.size * 15),
-      detail: {
-        findings,
-        affectedConsumers: [...affectedConsumers],
-        description: "Potential downstream consumer impact from contract changes",
-      },
-    },
-    findings,
-    affectedConsumers: [...affectedConsumers],
-  };
-}
-
 // ---------------------------------------------------------------------------
 // Session correlation (rapid-fire merge burst)
 // ---------------------------------------------------------------------------
@@ -1621,7 +1575,16 @@ export async function evaluateGate(
   if (duplicateLogic.factor) {
     riskFactors.push(duplicateLogic.factor);
   }
-  const crossRepoImpact = detectCrossRepoImpact(files, repoConfig);
+  const crossRepoRegistryPath =
+    repoConfig?.policies?.cross_repo_impact?.consumer_registry_path;
+  const externalConsumerRegistry = crossRepoRegistryPath
+    ? loadConsumerRegistryFile(crossRepoRegistryPath)
+    : null;
+  const crossRepoImpact = detectCrossRepoImpact(
+    files,
+    repoConfig,
+    externalConsumerRegistry,
+  );
   if (crossRepoImpact.factor) {
     riskFactors.push(crossRepoImpact.factor);
   }
@@ -1819,6 +1782,21 @@ export async function evaluateGate(
     trust_profile: trustProfile,
     gateMode,
     context: matchedContext?.matched,
+    cross_repo_impact:
+      crossRepoImpact.services.length > 0
+        ? {
+            services: crossRepoImpact.services.map((service) => ({
+              serviceName: service.serviceName,
+              touchedFiles: service.touchedFiles,
+              consumers: service.consumers.map((consumer) => ({
+                id: consumer.id,
+                repo: consumer.repo,
+                branch: consumer.branch,
+              })),
+              notify_webhook: service.notify_webhook,
+            })),
+          }
+        : undefined,
   };
 
   let ciSummary: CiSummary | null = null;
@@ -1900,6 +1878,14 @@ export async function evaluateGate(
         evaluationMs: Date.now() - start,
       };
     }
+  }
+
+  if (crossRepoImpact.services.length > 0) {
+    await sendCrossRepoImpactWebhooks(crossRepoImpact, {
+      repoId: localEvaluation.repoId,
+      commitSha: localEvaluation.commitSha,
+      prNumber: localEvaluation.prNumber,
+    });
   }
 
   return localEvaluation;
@@ -2387,6 +2373,26 @@ export function formatGateReport(
         lines.push(`- ${reason}`);
       }
       lines.push(``);
+    }
+
+    if (evaluation.cross_repo_impact) {
+      lines.push(
+        ...formatCrossRepoImpactSection({
+          factor: null,
+          findings: [],
+          affectedConsumers: [],
+          services: evaluation.cross_repo_impact.services.map((service) => ({
+            serviceName: service.serviceName,
+            touchedFiles: service.touchedFiles,
+            notify_webhook: service.notify_webhook,
+            consumers: service.consumers.map((consumer) => ({
+              id: consumer.id,
+              repo: consumer.repo,
+              branch: consumer.branch,
+            })),
+          })),
+        }),
+      );
     }
   } else {
     lines.push(

--- a/src/types.ts
+++ b/src/types.ts
@@ -152,6 +152,24 @@ export const GateEvaluation = z.object({
   context: MatchedContext.optional(),
   gateMode: GateMode.optional(),
   storePersisted: z.boolean().optional(),
+  cross_repo_impact: z
+    .object({
+      services: z.array(
+        z.object({
+          serviceName: z.string(),
+          touchedFiles: z.array(z.string()),
+          consumers: z.array(
+            z.object({
+              id: z.string(),
+              repo: z.string().optional(),
+              branch: z.string().optional(),
+            }),
+          ),
+          notify_webhook: z.string().url().optional(),
+        }),
+      ),
+    })
+    .optional(),
 });
 export type GateEvaluation = z.infer<typeof GateEvaluation>;
 
@@ -182,11 +200,25 @@ export const EnvironmentConfig = z.object({
 });
 export type EnvironmentConfig = z.infer<typeof EnvironmentConfig>;
 
+export const ServiceConsumerRef = z.object({
+  repo: z.string().min(1),
+  name: z.string().optional(),
+  branch: z.string().optional(),
+  notify_webhook: z.string().url().optional(),
+});
+
+export const ServiceConsumer = z.union([z.string(), ServiceConsumerRef]);
+export type ServiceConsumer = z.infer<typeof ServiceConsumer>;
+
+export const ConsumerRegistry = z.record(z.string(), ServiceConsumerRef);
+export type ConsumerRegistry = z.infer<typeof ConsumerRegistry>;
+
 export const ServiceMapping = z.object({
   paths: z.array(z.string()),
   environment: z.string().optional(),
-  consumers: z.array(z.string()).default([]),
+  consumers: z.array(ServiceConsumer).default([]),
   contracts: z.array(z.string()).default([]),
+  notify_webhook: z.string().url().optional(),
 });
 export type ServiceMapping = z.infer<typeof ServiceMapping>;
 
@@ -276,6 +308,7 @@ export const RepoConfig = z.object({
   freeze: z.array(FreezeWindow).default([]),
   environments: z.record(EnvironmentConfig).default({}),
   services: z.record(ServiceMapping).default({}),
+  consumer_registry: z.record(ServiceConsumerRef).default({}),
   security: SecurityConfig.default({}),
   canary: CanaryConfig.optional(),
   escalation: z
@@ -351,6 +384,7 @@ export const RepoConfig = z.object({
         .object({
           enabled: z.boolean().default(true),
           mode: z.enum(["warn", "block"]).default("warn"),
+          consumer_registry_path: z.string().optional(),
         })
         .default({}),
     })


### PR DESCRIPTION
## Summary
- **E16.1** — `consumer_registry` + inline `{ repo: org/repo }` consumer refs; optional `consumer_registry_path` JSON file
- **E16.2** — `services.*.notify_webhook` and per-consumer webhooks POST `contract_change` payloads (fail-open)
- **E16.3** — **Cross-Repo Impact** section in Release Ready PR comments listing downstream repos

Closes #207, #208, #209

## Test plan
- [x] `npm test` — 533 passed (9 new)
- [x] `npm run lint` — clean
- [x] `npm run build` — dist updated
- [ ] CI green on PR


Made with [Cursor](https://cursor.com)