### PR TITLE
feat(cli): trailhead doctor — validate config + check name mismatches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Typecheck cli/
         run: |
-          cd cli && npm ci && npx tsc --noEmit
+          cd cli && npm ci && npm run prebuild && npx tsc --noEmit
 
       - name: Typecheck app/
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ out/
 .DS_Store
 coverage/
 cli/dist/
+cli/src/shared/
 .turbo/
 .firecrawl/
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,52 +1,85 @@
 # Trailhead CLI
 
-Interactive setup wizard for Trailhead. Generates `.trailhead.yml` and the GitHub Actions workflow YAML with all v3 features configured.
+Interactive setup wizard and diagnostics for Trailhead. Generates `.trailhead.yml`, validates policy files, and compares configured CI check names against GitHub.
 
 ## Usage
 
 ```bash
 npx @komatikai/trailhead init
+npx @komatikai/trailhead doctor
 ```
+
+### `trailhead init`
 
 No installation required. The wizard walks you through:
 
-1. **Sensitivity patterns** — which file paths are high/medium risk (auth, payments, migrations)
-2. **Thresholds** — risk and warn scores (defaults: 70/55)
-3. **Freeze windows** — days and hours when deployments are blocked
-4. **Environments** — per-environment threshold overrides (production, staging, etc.)
-5. **Services** — monorepo service boundaries with path patterns
-6. **Security gate** — whether to include Code Scanning alerts as a risk factor
-7. **Canary tracking** — Vercel or generic deploy outcome webhook type
-8. **DORA metrics** — whether to compute DORA-5 alongside gate evaluations
-9. **Health checks** — URLs to probe before scoring
-10. **Webhooks** — Slack/Discord notification URL and trigger events
-11. **OpenTelemetry** — OTLP endpoint for evaluation span export
-12. **Evaluation store** — URL for persisting evaluations to a trend dashboard
+1. **Gate mode** — release-ready, advisory, or risk-only
+2. **Branch model** — main-only or progressive promotion paths
+3. **Required checks** — CI job names for release-ready contexts
+4. **Sensitivity patterns** — which file paths are high/medium risk
+5. **Thresholds** — risk and warn scores
+6. **Freeze windows** — days and hours when deployments are blocked
+7. **Environments** — per-environment threshold overrides
+8. **Services** — monorepo service boundaries with path patterns
+9. **Security gate** — Code Scanning alerts as a risk factor
+10. **Canary tracking** — deploy outcome webhook type
+11. **DORA metrics** — compute DORA-5 alongside gate evaluations
+12. **Health checks** — URLs to probe before scoring
+13. **OpenTelemetry** — OTLP endpoint for evaluation span export
+14. **Evaluation store** — URL for persisting evaluations to a trend dashboard
 
-## Output
+### `trailhead doctor`
+
+Validates `.trailhead.yml` (or legacy `.deployguard.yml`) and optionally compares `contexts[].ci.required_checks` against recent GitHub check runs.
+
+```bash
+# Config-only validation (no GitHub API)
+trailhead doctor --offline
+
+# Compare against GitHub (needs token + repo)
+GITHUB_TOKEN=ghp_... trailhead doctor --repo owner/repo
+
+# Machine-readable output
+trailhead doctor --json
+```
+
+Options:
+
+| Flag                  | Description                            |
+| --------------------- | -------------------------------------- |
+| `--path <dir>`        | Directory to scan (default: cwd)       |
+| `--repo <owner/name>` | GitHub repository for check lookup     |
+| `--token <token>`     | GitHub token (default: `GITHUB_TOKEN`) |
+| `--ref <sha>`         | Commit SHA for check runs              |
+| `--offline`           | Skip GitHub API comparison             |
+| `--json`              | Output report as JSON                  |
+
+Exit code `0` when there are no errors; `1` when config is missing/invalid or structural errors are found. Warnings do not fail the command.
+
+## Output (`init`)
 
 The wizard generates two files:
 
-- **`.trailhead.yml`** — per-repo configuration (sensitivity, thresholds, freeze windows, environments, services, security, canary)
-- **`.github/workflows/trailhead.yml`** — GitHub Actions workflow with all selected features
+- **`.trailhead.yml`** — per-repo configuration
+- **`.github/workflows/trailhead.yml`** — GitHub Actions workflow with selected features
 
 ## Development
 
 ```bash
 cd cli
 npm install
-npx tsc
-node dist/index.js
+npm run build
+node dist/index.js doctor --offline --path ..
 ```
 
-The CLI is a zero-dependency ESM module. Build output goes to `cli/dist/` (gitignored — build before npm publish).
+The CLI copies shared validation modules from `src/` during prebuild. Build output goes to `cli/dist/` (gitignored — build before npm publish).
 
 ## Publishing
 
 ```bash
 cd cli
-npx tsc
+npm run build
 npm publish
 ```
 
-The package is published as `@komatikai/trailhead` on npm, making `npx @komatikai/trailhead init` work without installation.
+The package is published as `@komatikai/trailhead` on npm.

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,13 +1,16 @@
 {
   "name": "@komatikai/trailhead",
-  "version": "3.0.3",
+  "version": "4.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@komatikai/trailhead",
-      "version": "3.0.3",
+      "version": "4.2.0",
       "license": "MIT",
+      "dependencies": {
+        "zod": "^3.24.0"
+      },
       "bin": {
         "trailhead": "dist/index.js"
       },
@@ -46,6 +49,15 @@
       "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     }
   }
 }

--- a/cli/package.json
+++ b/cli/package.json
@@ -7,7 +7,8 @@
     "trailhead": "dist/index.js"
   },
   "scripts": {
-    "build": "tsc",
+    "prebuild": "node ../scripts/copy-shared-src.mjs cli",
+    "build": "npm run prebuild && tsc",
     "prepublishOnly": "npm run build",
     "start": "node dist/index.js"
   },
@@ -24,7 +25,9 @@
     "dora"
   ],
   "license": "MIT",
-  "dependencies": {},
+  "dependencies": {
+    "zod": "^3.24.0"
+  },
   "devDependencies": {
     "@types/node": "^25.8.0",
     "typescript": "^6.0.3"

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -3,6 +3,9 @@
 import * as readline from "node:readline";
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { runDoctorCommand } from "./run-doctor.js";
+
+const CLI_VERSION = "4.2.0";
 
 const BOLD = "\x1b[1m";
 const GREEN = "\x1b[32m";
@@ -421,12 +424,18 @@ async function main() {
   const args = process.argv.slice(2);
   const command = args[0];
 
+  if (command === "doctor") {
+    const code = await runDoctorCommand(args.slice(1));
+    process.exit(code);
+  }
+
   if (command !== "init") {
     print(`
-${BOLD}${GREEN}Trailhead CLI v3.0.2${RESET}
+${BOLD}${GREEN}Trailhead CLI v${CLI_VERSION}${RESET}
 
 ${BOLD}Usage:${RESET}
-  npx @komatikai/trailhead init    Interactive setup wizard
+  npx @komatikai/trailhead init     Interactive setup wizard
+  npx @komatikai/trailhead doctor   Validate config and CI check names
 
 ${BOLD}Learn more:${RESET}
   https://github.com/KomatikAI/trailhead

--- a/cli/src/run-doctor.ts
+++ b/cli/src/run-doctor.ts
@@ -1,0 +1,88 @@
+import { formatDoctorReport, runDoctor } from "./shared/doctor.js";
+
+function printUsage(): void {
+  process.stdout.write(`
+Trailhead Doctor — validate .trailhead.yml and compare CI check names
+
+Usage:
+  trailhead doctor [options]
+
+Options:
+  --path <dir>       Directory to scan (default: cwd)
+  --repo <owner/name>  GitHub repository for check lookup
+  --token <token>    GitHub token (default: GITHUB_TOKEN)
+  --ref <sha>        Commit SHA for check runs (default: latest open PR or default branch)
+  --offline          Skip GitHub API check comparison
+  --json             Output report as JSON
+  -h, --help         Show this help
+
+Environment:
+  GITHUB_TOKEN       Personal access token with checks:read
+  GITHUB_REPOSITORY  owner/repo when running in GitHub Actions
+`);
+}
+
+export async function runDoctorCommand(args: string[]): Promise<number> {
+  if (args.includes("-h") || args.includes("--help")) {
+    printUsage();
+    return 0;
+  }
+
+  let cwd = process.cwd();
+  let repo: string | undefined;
+  let token: string | undefined;
+  let ref: string | undefined;
+  let offline = false;
+  let json = false;
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === "--offline") {
+      offline = true;
+      continue;
+    }
+    if (arg === "--json") {
+      json = true;
+      continue;
+    }
+    if (arg === "--path" && args[i + 1]) {
+      cwd = args[i + 1];
+      i += 1;
+      continue;
+    }
+    if (arg === "--repo" && args[i + 1]) {
+      repo = args[i + 1];
+      i += 1;
+      continue;
+    }
+    if (arg === "--token" && args[i + 1]) {
+      token = args[i + 1];
+      i += 1;
+      continue;
+    }
+    if (arg === "--ref" && args[i + 1]) {
+      ref = args[i + 1];
+      i += 1;
+      continue;
+    }
+    process.stderr.write(`Unknown option: ${arg}\n`);
+    printUsage();
+    return 2;
+  }
+
+  const report = await runDoctor({
+    cwd,
+    offline,
+    githubToken: token,
+    repo,
+    ref,
+  });
+
+  if (json) {
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  } else {
+    process.stdout.write(`${formatDoctorReport(report)}\n`);
+  }
+
+  return report.ok ? 0 : 1;
+}

--- a/scripts/copy-shared-src.mjs
+++ b/scripts/copy-shared-src.mjs
@@ -11,8 +11,13 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, "..");
 const targetName = process.argv[2];
 
-if (targetName !== "app" && targetName !== "mcp" && targetName !== "cloud") {
-  console.error("Usage: node scripts/copy-shared-src.mjs <app|mcp|cloud>");
+if (
+  targetName !== "app" &&
+  targetName !== "mcp" &&
+  targetName !== "cloud" &&
+  targetName !== "cli"
+) {
+  console.error("Usage: node scripts/copy-shared-src.mjs <app|mcp|cloud|cli>");
   process.exit(1);
 }
 
@@ -29,14 +34,28 @@ const sharedFiles = [
 
 const cloudOnlyFiles = ["feedback-core.ts"];
 
+const cliFiles = [
+  "config-core.ts",
+  "types.ts",
+  "ci-core.ts",
+  "ci-manifest.ts",
+  "release-ready.ts",
+  "doctor.ts",
+];
+
 const filesToCopy =
   targetName === "cloud"
     ? cloudOnlyFiles
-    : targetName === "mcp"
-      ? [...sharedFiles, ...cloudOnlyFiles]
-      : sharedFiles;
+    : targetName === "cli"
+      ? cliFiles
+      : targetName === "mcp"
+        ? [...sharedFiles, ...cloudOnlyFiles]
+        : sharedFiles;
 
-const targetDir = path.join(root, targetName, "src");
+const targetDir =
+  targetName === "cli"
+    ? path.join(root, targetName, "src", "shared")
+    : path.join(root, targetName, "src");
 fs.mkdirSync(targetDir, { recursive: true });
 
 for (const file of filesToCopy) {
@@ -63,4 +82,4 @@ if (targetName === "mcp") {
   }
 }
 
-console.log(`Copied ${filesToCopy.length} shared modules to ${targetName}/src/`);
+console.log(`Copied ${filesToCopy.length} shared modules to ${targetDir.replace(root + path.sep, "")}/`);

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -19,6 +19,7 @@ vi.mock("@actions/github", () => ({
 import * as github from "@actions/github";
 import * as core from "@actions/core";
 import { loadRepoConfig, matchesGlobs } from "../config.js";
+import { parseRepoConfigContent } from "../config-core.js";
 import { RepoConfig } from "../types.js";
 
 function encodeYaml(yaml: string): string {
@@ -363,6 +364,25 @@ policies:
     expect(parsed.data.contexts[0].name).toBe("feature");
     expect(parsed.data.contexts[0].thresholds.risk).toBe(70);
     expect(parsed.data.contexts[0].ci.required_checks).toEqual(["CI Gate"]);
+  });
+
+  it("parses inline flow-style YAML arrays", () => {
+    const parsed = parseRepoConfigContent(`schema_version: 2
+gate:
+  mode: release-ready
+thresholds:
+  risk: 70
+  warn: 55
+contexts:
+  - name: main
+    match:
+      base_branch: [main]
+    ci:
+      required_checks: [CI Gate, Build]
+`);
+    expect(parsed).not.toBeNull();
+    expect(parsed!.contexts[0].match.base_branch).toEqual(["main"]);
+    expect(parsed!.contexts[0].ci.required_checks).toEqual(["CI Gate", "Build"]);
   });
 
   it("defaults v1 schema without gate section", () => {

--- a/src/__tests__/doctor.test.ts
+++ b/src/__tests__/doctor.test.ts
@@ -1,0 +1,186 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  collectConfiguredChecks,
+  compareConfiguredChecks,
+  formatDoctorReport,
+  loadRepoConfig,
+  parseRepoRef,
+  runDoctor,
+  validateConfigStructure,
+} from "../doctor.js";
+import { parseRepoConfigContent } from "../config-core.js";
+
+const tempDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "trailhead-doctor-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("parseRepoRef", () => {
+  it("parses owner/repo", () => {
+    expect(parseRepoRef("KomatikAI/trailhead")).toEqual({
+      owner: "KomatikAI",
+      repo: "trailhead",
+    });
+  });
+
+  it("rejects invalid refs", () => {
+    expect(parseRepoRef("not-a-repo")).toBeNull();
+  });
+});
+
+describe("loadRepoConfig", () => {
+  it("loads .trailhead.yml from a directory", () => {
+    const dir = makeTempDir();
+    fs.writeFileSync(
+      path.join(dir, ".trailhead.yml"),
+      `schema_version: 2
+gate:
+  mode: release-ready
+thresholds:
+  risk: 70
+  warn: 55
+contexts:
+  - name: main
+    match:
+      base_branch: [main]
+    ci:
+      required_checks: [CI Gate]
+`,
+    );
+
+    const loaded = loadRepoConfig(dir);
+    expect(loaded.configPath).toContain(".trailhead.yml");
+    expect(loaded.config?.gate.mode).toBe("release-ready");
+  });
+
+  it("falls back to .deployguard.yml", () => {
+    const dir = makeTempDir();
+    fs.writeFileSync(
+      path.join(dir, ".deployguard.yml"),
+      `thresholds:
+  risk: 70
+  warn: 55
+`,
+    );
+
+    const loaded = loadRepoConfig(dir);
+    expect(loaded.configPath).toContain(".deployguard.yml");
+    expect(loaded.config?.thresholds.risk).toBe(70);
+  });
+});
+
+describe("validateConfigStructure", () => {
+  it("warns when configured checks are missing on GitHub", () => {
+    const config = parseRepoConfigContent(`
+schema_version: 2
+gate:
+  mode: release-ready
+thresholds:
+  risk: 70
+  warn: 55
+contexts:
+  - name: main
+    match:
+      base_branch: [main]
+    ci:
+      required_checks: [CI Gate, Playwright]
+`)!;
+
+    const findings = compareConfiguredChecks(collectConfiguredChecks(config), [
+      "CI Gate",
+      "Lint",
+    ]);
+
+    expect(
+      findings.some(
+        (f) => f.code === "unknown_check_name" && f.message.includes("Playwright"),
+      ),
+    ).toBe(true);
+    expect(
+      findings.some((f) => f.code === "unconfigured_check" && f.message.includes("Lint")),
+    ).toBe(true);
+  });
+
+  it("matches check names case-insensitively and by prefix", () => {
+    const findings = compareConfiguredChecks(["ci gate"], ["CI Gate / lint"]);
+    expect(findings.filter((f) => f.code === "unknown_check_name")).toHaveLength(0);
+  });
+
+  it("flags threshold ordering issues", () => {
+    const config = parseRepoConfigContent(`
+schema_version: 2
+gate:
+  mode: release-ready
+thresholds:
+  risk: 60
+  warn: 70
+contexts:
+  - name: main
+    match:
+      base_branch: [main]
+    ci:
+      required_checks: [CI Gate]
+`)!;
+
+    const findings = validateConfigStructure(config, ".trailhead.yml");
+    expect(findings.some((f) => f.code === "threshold_order")).toBe(true);
+  });
+});
+
+describe("runDoctor", () => {
+  it("reports missing config as failure", async () => {
+    const dir = makeTempDir();
+    const report = await runDoctor({ cwd: dir, offline: true });
+    expect(report.ok).toBe(false);
+    expect(report.findings[0]?.code).toBe("config_missing");
+  });
+
+  it("passes offline validation for a valid config", async () => {
+    const dir = makeTempDir();
+    fs.copyFileSync(
+      path.join(process.cwd(), "examples/policy-pack/trailhead-starter.main-only.v2.yml"),
+      path.join(dir, ".trailhead.yml"),
+    );
+
+    const report = await runDoctor({ cwd: dir, offline: true });
+    expect(report.configValid).toBe(true);
+    expect(report.configuredChecks).toContain("CI Gate");
+    expect(report.ok).toBe(true);
+  });
+});
+
+describe("formatDoctorReport", () => {
+  it("includes severity labels and result summary", () => {
+    const text = formatDoctorReport({
+      configPath: ".trailhead.yml",
+      configValid: true,
+      gateMode: "release-ready",
+      expectedCheckName: "Trailhead — Release Ready",
+      configuredChecks: ["Lint"],
+      observedChecks: [],
+      findings: [
+        {
+          severity: "warn",
+          code: "unknown_check_name",
+          message: 'Configured check "Lint" did not match any recent GitHub check run',
+        },
+      ],
+      ok: true,
+    });
+
+    expect(text).toContain("WARN [unknown_check_name]");
+    expect(text).toContain("Result: OK");
+  });
+});

--- a/src/config-core.ts
+++ b/src/config-core.ts
@@ -55,9 +55,41 @@ export function parseYaml(input: string): unknown {
         const child: Record<string, unknown> = {};
         container.push(child);
         stack.push({ indent, value: child });
-      } else {
-        container.push(parseScalar(itemRaw));
+        continue;
       }
+
+      const itemKeyMatch = itemRaw.match(/^([A-Za-z0-9_-]+):\s*(.*)$/);
+      if (itemKeyMatch) {
+        const child: Record<string, unknown> = {};
+        const [, itemKey, itemVal] = itemKeyMatch;
+        if (itemVal === "") {
+          const nextLine = findNextSignificantLine(i);
+          const nextIndent = nextLine?.match(/^ */)?.[0].length ?? -1;
+          const nextTrimmed = nextLine?.trim() ?? "";
+          const useArray =
+            nextLine !== null && nextIndent > indent && nextTrimmed.startsWith("- ");
+          child[itemKey] = useArray ? [] : {};
+          if (!useArray && typeof child[itemKey] === "object" && child[itemKey] !== null) {
+            stack.push({ indent, value: child[itemKey] });
+          }
+        } else {
+          const trimmedVal = itemVal.trim();
+          if (trimmedVal.startsWith("[") && trimmedVal.endsWith("]")) {
+            const inner = trimmedVal.slice(1, -1).trim();
+            child[itemKey] =
+              inner === ""
+                ? []
+                : inner.split(",").map((item) => parseScalar(item.trim()));
+          } else {
+            child[itemKey] = parseScalar(itemVal);
+          }
+        }
+        container.push(child);
+        stack.push({ indent, value: child });
+        continue;
+      }
+
+      container.push(parseScalar(itemRaw));
       continue;
     }
 
@@ -73,6 +105,15 @@ export function parseYaml(input: string): unknown {
 
     const [, key, rawVal] = keyMatch;
     if (rawVal !== "") {
+      const trimmedVal = rawVal.trim();
+      if (trimmedVal.startsWith("[") && trimmedVal.endsWith("]")) {
+        const inner = trimmedVal.slice(1, -1).trim();
+        (container as Record<string, unknown>)[key] =
+          inner === ""
+            ? []
+            : inner.split(",").map((item) => parseScalar(item.trim()));
+        continue;
+      }
       (container as Record<string, unknown>)[key] = parseScalar(rawVal);
       continue;
     }

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -1,0 +1,422 @@
+import fs from "node:fs";
+import path from "node:path";
+import { checkNameMatches } from "./ci-core.js";
+import { parseRepoConfigContent } from "./config-core.js";
+import { resolveCheckName } from "./release-ready.js";
+import type { GateMode, RepoConfig } from "./types.js";
+
+export type DoctorSeverity = "error" | "warn" | "info";
+
+export interface DoctorFinding {
+  severity: DoctorSeverity;
+  code: string;
+  message: string;
+}
+
+export interface DoctorReport {
+  configPath: string | null;
+  configValid: boolean;
+  gateMode: GateMode;
+  expectedCheckName: string;
+  configuredChecks: string[];
+  observedChecks: string[];
+  findings: DoctorFinding[];
+  ok: boolean;
+}
+
+export interface RunDoctorOptions {
+  cwd?: string;
+  offline?: boolean;
+  githubToken?: string;
+  repo?: string;
+  ref?: string;
+}
+
+const CONFIG_CANDIDATES = [".trailhead.yml", ".deployguard.yml"];
+
+export function findConfigPath(cwd: string): string | null {
+  for (const name of CONFIG_CANDIDATES) {
+    const candidate = path.join(cwd, name);
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+export function loadRepoConfig(cwd: string): {
+  configPath: string | null;
+  config: RepoConfig | null;
+  error?: string;
+} {
+  const configPath = findConfigPath(cwd);
+  if (!configPath) {
+    return {
+      configPath: null,
+      config: null,
+      error: "No .trailhead.yml or .deployguard.yml found",
+    };
+  }
+
+  const content = fs.readFileSync(configPath, "utf8");
+  const config = parseRepoConfigContent(content);
+  if (!config) {
+    return {
+      configPath,
+      config: null,
+      error: `Failed to parse ${path.basename(configPath)} — check YAML structure and schema fields`,
+    };
+  }
+
+  return { configPath, config };
+}
+
+export function collectConfiguredChecks(config: RepoConfig): string[] {
+  const names = new Set<string>();
+  for (const context of config.contexts) {
+    for (const name of context.ci?.required_checks ?? []) {
+      names.add(name);
+    }
+    for (const name of context.ci?.optional_checks ?? []) {
+      names.add(name);
+    }
+  }
+  return [...names];
+}
+
+export function validateConfigStructure(
+  config: RepoConfig,
+  configPath: string,
+): DoctorFinding[] {
+  const findings: DoctorFinding[] = [];
+  const fileName = path.basename(configPath);
+  const gateMode = config.gate.mode;
+
+  if (gateMode !== "risk-only" && config.schema_version < 2) {
+    findings.push({
+      severity: "warn",
+      code: "schema_version",
+      message: `${fileName} uses schema_version ${config.schema_version} with gate.mode=${gateMode} — consider schema_version: 2 and contexts[]`,
+    });
+  }
+
+  const risk = config.thresholds.risk;
+  const warn = config.thresholds.warn;
+  if (risk !== undefined && warn !== undefined && warn >= risk) {
+    findings.push({
+      severity: "warn",
+      code: "threshold_order",
+      message: `warn threshold (${warn}) should be lower than risk threshold (${risk})`,
+    });
+  }
+
+  if (gateMode !== "risk-only") {
+    if (config.contexts.length === 0) {
+      findings.push({
+        severity: "error",
+        code: "missing_contexts",
+        message:
+          "release-ready/advisory mode requires at least one contexts[] entry with ci.required_checks",
+      });
+    }
+
+    for (const context of config.contexts) {
+      const required = context.ci?.required_checks ?? [];
+      if (required.length === 0) {
+        findings.push({
+          severity: "warn",
+          code: "empty_required_checks",
+          message: `Context "${context.name}" has no ci.required_checks — release-ready may not wait for CI`,
+        });
+      }
+    }
+  }
+
+  const gateCheck = resolveCheckName(gateMode, config.gate.check_name);
+  if (gateMode !== "risk-only" && !gateCheck.includes("Release Ready")) {
+    findings.push({
+      severity: "info",
+      code: "custom_check_name",
+      message: `Branch protection should require check name "${gateCheck}"`,
+    });
+  }
+
+  return findings;
+}
+
+export function compareConfiguredChecks(
+  configuredChecks: string[],
+  observedChecks: string[],
+): DoctorFinding[] {
+  if (observedChecks.length === 0) {
+    return [];
+  }
+
+  const findings: DoctorFinding[] = [];
+  const observed = [...new Set(observedChecks)];
+
+  for (const configured of configuredChecks) {
+    const matched = observed.some((actual) => checkNameMatches(configured, actual));
+    if (!matched) {
+      findings.push({
+        severity: "warn",
+        code: "unknown_check_name",
+        message: `Configured check "${configured}" did not match any recent GitHub check run`,
+      });
+    }
+  }
+
+  const selfChecks = new Set([
+    "Trailhead",
+    "Trailhead — Release Ready",
+    resolveCheckName("release-ready"),
+    resolveCheckName("risk-only"),
+  ]);
+
+  for (const actual of observed) {
+    if (selfChecks.has(actual)) continue;
+    const referenced = configuredChecks.some((configured) =>
+      checkNameMatches(configured, actual),
+    );
+    if (!referenced) {
+      findings.push({
+        severity: "info",
+        code: "unconfigured_check",
+        message: `GitHub check "${actual}" is not referenced in contexts[].ci (optional unless required)`,
+      });
+    }
+  }
+
+  return findings;
+}
+
+export interface GitHubRepoRef {
+  owner: string;
+  repo: string;
+}
+
+export function parseRepoRef(input: string): GitHubRepoRef | null {
+  const match = input.match(/^([^/]+)\/([^/]+)$/);
+  if (!match) return null;
+  return { owner: match[1], repo: match[2] };
+}
+
+async function githubRequest<T>(
+  token: string,
+  url: string,
+): Promise<{ ok: true; data: T } | { ok: false; status: number; message: string }> {
+  const response = await fetch(url, {
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${token}`,
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+  });
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => "");
+    return {
+      ok: false,
+      status: response.status,
+      message: body || response.statusText,
+    };
+  }
+
+  return { ok: true, data: (await response.json()) as T };
+}
+
+async function resolveCommitSha(
+  token: string,
+  repoRef: GitHubRepoRef,
+  ref?: string,
+): Promise<string | null> {
+  if (ref) return ref;
+
+  const pulls = await githubRequest<Array<{ head: { sha: string } }>>(
+    token,
+    `https://api.github.com/repos/${repoRef.owner}/${repoRef.repo}/pulls?state=open&per_page=1`,
+  );
+  if (pulls.ok && pulls.data[0]?.head.sha) {
+    return pulls.data[0].head.sha;
+  }
+
+  const repo = await githubRequest<{ default_branch: string }>(
+    token,
+    `https://api.github.com/repos/${repoRef.owner}/${repoRef.repo}`,
+  );
+  if (!repo.ok) return null;
+
+  const branch = await githubRequest<{ commit: { sha: string } }>(
+    token,
+    `https://api.github.com/repos/${repoRef.owner}/${repoRef.repo}/branches/${encodeURIComponent(repo.data.default_branch)}`,
+  );
+  return branch.ok ? branch.data.commit.sha : null;
+}
+
+export async function fetchObservedCheckNames(options: {
+  token: string;
+  repo: GitHubRepoRef;
+  ref?: string;
+}): Promise<{ checks: string[]; error?: string }> {
+  const sha = await resolveCommitSha(options.token, options.repo, options.ref);
+  if (!sha) {
+    return { checks: [], error: "Could not resolve a commit SHA for check lookup" };
+  }
+
+  const names = new Set<string>();
+  let page = 1;
+
+  while (true) {
+    const result = await githubRequest<{
+      check_runs: Array<{ name: string }>;
+    }>(
+      options.token,
+      `https://api.github.com/repos/${options.repo.owner}/${options.repo.repo}/commits/${sha}/check-runs?per_page=100&page=${page}`,
+    );
+
+    if (!result.ok) {
+      return {
+        checks: [],
+        error: `GitHub Checks API failed (HTTP ${result.status})`,
+      };
+    }
+
+    for (const run of result.data.check_runs) {
+      names.add(run.name);
+    }
+
+    if (result.data.check_runs.length < 100) break;
+    page += 1;
+  }
+
+  return { checks: [...names].sort() };
+}
+
+export async function runDoctor(options: RunDoctorOptions = {}): Promise<DoctorReport> {
+  const cwd = options.cwd ?? process.cwd();
+  const loaded = loadRepoConfig(cwd);
+  const findings: DoctorFinding[] = [];
+
+  if (!loaded.configPath || !loaded.config) {
+    findings.push({
+      severity: "error",
+      code: "config_missing",
+      message: loaded.error ?? "Configuration file not found",
+    });
+    return {
+      configPath: loaded.configPath,
+      configValid: false,
+      gateMode: "risk-only",
+      expectedCheckName: "Trailhead",
+      configuredChecks: [],
+      observedChecks: [],
+      findings,
+      ok: false,
+    };
+  }
+
+  const config = loaded.config;
+  const gateMode = config.gate.mode;
+  const expectedCheckName = resolveCheckName(gateMode, config.gate.check_name);
+  const configuredChecks = collectConfiguredChecks(config);
+
+  findings.push(...validateConfigStructure(config, loaded.configPath));
+
+  let observedChecks: string[] = [];
+  if (!options.offline) {
+    const token = options.githubToken ?? process.env.GITHUB_TOKEN ?? "";
+    const repoInput = options.repo ?? process.env.GITHUB_REPOSITORY ?? "";
+    const repoRef = parseRepoRef(repoInput);
+
+    if (!token) {
+      findings.push({
+        severity: "info",
+        code: "offline_checks",
+        message:
+          "Set GITHUB_TOKEN (or pass --token) to compare configured checks against GitHub",
+      });
+    } else if (!repoRef) {
+      findings.push({
+        severity: "info",
+        code: "offline_checks",
+        message:
+          "Set GITHUB_REPOSITORY (or pass --repo owner/name) to compare checks against GitHub",
+      });
+    } else {
+      const observed = await fetchObservedCheckNames({
+        token,
+        repo: repoRef,
+        ref: options.ref,
+      });
+      observedChecks = observed.checks;
+      if (observed.error) {
+        findings.push({
+          severity: "warn",
+          code: "github_checks",
+          message: observed.error,
+        });
+      } else if (configuredChecks.length > 0) {
+        findings.push(...compareConfiguredChecks(configuredChecks, observedChecks));
+      }
+    }
+  }
+
+  const ok = !findings.some((finding) => finding.severity === "error");
+  return {
+    configPath: loaded.configPath,
+    configValid: true,
+    gateMode,
+    expectedCheckName,
+    configuredChecks,
+    observedChecks,
+    findings,
+    ok,
+  };
+}
+
+export function formatDoctorReport(report: DoctorReport): string {
+  const lines: string[] = [];
+  lines.push("Trailhead Doctor");
+  lines.push("================");
+  lines.push("");
+
+  if (report.configPath) {
+    lines.push(`Config: ${report.configPath}`);
+  } else {
+    lines.push("Config: (not found)");
+  }
+
+  lines.push(`Gate mode: ${report.gateMode}`);
+  lines.push(`Expected branch protection check: ${report.expectedCheckName}`);
+
+  if (report.configuredChecks.length > 0) {
+    lines.push(`Configured CI checks: ${report.configuredChecks.join(", ")}`);
+  }
+
+  if (report.observedChecks.length > 0) {
+    lines.push(`Observed GitHub checks: ${report.observedChecks.join(", ")}`);
+  }
+
+  if (report.findings.length === 0) {
+    lines.push("");
+    lines.push("No issues found.");
+    return lines.join("\n");
+  }
+
+  lines.push("");
+  for (const finding of report.findings) {
+    const label =
+      finding.severity === "error"
+        ? "ERROR"
+        : finding.severity === "warn"
+          ? "WARN"
+          : "INFO";
+    lines.push(`${label} [${finding.code}] ${finding.message}`);
+  }
+
+  lines.push("");
+  lines.push(
+    report.ok
+      ? "Result: OK (review warnings before release-ready rollout)"
+      : "Result: FAILED",
+  );
+  return lines.join("\n");
+}


### PR DESCRIPTION
## Summary
- Adds `trailhead doctor` CLI command (#155) to validate `.trailhead.yml` / `.deployguard.yml` and compare `contexts[].ci.required_checks` against recent GitHub check runs
- Introduces shared `src/doctor.ts` with offline config validation and optional GitHub Checks API lookup (`--offline`, `--repo`, `--token`, `--json`)
- Fixes YAML parser for real-world policy files: `- name: main` context lists and inline flow arrays like `[Lint]` / `[CI Gate, Build]`

## Test plan
- [x] `npx vitest run` — 544 tests passing
- [x] `cd cli && npm run build && node dist/index.js doctor --offline --path ..`
- [ ] CI green on PR

Closes #155

Made with [Cursor](https://cursor.com)