### PR TITLE
feat(store): read previous evaluations from komatik.ai list API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -637,21 +637,18 @@ Runtime state lives in PostgreSQL, not in git-committed files.
 
 ### What this project is
 
-Trailhead is the canonical name for the deployment gate formerly known as DeployGuard. It is a GitHub Action (current release **v4.2.1**, floating tag **`v4`**) that scores pull request risk, waits for required CI, publishes a composite **Release Ready** check, checks production health, integrates **security signals** (Code Scanning / SARIF), computes **DORA-5** metrics, tracks deployment outcomes via **canary hooks**, exports **OpenTelemetry** spans, and blocks dangerous releases. It also ships a **`trailhead init`** / **`trailhead doctor`** CLI, an optional **GitHub App** (`app/`) for deployment protection rules, a standalone **MCP server** (`mcp/`, package **`@trailhead/mcp-server` v4.2.1**) with 22 tools for AI agents, and **Trailhead Cloud** (`cloud/`) for hosted evaluation storage, analytics, feedback, and org billing tiers.
+Trailhead is the canonical name for the deployment gate formerly known as DeployGuard. It is a GitHub Action (released **v4.3.0**; floating tag **`@v4`** remains **v4.2.2**) that scores pull request risk, waits for required CI, publishes a composite **Release Ready** check, checks production health, integrates **security signals** (Code Scanning / SARIF), computes **DORA-5** metrics, tracks deployment outcomes via **canary hooks**, exports **OpenTelemetry** spans, and blocks dangerous releases. It also ships a **`trailhead init`** / **`trailhead doctor`** CLI, an optional **GitHub App** (`app/`) for deployment protection rules, a standalone **MCP server** (`mcp/`, package **`@trailhead/mcp-server`**) with 22 tools for AI agents, and **Trailhead Cloud** (`cloud/`) for hosted evaluation storage, analytics, feedback, and org billing tiers.
 
 ### Current repo state (May 27, 2026)
 
 - **Branch model**: **`dev`** is the default integration branch — open all feature PRs against `dev`. Promote with fast-forward only: `dev` → `staging` → `main` (production). Do **not** merge features directly to `main`.
-- **Released tag**: **v4.2.2** on `@v4`. **v4.3 Phase A** in progress on `dev`/`main` (ahead of tag):
-  - A1 remediation schema ✅
-  - A2 agent brief in PR comments ✅
-  - A3 semantic webhooks + MCP `get-remediation` / `subscribe-events` ✅
-  - A4 loop bookkeeping — PR targeting `dev`
-  - komatik-agents coordinator handler ✅ merged ([#175](https://github.com/KomatikAI/agents/pull/175)); **Spark deploy pending**
-- **Tests:** **609** root + **21** cloud (on `dev`; counts rise with A4)
-- **Legacy compatibility**: Trailhead remains backwards-compatible with existing `.deployguard.yml` configs and `DEPLOYGUARD_*` environment variables where those surfaces were already shipped.
-- **Known unpromoted branch**: `origin/experiment/rd-satellite/deployguard-supply-chain-risk` has useful supply-chain scoring work, but it is **not merge-ready**. Targeted tests pass, but `app` and `mcp` builds fail because shared `risk-engine.ts` imports `supply-chain.js` without copying that module during prebuild.
-- **Coordinator deploy gap**: `agent/*` branch routing is forward-built (inert until suggestions→PR bridge). Operator `claude/*`/`cursor/*` PRs are skipped — see `komatik-agents/docs/runbooks/TRAILHEAD-COORDINATOR.md`.
+- **Released tag**: **v4.3.0** on `main` (immutable). Floating **`@v4`** deliberately remains **v4.2.2** — pin consumers explicitly until fleet re-pin is approved.
+- **Phase A (v4.3.0):** A1–A4 merged (remediation schema, agent brief, semantic webhooks, loop bookkeeping in action).
+- **A6 fleet rollout:** ✅ 7 active satellites on `@v4.3.0` + `/api/trailhead/store` (cairn, frontier, kindling, pack, slipstream, sundog, trace). **Excluded:** drift, floe, traverse, watchtower (retired/archived; trace absorbed them).
+- **Komatik hosted store:** Loop columns + GET API in [Komatik #2014](https://github.com/KomatikAI/komatik/pull/2014); read path in [Trailhead #236](https://github.com/KomatikAI/trailhead/pull/236) → **v4.3.1** + fleet re-pin. See `docs/komatik-hosted-store.md`.
+- **Tests:** 609+ root + 21 cloud on `dev`.
+- **Legacy compatibility**: `.deployguard.yml` configs and `DEPLOYGUARD_*` env vars still accepted where already shipped.
+- **Coordinator:** komatik-agents #175 merged; deploy pending suggestions→PR bridge — see `komatik-agents/docs/runbooks/TRAILHEAD-COORDINATOR.md`.
 
 **Promotion (fast-forward only):**
 
@@ -671,6 +668,7 @@ Tag releases on `main` after promotion (`git tag v4.x.y && git push origin v4.x.
 4. **Test healer proposes, developer approves** — self-healing changes are suggestions (e.g. PR comments), never force-pushed.
 5. **Shared risk engine** — `src/risk-engine.ts` is the canonical scoring implementation; MCP and app MUST use prebuild copies, not independent implementations. If `risk-engine.ts` imports a new local module, update both `app` and `mcp` prebuild flows and committed runtime artifacts.
 6. **Merge-base drift protection** — `fetchPrFiles` cross-checks GitHub's `pulls.listFiles` against commit-level files when >30 files reported; falls back to commit-derived list when API count exceeds 2x actual. Applied to Action, App, and MCP server.
+7. **No direct prod deploy via MCP** — never `apply_migration` or DDL against Komatik prod Supabase from Cursor MCP. Schema and store routes ship via **Komatik PR → merge → deploy** only. MCP is read-only for verification (`list_migrations`, SELECT). See `docs/komatik-hosted-store.md` and Komatik `docs/runbooks/TRAILHEAD-EVALUATION-STORE.md`.
 
 ### Dependencies
 
@@ -748,3 +746,4 @@ Tag releases on `main` after promotion (`git tag v4.x.y && git push origin v4.x.
 | `cli/src/index.ts`   | `trailhead init` wizard                             |
 | `src/__tests__/`     | Vitest test suite (561 tests)                       |
 | `cloud/src/__tests__/` | Cloud API tests (19 tests)                        |
+| `docs/komatik-hosted-store.md` | Fleet evaluation store at komatik.ai        |

--- a/cloud/migrations/002_loop_bookkeeping.sql
+++ b/cloud/migrations/002_loop_bookkeeping.sql
@@ -1,5 +1,9 @@
 -- A4 loop bookkeeping columns for trailhead_evaluations
 -- Apply in Supabase SQL editor or via migration tooling.
+--
+-- **Trailhead Cloud only.** Komatik fleet store uses
+-- Komatik/supabase/migrations/20260527073857_trailhead_loop_bookkeeping.sql
+-- — deploy via Komatik PR, never MCP apply_migration to prod.
 
 ALTER TABLE trailhead_evaluations
   ADD COLUMN IF NOT EXISTS remediation jsonb,

--- a/dist/index.js
+++ b/dist/index.js
@@ -42788,6 +42788,7 @@ function formatAgentBrief(remediation, mode) {
 ;// CONCATENATED MODULE: ./src/evaluation-history.ts
 
 const LOOKUP_TIMEOUT_MS = 8_000;
+const KOMATIK_STORE_PATH = /\/api\/(?:trailhead|deployguard)\/store$/;
 function buildAuthHeaders(params) {
     const headers = { Accept: "application/json" };
     const secret = params.storeSecret ?? process.env.EVALUATION_STORE_SECRET;
@@ -42810,12 +42811,52 @@ function resolveCloudListUrl(storeUrl) {
     }
     return null;
 }
-async function fetchFromCloudStore(params) {
-    if (!params.storeUrl)
+/** komatik.ai hosted store → loop lookup list endpoint. */
+function resolveKomatikListUrl(storeUrl) {
+    const trimmed = storeUrl.replace(/\/$/, "");
+    if (!KOMATIK_STORE_PATH.test(trimmed))
         return null;
-    const listUrl = resolveCloudListUrl(params.storeUrl);
-    if (!listUrl)
-        return null;
+    return trimmed.replace(KOMATIK_STORE_PATH, "/api/trailhead/evaluations");
+}
+function enrichSnapshotFromLoopColumns(parsed, row) {
+    if (parsed.remediation || typeof row.loop_round !== "number") {
+        return parsed;
+    }
+    return {
+        ...parsed,
+        remediation: {
+            schema: "trailhead.remediation.v1",
+            release_ready: false,
+            fixes: [],
+            blocking_count: 0,
+            warn_count: 0,
+            advisory_count: 0,
+            autofix_eligible_count: 0,
+            loop_round: row.loop_round,
+            max_loop_rounds: 3,
+            fixes_resolved: Array.isArray(row.fixes_resolved)
+                ? row.fixes_resolved
+                : [],
+            fixes_introduced: Array.isArray(row.fixes_introduced)
+                ? row.fixes_introduced
+                : [],
+            next_action: "fix_and_retry",
+        },
+    };
+}
+function pickPreviousFromRows(rows, excludeEvaluationId) {
+    for (const row of rows) {
+        const parsed = pickLatestPreviousEvaluation([row], excludeEvaluationId);
+        if (!parsed)
+            continue;
+        if (row && typeof row === "object") {
+            return enrichSnapshotFromLoopColumns(parsed, row);
+        }
+        return parsed;
+    }
+    return null;
+}
+async function fetchEvaluationList(listUrl, params) {
     const url = new URL(listUrl);
     url.searchParams.set("repo_id", params.repoId);
     url.searchParams.set("pr_number", String(params.prNumber));
@@ -42830,7 +42871,23 @@ async function fetchFromCloudStore(params) {
     const body = (await response.json());
     if (!Array.isArray(body.evaluations))
         return null;
-    return pickLatestPreviousEvaluation(body.evaluations, params.excludeEvaluationId);
+    return pickPreviousFromRows(body.evaluations, params.excludeEvaluationId);
+}
+async function fetchFromCloudStore(params) {
+    if (!params.storeUrl)
+        return null;
+    const listUrl = resolveCloudListUrl(params.storeUrl);
+    if (!listUrl)
+        return null;
+    return fetchEvaluationList(listUrl, params);
+}
+async function fetchFromKomatikStore(params) {
+    if (!params.storeUrl)
+        return null;
+    const listUrl = resolveKomatikListUrl(params.storeUrl);
+    if (!listUrl)
+        return null;
+    return fetchEvaluationList(listUrl, params);
 }
 async function fetchFromSupabase(params) {
     const supabaseUrl = process.env.SUPABASE_URL;
@@ -42857,42 +42914,21 @@ async function fetchFromSupabase(params) {
     const rows = (await response.json());
     if (!Array.isArray(rows))
         return null;
-    for (const row of rows) {
-        const parsed = pickLatestPreviousEvaluation([row], params.excludeEvaluationId);
-        if (!parsed)
-            continue;
-        if (!parsed.remediation && row && typeof row === "object") {
-            const record = row;
-            if (typeof record.loop_round === "number") {
-                parsed.remediation = {
-                    schema: "trailhead.remediation.v1",
-                    release_ready: false,
-                    fixes: [],
-                    blocking_count: 0,
-                    warn_count: 0,
-                    advisory_count: 0,
-                    autofix_eligible_count: 0,
-                    loop_round: record.loop_round,
-                    max_loop_rounds: 3,
-                    fixes_resolved: Array.isArray(record.fixes_resolved)
-                        ? record.fixes_resolved
-                        : [],
-                    fixes_introduced: Array.isArray(record.fixes_introduced)
-                        ? record.fixes_introduced
-                        : [],
-                    next_action: "fix_and_retry",
-                };
-            }
-        }
-        return parsed;
-    }
-    return null;
+    return pickPreviousFromRows(rows, params.excludeEvaluationId);
 }
 async function fetchPreviousEvaluationForPr(params) {
     try {
         const fromCloud = await fetchFromCloudStore(params);
         if (fromCloud)
             return fromCloud;
+    }
+    catch {
+        // Fail-open — loop bookkeeping defaults to round 0.
+    }
+    try {
+        const fromKomatik = await fetchFromKomatikStore(params);
+        if (fromKomatik)
+            return fromKomatik;
     }
     catch {
         // Fail-open — loop bookkeeping defaults to round 0.

--- a/docs/README.md
+++ b/docs/README.md
@@ -291,7 +291,7 @@ Human PRs (`claude/*`, `cursor/*`, explicit `human` provenance) are unchanged �
 
 This repository uses the **progressive branch model**: **`dev`** (integration/default) → **`staging`** (pre-production) → **`main`** (production). Open feature PRs against **`dev`**. CI runs on PRs to `dev` and on pushes to `dev`, `staging`, and `main`. Promote with fast-forward merges only; tag releases on `main`.
 
-**Current state (May 2026):** `@v4` tag **v4.2.2** on `main`; **v4.3 Phase A** (A1–A3) merged on `dev`/`main` ahead of the tag. **A4** loop bookkeeping in review. Release **v4.3.0** after Phase A exit criteria + fleet rollout.
+**Current state (May 2026):** **v4.3.0** released on `main` (explicit tag; `@v4` remains **v4.2.2**). Phase A A1–A4 merged. **A6** fleet pin + store URL migration complete on 7 active satellites. Komatik hosted store loop persistence: [komatik-hosted-store.md](./komatik-hosted-store.md). Pending: Komatik store PR + Trailhead v4.3.1 read path.
 
 The unmerged legacy supply-chain experiment branch is known not to be promotion-ready: its
 targeted tests pass, but `app` and `mcp` builds fail until their prebuild scripts copy the

--- a/docs/evaluation-storage.md
+++ b/docs/evaluation-storage.md
@@ -70,6 +70,17 @@ The Action sends:
 
 Deploy outcomes use a sibling endpoint: replace `/store` with `/deploy-event` on the same base path.
 
+### Komatik fleet store (`komatik.ai`)
+
+The Komatik platform hosts the shared evaluation store for fleet satellites:
+
+- **POST** `https://komatik.ai/api/trailhead/store`
+- **GET** `https://komatik.ai/api/trailhead/evaluations?repo_id=&pr_number=` — prior evals for loop bookkeeping (v4.3.1+ action)
+
+Legacy alias `/api/deployguard/store` remains until all active consumers migrate. Full contract: [komatik-hosted-store.md](./komatik-hosted-store.md).
+
+Loop fields (`loop_round`, `fixes_resolved`, `fixes_introduced`, …) require the Komatik store route **and** schema migration — not Trailhead Cloud's `cloud/migrations/002`.
+
 ### Supabase fallback
 
 If the primary store URL fails (e.g. Vercel bot protection returns HTML), Trailhead falls back to direct Supabase REST when configured:
@@ -96,3 +107,4 @@ This is **fail-open** — storage failures never block merges.
 
 - [Trailhead v4 roadmap](./roadmap-v4.md)
 - [Migration v3 → v4](./migration-v3-to-v4.md)
+- [Komatik hosted store](./komatik-hosted-store.md) — fleet `komatik.ai` endpoint

--- a/docs/komatik-hosted-store.md
+++ b/docs/komatik-hosted-store.md
@@ -1,0 +1,87 @@
+# Komatik hosted evaluation store (`komatik.ai`)
+
+Fleet satellites POST gate evaluations to **`https://komatik.ai/api/trailhead/store`**
+(legacy alias: `/api/deployguard/store` — retire only after all active consumers confirm migration).
+
+Implementation lives in **Komatik** (`platform/web/app/api/deployguard/store/route.ts`), not in Trailhead Cloud.
+
+## Endpoints
+
+| Method | Path | Purpose |
+| ------ | ---- | ------- |
+| `POST` | `/api/trailhead/store` | Persist evaluation (GateEvaluation JSON or snake_case row) |
+| `GET` | `/api/trailhead/evaluations` | Prior evaluations for loop bookkeeping lookup |
+| `POST` | `/api/trailhead/deploy-event` | Deploy outcome correlation (alias of deployguard path) |
+
+Auth: `Authorization: Bearer $INTERNAL_API_SECRET` (same secret as `evaluation-store-secret` in consumer workflows).
+
+### POST body shapes
+
+The store accepts **both**:
+
+1. **HTTP path** — full `GateEvaluation` camelCase from `storeViaApi` (`remediation.loop_round` nested)
+2. **Supabase fallback** — snake_case from `buildEvaluationStoreRow()` in `src/notify.ts`
+
+Persisted loop columns (v4.3+): `remediation`, `loop_round`, `previous_evaluation_id`, `fixes_resolved`, `fixes_introduced`, `release_ready`, `pr`.
+
+### GET loop lookup
+
+```
+GET /api/trailhead/evaluations?repo_id=KomatikAI/cairn&pr_number=28&limit=10
+Authorization: Bearer <INTERNAL_API_SECRET>
+```
+
+Response:
+
+```json
+{
+  "evaluations": [
+    {
+      "id": "dg-…",
+      "remediation": { "loop_round": 0, "…": "…" },
+      "loop_round": 0,
+      "fixes_resolved": [],
+      "fixes_introduced": ["ci.failed"]
+    }
+  ]
+}
+```
+
+Trailhead **v4.3.1+** resolves this URL automatically when `evaluation-store-url` ends with `/api/trailhead/store` or `/api/deployguard/store` — fleet repos do **not** need `SUPABASE_URL` in the workflow for round N+1 lookup.
+
+## Schema (Komatik Supabase)
+
+Table: `public.trailhead_evaluations`
+
+Base migration: `Komatik/supabase/migrations/20260524090000_trailhead_evaluations.sql`  
+Loop columns: `…/20260527073857_trailhead_loop_bookkeeping.sql`
+
+Reference copy for Trailhead Cloud hosted tier: `cloud/migrations/002_loop_bookkeeping.sql` (different deployment — do not conflate).
+
+## Fleet rollout status (May 2026)
+
+**A6 complete** for active consumers — pinned `@v4.3.0`, store URL on `/api/trailhead/store`:
+
+| Repo | Status |
+| ---- | ------ |
+| cairn, frontier, kindling, pack, slipstream, sundog, trace | Merged |
+| drift, floe, traverse, watchtower | **Retired** (archived; absorbed into trace) — do not unarchive for rollout |
+
+**Pending:**
+
+- [Komatik #2014](https://github.com/KomatikAI/komatik/pull/2014) — store persistence + GET API
+- [Trailhead #236](https://github.com/KomatikAI/trailhead/pull/236) — komatik list read path → tag **v4.3.1**, re-pin fleet
+
+## Deployment rules (mandatory)
+
+> **Never apply Komatik Supabase migrations or deploy store API changes via MCP `apply_migration` / direct SQL to production.**
+>
+> All schema and route changes must land through a **Komatik PR → merge → Vercel deploy**. Remote-only migrations break CI **Migration Drift Check** until the matching file exists in git at the **exact version** Supabase recorded.
+
+If prod was changed out-of-band, reconcile by renaming the local migration file to match the remote version (see Komatik runbook `docs/runbooks/TRAILHEAD-EVALUATION-STORE.md`).
+
+## Related
+
+- [Evaluation storage](./evaluation-storage.md)
+- [Roadmap v4.3 Phase A](./roadmap-v4.3-agent-autonomy.md)
+- `scripts/batch-v4.3-rollout-prs.mjs` — fleet pin + store URL batch PRs

--- a/docs/komatik-hosted-store.md
+++ b/docs/komatik-hosted-store.md
@@ -7,11 +7,11 @@ Implementation lives in **Komatik** (`platform/web/app/api/deployguard/store/rou
 
 ## Endpoints
 
-| Method | Path | Purpose |
-| ------ | ---- | ------- |
-| `POST` | `/api/trailhead/store` | Persist evaluation (GateEvaluation JSON or snake_case row) |
-| `GET` | `/api/trailhead/evaluations` | Prior evaluations for loop bookkeeping lookup |
-| `POST` | `/api/trailhead/deploy-event` | Deploy outcome correlation (alias of deployguard path) |
+| Method | Path                          | Purpose                                                    |
+| ------ | ----------------------------- | ---------------------------------------------------------- |
+| `POST` | `/api/trailhead/store`        | Persist evaluation (GateEvaluation JSON or snake_case row) |
+| `GET`  | `/api/trailhead/evaluations`  | Prior evaluations for loop bookkeeping lookup              |
+| `POST` | `/api/trailhead/deploy-event` | Deploy outcome correlation (alias of deployguard path)     |
 
 Auth: `Authorization: Bearer $INTERNAL_API_SECRET` (same secret as `evaluation-store-secret` in consumer workflows).
 
@@ -62,10 +62,10 @@ Reference copy for Trailhead Cloud hosted tier: `cloud/migrations/002_loop_bookk
 
 **A6 complete** for active consumers — pinned `@v4.3.0`, store URL on `/api/trailhead/store`:
 
-| Repo | Status |
-| ---- | ------ |
-| cairn, frontier, kindling, pack, slipstream, sundog, trace | Merged |
-| drift, floe, traverse, watchtower | **Retired** (archived; absorbed into trace) — do not unarchive for rollout |
+| Repo                                                       | Status                                                                     |
+| ---------------------------------------------------------- | -------------------------------------------------------------------------- |
+| cairn, frontier, kindling, pack, slipstream, sundog, trace | Merged                                                                     |
+| drift, floe, traverse, watchtower                          | **Retired** (archived; absorbed into trace) — do not unarchive for rollout |
 
 **Pending:**
 

--- a/docs/roadmap-v4.3-agent-autonomy.md
+++ b/docs/roadmap-v4.3-agent-autonomy.md
@@ -318,24 +318,33 @@ Trust scoring proper waits for Phase B, but the strict-everywhere rollout needs 
 - Auto-downgrade verified end-to-end on a synthetic high-FP detector fixture
 - Per-agent rolling stats query returns < 500ms p95 over Komatik's evaluation volume
 
-### A6 — Fleet rollout (21 repos)
+### A6 — Fleet rollout (active satellites)
+
+**Scope (May 2026):** Pin **`@v4.3.0`** (explicit tag; `@v4` stays on v4.2.2) and migrate `evaluation-store-url` to `https://komatik.ai/api/trailhead/store`.
 
 **Deliverables:**
 
-- `scripts/batch-v4.3-rollout-prs.mjs` — modeled on `scripts/batch-dora-permissions-prs.mjs`. Per repo:
-  - Bump `@v4` consumers to `@v4.3` in `.github/workflows/trailhead.yml`
-  - Add `presets: ["@trailhead/strict-agents"]` line to `.trailhead.yml` (creates the file if missing)
-  - Open a PR with standardized title `chore(trailhead): adopt v4.3 strict-agent gate + remediation loop`
-  - PR body explains the change, links to `docs/roadmap-v4.3-agent-autonomy.md`, includes rollback instructions
-- Each PR auto-labeled `trailhead-v4.3-rollout`
-- Script runs in dry-run mode by default; `--apply` flag actually opens PRs
-- Post-rollout dashboard: which repos have merged, which are pending, FP rate per repo first 7 days
+- `scripts/batch-v4.3-rollout-prs.mjs` — per active repo:
+  - Bump action ref → `KomatikAI/trailhead@v4.3.0`
+  - Flip store URL → `/api/trailhead/store`
+  - Handles `trailhead.yml` or legacy `deployguard.yml`; default branch `dev`
+- **Excluded:** drift, floe, traverse, watchtower (archived; trace absorbed them)
+
+**Status:** ✅ Merged on cairn, frontier, kindling, pack, slipstream, sundog, trace.
+
+**Follow-up (store loop fields):**
+
+- Komatik PR — persist A4 columns + `GET /api/trailhead/evaluations`
+- Trailhead v4.3.1 — `fetchPreviousEvaluationForPr` komatik list read path
+- Re-pin fleet `@v4.3.1` after both merge
+
+See [komatik-hosted-store.md](./komatik-hosted-store.md). **Do not apply Komatik migrations via MCP** — PR-only deploys.
 
 **Acceptance:**
 
-- All 21 PRs opened within a single script invocation
-- Dry-run output reviewable before any PR is created
-- 100% of merged adopters report a successful gate evaluation within 24 hours of merge
+- All active consumer PRs merged
+- Loop fields persist and round N+1 increments on smoke PR
+- `/api/deployguard/store` alias retired after confirmation
 
 ### A7 — Override mechanism
 

--- a/scripts/batch-v4.3-rollout-prs.mjs
+++ b/scripts/batch-v4.3-rollout-prs.mjs
@@ -31,8 +31,7 @@ const WORKFLOW_CANDIDATES = [
   ".github/workflows/trailhead.yml",
   ".github/workflows/deployguard.yml",
 ];
-const TARGET_VERSION =
-  process.env.TRAILHEAD_ROLLOUT_VERSION || "4.3.0";
+const TARGET_VERSION = process.env.TRAILHEAD_ROLLOUT_VERSION || "4.3.0";
 const TARGET_REF = `@v${TARGET_VERSION}`; // @v4.3.0
 const LEGACY_STORE = "/api/deployguard/store";
 const CANONICAL_STORE = "/api/trailhead/store";
@@ -121,10 +120,7 @@ function patchWorkflow(content) {
     return `${prefix}${ACTION_REPO}${TARGET_REF}`;
   });
 
-  const storeRegex = new RegExp(
-    LEGACY_STORE.replace(/\//g, "\\/"),
-    "g",
-  );
+  const storeRegex = new RegExp(LEGACY_STORE.replace(/\//g, "\\/"), "g");
   const nextStore = nextAction.replace(storeRegex, () => {
     storeChanged = true;
     return CANONICAL_STORE;
@@ -169,7 +165,7 @@ function prBody(name, plan) {
   lines.push("## Why");
   lines.push("");
   lines.push(
-    "v4.3.0 ships Phase A \"Coach\" (remediation schema, agent brief, semantic webhooks, loop bookkeeping). Explicit pin avoids the fleet-wide `@v4` tag move until deliberately approved.",
+    'v4.3.0 ships Phase A "Coach" (remediation schema, agent brief, semantic webhooks, loop bookkeeping). Explicit pin avoids the fleet-wide `@v4` tag move until deliberately approved.',
   );
   lines.push("");
   lines.push("## Rollback");
@@ -180,7 +176,9 @@ function prBody(name, plan) {
   lines.push("");
   lines.push("## Context");
   lines.push("");
-  lines.push(`- Release: [${TARGET_REF}](https://github.com/${ACTION_REPO}/releases/tag/${TARGET_VERSION})`);
+  lines.push(
+    `- Release: [${TARGET_REF}](https://github.com/${ACTION_REPO}/releases/tag/${TARGET_VERSION})`,
+  );
   lines.push(
     `- Roadmap: [\`docs/roadmap-v4.3-agent-autonomy.md\`](https://github.com/${ACTION_REPO}/blob/main/docs/roadmap-v4.3-agent-autonomy.md) (A6)`,
   );
@@ -216,9 +214,7 @@ function planRepo({ name }) {
     base,
     hasWorkflow: true,
     skip: noop,
-    reason: noop
-      ? `already on ${TARGET_REF} + ${CANONICAL_STORE}`
-      : null,
+    reason: noop ? `already on ${TARGET_REF} + ${CANONICAL_STORE}` : null,
     workflow: { ...workflow, content: patch.content },
     workflowPath: workflow.path,
     actionChanged: patch.actionChanged,

--- a/scripts/batch-v4.3-rollout-prs.mjs
+++ b/scripts/batch-v4.3-rollout-prs.mjs
@@ -1,70 +1,52 @@
 #!/usr/bin/env node
 /**
- * Batch PRs: adopt Trailhead v4.3 strict-agent gate + remediation loop.
+ * A6 fleet rollout: pin Trailhead v4.3.0 + migrate evaluation store URL.
  *
- * Per repo:
- *   1. Bump  @v4  →  @v4.3  in .github/workflows/trailhead.yml (when present)
- *   2. Add (or create) .trailhead.yml with `presets: ["@trailhead/strict-agents"]`
- *   3. Open a PR titled "chore(trailhead): adopt v4.3 strict-agent gate + remediation loop"
+ * Repos still on legacy deployguard store endpoint — active fleet only (see docs/komatik-hosted-store.md):
+ *   cairn, frontier, kindling, pack, slipstream, sundog, trace
+ * Excluded (retired/archived, trace absorbed): drift, floe, traverse, watchtower
+ *
+ * Deploy rule: Komatik schema/routes via PR only — never apply_migration to prod via MCP.
+ *   1. Bump action ref → KomatikAI/trailhead@v4.3.0 (explicit tag, NOT @v4)
+ *   2. Flip evaluation-store-url → .../api/trailhead/store
+ *
+ * Workflow file: `.github/workflows/trailhead.yml` or `deployguard.yml` (legacy filename).
+ * Base branch: repo default (dev for satellites; main for komatik-agents).
  *
  * Usage:
- *   node scripts/batch-v4.3-rollout-prs.mjs             # dry-run, prints per-repo plan
- *   node scripts/batch-v4.3-rollout-prs.mjs --apply     # actually opens PRs
+ *   node scripts/batch-v4.3-rollout-prs.mjs             # dry-run
+ *   node scripts/batch-v4.3-rollout-prs.mjs --apply     # open PRs
  *   node scripts/batch-v4.3-rollout-prs.mjs --only=kindling,sundog
  *   node scripts/batch-v4.3-rollout-prs.mjs --skip-missing-workflow
  *
- * Safety:
- *   - Idempotent: SKIPs any repo already pinned to @v4.3 and already opted into the preset.
- *   - Each repo gets its own branch `cursor/trailhead-v4.3-rollout` so retries are easy.
- *   - PR body includes a 1-line rollback recipe.
- *   - Reads the action version from package.json so a future v4.4 rollout reuses this script.
+ * Override release pin: TRAILHEAD_ROLLOUT_VERSION=4.3.0 node scripts/...
  */
 
 import { execFileSync } from "node:child_process";
-import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-
-const REPOS = [
-  // Base Camp monitored (14)
-  { name: "Komatik", org: "KomatikAI", base: "main" },
-  { name: "komatik-agents", org: "KomatikAI", base: "main" },
-  { name: "komatik-base-camp", org: "KomatikAI", base: "main" },
-  { name: "deployguard", org: "KomatikAI", base: "main" },
-  { name: "daydream-studio", org: "KomatikAI", base: "main" },
-  { name: "storyboard-studio", org: "KomatikAI", base: "main" },
-  { name: "shieldcheck", org: "KomatikAI", base: "main" },
-  { name: "reviewflow", org: "KomatikAI", base: "main" },
-  { name: "mcp-brokerage", org: "KomatikAI", base: "main" },
-  { name: "rescue-engineering", org: "KomatikAI", base: "main" },
-  { name: "shadow-ai-governance", org: "KomatikAI", base: "main" },
-  { name: "drift", org: "KomatikAI", base: "main" },
-  { name: "komatik-yggdrasil", org: "KomatikAI", base: "main" },
-  { name: "Bored", org: "KomatikAI", base: "main" },
-  // DORA-enabled satellites (7)
-  { name: "trace", org: "KomatikAI", base: "main" },
-  { name: "pack", org: "KomatikAI", base: "main" },
-  { name: "cairn", org: "KomatikAI", base: "main" },
-  { name: "kindling", org: "KomatikAI", base: "main" },
-  { name: "sundog", org: "KomatikAI", base: "main" },
-  { name: "frontier", org: "KomatikAI", base: "main" },
-  { name: "slipstream", org: "KomatikAI", base: "main" },
-];
-
-const BRANCH = "cursor/trailhead-v4.3-rollout";
-const WORKFLOW_PATH = ".github/workflows/trailhead.yml";
-const CONFIG_PATH = ".trailhead.yml";
-const PRESET_KEY = "@trailhead/strict-agents";
+const ORG = "KomatikAI";
 const ACTION_REPO = "KomatikAI/trailhead";
+const BRANCH = "cursor/trailhead-v4.3.0-a6-rollout";
+const WORKFLOW_CANDIDATES = [
+  ".github/workflows/trailhead.yml",
+  ".github/workflows/deployguard.yml",
+];
+const TARGET_VERSION =
+  process.env.TRAILHEAD_ROLLOUT_VERSION || "4.3.0";
+const TARGET_REF = `@v${TARGET_VERSION}`; // @v4.3.0
+const LEGACY_STORE = "/api/deployguard/store";
+const CANONICAL_STORE = "/api/trailhead/store";
 
-// Read the desired action version from this repo's package.json so the script
-// stays in sync with the latest release tag.
-const PKG = JSON.parse(readFileSync(join(__dirname, "..", "package.json"), "utf8"));
-const ACTION_VERSION_MAJOR_MINOR =
-  process.env.TRAILHEAD_ROLLOUT_VERSION || PKG.version.split(".").slice(0, 2).join("."); // e.g. "4.3"
-const TARGET_REF = `@v${ACTION_VERSION_MAJOR_MINOR}`; // "@v4.3"
+/** Repos on legacy store URL — active fleet only. Retired: drift, floe, traverse, watchtower. */
+const REPOS = [
+  { name: "cairn" },
+  { name: "frontier" },
+  { name: "kindling" },
+  { name: "pack" },
+  { name: "slipstream" },
+  { name: "sundog" },
+  { name: "trace" },
+];
 
 const args = new Set(process.argv.slice(2));
 const apply = args.has("--apply");
@@ -99,219 +81,244 @@ function tryGh(ghArgs) {
   }
 }
 
-function getFile(org, name, ref, path) {
+function getRepoMeta(name) {
+  return JSON.parse(
+    gh(["api", `repos/${ORG}/${name}`, "--jq", "{default_branch, archived}"]),
+  );
+}
+
+function getFile(name, ref, path) {
   const res = tryGh([
     "api",
-    `repos/${org}/${name}/contents/${path}?ref=${ref}`,
+    `repos/${ORG}/${name}/contents/${path}?ref=${ref}`,
     "--jq",
     "{sha: .sha, content: .content}",
   ]);
   if (!res.ok) {
     if (/Not Found|404/.test(res.err)) return null;
-    throw new Error(`getFile ${org}/${name} ${path}: ${res.err}`);
+    throw new Error(`getFile ${name} ${path}: ${res.err}`);
   }
   const { sha, content: b64 } = JSON.parse(res.out);
-  return { sha, content: Buffer.from(b64, "base64").toString("utf8") };
+  return { sha, content: Buffer.from(b64, "base64").toString("utf8"), path };
 }
 
-function bumpWorkflowRef(content) {
-  // Trailhead Action uses (a) KomatikAI/trailhead@vX and (b) KomatikAI/deployguard@vX (legacy alias).
-  // Match either, only the @v<num> form (don't touch SHA pins or @v4.2.1 etc.).
-  const refRegex = /(uses:\s*KomatikAI\/(trailhead|deployguard))@v\d+(?:\.\d+)?(?!\.\d)/g;
-  let changed = false;
-  const patched = content.replace(refRegex, (_, prefix) => {
-    changed = true;
-    return `${prefix}${TARGET_REF}`;
+function findWorkflow(name, base) {
+  for (const path of WORKFLOW_CANDIDATES) {
+    const file = getFile(name, base, path);
+    if (file) return file;
+  }
+  return null;
+}
+
+function patchWorkflow(content) {
+  let actionChanged = false;
+  let storeChanged = false;
+
+  const actionRegex =
+    /(uses:\s*)(?:KomatikAI\/(?:trailhead|deployguard)|dschirmer-shiftkey\/deployguard)@[^\s#]+/g;
+  const nextAction = content.replace(actionRegex, (_, prefix) => {
+    actionChanged = true;
+    return `${prefix}${ACTION_REPO}${TARGET_REF}`;
   });
-  return { content: patched, changed };
+
+  const storeRegex = new RegExp(
+    LEGACY_STORE.replace(/\//g, "\\/"),
+    "g",
+  );
+  const nextStore = nextAction.replace(storeRegex, () => {
+    storeChanged = true;
+    return CANONICAL_STORE;
+  });
+
+  const alreadyPinned = new RegExp(
+    `${ACTION_REPO.replace("/", "\\/")}${TARGET_REF.replace(".", "\\.")}(?:\\s|$)`,
+  ).test(content);
+  const alreadyStore = !content.includes(LEGACY_STORE);
+
+  return {
+    content: nextStore,
+    actionChanged: actionChanged && !alreadyPinned,
+    storeChanged: storeChanged && !alreadyStore,
+    alreadyPinned,
+    alreadyStore,
+  };
 }
 
-function ensureConfigHasPreset(content) {
-  if (content === null) {
-    return {
-      content: [
-        "# Trailhead config — adopted v4.3 strict-agents preset",
-        "schema_version: 1",
-        `presets:`,
-        `  - "${PRESET_KEY}"`,
-        "",
-      ].join("\n"),
-      changed: true,
-      created: true,
-    };
-  }
-
-  if (
-    /^\s*-\s*["']?@trailhead\/strict-agents["']?\s*$/m.test(content) ||
-    /presets:\s*\[[^\]]*@trailhead\/strict-agents[^\]]*\]/.test(content)
-  ) {
-    return { content, changed: false, created: false };
-  }
-
-  if (/^presets:\s*$/m.test(content) || /^presets:\s*\n(?:\s+-\s+.*\n)+/m.test(content)) {
-    const next = content.replace(
-      /(^presets:\s*\n(?:\s+-\s+.*\n)*)/m,
-      (block) => `${block}  - "${PRESET_KEY}"\n`,
-    );
-    return { content: next, changed: next !== content, created: false };
-  }
-
-  const next =
-    content + (content.endsWith("\n") ? "" : "\n") + `presets:\n  - "${PRESET_KEY}"\n`;
-  return { content: next, changed: true, created: false };
-}
-
-function prBody(repo, plan) {
+function prBody(name, plan) {
   const lines = [
     "## Summary",
     "",
-    `Adopt Trailhead **v4.3** (\`${TARGET_REF}\`) and opt this repo into the strict-agent gate + remediation loop.`,
+    `Pin Trailhead to **${TARGET_REF}** and migrate the evaluation store URL to the canonical \`${CANONICAL_STORE}\` endpoint.`,
     "",
     "## What changes",
     "",
   ];
 
-  if (plan.workflowBumped) {
-    lines.push(`- Bump action ref in \`${WORKFLOW_PATH}\` to \`${TARGET_REF}\``);
+  if (plan.actionChanged) {
+    lines.push(
+      `- Bump action ref in \`${plan.workflowPath}\` to \`${ACTION_REPO}${TARGET_REF}\` (explicit tag; \`@v4\` remains on v4.2.2)`,
+    );
   }
-  if (plan.configCreated) {
-    lines.push(`- Create \`${CONFIG_PATH}\` opting into the \`${PRESET_KEY}\` preset`);
-  } else if (plan.presetAdded) {
-    lines.push(`- Add \`${PRESET_KEY}\` to \`${CONFIG_PATH}\` presets list`);
+  if (plan.storeChanged) {
+    lines.push(
+      `- Migrate \`evaluation-store-url\` from \`${LEGACY_STORE}\` → \`${CANONICAL_STORE}\` (alias already live on komatik.ai)`,
+    );
   }
 
   lines.push("");
-  lines.push("## Behavior change");
-  lines.push("");
-  lines.push("- **Human PRs:** unchanged (mode falls back to existing config)");
-  lines.push(
-    "- **Agent-provenance PRs:** strict thresholds (risk 40, max_files 30) and a structured Remediation block agents can act on. Up to 5 fix-and-retry rounds per PR.",
-  );
-  lines.push("");
-  lines.push("## Escape valve");
+  lines.push("## Why");
   lines.push("");
   lines.push(
-    "Label any PR with `trailhead-override` and add a comment matching `trailhead-override: <reason>` to bypass the gate. All overrides are audited.",
+    "v4.3.0 ships Phase A \"Coach\" (remediation schema, agent brief, semantic webhooks, loop bookkeeping). Explicit pin avoids the fleet-wide `@v4` tag move until deliberately approved.",
   );
   lines.push("");
   lines.push("## Rollback");
   lines.push("");
   lines.push(
-    `If anything goes sideways: revert this PR — Trailhead falls back to the previous \`@v4\` behavior immediately.`,
+    "Revert this PR to restore the previous action ref and store URL. The `/api/deployguard/store` alias remains until all consumers confirm migration.",
   );
   lines.push("");
   lines.push("## Context");
   lines.push("");
-  lines.push(`- Epic: ${ACTION_REPO}#223`);
+  lines.push(`- Release: [${TARGET_REF}](https://github.com/${ACTION_REPO}/releases/tag/${TARGET_VERSION})`);
   lines.push(
-    `- Roadmap: [\`docs/roadmap-v4.3-agent-autonomy.md\`](https://github.com/${ACTION_REPO}/blob/main/docs/roadmap-v4.3-agent-autonomy.md)`,
+    `- Roadmap: [\`docs/roadmap-v4.3-agent-autonomy.md\`](https://github.com/${ACTION_REPO}/blob/main/docs/roadmap-v4.3-agent-autonomy.md) (A6)`,
   );
 
   return lines.join("\n");
 }
 
-function planRepo({ org, name, base }) {
-  const workflow = getFile(org, name, base, WORKFLOW_PATH);
-  if (!workflow) {
+function planRepo({ name }) {
+  const { default_branch: base, archived } = getRepoMeta(name);
+  if (archived) {
     return {
+      base,
       hasWorkflow: false,
       skip: true,
-      reason: "no .github/workflows/trailhead.yml",
+      reason: "repo archived — unarchive before opening rollout PR",
+      archived: true,
+    };
+  }
+  const workflow = findWorkflow(name, base);
+  if (!workflow) {
+    return {
+      base,
+      hasWorkflow: false,
+      skip: true,
+      reason: "no trailhead.yml or deployguard.yml workflow",
     };
   }
 
-  const bumpResult = bumpWorkflowRef(workflow.content);
-  const config = getFile(org, name, base, CONFIG_PATH);
-  const presetResult = ensureConfigHasPreset(config?.content ?? null);
-
-  const noop = !bumpResult.changed && !presetResult.changed;
+  const patch = patchWorkflow(workflow.content);
+  const noop = !patch.actionChanged && !patch.storeChanged;
 
   return {
+    base,
     hasWorkflow: true,
     skip: noop,
-    reason: noop ? "already adopted v4.3 + strict-agents preset" : null,
-    workflow: { ...workflow, ...bumpResult },
-    config: config ? { ...config, ...presetResult } : { sha: null, ...presetResult },
-    workflowBumped: bumpResult.changed,
-    presetAdded: !presetResult.created && presetResult.changed,
-    configCreated: presetResult.created,
+    reason: noop
+      ? `already on ${TARGET_REF} + ${CANONICAL_STORE}`
+      : null,
+    workflow: { ...workflow, content: patch.content },
+    workflowPath: workflow.path,
+    actionChanged: patch.actionChanged,
+    storeChanged: patch.storeChanged,
   };
 }
 
-async function applyRepo({ org, name, base }, plan) {
+async function applyRepo({ name }, plan) {
   const baseSha = gh([
     "api",
-    `repos/${org}/${name}/git/ref/heads/${base}`,
+    `repos/${ORG}/${name}/git/ref/heads/${plan.base}`,
     "--jq",
     ".object.sha",
   ]);
 
-  const refCreate = tryGh([
+  const branchExists = tryGh([
     "api",
-    `repos/${org}/${name}/git/refs`,
-    "-f",
-    `ref=refs/heads/${BRANCH}`,
-    "-f",
-    `sha=${baseSha}`,
+    `repos/${ORG}/${name}/git/ref/heads/${BRANCH}`,
+    "--jq",
+    ".object.sha",
   ]);
-  if (!refCreate.ok && !/Reference already exists/.test(refCreate.err)) {
-    throw new Error(`branch create ${org}/${name}: ${refCreate.err}`);
+
+  if (!branchExists.ok) {
+    const refCreate = tryGh([
+      "api",
+      `repos/${ORG}/${name}/git/refs`,
+      "-f",
+      `ref=refs/heads/${BRANCH}`,
+      "-f",
+      `sha=${baseSha}`,
+    ]);
+    if (!refCreate.ok && !/Reference already exists/.test(refCreate.err)) {
+      throw new Error(`branch create ${name}: ${refCreate.err}`);
+    }
   }
 
-  if (plan.workflowBumped) {
+  let fileSha = plan.workflow.sha;
+  let skipPut = false;
+  const onBranch = getFile(name, BRANCH, plan.workflowPath);
+  if (onBranch) {
+    fileSha = onBranch.sha;
+    if (onBranch.content === plan.workflow.content) {
+      skipPut = true;
+      const existingPr = tryGh([
+        "pr",
+        "list",
+        "--repo",
+        `${ORG}/${name}`,
+        "--head",
+        BRANCH,
+        "--state",
+        "open",
+        "--json",
+        "url",
+        "--jq",
+        ".[0].url",
+      ]);
+      if (existingPr.ok && existingPr.out) {
+        return { url: existingPr.out, reused: true };
+      }
+    }
+  }
+
+  if (!skipPut) {
     const encoded = Buffer.from(plan.workflow.content, "utf8").toString("base64");
+    const msgParts = [];
+    if (plan.actionChanged) msgParts.push(`pin ${TARGET_REF}`);
+    if (plan.storeChanged) msgParts.push("migrate store URL");
     gh([
       "api",
-      `repos/${org}/${name}/contents/${WORKFLOW_PATH}`,
+      `repos/${ORG}/${name}/contents/${plan.workflowPath}`,
       "-X",
       "PUT",
       "-f",
-      `message=chore(trailhead): bump action ref to ${TARGET_REF}`,
+      `message=chore(trailhead): ${msgParts.join(" + ")}`,
       "-f",
       `content=${encoded}`,
       "-f",
-      `sha=${plan.workflow.sha}`,
+      `sha=${fileSha}`,
       "-f",
       `branch=${BRANCH}`,
     ]);
   }
 
-  if (plan.presetAdded || plan.configCreated) {
-    const encoded = Buffer.from(plan.config.content, "utf8").toString("base64");
-    const args = [
-      "api",
-      `repos/${org}/${name}/contents/${CONFIG_PATH}`,
-      "-X",
-      "PUT",
-      "-f",
-      `message=chore(trailhead): opt in to ${PRESET_KEY} preset`,
-      "-f",
-      `content=${encoded}`,
-      "-f",
-      `branch=${BRANCH}`,
-    ];
-    if (plan.config.sha) {
-      args.push("-f", `sha=${plan.config.sha}`);
-    }
-    gh(args);
-  }
-
-  const prCreate = tryGh([
+  const title = "chore(trailhead): pin v4.3.0 and migrate evaluation store URL";
+  const prArgs = [
     "pr",
     "create",
     "--repo",
-    `${org}/${name}`,
+    `${ORG}/${name}`,
     "--base",
-    base,
+    plan.base,
     "--head",
     BRANCH,
     "--title",
-    "chore(trailhead): adopt v4.3 strict-agent gate + remediation loop",
-    "--label",
-    "trailhead-v4.3-rollout",
+    title,
     "--body",
     prBody(name, plan),
-  ]);
+  ];
+  const prCreate = tryGh(prArgs);
 
   if (!prCreate.ok) {
     if (/already exists/.test(prCreate.err)) {
@@ -319,7 +326,7 @@ async function applyRepo({ org, name, base }, plan) {
         "pr",
         "list",
         "--repo",
-        `${org}/${name}`,
+        `${ORG}/${name}`,
         "--head",
         BRANCH,
         "--state",
@@ -334,6 +341,16 @@ async function applyRepo({ org, name, base }, plan) {
     throw new Error(prCreate.err);
   }
 
+  tryGh([
+    "pr",
+    "edit",
+    prCreate.out.split("/").pop(),
+    "--repo",
+    `${ORG}/${name}`,
+    "--add-label",
+    "trailhead-v4.3-rollout",
+  ]);
+
   return { url: prCreate.out, reused: false };
 }
 
@@ -345,13 +362,13 @@ for (const repo of repos) {
     const plan = planRepo(repo);
 
     if (!plan.hasWorkflow) {
-      if (skipMissingWorkflow) {
-        console.log(`SKIP ${repo.name}: ${plan.reason}`);
-      } else {
-        console.log(
-          `MISSING ${repo.name}: ${plan.reason} (use --skip-missing-workflow to silence)`,
-        );
-      }
+      const tag = plan.archived ? "ARCHIVED" : skipMissingWorkflow ? "SKIP" : "MISSING";
+      const hint = plan.archived
+        ? ""
+        : skipMissingWorkflow
+          ? ""
+          : " (use --skip-missing-workflow to silence)";
+      console.log(`${tag} ${repo.name}: ${plan.reason}${hint}`);
       continue;
     }
 
@@ -362,10 +379,11 @@ for (const repo of repos) {
 
     if (!apply) {
       const parts = [];
-      if (plan.workflowBumped) parts.push(`bump workflow → ${TARGET_REF}`);
-      if (plan.configCreated) parts.push(`create ${CONFIG_PATH}`);
-      else if (plan.presetAdded) parts.push(`add ${PRESET_KEY} preset`);
-      console.log(`PLAN ${repo.name}: ${parts.join(" + ")}`);
+      if (plan.actionChanged) parts.push(`pin → ${TARGET_REF}`);
+      if (plan.storeChanged) parts.push(`store → ${CANONICAL_STORE}`);
+      console.log(
+        `PLAN ${repo.name} (base=${plan.base}, ${plan.workflowPath}): ${parts.join(" + ")}`,
+      );
       results.push({ repo: repo.name, planned: true });
       continue;
     }
@@ -384,7 +402,8 @@ const planned = results.filter((r) => r.planned);
 const failed = results.filter((r) => r.error);
 
 console.log("\n--- Summary ---");
-console.log(`Action ref: ${TARGET_REF}`);
+console.log(`Action ref: ${ACTION_REPO}${TARGET_REF}`);
+console.log(`Store URL:  ${CANONICAL_STORE}`);
 console.log(`Mode:       ${apply ? "APPLY" : "DRY-RUN"}`);
 console.log(`Repos seen: ${repos.length}`);
 console.log(`Planned:    ${planned.length}`);

--- a/src/__tests__/evaluation-history.test.ts
+++ b/src/__tests__/evaluation-history.test.ts
@@ -1,6 +1,24 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { fetchPreviousEvaluationForPr } from "../evaluation-history.js";
+import {
+  fetchPreviousEvaluationForPr,
+  resolveKomatikListUrl,
+} from "../evaluation-history.js";
+
+describe("resolveKomatikListUrl", () => {
+  it("maps trailhead store URL to evaluations list", () => {
+    expect(resolveKomatikListUrl("https://komatik.ai/api/trailhead/store")).toBe(
+      "https://komatik.ai/api/trailhead/evaluations",
+    );
+    expect(resolveKomatikListUrl("https://komatik.ai/api/deployguard/store")).toBe(
+      "https://komatik.ai/api/trailhead/evaluations",
+    );
+  });
+
+  it("returns null for unrelated store URLs", () => {
+    expect(resolveKomatikListUrl("https://api.trailhead.dev/v1/evaluations")).toBeNull();
+  });
+});
 
 describe("fetchPreviousEvaluationForPr", () => {
   beforeEach(() => {
@@ -68,6 +86,57 @@ describe("fetchPreviousEvaluationForPr", () => {
     expect(previous?.id).toBe("eval-prev");
     expect(previous?.remediation?.loop_round).toBe(0);
     expect(vi.mocked(fetch).mock.calls[0][0]).toContain("pr_number=42");
+  });
+
+  it("loads previous evaluation from komatik.ai list API", async () => {
+    process.env.EVALUATION_STORE_SECRET = "internal-secret";
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          evaluations: [
+            {
+              id: "eval-current",
+              loop_round: 1,
+              fixes_resolved: [],
+              fixes_introduced: [],
+            },
+            {
+              id: "eval-prev",
+              loop_round: 0,
+              fixes_resolved: [],
+              fixes_introduced: ["ci.failed"],
+              remediation: {
+                schema: "trailhead.remediation.v1",
+                loop_round: 0,
+                fixes: [],
+                blocking_count: 1,
+                warn_count: 0,
+                advisory_count: 0,
+                autofix_eligible_count: 0,
+                max_loop_rounds: 3,
+                fixes_resolved: [],
+                fixes_introduced: ["ci.failed"],
+                next_action: "fix_and_retry",
+                release_ready: false,
+              },
+            },
+          ],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    const previous = await fetchPreviousEvaluationForPr({
+      repoId: "KomatikAI/cairn",
+      prNumber: 28,
+      excludeEvaluationId: "eval-current",
+      storeUrl: "https://komatik.ai/api/trailhead/store",
+    });
+
+    expect(previous?.id).toBe("eval-prev");
+    expect(previous?.remediation?.loop_round).toBe(0);
+    expect(vi.mocked(fetch).mock.calls[0][0]).toContain("/api/trailhead/evaluations");
+    expect(vi.mocked(fetch).mock.calls[0][0]).toContain("repo_id=KomatikAI%2Fcairn");
   });
 
   it("falls back to Supabase when Cloud list URL is unavailable", async () => {

--- a/src/evaluation-history.ts
+++ b/src/evaluation-history.ts
@@ -4,6 +4,7 @@ import {
 } from "./loop-bookkeeping.js";
 
 const LOOKUP_TIMEOUT_MS = 8_000;
+const KOMATIK_STORE_PATH = /\/api\/(?:trailhead|deployguard)\/store$/;
 
 export interface FetchPreviousEvaluationParams {
   repoId: string;
@@ -38,13 +39,63 @@ function resolveCloudListUrl(storeUrl: string): string | null {
   return null;
 }
 
-async function fetchFromCloudStore(
+/** komatik.ai hosted store → loop lookup list endpoint. */
+export function resolveKomatikListUrl(storeUrl: string): string | null {
+  const trimmed = storeUrl.replace(/\/$/, "");
+  if (!KOMATIK_STORE_PATH.test(trimmed)) return null;
+  return trimmed.replace(KOMATIK_STORE_PATH, "/api/trailhead/evaluations");
+}
+
+function enrichSnapshotFromLoopColumns(
+  parsed: PreviousEvaluationSnapshot,
+  row: Record<string, unknown>,
+): PreviousEvaluationSnapshot {
+  if (parsed.remediation || typeof row.loop_round !== "number") {
+    return parsed;
+  }
+
+  return {
+    ...parsed,
+    remediation: {
+      schema: "trailhead.remediation.v1",
+      release_ready: false,
+      fixes: [],
+      blocking_count: 0,
+      warn_count: 0,
+      advisory_count: 0,
+      autofix_eligible_count: 0,
+      loop_round: row.loop_round as number,
+      max_loop_rounds: 3,
+      fixes_resolved: Array.isArray(row.fixes_resolved)
+        ? (row.fixes_resolved as string[])
+        : [],
+      fixes_introduced: Array.isArray(row.fixes_introduced)
+        ? (row.fixes_introduced as string[])
+        : [],
+      next_action: "fix_and_retry",
+    },
+  };
+}
+
+function pickPreviousFromRows(
+  rows: unknown[],
+  excludeEvaluationId?: string,
+): PreviousEvaluationSnapshot | null {
+  for (const row of rows) {
+    const parsed = pickLatestPreviousEvaluation([row], excludeEvaluationId);
+    if (!parsed) continue;
+    if (row && typeof row === "object") {
+      return enrichSnapshotFromLoopColumns(parsed, row as Record<string, unknown>);
+    }
+    return parsed;
+  }
+  return null;
+}
+
+async function fetchEvaluationList(
+  listUrl: string,
   params: FetchPreviousEvaluationParams,
 ): Promise<PreviousEvaluationSnapshot | null> {
-  if (!params.storeUrl) return null;
-  const listUrl = resolveCloudListUrl(params.storeUrl);
-  if (!listUrl) return null;
-
   const url = new URL(listUrl);
   url.searchParams.set("repo_id", params.repoId);
   url.searchParams.set("pr_number", String(params.prNumber));
@@ -59,7 +110,25 @@ async function fetchFromCloudStore(
   if (!response.ok) return null;
   const body = (await response.json()) as { evaluations?: unknown[] };
   if (!Array.isArray(body.evaluations)) return null;
-  return pickLatestPreviousEvaluation(body.evaluations, params.excludeEvaluationId);
+  return pickPreviousFromRows(body.evaluations, params.excludeEvaluationId);
+}
+
+async function fetchFromCloudStore(
+  params: FetchPreviousEvaluationParams,
+): Promise<PreviousEvaluationSnapshot | null> {
+  if (!params.storeUrl) return null;
+  const listUrl = resolveCloudListUrl(params.storeUrl);
+  if (!listUrl) return null;
+  return fetchEvaluationList(listUrl, params);
+}
+
+async function fetchFromKomatikStore(
+  params: FetchPreviousEvaluationParams,
+): Promise<PreviousEvaluationSnapshot | null> {
+  if (!params.storeUrl) return null;
+  const listUrl = resolveKomatikListUrl(params.storeUrl);
+  if (!listUrl) return null;
+  return fetchEvaluationList(listUrl, params);
 }
 
 async function fetchFromSupabase(
@@ -92,37 +161,7 @@ async function fetchFromSupabase(
   if (!response.ok) return null;
   const rows = (await response.json()) as unknown[];
   if (!Array.isArray(rows)) return null;
-
-  for (const row of rows) {
-    const parsed = pickLatestPreviousEvaluation([row], params.excludeEvaluationId);
-    if (!parsed) continue;
-    if (!parsed.remediation && row && typeof row === "object") {
-      const record = row as Record<string, unknown>;
-      if (typeof record.loop_round === "number") {
-        parsed.remediation = {
-          schema: "trailhead.remediation.v1",
-          release_ready: false,
-          fixes: [],
-          blocking_count: 0,
-          warn_count: 0,
-          advisory_count: 0,
-          autofix_eligible_count: 0,
-          loop_round: record.loop_round as number,
-          max_loop_rounds: 3,
-          fixes_resolved: Array.isArray(record.fixes_resolved)
-            ? (record.fixes_resolved as string[])
-            : [],
-          fixes_introduced: Array.isArray(record.fixes_introduced)
-            ? (record.fixes_introduced as string[])
-            : [],
-          next_action: "fix_and_retry",
-        };
-      }
-    }
-    return parsed;
-  }
-
-  return null;
+  return pickPreviousFromRows(rows, params.excludeEvaluationId);
 }
 
 export async function fetchPreviousEvaluationForPr(
@@ -131,6 +170,13 @@ export async function fetchPreviousEvaluationForPr(
   try {
     const fromCloud = await fetchFromCloudStore(params);
     if (fromCloud) return fromCloud;
+  } catch {
+    // Fail-open — loop bookkeeping defaults to round 0.
+  }
+
+  try {
+    const fromKomatik = await fetchFromKomatikStore(params);
+    if (fromKomatik) return fromKomatik;
   } catch {
     // Fail-open — loop bookkeeping defaults to round 0.
   }


### PR DESCRIPTION
## Summary
- Add `resolveKomatikListUrl()` to map `.../api/trailhead/store` → `.../api/trailhead/evaluations`
- `fetchPreviousEvaluationForPr()` now queries the komatik hosted list API before Supabase direct fallback
- Enables loop_round N+1 on fleet repos that only configure `evaluation-store-url` (no Supabase creds)

## Depends on
Komatik PR deploying `GET /api/trailhead/evaluations` + store route loop field persistence.

## Test plan
- [x] `npx vitest run src/__tests__/evaluation-history.test.ts`
- [ ] Tag v4.3.1 after merge; re-pin fleet consumers from v4.3.0


Made with [Cursor](https://cursor.com)