### PR TITLE
fix(dora): permissions warnings and evaluation-store FDRT fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,11 +225,13 @@ security:
 Enable built-in DORA-5 metrics to track deployment health:
 
 ```yaml
-- uses: KomatikAI/trailhead@v3
+- uses: KomatikAI/trailhead@v4
   with:
     dora-metrics: "true"
-    dora-environment: "production"
+    dora-environment: "Production"
 ```
+
+**Workflow permissions:** add `actions: read` (deployment frequency) and `deployments: read` (FDRT) to the job or workflow. If those APIs are unavailable, Trailhead can fall back to `trailhead_evaluations.deploy_outcome` when `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` are set (same as the evaluation store direct-insert path).
 
 Trailhead computes all five DORA metrics from your GitHub data:
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -44476,6 +44476,116 @@ function overallDoraRating(metrics) {
     const midIndex = Math.round(ratings.reduce((sum, r) => sum + order.indexOf(r), 0) / ratings.length);
     return order[Math.min(midIndex, order.length - 1)];
 }
+const FAILED_DEPLOY_OUTCOMES = new Set(["failure", "rollback", "error"]);
+const SUCCESS_DEPLOY_OUTCOMES = new Set(["success"]);
+function repoFullName() {
+    const { owner, repo } = github_context.repo;
+    return `${owner}/${repo}`;
+}
+function environmentCandidates(environment) {
+    const base = environment ?? "production";
+    const candidates = [base];
+    if (base.toLowerCase() === "production") {
+        candidates.push("Production");
+    }
+    else if (base === "Production") {
+        candidates.push("production");
+    }
+    return [...new Set(candidates)];
+}
+function median(values) {
+    if (values.length === 0)
+        return 0;
+    const sorted = [...values].sort((a, b) => a - b);
+    const mid = Math.floor(sorted.length / 2);
+    return sorted.length % 2 === 0
+        ? Math.round(((sorted[mid - 1] + sorted[mid]) / 2) * 10) / 10
+        : Math.round(sorted[mid] * 10) / 10;
+}
+function computeDeploymentFrequencyFromDeployEvents(events, windowDays) {
+    const successes = events.filter((event) => SUCCESS_DEPLOY_OUTCOMES.has(event.outcome)).length;
+    const weeks = windowDays / 7;
+    const deploysPerWeek = weeks > 0 ? Math.round((successes / weeks) * 100) / 100 : 0;
+    return {
+        deploysPerWeek,
+        rating: rateDeploymentFrequency(deploysPerWeek),
+        window: windowDays,
+    };
+}
+function computeFdrtFromDeployEvents(events) {
+    const sorted = [...events].sort((a, b) => new Date(a.deployedAt).getTime() - new Date(b.deployedAt).getTime());
+    const recoveryTimesHours = [];
+    for (let i = 0; i < sorted.length; i += 1) {
+        if (!FAILED_DEPLOY_OUTCOMES.has(sorted[i].outcome))
+            continue;
+        const failureTime = new Date(sorted[i].deployedAt).getTime();
+        for (let j = i + 1; j < sorted.length; j += 1) {
+            if (!SUCCESS_DEPLOY_OUTCOMES.has(sorted[j].outcome))
+                continue;
+            recoveryTimesHours.push(Math.max(0, (new Date(sorted[j].deployedAt).getTime() - failureTime) / (1000 * 60 * 60)));
+            break;
+        }
+    }
+    if (recoveryTimesHours.length === 0) {
+        return { medianHours: 0, rating: "elite", incidentCount: 0 };
+    }
+    const medianHours = median(recoveryTimesHours);
+    return {
+        medianHours,
+        rating: rateFDRT(medianHours),
+        incidentCount: recoveryTimesHours.length,
+    };
+}
+async function fetchDeployEventsFromStore(windowDays) {
+    const supabaseUrl = process.env.SUPABASE_URL;
+    const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    if (!supabaseUrl || !serviceKey)
+        return null;
+    const since = new Date(Date.now() - windowDays * 24 * 60 * 60 * 1000).toISOString();
+    const repoId = encodeURIComponent(repoFullName());
+    const url = `${supabaseUrl}/rest/v1/trailhead_evaluations` +
+        `?select=deploy_outcome,deployed_at` +
+        `&repo_id=eq.${repoId}` +
+        `&deploy_outcome=neq.null` +
+        `&deployed_at=gte.${encodeURIComponent(since)}` +
+        `&order=deployed_at.desc` +
+        `&limit=200`;
+    try {
+        const response = await fetch(url, {
+            headers: {
+                apikey: serviceKey,
+                Authorization: `Bearer ${serviceKey}`,
+                Accept: "application/json",
+            },
+            signal: AbortSignal.timeout(10_000),
+        });
+        if (!response.ok)
+            return null;
+        const rows = (await response.json());
+        return rows.map((row) => ({
+            outcome: row.deploy_outcome,
+            deployedAt: row.deployed_at,
+        }));
+    }
+    catch {
+        return null;
+    }
+}
+async function loadDeploymentsInWindow(octokit, owner, repo, since, environment) {
+    for (const env of environmentCandidates(environment)) {
+        const { data } = await octokit.request("GET /repos/{owner}/{repo}/deployments", {
+            owner,
+            repo,
+            environment: env,
+            per_page: 100,
+        });
+        const deploymentsInWindow = data.filter((deployment) => new Date(deployment.created_at).toISOString() >= since);
+        if (deploymentsInWindow.length > 0) {
+            return deploymentsInWindow;
+        }
+    }
+    return [];
+}
 // ---------------------------------------------------------------------------
 // Deployment Frequency
 // ---------------------------------------------------------------------------
@@ -44485,43 +44595,57 @@ async function computeDeploymentFrequency(token, windowDays, environment) {
         const { owner, repo } = github_context.repo;
         const since = new Date(Date.now() - windowDays * 24 * 60 * 60 * 1000).toISOString();
         if (environment) {
-            const { data: deployments } = await octokit.request("GET /repos/{owner}/{repo}/deployments", {
-                owner,
-                repo,
-                environment,
-                per_page: 100,
-            });
-            const deploymentsInWindow = deployments.filter((d) => new Date(d.created_at).toISOString() >= since);
+            const deploymentsInWindow = await loadDeploymentsInWindow(octokit, owner, repo, since, environment);
             const weeks = windowDays / 7;
             const deploysPerWeek = weeks > 0 ? Math.round((deploymentsInWindow.length / weeks) * 100) / 100 : 0;
-            return {
-                deploysPerWeek,
-                rating: rateDeploymentFrequency(deploysPerWeek),
-                window: windowDays,
-            };
+            if (deploysPerWeek > 0) {
+                return {
+                    deploysPerWeek,
+                    rating: rateDeploymentFrequency(deploysPerWeek),
+                    window: windowDays,
+                };
+            }
         }
-        const { data } = await octokit.rest.actions.listWorkflowRunsForRepo({
-            owner,
-            repo,
-            status: "success",
-            created: `>=${since}`,
-            per_page: 100,
-            event: "push",
-        });
-        const { data: repoInfo } = await octokit.rest.repos.get({ owner, repo });
-        const defaultBranch = repoInfo.default_branch;
-        const deployRuns = data.workflow_runs.filter((r) => r.head_branch === defaultBranch);
-        const deployCount = deployRuns.length;
-        const weeks = windowDays / 7;
-        const deploysPerWeek = weeks > 0 ? Math.round((deployCount / weeks) * 100) / 100 : 0;
-        return {
-            deploysPerWeek,
-            rating: rateDeploymentFrequency(deploysPerWeek),
-            window: windowDays,
-        };
+        else {
+            const { data } = await octokit.rest.actions.listWorkflowRunsForRepo({
+                owner,
+                repo,
+                status: "success",
+                created: `>=${since}`,
+                per_page: 100,
+                event: "push",
+            });
+            const { data: repoInfo } = await octokit.rest.repos.get({ owner, repo });
+            const defaultBranch = repoInfo.default_branch;
+            const deployRuns = data.workflow_runs.filter((r) => r.head_branch === defaultBranch);
+            const deployCount = deployRuns.length;
+            const weeks = windowDays / 7;
+            const deploysPerWeek = weeks > 0 ? Math.round((deployCount / weeks) * 100) / 100 : 0;
+            if (deploysPerWeek > 0) {
+                return {
+                    deploysPerWeek,
+                    rating: rateDeploymentFrequency(deploysPerWeek),
+                    window: windowDays,
+                };
+            }
+        }
+        const storeEvents = await fetchDeployEventsFromStore(windowDays);
+        if (storeEvents && storeEvents.length > 0) {
+            const fromStore = computeDeploymentFrequencyFromDeployEvents(storeEvents, windowDays);
+            if (fromStore.deploysPerWeek > 0) {
+                info(`DORA deployment frequency: using ${storeEvents.length} deploy event(s) from evaluation store`);
+                return fromStore;
+            }
+        }
+        return { deploysPerWeek: 0, rating: "low", window: windowDays };
     }
     catch (error) {
-        core_debug(`DORA deployment frequency failed: ${error}`);
+        warning(`DORA deployment frequency: GitHub Actions API failed (${error}). ` +
+            `Grant actions:read to GITHUB_TOKEN, or set SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY for evaluation-store fallback.`);
+        const storeEvents = await fetchDeployEventsFromStore(windowDays);
+        if (storeEvents && storeEvents.length > 0) {
+            return computeDeploymentFrequencyFromDeployEvents(storeEvents, windowDays);
+        }
         return { deploysPerWeek: 0, rating: "low", window: windowDays };
     }
 }
@@ -44655,15 +44779,19 @@ async function computeLeadTimeToChange(token, windowDays, servicePaths) {
 // Failed Deployment Recovery Time (FDRT) — new in DORA-5
 // ---------------------------------------------------------------------------
 async function computeFailedDeployRecoveryTime(token, windowDays, environment) {
+    const emptyResult = { medianHours: 0, rating: "elite", incidentCount: 0 };
     try {
         const octokit = getOctokit(token);
         const { owner, repo } = github_context.repo;
         const since = new Date(Date.now() - windowDays * 24 * 60 * 60 * 1000).toISOString();
-        const env = environment ?? "production";
-        const { data: deployments } = await octokit.request("GET /repos/{owner}/{repo}/deployments", { owner, repo, environment: env, per_page: 50 });
-        const deploymentsInWindow = deployments.filter((d) => new Date(d.created_at).toISOString() >= since);
+        const deploymentsInWindow = await loadDeploymentsInWindow(octokit, owner, repo, since, environment);
         if (deploymentsInWindow.length === 0) {
-            return { medianHours: 0, rating: "elite", incidentCount: 0 };
+            const storeEvents = await fetchDeployEventsFromStore(windowDays);
+            if (storeEvents && storeEvents.length > 0) {
+                info(`DORA FDRT: using ${storeEvents.length} deploy event(s) from evaluation store`);
+                return computeFdrtFromDeployEvents(storeEvents);
+            }
+            return emptyResult;
         }
         const recoveryTimesHours = [];
         for (let i = 0; i < deploymentsInWindow.length; i++) {
@@ -44693,23 +44821,31 @@ async function computeFailedDeployRecoveryTime(token, windowDays, environment) {
                 // skip deployments we can't fetch statuses for
             }
         }
-        if (recoveryTimesHours.length === 0) {
-            return { medianHours: 0, rating: "elite", incidentCount: 0 };
+        if (recoveryTimesHours.length > 0) {
+            const medianHours = median(recoveryTimesHours);
+            return {
+                medianHours,
+                rating: rateFDRT(medianHours),
+                incidentCount: recoveryTimesHours.length,
+            };
         }
-        recoveryTimesHours.sort((a, b) => a - b);
-        const mid = Math.floor(recoveryTimesHours.length / 2);
-        const medianHours = recoveryTimesHours.length % 2 === 0
-            ? Math.round(((recoveryTimesHours[mid - 1] + recoveryTimesHours[mid]) / 2) * 10) /
-                10
-            : Math.round(recoveryTimesHours[mid] * 10) / 10;
-        return {
-            medianHours,
-            rating: rateFDRT(medianHours),
-            incidentCount: recoveryTimesHours.length,
-        };
+        const storeEvents = await fetchDeployEventsFromStore(windowDays);
+        if (storeEvents && storeEvents.length > 0) {
+            const fromStore = computeFdrtFromDeployEvents(storeEvents);
+            if (fromStore.incidentCount > 0) {
+                info(`DORA FDRT: using evaluation store (${fromStore.incidentCount} incident(s))`);
+                return fromStore;
+            }
+        }
+        return emptyResult;
     }
     catch (error) {
-        core_debug(`DORA FDRT failed: ${error}`);
+        warning(`DORA FDRT: GitHub Deployments API failed (${error}). ` +
+            `Grant deployments:read to GITHUB_TOKEN, or set SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY for evaluation-store fallback.`);
+        const storeEvents = await fetchDeployEventsFromStore(windowDays);
+        if (storeEvents && storeEvents.length > 0) {
+            return computeFdrtFromDeployEvents(storeEvents);
+        }
         return { medianHours: 0, rating: "low", incidentCount: 0 };
     }
 }

--- a/docs/adr/005-dora-from-github-data.md
+++ b/docs/adr/005-dora-from-github-data.md
@@ -22,6 +22,8 @@ Compute all five DORA metrics **directly from GitHub APIs** — workflow runs, p
 | Failed Deployment Recovery Time | Median time between failed and next successful deployment                |
 | Change Rework Rate              | PRs modifying same files as recently merged PRs                          |
 
+**Workflow permissions:** deployment frequency needs `actions: read` on `GITHUB_TOKEN`. FDRT needs `deployments: read` (or GitHub Deployments enabled). When those APIs are unavailable, Trailhead falls back to `trailhead_evaluations.deploy_outcome` rows when `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` are set (same env vars as the evaluation store direct-insert path).
+
 ## Rationale
 
 - GitHub data is universally available — zero additional infrastructure.

--- a/src/__tests__/dora.test.ts
+++ b/src/__tests__/dora.test.ts
@@ -17,6 +17,8 @@ vi.mock("@actions/github", () => ({
 import * as github from "@actions/github";
 import {
   computeDoraMetrics,
+  computeDeploymentFrequencyFromDeployEvents,
+  computeFdrtFromDeployEvents,
   formatDoraReport,
   formatDeploymentFrequencyForOutput,
 } from "../dora.js";
@@ -258,6 +260,44 @@ describe("computeDoraMetrics", () => {
     });
 
     expect(metrics.environment).toBe("staging");
+  });
+});
+
+describe("computeFdrtFromDeployEvents", () => {
+  it("computes median recovery time from failure followed by success", () => {
+    const result = computeFdrtFromDeployEvents([
+      { outcome: "success", deployedAt: "2026-05-01T12:00:00Z" },
+      { outcome: "failure", deployedAt: "2026-05-01T10:00:00Z" },
+    ]);
+
+    expect(result.incidentCount).toBe(1);
+    expect(result.medianHours).toBe(2);
+    expect(result.rating).toBe("high");
+  });
+
+  it("returns no incidents when no failure-to-success pairs exist", () => {
+    const result = computeFdrtFromDeployEvents([
+      { outcome: "success", deployedAt: "2026-05-01T12:00:00Z" },
+      { outcome: "success", deployedAt: "2026-05-01T10:00:00Z" },
+    ]);
+
+    expect(result.incidentCount).toBe(0);
+  });
+});
+
+describe("computeDeploymentFrequencyFromDeployEvents", () => {
+  it("counts successful deploy events per week", () => {
+    const result = computeDeploymentFrequencyFromDeployEvents(
+      [
+        { outcome: "success", deployedAt: "2026-05-01T12:00:00Z" },
+        { outcome: "failure", deployedAt: "2026-05-01T10:00:00Z" },
+        { outcome: "success", deployedAt: "2026-05-02T12:00:00Z" },
+      ],
+      30,
+    );
+
+    expect(result.deploysPerWeek).toBeGreaterThan(0);
+    expect(result.window).toBe(30);
   });
 });
 

--- a/src/dora.ts
+++ b/src/dora.ts
@@ -102,6 +102,161 @@ function overallDoraRating(
   return order[Math.min(midIndex, order.length - 1)];
 }
 
+export interface DeployEvent {
+  outcome: string;
+  deployedAt: string;
+}
+
+const FAILED_DEPLOY_OUTCOMES = new Set(["failure", "rollback", "error"]);
+const SUCCESS_DEPLOY_OUTCOMES = new Set(["success"]);
+
+function repoFullName(): string {
+  const { owner, repo } = github.context.repo;
+  return `${owner}/${repo}`;
+}
+
+function environmentCandidates(environment?: string): string[] {
+  const base = environment ?? "production";
+  const candidates = [base];
+  if (base.toLowerCase() === "production") {
+    candidates.push("Production");
+  } else if (base === "Production") {
+    candidates.push("production");
+  }
+  return [...new Set(candidates)];
+}
+
+function median(values: number[]): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? Math.round(((sorted[mid - 1] + sorted[mid]) / 2) * 10) / 10
+    : Math.round(sorted[mid] * 10) / 10;
+}
+
+export function computeDeploymentFrequencyFromDeployEvents(
+  events: DeployEvent[],
+  windowDays: number,
+): DoraMetrics["deploymentFrequency"] {
+  const successes = events.filter((event) =>
+    SUCCESS_DEPLOY_OUTCOMES.has(event.outcome),
+  ).length;
+  const weeks = windowDays / 7;
+  const deploysPerWeek = weeks > 0 ? Math.round((successes / weeks) * 100) / 100 : 0;
+  return {
+    deploysPerWeek,
+    rating: rateDeploymentFrequency(deploysPerWeek),
+    window: windowDays,
+  };
+}
+
+export function computeFdrtFromDeployEvents(
+  events: DeployEvent[],
+): DoraMetrics["failedDeployRecoveryTime"] {
+  const sorted = [...events].sort(
+    (a, b) => new Date(a.deployedAt).getTime() - new Date(b.deployedAt).getTime(),
+  );
+  const recoveryTimesHours: number[] = [];
+
+  for (let i = 0; i < sorted.length; i += 1) {
+    if (!FAILED_DEPLOY_OUTCOMES.has(sorted[i].outcome)) continue;
+
+    const failureTime = new Date(sorted[i].deployedAt).getTime();
+    for (let j = i + 1; j < sorted.length; j += 1) {
+      if (!SUCCESS_DEPLOY_OUTCOMES.has(sorted[j].outcome)) continue;
+      recoveryTimesHours.push(
+        Math.max(
+          0,
+          (new Date(sorted[j].deployedAt).getTime() - failureTime) / (1000 * 60 * 60),
+        ),
+      );
+      break;
+    }
+  }
+
+  if (recoveryTimesHours.length === 0) {
+    return { medianHours: 0, rating: "elite", incidentCount: 0 };
+  }
+
+  const medianHours = median(recoveryTimesHours);
+  return {
+    medianHours,
+    rating: rateFDRT(medianHours),
+    incidentCount: recoveryTimesHours.length,
+  };
+}
+
+async function fetchDeployEventsFromStore(
+  windowDays: number,
+): Promise<DeployEvent[] | null> {
+  const supabaseUrl = process.env.SUPABASE_URL;
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceKey) return null;
+
+  const since = new Date(Date.now() - windowDays * 24 * 60 * 60 * 1000).toISOString();
+  const repoId = encodeURIComponent(repoFullName());
+  const url =
+    `${supabaseUrl}/rest/v1/trailhead_evaluations` +
+    `?select=deploy_outcome,deployed_at` +
+    `&repo_id=eq.${repoId}` +
+    `&deploy_outcome=neq.null` +
+    `&deployed_at=gte.${encodeURIComponent(since)}` +
+    `&order=deployed_at.desc` +
+    `&limit=200`;
+
+  try {
+    const response = await fetch(url, {
+      headers: {
+        apikey: serviceKey,
+        Authorization: `Bearer ${serviceKey}`,
+        Accept: "application/json",
+      },
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!response.ok) return null;
+
+    const rows = (await response.json()) as Array<{
+      deploy_outcome: string;
+      deployed_at: string;
+    }>;
+
+    return rows.map((row) => ({
+      outcome: row.deploy_outcome,
+      deployedAt: row.deployed_at,
+    }));
+  } catch {
+    return null;
+  }
+}
+
+async function loadDeploymentsInWindow(
+  octokit: ReturnType<typeof github.getOctokit>,
+  owner: string,
+  repo: string,
+  since: string,
+  environment?: string,
+): Promise<Array<{ id: number; created_at: string }>> {
+  for (const env of environmentCandidates(environment)) {
+    const { data } = await octokit.request("GET /repos/{owner}/{repo}/deployments", {
+      owner,
+      repo,
+      environment: env,
+      per_page: 100,
+    });
+
+    const deploymentsInWindow = (
+      data as Array<{ id: number; created_at: string }>
+    ).filter((deployment) => new Date(deployment.created_at).toISOString() >= since);
+
+    if (deploymentsInWindow.length > 0) {
+      return deploymentsInWindow;
+    }
+  }
+
+  return [];
+}
+
 // ---------------------------------------------------------------------------
 // Deployment Frequency
 // ---------------------------------------------------------------------------
@@ -118,56 +273,80 @@ async function computeDeploymentFrequency(
     const since = new Date(Date.now() - windowDays * 24 * 60 * 60 * 1000).toISOString();
 
     if (environment) {
-      const { data: deployments } = await octokit.request(
-        "GET /repos/{owner}/{repo}/deployments",
-        {
-          owner,
-          repo,
-          environment,
-          per_page: 100,
-        },
-      );
-
-      const deploymentsInWindow = deployments.filter(
-        (d: { created_at: string }) => new Date(d.created_at).toISOString() >= since,
+      const deploymentsInWindow = await loadDeploymentsInWindow(
+        octokit,
+        owner,
+        repo,
+        since,
+        environment,
       );
 
       const weeks = windowDays / 7;
       const deploysPerWeek =
         weeks > 0 ? Math.round((deploymentsInWindow.length / weeks) * 100) / 100 : 0;
 
-      return {
-        deploysPerWeek,
-        rating: rateDeploymentFrequency(deploysPerWeek),
-        window: windowDays,
-      };
+      if (deploysPerWeek > 0) {
+        return {
+          deploysPerWeek,
+          rating: rateDeploymentFrequency(deploysPerWeek),
+          window: windowDays,
+        };
+      }
+    } else {
+      const { data } = await octokit.rest.actions.listWorkflowRunsForRepo({
+        owner,
+        repo,
+        status: "success",
+        created: `>=${since}`,
+        per_page: 100,
+        event: "push",
+      });
+
+      const { data: repoInfo } = await octokit.rest.repos.get({ owner, repo });
+      const defaultBranch = repoInfo.default_branch;
+
+      const deployRuns = data.workflow_runs.filter(
+        (r) => r.head_branch === defaultBranch,
+      );
+
+      const deployCount = deployRuns.length;
+      const weeks = windowDays / 7;
+      const deploysPerWeek =
+        weeks > 0 ? Math.round((deployCount / weeks) * 100) / 100 : 0;
+
+      if (deploysPerWeek > 0) {
+        return {
+          deploysPerWeek,
+          rating: rateDeploymentFrequency(deploysPerWeek),
+          window: windowDays,
+        };
+      }
     }
 
-    const { data } = await octokit.rest.actions.listWorkflowRunsForRepo({
-      owner,
-      repo,
-      status: "success",
-      created: `>=${since}`,
-      per_page: 100,
-      event: "push",
-    });
+    const storeEvents = await fetchDeployEventsFromStore(windowDays);
+    if (storeEvents && storeEvents.length > 0) {
+      const fromStore = computeDeploymentFrequencyFromDeployEvents(
+        storeEvents,
+        windowDays,
+      );
+      if (fromStore.deploysPerWeek > 0) {
+        core.info(
+          `DORA deployment frequency: using ${storeEvents.length} deploy event(s) from evaluation store`,
+        );
+        return fromStore;
+      }
+    }
 
-    const { data: repoInfo } = await octokit.rest.repos.get({ owner, repo });
-    const defaultBranch = repoInfo.default_branch;
-
-    const deployRuns = data.workflow_runs.filter((r) => r.head_branch === defaultBranch);
-
-    const deployCount = deployRuns.length;
-    const weeks = windowDays / 7;
-    const deploysPerWeek = weeks > 0 ? Math.round((deployCount / weeks) * 100) / 100 : 0;
-
-    return {
-      deploysPerWeek,
-      rating: rateDeploymentFrequency(deploysPerWeek),
-      window: windowDays,
-    };
+    return { deploysPerWeek: 0, rating: "low", window: windowDays };
   } catch (error) {
-    core.debug(`DORA deployment frequency failed: ${error}`);
+    core.warning(
+      `DORA deployment frequency: GitHub Actions API failed (${error}). ` +
+        `Grant actions:read to GITHUB_TOKEN, or set SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY for evaluation-store fallback.`,
+    );
+    const storeEvents = await fetchDeployEventsFromStore(windowDays);
+    if (storeEvents && storeEvents.length > 0) {
+      return computeDeploymentFrequencyFromDeployEvents(storeEvents, windowDays);
+    }
     return { deploysPerWeek: 0, rating: "low", window: windowDays };
   }
 }
@@ -355,34 +534,36 @@ async function computeFailedDeployRecoveryTime(
   windowDays: number,
   environment?: string,
 ): Promise<DoraMetrics["failedDeployRecoveryTime"]> {
+  const emptyResult = { medianHours: 0, rating: "elite" as const, incidentCount: 0 };
+
   try {
     const octokit = github.getOctokit(token);
     const { owner, repo } = github.context.repo;
 
     const since = new Date(Date.now() - windowDays * 24 * 60 * 60 * 1000).toISOString();
-
-    const env = environment ?? "production";
-
-    const { data: deployments } = await octokit.request(
-      "GET /repos/{owner}/{repo}/deployments",
-      { owner, repo, environment: env, per_page: 50 },
-    );
-
-    const deploymentsInWindow = deployments.filter(
-      (d: { created_at: string }) => new Date(d.created_at).toISOString() >= since,
+    const deploymentsInWindow = await loadDeploymentsInWindow(
+      octokit,
+      owner,
+      repo,
+      since,
+      environment,
     );
 
     if (deploymentsInWindow.length === 0) {
-      return { medianHours: 0, rating: "elite", incidentCount: 0 };
+      const storeEvents = await fetchDeployEventsFromStore(windowDays);
+      if (storeEvents && storeEvents.length > 0) {
+        core.info(
+          `DORA FDRT: using ${storeEvents.length} deploy event(s) from evaluation store`,
+        );
+        return computeFdrtFromDeployEvents(storeEvents);
+      }
+      return emptyResult;
     }
 
     const recoveryTimesHours: number[] = [];
 
     for (let i = 0; i < deploymentsInWindow.length; i++) {
-      const dep = deploymentsInWindow[i] as {
-        id: number;
-        created_at: string;
-      };
+      const dep = deploymentsInWindow[i];
       try {
         const { data: statuses } = await octokit.request(
           "GET /repos/{owner}/{repo}/deployments/{deployment_id}/statuses",
@@ -398,10 +579,7 @@ async function computeFailedDeployRecoveryTime(
           let recoveryTime: number | null = null;
 
           for (let j = i - 1; j >= 0; j--) {
-            const nextDep = deploymentsInWindow[j] as {
-              id: number;
-              created_at: string;
-            };
+            const nextDep = deploymentsInWindow[j];
             const { data: nextStatuses } = await octokit.request(
               "GET /repos/{owner}/{repo}/deployments/{deployment_id}/statuses",
               { owner, repo, deployment_id: nextDep.id, per_page: 10 },
@@ -425,25 +603,36 @@ async function computeFailedDeployRecoveryTime(
       }
     }
 
-    if (recoveryTimesHours.length === 0) {
-      return { medianHours: 0, rating: "elite", incidentCount: 0 };
+    if (recoveryTimesHours.length > 0) {
+      const medianHours = median(recoveryTimesHours);
+      return {
+        medianHours,
+        rating: rateFDRT(medianHours),
+        incidentCount: recoveryTimesHours.length,
+      };
     }
 
-    recoveryTimesHours.sort((a, b) => a - b);
-    const mid = Math.floor(recoveryTimesHours.length / 2);
-    const medianHours =
-      recoveryTimesHours.length % 2 === 0
-        ? Math.round(((recoveryTimesHours[mid - 1] + recoveryTimesHours[mid]) / 2) * 10) /
-          10
-        : Math.round(recoveryTimesHours[mid] * 10) / 10;
+    const storeEvents = await fetchDeployEventsFromStore(windowDays);
+    if (storeEvents && storeEvents.length > 0) {
+      const fromStore = computeFdrtFromDeployEvents(storeEvents);
+      if (fromStore.incidentCount > 0) {
+        core.info(
+          `DORA FDRT: using evaluation store (${fromStore.incidentCount} incident(s))`,
+        );
+        return fromStore;
+      }
+    }
 
-    return {
-      medianHours,
-      rating: rateFDRT(medianHours),
-      incidentCount: recoveryTimesHours.length,
-    };
+    return emptyResult;
   } catch (error) {
-    core.debug(`DORA FDRT failed: ${error}`);
+    core.warning(
+      `DORA FDRT: GitHub Deployments API failed (${error}). ` +
+        `Grant deployments:read to GITHUB_TOKEN, or set SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY for evaluation-store fallback.`,
+    );
+    const storeEvents = await fetchDeployEventsFromStore(windowDays);
+    if (storeEvents && storeEvents.length > 0) {
+      return computeFdrtFromDeployEvents(storeEvents);
+    }
     return { medianHours: 0, rating: "low", incidentCount: 0 };
   }
 }


### PR DESCRIPTION
## Summary
- Warn when GitHub Actions/Deployments APIs fail (missing `actions:read` / `deployments:read`) instead of silently returning empty metrics
- Fall back to `trailhead_evaluations.deploy_outcome` for deployment frequency and FDRT when Supabase env vars are configured
- Try `Production` / `production` environment aliases for GitHub Deployments lookups

## Test plan
- [x] `npx vitest run src/__tests__/dora.test.ts` — 18 tests
- [x] `npm run build` + committed `dist/`

Komatik consumer fix: https://github.com/KomatikAI/komatik/pull/2006