### PR TITLE
feat(v4.3): agent brief in PR comments + wire remediation (Epic A2)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -151,6 +151,10 @@ inputs:
     description: "GitHub check run name. Defaults to 'Trailhead — Release Ready' in release-ready mode, 'Trailhead' in risk-only mode."
     required: false
     default: ""
+  agent-brief:
+    description: "Agent remediation brief in PR comments: off, collapsed (default for agent PRs), or expanded. Omit to use .trailhead.yml gate.agent_brief or provenance-based default."
+    required: false
+    default: ""
   security-gate:
     description: "Enable GitHub Code Scanning alert integration as a risk factor. Set to 'false' to disable."
     required: false

--- a/cloud/docs/tuning-digest-spec.md
+++ b/cloud/docs/tuning-digest-spec.md
@@ -18,17 +18,17 @@ All data sourced from existing tables — no new tables required for v1.
 
 ### `trailhead_evaluations`
 
-| Column | Source | Notes |
-|--------|--------|-------|
-| `repo_id` | existing | group key |
-| `pr_number` | existing | join key |
-| `gate_decision` | existing | `allow` / `warn` / `block` |
-| `risk_factors` (JSONB) | existing | iterate to count per-detector triggers |
-| `policy_findings` (text[]) | existing | parse detector codes for ci_integrity, workflow_security, etc. |
-| `remediation` (JSONB, **new in A1**) | new | `fixes[].code` is the canonical detector identifier |
-| `policyOverride` (JSONB) | existing | non-null = override applied |
-| `agent_provenance_id` (text, **new in A5**) | new | denormalised from `pr.provenance.source` |
-| `created_at` | existing | windowing |
+| Column                                      | Source   | Notes                                                          |
+| ------------------------------------------- | -------- | -------------------------------------------------------------- |
+| `repo_id`                                   | existing | group key                                                      |
+| `pr_number`                                 | existing | join key                                                       |
+| `gate_decision`                             | existing | `allow` / `warn` / `block`                                     |
+| `risk_factors` (JSONB)                      | existing | iterate to count per-detector triggers                         |
+| `policy_findings` (text[])                  | existing | parse detector codes for ci_integrity, workflow_security, etc. |
+| `remediation` (JSONB, **new in A1**)        | new      | `fixes[].code` is the canonical detector identifier            |
+| `policyOverride` (JSONB)                    | existing | non-null = override applied                                    |
+| `agent_provenance_id` (text, **new in A5**) | new      | denormalised from `pr.provenance.source`                       |
+| `created_at`                                | existing | windowing                                                      |
 
 ### Feedback signals → `false_positive_rate` denominator
 
@@ -68,14 +68,18 @@ Payload posted to `digest_webhook_url` configured in `.trailhead.yml`. Default S
   "detectors": [
     {
       "code": "risk.test_coverage",
-      "blocked": 12, "warned": 24, "fixed_after_remediation": 18,
+      "blocked": 12,
+      "warned": 24,
+      "fixed_after_remediation": 18,
       "fp_signals": 1,
       "fp_rate": 0.028,
       "status": "ok"
     },
     {
       "code": "policy.duplicate_logic",
-      "blocked": 2, "warned": 19, "fixed_after_remediation": 3,
+      "blocked": 2,
+      "warned": 19,
+      "fixed_after_remediation": 3,
       "fp_signals": 6,
       "fp_rate": 0.286,
       "status": "auto_downgraded",
@@ -85,17 +89,30 @@ Payload posted to `digest_webhook_url` configured in `.trailhead.yml`. Default S
   "agents": [
     {
       "agent_id": "frontend-dev",
-      "prs": 22, "ready": 15, "blocked": 4, "abandoned": 3,
+      "prs": 22,
+      "ready": 15,
+      "blocked": 4,
+      "abandoned": 3,
       "median_rounds_to_ready": 2,
       "sensitive_path_violations": 0,
       "trust_signal": "converging"
     }
   ],
   "overrides": [
-    { "pr_url": "...", "author": "david", "reason": "hotfix: prod outage", "pre_decision": "block" }
+    {
+      "pr_url": "...",
+      "author": "david",
+      "reason": "hotfix: prod outage",
+      "pre_decision": "block"
+    }
   ],
   "auto_downgrades_last_7d": [
-    { "detector": "policy.duplicate_logic", "downgraded_at": "...", "fp_rate_at_trigger": 0.31, "tuning_issue": "#NNN" }
+    {
+      "detector": "policy.duplicate_logic",
+      "downgraded_at": "...",
+      "fp_rate_at_trigger": 0.31,
+      "tuning_issue": "#NNN"
+    }
   ]
 }
 ```
@@ -107,6 +124,7 @@ Cron schedule: hourly (allows fast reaction to a runaway detector).
 **Trigger:** any detector whose **fleet-wide** 7-day rolling FP rate ≥ `0.15` AND has ≥ 10 emissions in the window.
 
 **Effect:**
+
 - Detector's `mode` flipped from `block` → `warn` in the Trailhead Cloud config layer (overrides per-repo `.trailhead.yml` until cleared)
 - Auto-opens a tuning issue in `KomatikAI/trailhead` titled `[tune] detector <code> auto-downgraded (FP rate <pct>%)`
 - Issue body: detector code, FP rate, sample of recent flagged PRs, sample of feedback reasons

--- a/dist/index.js
+++ b/dist/index.js
@@ -40604,6 +40604,7 @@ const PrProvenance = objectType({
     source: stringType().optional(),
 });
 const GateMode = enumType(["release-ready", "advisory", "risk-only"]);
+const AgentBriefMode = enumType(["off", "collapsed", "expanded"]);
 const CiCheckStatusEnum = enumType([
     "pass",
     "fail",
@@ -40731,6 +40732,7 @@ const GateEvaluation = objectType({
     gateMode: GateMode.optional(),
     storePersisted: booleanType().optional(),
     remediation: Remediation.optional(),
+    agentBriefMode: AgentBriefMode.optional(),
     cross_repo_impact: objectType({
         services: arrayType(objectType({
             serviceName: stringType(),
@@ -40826,10 +40828,16 @@ const TrailheadContext = objectType({
 const GateConfig = objectType({
     mode: GateMode.default("risk-only"),
     check_name: stringType().default("Trailhead — Release Ready"),
+    agent_brief: AgentBriefMode.optional(),
+});
+const RemediationConfig = objectType({
+    enabled: booleanType().default(true),
+    max_loop_rounds: numberType().int().min(0).default(3),
 });
 const RepoConfig = objectType({
     schema_version: numberType().int().positive().default(1),
     gate: GateConfig.default({}),
+    remediation: RemediationConfig.optional(),
     contexts: arrayType(TrailheadContext).default([]),
     sensitivity: objectType({
         high: arrayType(stringType()).default([]),
@@ -42360,7 +42368,385 @@ function formatSecuritySection(alerts) {
     return lines.join("\n");
 }
 
+;// CONCATENATED MODULE: ./src/remediation.ts
+// Pure remediation derivation — no framework dependencies.
+// Maps gate findings (risk factors, CI failures, policy violations, release-ready
+// reasons) into a machine-readable Remediation block that agents can act on.
+//
+// Shared across the GitHub Action, MCP server, and GitHub App via the existing
+// prebuild copy pattern. Keep this module free of @actions/*, octokit, and Node
+// runtime imports so it stays portable.
+
+const SUGGESTED_TEST_COMMAND = "npm test -- --run";
+const SUGGESTED_LINT_COMMAND = "npm run lint -- --fix";
+const SUGGESTED_FORMAT_COMMAND = "npm run format";
+const factorCues = {
+    test_coverage: {
+        triggerScore: 60,
+        advisoryScore: 30,
+        build: (factor) => {
+            const missing = factor.detail?.missing_tests ?? [];
+            const filesText = missing.length
+                ? missing.slice(0, 5).join(", ") + (missing.length > 5 ? ", …" : "")
+                : "source files in this PR";
+            return {
+                code: "risk.test_coverage",
+                title: "Test coverage missing for changed source",
+                detail: `Source changes lack matching test coverage in ${filesText}. Add tests that exercise the added or modified exports, then re-run the gate.`,
+                files: missing,
+                suggested_action: "Add a test file (or extend an existing one) covering the modified exports.",
+                suggested_command: SUGGESTED_TEST_COMMAND,
+                autofix_eligible: missing.length > 0,
+                autofix_class: "test-scaffold",
+            };
+        },
+    },
+    sensitive_files: {
+        triggerScore: 50,
+        advisoryScore: 25,
+        build: (factor) => {
+            const touched = factor.detail?.files ?? [];
+            return {
+                code: "risk.sensitive_files",
+                severity: "warn",
+                title: "Sensitive files modified",
+                detail: `This PR touches paths flagged as sensitive: ${touched.slice(0, 8).join(", ")}. These require a CODEOWNER review before merge.`,
+                files: touched,
+                suggested_action: "Request review from a CODEOWNER for the touched paths, or split sensitive changes into a dedicated PR.",
+                autofix_eligible: false,
+            };
+        },
+    },
+    ci_integrity: {
+        triggerScore: 40,
+        build: (factor) => {
+            const reasons = factor.detail?.reasons ?? [];
+            return {
+                code: "policy.ci_integrity",
+                title: "CI confidence downgrade detected",
+                detail: `Trailhead detected a CI confidence change: ${reasons.join("; ") || "tests deleted, coverage reduced, or workflow weakened"}. Restore the removed signal or justify the change in the PR description.`,
+                suggested_action: "Restore deleted tests, undo the workflow change, or add a justification comment.",
+                autofix_eligible: false,
+            };
+        },
+    },
+    workflow_security: {
+        triggerScore: 40,
+        build: (factor) => {
+            const violations = factor.detail?.violations ?? [];
+            return {
+                code: "policy.workflow_security",
+                title: "Workflow security violation",
+                detail: `Detected unsafe GitHub Actions usage: ${violations.join("; ") || "unpinned action, write permissions, or untrusted PR runner"}. Pin to SHA or remove the change.`,
+                files: violations.filter((v) => v.includes("/")),
+                suggested_action: "Pin all third-party actions to commit SHAs; reduce permissions to least privilege.",
+                autofix_eligible: false,
+            };
+        },
+    },
+    prompt_injection_risk: {
+        triggerScore: 40,
+        build: (factor) => {
+            const sources = factor.detail?.sources ?? [];
+            return {
+                code: "policy.prompt_injection",
+                title: "Potential prompt injection sink",
+                detail: `Untrusted input flows into an LLM call without sanitisation in ${sources.join(", ") || "the changed files"}. Wrap inputs in sanitizeForPrompt() or an equivalent guard.`,
+                files: sources,
+                suggested_action: "Pass user-controlled strings through a sanitiser before they reach any LLM prompt.",
+                autofix_eligible: false,
+            };
+        },
+    },
+    pr_scope: {
+        triggerScore: 50,
+        advisoryScore: 20,
+        build: (factor) => {
+            const files = factor.detail?.file_count ?? 0;
+            const changes = factor.detail?.line_count ?? 0;
+            return {
+                code: "policy.pr_scope",
+                severity: "warn",
+                title: "PR scope larger than recommended",
+                detail: `This PR changes ${files} files / ${changes} lines, above the configured budget. Split into smaller PRs grouped by intent (e.g. one PR for refactor, one for feature).`,
+                suggested_action: "Split this PR into 2–3 smaller PRs grouped by intent.",
+                autofix_eligible: false,
+            };
+        },
+    },
+    duplicate_logic: {
+        triggerScore: 40,
+        build: (factor) => {
+            const matches = factor.detail?.matches ?? [];
+            return {
+                code: "policy.duplicate_logic",
+                severity: "warn",
+                title: "Duplicate logic detected",
+                detail: `Added code overlaps with existing implementations: ${matches.slice(0, 5).join(", ")}. Reuse the existing utility instead of re-implementing.`,
+                files: matches,
+                suggested_action: "Import the existing utility instead of re-implementing.",
+                autofix_eligible: true,
+                autofix_class: "import-fix",
+            };
+        },
+    },
+    security_alerts: {
+        triggerScore: 40,
+        build: (factor) => {
+            const topRules = factor.detail?.topRules ?? [];
+            return {
+                code: "security.code_scanning",
+                title: "Code scanning alerts on changed code",
+                detail: `Code scanning surfaced alerts on touched files${topRules.length ? `: ${topRules.join(", ")}` : ""}. Address the alerts or document an exception.`,
+                suggested_action: "Open the Security tab on the PR, resolve or dismiss alerts with justification.",
+                autofix_eligible: false,
+            };
+        },
+    },
+    supply_chain: {
+        triggerScore: 60,
+        build: (factor) => {
+            const packages = factor.detail?.packages ?? [];
+            return {
+                code: "risk.supply_chain",
+                title: "Supply chain risk on dependency change",
+                detail: `New or updated dependencies scored high on supply-chain risk: ${packages.join(", ")}. Verify provenance, pin versions, and document the change.`,
+                files: ["package.json", "package-lock.json"],
+                suggested_action: "Pin to known-good versions; add to allowlist if intentional.",
+                autofix_eligible: false,
+            };
+        },
+    },
+};
+function deriveCiFixes(ci) {
+    if (!ci)
+        return [];
+    const fixes = [];
+    const failed = ci.checks.filter((c) => c.status === "fail");
+    if (failed.length > 0) {
+        fixes.push(RemediationFix.parse({
+            code: "ci.failed",
+            severity: "blocking",
+            title: `${failed.length} required check${failed.length === 1 ? "" : "s"} failing`,
+            detail: `Failing checks: ${failed.map((c) => c.name).join(", ")}. Open the linked run, fix the underlying issue, and push a new commit.`,
+            suggested_action: "Re-run the failing checks locally; fix the underlying issue before pushing.",
+            suggested_command: SUGGESTED_TEST_COMMAND,
+        }));
+    }
+    const missing = ci.checks.filter((c) => c.status === "missing" && c.required);
+    if (missing.length > 0) {
+        fixes.push(RemediationFix.parse({
+            code: "ci.missing",
+            severity: "blocking",
+            title: `${missing.length} required check${missing.length === 1 ? "" : "s"} not reported`,
+            detail: `Required checks did not run: ${missing.map((c) => c.name).join(", ")}. Verify the workflow triggers on this PR and that required jobs are configured.`,
+        }));
+    }
+    return fixes;
+}
+function derivePolicyFindingFixes(findings) {
+    if (!findings || findings.length === 0)
+        return [];
+    return [
+        RemediationFix.parse({
+            code: "policy.finding",
+            severity: "blocking",
+            title: `${findings.length} policy finding${findings.length === 1 ? "" : "s"}`,
+            detail: findings.map((f) => `- ${f}`).join("\n"),
+        }),
+    ];
+}
+function fixSeverityFromFactor(factor, cue) {
+    if (factor.score >= cue.triggerScore)
+        return "blocking";
+    if (cue.advisoryScore != null && factor.score >= cue.advisoryScore)
+        return "warn";
+    return "advisory";
+}
+function diffFixCodes(current, previous) {
+    const currentCodes = new Set(current.map((f) => f.code));
+    const previousCodes = new Set((previous ?? []).map((f) => f.code));
+    const resolved = [];
+    const introduced = [];
+    for (const code of previousCodes) {
+        if (!currentCodes.has(code))
+            resolved.push(code);
+    }
+    for (const code of currentCodes) {
+        if (!previousCodes.has(code))
+            introduced.push(code);
+    }
+    return { resolved, introduced };
+}
+function computeNextAction(args) {
+    if (args.releaseReady) {
+        return args.redLane ? "human_review_required" : "ready_to_merge";
+    }
+    if (args.blockingCount === 0) {
+        return "human_review_required";
+    }
+    if (args.loopRound >= args.maxLoopRounds) {
+        return "max_rounds_exceeded";
+    }
+    return "fix_and_retry";
+}
+function buildRemediation(input) {
+    const fixes = [];
+    for (const factor of input.evaluation.riskFactors ?? []) {
+        const cue = factorCues[factor.type];
+        if (!cue)
+            continue;
+        if (factor.score < cue.triggerScore &&
+            (cue.advisoryScore == null || factor.score < cue.advisoryScore)) {
+            continue;
+        }
+        const built = cue.build(factor);
+        const severity = built.severity ?? fixSeverityFromFactor(factor, cue);
+        fixes.push(RemediationFix.parse({ ...built, severity }));
+    }
+    fixes.push(...deriveCiFixes(input.evaluation.ci));
+    fixes.push(...derivePolicyFindingFixes(input.evaluation.policyFindings));
+    // Deduplicate by code, keeping the highest severity occurrence.
+    const severityRank = {
+        blocking: 3,
+        warn: 2,
+        advisory: 1,
+    };
+    const byCode = new Map();
+    for (const fix of fixes) {
+        const existing = byCode.get(fix.code);
+        if (!existing || severityRank[fix.severity] > severityRank[existing.severity]) {
+            byCode.set(fix.code, fix);
+        }
+    }
+    const dedupedFixes = Array.from(byCode.values()).sort((a, b) => {
+        const sev = severityRank[b.severity] - severityRank[a.severity];
+        if (sev !== 0)
+            return sev;
+        return a.code.localeCompare(b.code);
+    });
+    const blocking_count = dedupedFixes.filter((f) => f.severity === "blocking").length;
+    const warn_count = dedupedFixes.filter((f) => f.severity === "warn").length;
+    const advisory_count = dedupedFixes.filter((f) => f.severity === "advisory").length;
+    const autofix_eligible_count = dedupedFixes.filter((f) => f.autofix_eligible).length;
+    const loopRound = input.loopRound ?? (input.previousEvaluation ? 1 : 0);
+    const maxLoopRounds = input.maxLoopRounds ?? 3;
+    const releaseReady = input.evaluation.releaseReady ??
+        (input.evaluation.gateDecision !== "block" && blocking_count === 0);
+    const { resolved, introduced } = diffFixCodes(dedupedFixes, input.previousEvaluation?.remediation?.fixes);
+    const next_action = computeNextAction({
+        releaseReady,
+        blockingCount: blocking_count,
+        loopRound,
+        maxLoopRounds,
+    });
+    return {
+        schema: "trailhead.remediation.v1",
+        release_ready: releaseReady,
+        fixes: dedupedFixes,
+        blocking_count,
+        warn_count,
+        advisory_count,
+        autofix_eligible_count,
+        loop_round: loopRound,
+        max_loop_rounds: maxLoopRounds,
+        previous_evaluation_id: input.previousEvaluation?.id,
+        fixes_resolved: resolved,
+        fixes_introduced: introduced,
+        next_action,
+    };
+}
+const SUGGESTED_COMMANDS = {
+    test: SUGGESTED_TEST_COMMAND,
+    lint: SUGGESTED_LINT_COMMAND,
+    format: SUGGESTED_FORMAT_COMMAND,
+};
+function resolveAgentBriefMode(input) {
+    if (input.actionSetting)
+        return input.actionSetting;
+    if (input.repoSetting)
+        return input.repoSetting;
+    if (input.provenanceType === "human")
+        return "off";
+    return "collapsed";
+}
+function formatFixListItem(fix, index) {
+    const prefix = index !== undefined
+        ? `${index + 1}. **\`${fix.code}\` — ${fix.title}**`
+        : `- \`${fix.code}\` — ${fix.title}`;
+    const lines = [prefix];
+    if (fix.files.length > 0) {
+        lines.push(`   - Files: ${fix.files
+            .slice(0, 8)
+            .map((f) => `\`${f}\``)
+            .join(", ")}${fix.files.length > 8 ? ", …" : ""}`);
+    }
+    if (fix.suggested_action) {
+        lines.push(`   - Fix: ${fix.suggested_action}`);
+    }
+    if (fix.suggested_command) {
+        lines.push(`   - Command: \`${fix.suggested_command}\``);
+    }
+    return lines;
+}
+function formatAgentBrief(remediation, mode) {
+    if (mode === "off")
+        return "";
+    const summaryParts = [];
+    if (remediation.blocking_count > 0) {
+        summaryParts.push(`${remediation.blocking_count} blocking`);
+    }
+    if (remediation.warn_count > 0) {
+        summaryParts.push(`${remediation.warn_count} warn`);
+    }
+    if (summaryParts.length === 0 && remediation.advisory_count > 0) {
+        summaryParts.push(`${remediation.advisory_count} advisory`);
+    }
+    const summaryLabel = summaryParts.length > 0 ? summaryParts.join(", ") : "no issues";
+    const title = `🤖 Agent instructions (${summaryLabel})`;
+    const bodyLines = [
+        "```json",
+        JSON.stringify(remediation, null, 2),
+        "```",
+        "",
+    ];
+    const blocking = remediation.fixes.filter((f) => f.severity === "blocking");
+    const warn = remediation.fixes.filter((f) => f.severity === "warn");
+    const advisory = remediation.fixes.filter((f) => f.severity === "advisory");
+    if (blocking.length > 0) {
+        bodyLines.push("**Blocking:**");
+        blocking.forEach((fix, index) => {
+            bodyLines.push(...formatFixListItem(fix, index));
+        });
+        bodyLines.push("");
+    }
+    if (warn.length > 0) {
+        bodyLines.push("**Warn (non-blocking):**");
+        for (const fix of warn) {
+            bodyLines.push(...formatFixListItem(fix));
+        }
+        bodyLines.push("");
+    }
+    if (advisory.length > 0 && mode === "expanded") {
+        bodyLines.push("**Advisory:**");
+        for (const fix of advisory) {
+            bodyLines.push(...formatFixListItem(fix));
+        }
+        bodyLines.push("");
+    }
+    if (remediation.fixes.length === 0 && remediation.release_ready) {
+        bodyLines.push("No remediation items — this PR is ready to merge under current policy.", "");
+    }
+    bodyLines.push(`**Loop:** round ${remediation.loop_round} of ${remediation.max_loop_rounds} · **Next action:** \`${remediation.next_action}\``);
+    const body = bodyLines.join("\n");
+    if (mode === "expanded") {
+        return `### ${title}\n\n${body}`;
+    }
+    return `<details><summary><strong>${title}</strong></summary>\n\n${body}\n\n</details>`;
+}
+
 ;// CONCATENATED MODULE: ./src/gate.ts
+
 
 
 
@@ -43763,6 +44149,28 @@ async function evaluateGate(config, commitSha, prNumber) {
             prNumber: localEvaluation.prNumber,
         });
     }
+    const remediationSettings = repoConfig?.remediation;
+    const agentBriefMode = resolveAgentBriefMode({
+        actionSetting: config.agentBrief,
+        repoSetting: repoConfig?.gate?.agent_brief,
+        provenanceType: localEvaluation.pr?.provenance?.type,
+    });
+    localEvaluation.agentBriefMode = agentBriefMode;
+    const remediationEnabled = remediationSettings?.enabled !== false;
+    if (remediationEnabled) {
+        localEvaluation.remediation = buildRemediation({
+            evaluation: {
+                id: localEvaluation.id,
+                riskFactors: localEvaluation.riskFactors,
+                ci: localEvaluation.ci,
+                releaseReady: localEvaluation.releaseReady,
+                releaseReadyReasons: localEvaluation.releaseReadyReasons,
+                policyFindings: localEvaluation.policyFindings,
+                gateDecision: localEvaluation.gateDecision,
+            },
+            maxLoopRounds: remediationSettings?.max_loop_rounds ?? 3,
+        });
+    }
     return localEvaluation;
 }
 // ---------------------------------------------------------------------------
@@ -44180,6 +44588,12 @@ function formatGateReport(evaluation, riskThreshold) {
             (evaluation.healthChecks.length > 0 ? healthBadge(evaluation.healthScore) : ""), ``, `| Metric | Score |`, `|--------|-------|`, `| Health | ${healthDisplay} |`, `| Risk   | ${evaluation.riskScore}/100 |`, `| **Decision** | **${evaluation.gateDecision.toUpperCase()}** |`, ``);
         if (riskThreshold !== undefined) {
             lines.push(`**Risk:** ${buildScoreBar(evaluation.riskScore, riskThreshold)}`, ``);
+        }
+    }
+    if (evaluation.remediation && evaluation.agentBriefMode !== "off") {
+        const brief = formatAgentBrief(evaluation.remediation, evaluation.agentBriefMode ?? "collapsed");
+        if (brief) {
+            lines.push(brief, ``);
         }
     }
     if (evaluation.pr?.provenance) {
@@ -46108,6 +46522,12 @@ async function run() {
             gateModeInput === "risk-only"
             ? gateModeInput
             : undefined;
+        const agentBriefInput = getInput("agent-brief");
+        const agentBrief = agentBriefInput === "off" ||
+            agentBriefInput === "collapsed" ||
+            agentBriefInput === "expanded"
+            ? agentBriefInput
+            : undefined;
         const trailheadApiKey = getInput("trailhead-api-key") || "";
         const evaluationStoreUrl = resolveEvaluationStoreUrl({
             trailheadApiKey: trailheadApiKey || undefined,
@@ -46181,6 +46601,7 @@ async function run() {
             checkName: getInput("check-name") || undefined,
             ciManifest,
             ciManifestPath: ciManifestPath || undefined,
+            agentBrief,
         };
         if (policyOverride?.changes.riskThreshold !== undefined) {
             config.riskThreshold = policyOverride.changes.riskThreshold;

--- a/scripts/batch-v4.3-rollout-prs.mjs
+++ b/scripts/batch-v4.3-rollout-prs.mjs
@@ -63,8 +63,7 @@ const ACTION_REPO = "KomatikAI/trailhead";
 // stays in sync with the latest release tag.
 const PKG = JSON.parse(readFileSync(join(__dirname, "..", "package.json"), "utf8"));
 const ACTION_VERSION_MAJOR_MINOR =
-  process.env.TRAILHEAD_ROLLOUT_VERSION ||
-  PKG.version.split(".").slice(0, 2).join("."); // e.g. "4.3"
+  process.env.TRAILHEAD_ROLLOUT_VERSION || PKG.version.split(".").slice(0, 2).join("."); // e.g. "4.3"
 const TARGET_REF = `@v${ACTION_VERSION_MAJOR_MINOR}`; // "@v4.3"
 
 const args = new Set(process.argv.slice(2));
@@ -72,7 +71,13 @@ const apply = args.has("--apply");
 const skipMissingWorkflow = args.has("--skip-missing-workflow");
 const onlyArg = process.argv.find((a) => a.startsWith("--only="));
 const onlyList = onlyArg
-  ? new Set(onlyArg.replace("--only=", "").split(",").map((s) => s.trim()).filter(Boolean))
+  ? new Set(
+      onlyArg
+        .replace("--only=", "")
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean),
+    )
   : null;
 
 function gh(ghArgs) {
@@ -151,7 +156,8 @@ function ensureConfigHasPreset(content) {
     return { content: next, changed: next !== content, created: false };
   }
 
-  const next = content + (content.endsWith("\n") ? "" : "\n") + `presets:\n  - "${PRESET_KEY}"\n`;
+  const next =
+    content + (content.endsWith("\n") ? "" : "\n") + `presets:\n  - "${PRESET_KEY}"\n`;
   return { content: next, changed: true, created: false };
 }
 
@@ -178,20 +184,28 @@ function prBody(repo, plan) {
   lines.push("## Behavior change");
   lines.push("");
   lines.push("- **Human PRs:** unchanged (mode falls back to existing config)");
-  lines.push("- **Agent-provenance PRs:** strict thresholds (risk 40, max_files 30) and a structured Remediation block agents can act on. Up to 5 fix-and-retry rounds per PR.");
+  lines.push(
+    "- **Agent-provenance PRs:** strict thresholds (risk 40, max_files 30) and a structured Remediation block agents can act on. Up to 5 fix-and-retry rounds per PR.",
+  );
   lines.push("");
   lines.push("## Escape valve");
   lines.push("");
-  lines.push("Label any PR with `trailhead-override` and add a comment matching `trailhead-override: <reason>` to bypass the gate. All overrides are audited.");
+  lines.push(
+    "Label any PR with `trailhead-override` and add a comment matching `trailhead-override: <reason>` to bypass the gate. All overrides are audited.",
+  );
   lines.push("");
   lines.push("## Rollback");
   lines.push("");
-  lines.push(`If anything goes sideways: revert this PR — Trailhead falls back to the previous \`@v4\` behavior immediately.`);
+  lines.push(
+    `If anything goes sideways: revert this PR — Trailhead falls back to the previous \`@v4\` behavior immediately.`,
+  );
   lines.push("");
   lines.push("## Context");
   lines.push("");
   lines.push(`- Epic: ${ACTION_REPO}#223`);
-  lines.push(`- Roadmap: [\`docs/roadmap-v4.3-agent-autonomy.md\`](https://github.com/${ACTION_REPO}/blob/main/docs/roadmap-v4.3-agent-autonomy.md)`);
+  lines.push(
+    `- Roadmap: [\`docs/roadmap-v4.3-agent-autonomy.md\`](https://github.com/${ACTION_REPO}/blob/main/docs/roadmap-v4.3-agent-autonomy.md)`,
+  );
 
   return lines.join("\n");
 }
@@ -217,9 +231,7 @@ function planRepo({ org, name, base }) {
     skip: noop,
     reason: noop ? "already adopted v4.3 + strict-agents preset" : null,
     workflow: { ...workflow, ...bumpResult },
-    config: config
-      ? { ...config, ...presetResult }
-      : { sha: null, ...presetResult },
+    config: config ? { ...config, ...presetResult } : { sha: null, ...presetResult },
     workflowBumped: bumpResult.changed,
     presetAdded: !presetResult.created && presetResult.changed,
     configCreated: presetResult.created,
@@ -336,7 +348,9 @@ for (const repo of repos) {
       if (skipMissingWorkflow) {
         console.log(`SKIP ${repo.name}: ${plan.reason}`);
       } else {
-        console.log(`MISSING ${repo.name}: ${plan.reason} (use --skip-missing-workflow to silence)`);
+        console.log(
+          `MISSING ${repo.name}: ${plan.reason} (use --skip-missing-workflow to silence)`,
+        );
       }
       continue;
     }
@@ -379,7 +393,8 @@ console.log(`Failed:     ${failed.length}`);
 
 if (opened.length) {
   console.log("\n--- PRs ---");
-  for (const r of opened) console.log(`${r.repo}: ${r.url}${r.reused ? " (reused)" : ""}`);
+  for (const r of opened)
+    console.log(`${r.repo}: ${r.url}${r.reused ? " (reused)" : ""}`);
 }
 if (failed.length) {
   console.log("\n--- Failures ---");

--- a/src/__tests__/evaluate-gate.test.ts
+++ b/src/__tests__/evaluate-gate.test.ts
@@ -147,6 +147,14 @@ describe("evaluateGate (integration)", () => {
     expect(typeof result.trust_profile?.reason).toBe("string");
   });
 
+  it("populates remediation block and agentBriefMode in evaluation payload", async () => {
+    const config = makeConfig({ githubToken: "ghp_test" });
+    const result = await evaluateGate(config, "abc1234567890", 42);
+    expect(result.remediation).toBeDefined();
+    expect(result.remediation?.schema).toBe("trailhead.remediation.v1");
+    expect(result.agentBriefMode).toBe("off");
+  });
+
   it("respects custom warn threshold", async () => {
     const config = makeConfig({
       githubToken: "ghp_test",

--- a/src/__tests__/gate.test.ts
+++ b/src/__tests__/gate.test.ts
@@ -17,6 +17,7 @@ import {
   requestHighRiskReviewers,
   formatGateReport,
 } from "../gate.js";
+import { buildRemediation } from "../remediation.js";
 import type { GateEvaluation } from "../types.js";
 
 const {
@@ -876,6 +877,58 @@ describe("formatGateReport", () => {
     const report = formatGateReport(evaluation);
     expect(report).toContain("Suggested split");
     expect(report).toContain("separate PR");
+  });
+
+  it("includes collapsed agent brief when remediation and agentBriefMode are set", () => {
+    const remediation = buildRemediation({
+      evaluation: {
+        id: "eval-1",
+        riskFactors: [
+          {
+            type: "test_coverage",
+            score: 80,
+            detail: { missing_tests: ["src/foo.ts"] },
+          },
+        ],
+        gateDecision: "block",
+        releaseReady: false,
+      },
+    });
+    const evaluation: GateEvaluation = {
+      ...baseEvaluation,
+      gateDecision: "block",
+      agentBriefMode: "collapsed",
+      remediation,
+      pr: {
+        provenance: { type: "claude", confidence: 0.9, source: "branch:claude/foo" },
+      },
+    };
+    const report = formatGateReport(evaluation);
+    expect(report).toContain("Agent instructions");
+    expect(report).toContain("<details>");
+    expect(report).toContain("risk.test_coverage");
+    expect(report).toContain('"schema": "trailhead.remediation.v1"');
+  });
+
+  it("omits agent brief for human provenance when agentBriefMode is off", () => {
+    const remediation = buildRemediation({
+      evaluation: {
+        id: "eval-1",
+        riskFactors: [],
+        gateDecision: "allow",
+        releaseReady: true,
+      },
+    });
+    const evaluation: GateEvaluation = {
+      ...baseEvaluation,
+      agentBriefMode: "off",
+      remediation,
+      pr: {
+        provenance: { type: "human", confidence: 0.95, source: "author:david" },
+      },
+    };
+    const report = formatGateReport(evaluation);
+    expect(report).not.toContain("Agent instructions");
   });
 });
 

--- a/src/__tests__/remediation.test.ts
+++ b/src/__tests__/remediation.test.ts
@@ -1,4 +1,8 @@
-import { buildRemediation } from "../remediation.js";
+import {
+  buildRemediation,
+  formatAgentBrief,
+  resolveAgentBriefMode,
+} from "../remediation.js";
 import { Remediation } from "../types.js";
 import type { GateEvaluation, RiskFactor } from "../types.js";
 
@@ -301,6 +305,72 @@ describe("buildRemediation", () => {
         }),
       });
       expect(remediation.next_action).toBe("human_review_required");
+    });
+  });
+
+  describe("resolveAgentBriefMode", () => {
+    it("defaults to off for human provenance", () => {
+      expect(resolveAgentBriefMode({ provenanceType: "human" })).toBe("off");
+    });
+
+    it("defaults to collapsed for agent provenance", () => {
+      expect(resolveAgentBriefMode({ provenanceType: "claude" })).toBe("collapsed");
+      expect(resolveAgentBriefMode({ provenanceType: "unknown" })).toBe("collapsed");
+    });
+
+    it("prefers action input over repo setting and provenance default", () => {
+      expect(
+        resolveAgentBriefMode({
+          actionSetting: "expanded",
+          repoSetting: "off",
+          provenanceType: "human",
+        }),
+      ).toBe("expanded");
+    });
+
+    it("uses repo setting when action input is absent", () => {
+      expect(
+        resolveAgentBriefMode({
+          repoSetting: "expanded",
+          provenanceType: "human",
+        }),
+      ).toBe("expanded");
+    });
+  });
+
+  describe("formatAgentBrief", () => {
+    it("returns empty string when mode is off", () => {
+      const remediation = buildRemediation({ evaluation: evaluationFixture() });
+      expect(formatAgentBrief(remediation, "off")).toBe("");
+    });
+
+    it("renders collapsed details with JSON block and blocking fixes", () => {
+      const remediation = buildRemediation({
+        evaluation: evaluationFixture({
+          gateDecision: "block",
+          releaseReady: false,
+          riskFactors: [factor("test_coverage", 80, { missing_tests: ["src/foo.ts"] })],
+        }),
+      });
+      const brief = formatAgentBrief(remediation, "collapsed");
+      expect(brief).toContain("<details>");
+      expect(brief).toContain("Agent instructions");
+      expect(brief).toContain('"schema": "trailhead.remediation.v1"');
+      expect(brief).toContain("risk.test_coverage");
+      expect(brief).toContain("fix_and_retry");
+    });
+
+    it("renders expanded section without details wrapper", () => {
+      const remediation = buildRemediation({
+        evaluation: evaluationFixture({
+          gateDecision: "block",
+          releaseReady: false,
+          riskFactors: [factor("test_coverage", 80, { missing_tests: ["src/foo.ts"] })],
+        }),
+      });
+      const brief = formatAgentBrief(remediation, "expanded");
+      expect(brief).not.toContain("<details>");
+      expect(brief).toContain("### 🤖 Agent instructions");
     });
   });
 });

--- a/src/gate.ts
+++ b/src/gate.ts
@@ -50,6 +50,11 @@ import {
   type RiskFactorResult,
 } from "./risk-engine.js";
 import { fetchCodeScanningAlerts, computeSecurityRiskFactor } from "./security.js";
+import {
+  buildRemediation,
+  formatAgentBrief,
+  resolveAgentBriefMode,
+} from "./remediation.js";
 
 export {
   isSensitiveFile,
@@ -1889,6 +1894,30 @@ export async function evaluateGate(
     });
   }
 
+  const remediationSettings = repoConfig?.remediation;
+  const agentBriefMode = resolveAgentBriefMode({
+    actionSetting: config.agentBrief,
+    repoSetting: repoConfig?.gate?.agent_brief,
+    provenanceType: localEvaluation.pr?.provenance?.type,
+  });
+  localEvaluation.agentBriefMode = agentBriefMode;
+
+  const remediationEnabled = remediationSettings?.enabled !== false;
+  if (remediationEnabled) {
+    localEvaluation.remediation = buildRemediation({
+      evaluation: {
+        id: localEvaluation.id,
+        riskFactors: localEvaluation.riskFactors,
+        ci: localEvaluation.ci,
+        releaseReady: localEvaluation.releaseReady,
+        releaseReadyReasons: localEvaluation.releaseReadyReasons,
+        policyFindings: localEvaluation.policyFindings,
+        gateDecision: localEvaluation.gateDecision,
+      },
+      maxLoopRounds: remediationSettings?.max_loop_rounds ?? 3,
+    });
+  }
+
   return localEvaluation;
 }
 
@@ -2430,6 +2459,16 @@ export function formatGateReport(
 
     if (riskThreshold !== undefined) {
       lines.push(`**Risk:** ${buildScoreBar(evaluation.riskScore, riskThreshold)}`, ``);
+    }
+  }
+
+  if (evaluation.remediation && evaluation.agentBriefMode !== "off") {
+    const brief = formatAgentBrief(
+      evaluation.remediation,
+      evaluation.agentBriefMode ?? "collapsed",
+    );
+    if (brief) {
+      lines.push(brief, ``);
     }
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -208,6 +208,14 @@ async function run(): Promise<void> {
         ? gateModeInput
         : undefined;
 
+    const agentBriefInput = core.getInput("agent-brief");
+    const agentBrief =
+      agentBriefInput === "off" ||
+      agentBriefInput === "collapsed" ||
+      agentBriefInput === "expanded"
+        ? agentBriefInput
+        : undefined;
+
     const trailheadApiKey = core.getInput("trailhead-api-key") || "";
     const evaluationStoreUrl = resolveEvaluationStoreUrl({
       trailheadApiKey: trailheadApiKey || undefined,
@@ -288,6 +296,7 @@ async function run(): Promise<void> {
       checkName: core.getInput("check-name") || undefined,
       ciManifest,
       ciManifestPath: ciManifestPath || undefined,
+      agentBrief,
     };
 
     if (policyOverride?.changes.riskThreshold !== undefined) {

--- a/src/remediation.ts
+++ b/src/remediation.ts
@@ -9,7 +9,9 @@
 import type { z } from "zod";
 import { RemediationFix as RemediationFixSchema } from "./types.js";
 import type {
+  AgentBriefMode,
   GateEvaluation,
+  PrProvenance,
   Remediation,
   RemediationAutofixClass,
   RemediationNextAction,
@@ -369,3 +371,108 @@ export const SUGGESTED_COMMANDS = {
   lint: SUGGESTED_LINT_COMMAND,
   format: SUGGESTED_FORMAT_COMMAND,
 };
+
+export function resolveAgentBriefMode(input: {
+  actionSetting?: AgentBriefMode;
+  repoSetting?: AgentBriefMode;
+  provenanceType?: PrProvenance["type"];
+}): AgentBriefMode {
+  if (input.actionSetting) return input.actionSetting;
+  if (input.repoSetting) return input.repoSetting;
+  if (input.provenanceType === "human") return "off";
+  return "collapsed";
+}
+
+function formatFixListItem(fix: RemediationFix, index?: number): string[] {
+  const prefix =
+    index !== undefined
+      ? `${index + 1}. **\`${fix.code}\` — ${fix.title}**`
+      : `- \`${fix.code}\` — ${fix.title}`;
+  const lines = [prefix];
+  if (fix.files.length > 0) {
+    lines.push(
+      `   - Files: ${fix.files
+        .slice(0, 8)
+        .map((f) => `\`${f}\``)
+        .join(", ")}${fix.files.length > 8 ? ", …" : ""}`,
+    );
+  }
+  if (fix.suggested_action) {
+    lines.push(`   - Fix: ${fix.suggested_action}`);
+  }
+  if (fix.suggested_command) {
+    lines.push(`   - Command: \`${fix.suggested_command}\``);
+  }
+  return lines;
+}
+
+export function formatAgentBrief(remediation: Remediation, mode: AgentBriefMode): string {
+  if (mode === "off") return "";
+
+  const summaryParts: string[] = [];
+  if (remediation.blocking_count > 0) {
+    summaryParts.push(`${remediation.blocking_count} blocking`);
+  }
+  if (remediation.warn_count > 0) {
+    summaryParts.push(`${remediation.warn_count} warn`);
+  }
+  if (summaryParts.length === 0 && remediation.advisory_count > 0) {
+    summaryParts.push(`${remediation.advisory_count} advisory`);
+  }
+  const summaryLabel = summaryParts.length > 0 ? summaryParts.join(", ") : "no issues";
+  const title = `🤖 Agent instructions (${summaryLabel})`;
+
+  const bodyLines: string[] = [
+    "```json",
+    JSON.stringify(remediation, null, 2),
+    "```",
+    "",
+  ];
+
+  const blocking = remediation.fixes.filter((f) => f.severity === "blocking");
+  const warn = remediation.fixes.filter((f) => f.severity === "warn");
+  const advisory = remediation.fixes.filter((f) => f.severity === "advisory");
+
+  if (blocking.length > 0) {
+    bodyLines.push("**Blocking:**");
+    blocking.forEach((fix, index) => {
+      bodyLines.push(...formatFixListItem(fix, index));
+    });
+    bodyLines.push("");
+  }
+
+  if (warn.length > 0) {
+    bodyLines.push("**Warn (non-blocking):**");
+    for (const fix of warn) {
+      bodyLines.push(...formatFixListItem(fix));
+    }
+    bodyLines.push("");
+  }
+
+  if (advisory.length > 0 && mode === "expanded") {
+    bodyLines.push("**Advisory:**");
+    for (const fix of advisory) {
+      bodyLines.push(...formatFixListItem(fix));
+    }
+    bodyLines.push("");
+  }
+
+  if (remediation.fixes.length === 0 && remediation.release_ready) {
+    bodyLines.push(
+      "No remediation items — this PR is ready to merge under current policy.",
+      "",
+    );
+  }
+
+  bodyLines.push(
+    `**Loop:** round ${remediation.loop_round} of ${remediation.max_loop_rounds} · **Next action:** \`${remediation.next_action}\``,
+  );
+
+  const body = bodyLines.join("\n");
+
+  if (mode === "expanded") {
+    return `### ${title}\n\n${body}`;
+  }
+
+  return `<details><summary><strong>${title}</strong></summary>\n\n${body}\n\n</details>`;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,6 +55,9 @@ export type PrProvenance = z.infer<typeof PrProvenance>;
 export const GateMode = z.enum(["release-ready", "advisory", "risk-only"]);
 export type GateMode = z.infer<typeof GateMode>;
 
+export const AgentBriefMode = z.enum(["off", "collapsed", "expanded"]);
+export type AgentBriefMode = z.infer<typeof AgentBriefMode>;
+
 export const CiCheckStatusEnum = z.enum([
   "pass",
   "fail",
@@ -206,6 +209,7 @@ export const GateEvaluation = z.object({
   gateMode: GateMode.optional(),
   storePersisted: z.boolean().optional(),
   remediation: Remediation.optional(),
+  agentBriefMode: AgentBriefMode.optional(),
   cross_repo_impact: z
     .object({
       services: z.array(
@@ -336,12 +340,20 @@ export type TrailheadContext = z.infer<typeof TrailheadContext>;
 export const GateConfig = z.object({
   mode: GateMode.default("risk-only"),
   check_name: z.string().default("Trailhead — Release Ready"),
+  agent_brief: AgentBriefMode.optional(),
 });
 export type GateConfig = z.infer<typeof GateConfig>;
+
+export const RemediationConfig = z.object({
+  enabled: z.boolean().default(true),
+  max_loop_rounds: z.number().int().min(0).default(3),
+});
+export type RemediationConfig = z.infer<typeof RemediationConfig>;
 
 export const RepoConfig = z.object({
   schema_version: z.number().int().positive().default(1),
   gate: GateConfig.default({}),
+  remediation: RemediationConfig.optional(),
   contexts: z.array(TrailheadContext).default([]),
   sensitivity: z
     .object({
@@ -469,6 +481,7 @@ export interface TrailheadConfig {
   checkName?: string;
   ciManifest?: CiManifest | null;
   ciManifestPath?: string;
+  agentBrief?: AgentBriefMode;
 }
 
 export interface TestRepairResult {


### PR DESCRIPTION
## Summary

Completes **Epic A2** (#225): every gate run now ships a machine-readable `Remediation` block in `evaluation-json`, and agent-provenance PRs get a collapsed **Agent instructions** section in the Release Ready comment.

- `evaluateGate` calls `buildRemediation()` after release-ready scoring and attaches `evaluation.remediation`
- `formatGateReport` renders `formatAgentBrief()` when `agentBriefMode !== "off"`
- Provenance-aware defaults: **human PRs → off**, **agent PRs → collapsed** (unless overridden)
- New Action input `agent-brief` (`off` | `collapsed` | `expanded`) and repo config `gate.agent_brief`
- Optional repo config `remediation.enabled` / `remediation.max_loop_rounds`

## Example PR comment section

```markdown
<details>
<summary><strong>🤖 Agent instructions (1 blocking, 0 warn)</strong></summary>

```json
{ "schema": "trailhead.remediation.v1", "fixes": [...], "next_action": "fix_and_retry" }
```

**Blocking:**
1. **`risk.test_coverage` — Test coverage missing for changed source**
   - Files: `src/foo.ts`
   - Fix: Add a test file covering the modified exports.

**Loop:** round 0 of 3 · **Next action:** `fix_and_retry`
</details>
```

## Test plan

- [x] `npx vitest run src/__tests__/remediation.test.ts src/__tests__/gate.test.ts src/__tests__/evaluate-gate.test.ts` — 167/167 passing
- [x] `npm run lint` — clean
- [x] `npm run build` — dist updated
- [ ] CI green
- [ ] Smoke: open an agent-branch PR on a dogfood repo and confirm collapsed brief appears

## Depends on

- #222 (A1 — merged)

## Tracks

Epic #223 · Closes #225

Made with [Cursor](https://cursor.com)