### PR TITLE
chore(release): v4.3.0 — agent autonomy Coach (A1–A4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to Trailhead will be documented in this file.
 
 ## Unreleased
 
+## [4.3.0] - 2026-05-27
+
+### Added — Agent autonomy: Coach (Phase A)
+
+- **Remediation schema (A1, #222)** — typed `Remediation` block on `GateEvaluation` and `evaluation-json`; `buildRemediation()` derives machine-readable, agent-actionable fixes (code, severity, files, suggested action/command) from gate findings.
+- **Agent brief (A2, #232)** — collapsed "Agent instructions" `<details>` block in the Release Ready PR comment, gated by `gate.agent_brief: "off" | "collapsed" | "expanded"` (collapsed by default for agent provenance, off for humans).
+- **Coordinator event bus + semantic webhooks (A3, #233)** — emits `trailhead.blocked`, `trailhead.warn_high_risk`, `trailhead.ready`, `trailhead.loop_exceeded` (`trailhead.webhook.v1`) carrying the full `Remediation` block and `headRef`; new `webhook-events` types; shared `remediation.ts` / `trailhead-events.ts` copied into `app/` and `mcp/`.
+- **Loop bookkeeping (A4, #234)** — per-PR remediation loop tracking: `loop_round`, `previous_evaluation_id`, `fixes_resolved`, `fixes_introduced` persisted via `buildEvaluationStoreRow()`; `fetchPreviousEvaluationForPr()` (Cloud `GET /v1/evaluations?repo_id=&pr_number=` with Supabase fallback) auto-increments the round; `GET /v1/analytics/agent-loop-efficiency` + dashboard panel for rounds-to-ready by agent.
+
+### Database
+
+- **`cloud/migrations/002_loop_bookkeeping.sql`** — loop-bookkeeping columns + `(repo_id, pr_number, created_at)` index on `trailhead_evaluations`. Run on hosted Trailhead Cloud instances.
+
 ## [4.2.2] - 2026-05-27
 
 ### Fixed — DORA metrics

--- a/cloud/package.json
+++ b/cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trailhead-cloud",
-  "version": "4.2.2",
+  "version": "4.3.0",
   "private": true,
   "type": "module",
   "description": "Trailhead Cloud API — evaluation store, org/repo registry, deploy events",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trailhead",
-  "version": "4.2.2",
+  "version": "4.3.0",
   "private": true,
   "description": "Release readiness gate for GitHub PRs — waits for CI, scores code risk, checks production health, and blocks merges that are not release-ready.",
   "license": "MIT",


### PR DESCRIPTION
Cuts **v4.3.0**, releasing the Phase A (Coach) agent-autonomy epic already merged on `main`:

- A1 (#222) Remediation schema + `buildRemediation`
- A2 (#232) Agent brief in PR comments
- A3 (#233) Coordinator event bus + semantic webhooks (`trailhead.webhook.v1`)
- A4 (#234) Loop bookkeeping + `agent-loop-efficiency`

Bumps `package.json` + `cloud/package.json` to 4.3.0 and adds the `[4.3.0]` changelog section. No code changes — `main` already carries A1–A4.

**After merge:** tag `v4.3.0` on the merge commit and float `@v4 → v4.3.0`. That unblocks A6 (bump consumers `@v3/@v4 → @v4.3`), which is where the `deployguard → /api/trailhead/store` consumer flip rides along.

🤖 Generated with [Claude Code](https://claude.com/claude-code)