### PR TITLE
feat(security-guard): autonomous-merge backstop check

### DIFF
--- a/.github/workflows/security-guard.yml
+++ b/.github/workflows/security-guard.yml
@@ -1,0 +1,44 @@
+name: security-guard
+
+# The autonomous-merge backstop. Scans the PR diff + body + commits for high-risk
+# ACTION classes (fetch-and-execute, CI/workflow edits, externally-cited security
+# fixes, fleet-critical dependency bumps) and BLOCKS until a human adds the
+# `security-reviewed` label. This is the keystone, mirroring `ci-gate`: the single
+# job below is the one that should be a REQUIRED status check, so no autonomous
+# soak-then-merge can land a poisoned-but-plausible change with no human in the loop.
+#
+# SEQUENCING LOCK: do not enable any auto-merge / soak-then-merge until this job is
+# a required status check on the protected branches. See docs/SECURITY-GUARD.md.
+
+on:
+  pull_request:
+    branches: [dev, staging, main]
+  # Reusable across repos: a consumer adds a 3-line caller (see docs/SECURITY-GUARD.md).
+  workflow_call: {}
+
+# Read-only: reads changed files, PR body, commits, and labels. Never writes —
+# the human override is a label a maintainer adds, not something CI grants itself.
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: security-guard-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  security-guard:
+    name: security-guard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history so we can diff against the PR's merge-base.
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+      - name: Ensure base ref is available
+        run: git fetch origin "${{ github.event.pull_request.base.ref || github.base_ref || 'dev' }}" --depth=0 || true
+      - name: Scan diff for high-risk action patterns
+        run: node scripts/security-guard.mjs

--- a/docs/SECURITY-GUARD.md
+++ b/docs/SECURITY-GUARD.md
@@ -1,0 +1,109 @@
+# security-guard — the autonomous-merge backstop
+
+## Why
+
+As the fleet moves toward autonomous PR authoring and **soak-then-merge**, a
+poisoned-but-plausible change must not be able to land with no human in the loop.
+
+The motivating incident (2026-05-27): a fleet message relayed a **real** CVE
+(`CVE-2026-48710`, Starlette host-header auth bypass) — but the actual instruction
+buried in it was _"run the BadHost scanner against both services."_ The malice was
+in the **remediation action**, not the claim. A "is this a real CVE?" check passes;
+corroboration passes. The only thing that catches it is gating the **action class**
+in the diff — and refusing to auto-merge it without a human.
+
+`security-guard` is that gate. It is deliberately a **Trailhead** concern: Trailhead
+is the PR/release gate (runtime/agent-side guardrails are a separate Frontier layer).
+
+## What it does
+
+A single CI job (`security-guard`) scans the PR's diff, body, and commit messages
+and classifies findings:
+
+| Rule                        | Level            | Fires when                                                                                                                                                                                                      |
+| --------------------------- | ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `fetch-and-execute`         | **BLOCK**        | An added line downloads-and-runs (`curl … \| sh`, `bash <(curl …)`, `iwr … \| iex`, `base64 -d … \| sh`, …)                                                                                                     |
+| `ci-workflow-change`        | **BLOCK**        | The PR edits `.github/workflows/**`, `.github/actions/**`, or an `action.yml` (a malicious workflow can exfiltrate secrets)                                                                                     |
+| `external-advisory-cited`   | **BLOCK**        | PR title/body/commits cite a CVE/GHSA/PYSEC id or urgency phrasing ("patch immediately", "run the X scanner", "auth bypass", "RCE") — the diff may be fine, but a human must confirm the _fix_ isn't the attack |
+| `fleet-critical-dependency` | **BLOCK**        | A dependency manifest bumps a load-bearing package (`starlette`, `uvicorn`, `fastapi`, `litellm`, `vllm`, `gunicorn`, `anthropic`, `openai`) — coordinated, compat-checked upgrade only                         |
+| `dependency-change`         | **WARN** → BLOCK | Any dep/lockfile change. WARN normally; **BLOCK** when the same PR is advisory-cited                                                                                                                            |
+| `new-outbound-domain`       | **WARN**         | An added line references a host outside the build/CI allowlist                                                                                                                                                  |
+
+Any **BLOCK** finding fails the check. Ordinary dependency bumps and new outbound
+domains only warn, so everyday PRs aren't gummed up — the gate is tuned to stop the
+_autonomous-merge-of-a-poisoned-fix_ case, not to nag.
+
+### The human override
+
+A maintainer who has reviewed the change adds the **`security-reviewed`** label to
+the PR. The next run downgrades all BLOCK findings to advisory and the check passes.
+This is the only clear path — there is no admin-merge bypass (`gh pr merge --admin`
+to `master` is disabled fleet-wide), and CI never grants itself the label
+(permissions are read-only).
+
+## ⛓️ The sequencing lock (most important)
+
+**Autonomous soak-then-merge must not be enabled on any repo until `security-guard`
+is a _required_ status check on that repo's protected branches.** Otherwise the
+backstop is bypassable by definition — a soak timer alone would merge a blocked PR.
+
+Today no repo has required status checks (they're configured in the GitHub UI / org
+settings, not in-repo). So the order of operations is:
+
+1. Land this workflow on `dev` → `staging` → `main`.
+2. Wire it into each repo that will gain autonomy (below).
+3. Mark `security-guard` **required** on the protected branches.
+4. _Only then_ turn on auto-merge / soak.
+
+Make it required (per branch):
+
+```bash
+gh api -X PATCH repos/KomatikAI/<repo>/branches/<branch>/protection/required_status_checks \
+  -f 'checks[][context]=security-guard'
+```
+
+(or add `security-guard` under Branch protection → Require status checks in the UI.)
+
+## Consuming it from another repo
+
+`security-guard.yml` runs standalone on `pull_request` in this repo, and exposes a
+`workflow_call` entry for reuse. A consumer repo adds one thin caller workflow:
+
+```yaml
+# .github/workflows/security-guard.yml
+name: security-guard
+on:
+  pull_request:
+    branches: [dev, staging, main]
+jobs:
+  guard:
+    uses: KomatikAI/trailhead/.github/workflows/security-guard.yml@dev
+```
+
+The job name surfaced for branch protection is `security-guard / security-guard`
+(caller job → reusable job); use whatever the Checks tab shows when you mark it
+required.
+
+## Tuning
+
+- **`FLEET_CRITICAL`** and **`OUTBOUND_ALLOWLIST`** live at the top of
+  `scripts/security-guard.mjs`. Keep `FLEET_CRITICAL` short and intentional — every
+  entry hard-blocks a version bump.
+- The script is zero-dependency Node 24 (ESM) and reads GitHub context from
+  `$GITHUB_EVENT_PATH`. Run it locally against a branch with
+  `node scripts/security-guard.mjs` (diffs against `origin/<base>`).
+
+## Scope / where this sits
+
+This is **Layer 2** of a three-layer defense (see the umbrella plan):
+
+- **Layer 0 — ingress**: web-sweep / knowledge-scout treat scraped imperatives as
+  _data_, never forward them as action items (where today's message leaked through).
+- **Layer 1 — Frontier runtime**: the acting agent's non-overridable denylist
+  (fetch-and-execute, prod-service mutation, fleet-critical bumps never autonomous;
+  security changes need authoritative corroboration that is _not_ the requesting
+  source + human sign-off).
+- **Layer 2 — Trailhead** (this): the PR gate that no autonomous merge can skip.
+
+Neither layer is trusted alone; this is the backstop because the runtime gate can be
+jailbroken.

--- a/scripts/security-guard.mjs
+++ b/scripts/security-guard.mjs
@@ -1,0 +1,333 @@
+#!/usr/bin/env node
+// security-guard — Trailhead's autonomous-merge backstop.
+//
+// WHY THIS EXISTS
+// As the fleet moves to autonomous PR authoring + soak-then-merge, a poisoned-
+// but-plausible change must not be able to merge with no human in the loop. The
+// motivating case (2026-05-27): a fleet message relayed a *real* CVE
+// (CVE-2026-48710, Starlette host-header auth bypass) but the actual instruction
+// was "run the BadHost scanner against both services" — i.e. the malice is in the
+// REMEDIATION ACTION, not the claim. A "is this a real CVE?" check passes; the
+// danger is the action. So this guard gates ACTION CLASSES in the diff, not the
+// premise.
+//
+// CONTRACT
+// Scans the PR diff + PR body + commit messages and classifies findings as BLOCK
+// or WARN. Exits non-zero when any BLOCK finding is present, UNLESS the PR carries
+// the `security-reviewed` label (a human's explicit sign-off — the override path,
+// no admin-merge required). This script is meant to back the single required
+// status check `security-guard` (mirrors the `ci-gate` keystone pattern), so a
+// non-zero exit keeps the PR un-mergeable until a human clears it.
+//
+// Zero dependencies (Node 24, ESM). Reads GitHub context from $GITHUB_EVENT_PATH.
+
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+// ── Tunables ───────────────────────────────────────────────────────────────
+
+// Packages whose version is load-bearing for the running fleet. A bump here is
+// never a routine change — it gets a human even if everything else looks benign.
+// (litellm:4000 is the fleet front-door; a bad starlette/uvicorn pin has blacked
+// out the whole cron fleet before.) Keep this list short and intentional.
+const FLEET_CRITICAL = [
+  "starlette",
+  "uvicorn",
+  "fastapi",
+  "litellm",
+  "vllm",
+  "gunicorn",
+  "anthropic",
+  "openai",
+];
+
+// Hosts we expect to see in build/CI scripts. Anything outside this is surfaced
+// (WARN) so a reviewer notices a new exfil/download target. Not exhaustive auth —
+// just a nudge toward "why is this calling a new domain?".
+const OUTBOUND_ALLOWLIST = [
+  "github.com",
+  "githubusercontent.com",
+  "raw.githubusercontent.com",
+  "objects.githubusercontent.com",
+  "api.github.com",
+  "registry.npmjs.org",
+  "npmjs.com",
+  "pypi.org",
+  "files.pythonhosted.org",
+  "nodejs.org",
+  "deb.debian.org",
+  "security.debian.org",
+  "archive.ubuntu.com",
+  "ppa.launchpadcontent.net",
+  "ghcr.io",
+  "docker.io",
+  "registry-1.docker.io",
+  "auth.docker.io",
+  "proxy.golang.org",
+  "sum.golang.org",
+  "crates.io",
+  "static.crates.io",
+  "rubygems.org",
+  "astral.sh",
+  "osv.dev",
+  "nvd.nist.gov",
+];
+
+const DEP_FILE = [
+  /(^|\/)package\.json$/,
+  /(^|\/)package-lock\.json$/,
+  /(^|\/)npm-shrinkwrap\.json$/,
+  /(^|\/)yarn\.lock$/,
+  /(^|\/)pnpm-lock\.yaml$/,
+  /(^|\/)requirements[^/]*\.txt$/,
+  /(^|\/)pyproject\.toml$/,
+  /(^|\/)poetry\.lock$/,
+  /(^|\/)Pipfile(\.lock)?$/,
+  /(^|\/)uv\.lock$/,
+  /(^|\/)go\.(mod|sum)$/,
+  /(^|\/)Cargo\.(toml|lock)$/,
+  /(^|\/)Gemfile(\.lock)?$/,
+  /(^|\/)composer\.(json|lock)$/,
+];
+
+const WORKFLOW_FILE = [
+  /^\.github\/workflows\/.+\.ya?ml$/,
+  /^\.github\/actions\//,
+  /(^|\/)action\.ya?ml$/,
+];
+
+// Fetch-and-execute: download something and run it in one breath. Never auto.
+const FETCH_EXEC = [
+  /\b(curl|wget)\b[^|\n]*\|[^\n]*\b(sh|bash|zsh|dash|python[0-9.]*|node|ruby|perl)\b/i,
+  /\b(bash|sh|zsh|dash)\b[^\n]*<\(\s*(curl|wget)\b/i,
+  /\b(sh|bash|zsh)\b\s+-c\s+["']?\$\((curl|wget)\b/i,
+  /\beval\b[^\n]*\$\(\s*(curl|wget)\b/i,
+  /\b(iwr|irm|Invoke-WebRequest|Invoke-RestMethod)\b[^\n]*\|[^\n]*\b(iex|Invoke-Expression)\b/i,
+  /\bInvoke-Expression\b[^\n]*\b(DownloadString|iwr|irm|Invoke-WebRequest)\b/i,
+  /\bbase64\b[^\n]*(-d|--decode|-D)\b[^\n]*\|[^\n]*\b(sh|bash|zsh|python)\b/i,
+];
+
+// Signals a PR was driven by external security content (the today-case). Cited
+// CVE/advisory IDs or urgency/"run the scanner" phrasing → a human must look.
+const ADVISORY = [
+  /\bCVE-\d{4}-\d{3,7}\b/i,
+  /\bGHSA-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}\b/i,
+  /\bPYSEC-\d{4}-\d+\b/i,
+  /\bpatch immediately\b/i,
+  /\brun (the )?[\w-]+ scanner\b/i,
+  /\b(remote code execution|auth(?:entication)? bypass)\b/i,
+];
+
+// ── Context ──────────────────────────────────────────────────────────────────
+
+function loadEvent() {
+  const p = process.env.GITHUB_EVENT_PATH;
+  if (!p) return {};
+  try {
+    return JSON.parse(readFileSync(p, "utf8"));
+  } catch {
+    return {};
+  }
+}
+
+function git(args) {
+  try {
+    return execFileSync("git", args, { encoding: "utf8", maxBuffer: 64 * 1024 * 1024 });
+  } catch {
+    return "";
+  }
+}
+
+const event = loadEvent();
+const pr = event.pull_request ?? {};
+const baseRef = pr.base?.ref || process.env.SECURITY_GUARD_BASE || "dev";
+const labels = (pr.labels ?? []).map((l) => (typeof l === "string" ? l : l.name));
+const reviewed = labels.includes("security-reviewed");
+const prBody = pr.body || "";
+const prTitle = pr.title || "";
+
+// Diff against the merge-base so we only judge what THIS PR introduces.
+let range = "HEAD";
+const mergeBase = git(["merge-base", `origin/${baseRef}`, "HEAD"]).trim();
+if (mergeBase) range = `${mergeBase}..HEAD`;
+
+const changedFiles = git(["diff", "--name-only", range])
+  .split("\n")
+  .map((s) => s.trim())
+  .filter(Boolean);
+const addedLines = [];
+{
+  // --unified=0 → only changed hunks; keep '+' adds, drop the '+++' file headers.
+  const diff = git(["diff", "--unified=0", range]);
+  let currentFile = "";
+  for (const line of diff.split("\n")) {
+    if (line.startsWith("+++ b/")) currentFile = line.slice(6);
+    else if (line.startsWith("+") && !line.startsWith("+++")) {
+      addedLines.push({ file: currentFile, text: line.slice(1) });
+    }
+  }
+}
+const commitMsgs = mergeBase ? git(["log", "--format=%s%n%b", `${mergeBase}..HEAD`]) : "";
+
+// ── Rules ────────────────────────────────────────────────────────────────────
+
+const findings = [];
+const add = (level, rule, detail, file) => findings.push({ level, rule, detail, file });
+const matchAny = (res, s) => res.some((re) => re.test(s));
+
+// 1. Fetch-and-execute in added lines — BLOCK.
+//    Skip this file: its rule definitions literally contain `curl|…|sh` patterns
+//    and would otherwise match themselves.
+const SELF = "scripts/security-guard.mjs";
+for (const { file, text } of addedLines) {
+  if (file.endsWith(SELF)) continue;
+  if (matchAny(FETCH_EXEC, text)) {
+    add(
+      "BLOCK",
+      "fetch-and-execute",
+      `download-and-run pattern: \`${text.trim().slice(0, 120)}\``,
+      file,
+    );
+  }
+}
+
+// 2. CI / workflow / action changes — BLOCK (a malicious workflow can exfiltrate
+//    secrets; CI changes always get a human before autonomous merge).
+for (const f of changedFiles) {
+  if (WORKFLOW_FILE.some((re) => re.test(f))) {
+    add("BLOCK", "ci-workflow-change", "changes CI/workflow/action definitions", f);
+  }
+}
+
+// 3. External-advisory-driven PR — BLOCK. The diff may be legit; the point is a
+//    human must confirm the remediation isn't itself the attack.
+const advisoryHaystack = `${prTitle}\n${prBody}\n${commitMsgs}`;
+if (matchAny(ADVISORY, advisoryHaystack)) {
+  const hit = ADVISORY.find((re) => re.test(advisoryHaystack));
+  add(
+    "BLOCK",
+    "external-advisory-cited",
+    `PR text cites a security advisory/urgency signal (\`${(advisoryHaystack.match(hit) || [""])[0]}\`) — verify the fix is not itself a malicious action`,
+  );
+}
+
+// 4. Dependency / lockfile changes. WARN by default; BLOCK when a fleet-critical
+//    package is touched OR the PR is advisory-driven (supply-chain + urgency).
+const depFiles = changedFiles.filter((f) => DEP_FILE.some((re) => re.test(f)));
+if (depFiles.length) {
+  // Only look inside the dependency manifests themselves — not arbitrary source
+  // (e.g. this guard's own FLEET_CRITICAL list would otherwise self-match).
+  const depFileSet = new Set(depFiles);
+  const critHits = new Set();
+  for (const { file, text } of addedLines) {
+    if (!depFileSet.has(file)) continue;
+    for (const name of FLEET_CRITICAL) {
+      const re = new RegExp(`["'\\s/]${name}["'\\s@=<>:~^]|^${name}\\b`, "i");
+      if (re.test(text)) critHits.add(name);
+    }
+  }
+  if (critHits.size) {
+    add(
+      "BLOCK",
+      "fleet-critical-dependency",
+      `touches fleet-critical package(s): ${[...critHits].join(", ")} — coordinated, compat-checked upgrade only`,
+      depFiles.join(", "),
+    );
+  } else if (matchAny(ADVISORY, advisoryHaystack)) {
+    add(
+      "BLOCK",
+      "dependency-change",
+      `dependency/lockfile change on an advisory-driven PR — confirm provenance`,
+      depFiles.join(", "),
+    );
+  } else {
+    add(
+      "WARN",
+      "dependency-change",
+      `dependency/lockfile change (${depFiles.length} file(s)) — verify provenance`,
+      depFiles.join(", "),
+    );
+  }
+}
+
+// 5. New outbound domains in added lines — WARN (noticeable, not blocking).
+const urlRe = /https?:\/\/([a-z0-9.-]+)/gi;
+const seenHosts = new Set();
+for (const { file, text } of addedLines) {
+  for (const m of text.matchAll(urlRe)) {
+    const host = m[1].toLowerCase().replace(/\.$/, "");
+    if (seenHosts.has(host)) continue;
+    const ok = OUTBOUND_ALLOWLIST.some((a) => host === a || host.endsWith(`.${a}`));
+    if (!ok) {
+      seenHosts.add(host);
+      add(
+        "WARN",
+        "new-outbound-domain",
+        `references non-allowlisted host \`${host}\``,
+        file,
+      );
+    }
+  }
+}
+
+// ── Report ───────────────────────────────────────────────────────────────────
+
+const blocks = findings.filter((f) => f.level === "BLOCK");
+const warns = findings.filter((f) => f.level === "WARN");
+
+const lines = [];
+lines.push("# 🛡️ security-guard");
+lines.push("");
+lines.push(
+  `Base \`${baseRef}\` · ${changedFiles.length} changed file(s) · ${blocks.length} block · ${warns.length} warn`,
+);
+lines.push("");
+
+const render = (f) =>
+  `- **${f.rule}** — ${f.detail}${f.file ? ` _(in \`${f.file}\`)_` : ""}`;
+
+if (blocks.length) {
+  lines.push("## ❌ Blocking — human review required");
+  for (const f of blocks) {
+    lines.push(render(f));
+    console.log(`::error file=${f.file || "PR"}::security-guard[${f.rule}] ${f.detail}`);
+  }
+  lines.push("");
+}
+if (warns.length) {
+  lines.push("## ⚠️ Advisory");
+  for (const f of warns) {
+    lines.push(render(f));
+    console.log(
+      `::warning file=${f.file || "PR"}::security-guard[${f.rule}] ${f.detail}`,
+    );
+  }
+  lines.push("");
+}
+if (!findings.length) lines.push("✅ No high-risk action patterns detected.");
+
+let exitCode = 0;
+if (blocks.length && reviewed) {
+  lines.push("");
+  lines.push(
+    "> ✅ **Overridden by `security-reviewed` label** — a human has signed off. Blocking findings downgraded to advisory.",
+  );
+} else if (blocks.length) {
+  lines.push("");
+  lines.push(
+    "> A maintainer must verify the change is safe, then add the **`security-reviewed`** label to clear this check. Autonomous merge is blocked until then.",
+  );
+  exitCode = 1;
+}
+
+const report = lines.join("\n");
+console.log(report);
+if (process.env.GITHUB_STEP_SUMMARY) {
+  try {
+    execFileSync("bash", ["-c", `cat >> "$GITHUB_STEP_SUMMARY"`], { input: report });
+  } catch {
+    /* summary is best-effort */
+  }
+}
+
+process.exit(exitCode);


### PR DESCRIPTION
## What

Adds **`security-guard`** — a CI keystone (mirrors the `ci-gate` pattern: one always-run job that becomes the single required check) that blocks **autonomous soak-then-merge** of poisoned-but-plausible PRs.

It gates the **action classes** in a diff, not the premise:

| Rule | Level |
|---|---|
| `fetch-and-execute` (`curl … \| sh`, `bash <(curl)`, `iwr … \| iex`, …) | **BLOCK** |
| `ci-workflow-change` (edits to `.github/workflows`, `action.yml`) | **BLOCK** |
| `external-advisory-cited` (PR cites CVE/GHSA/"patch immediately"/"run the X scanner") | **BLOCK** |
| `fleet-critical-dependency` (bumps `starlette`/`litellm`/`vllm`/`fastapi`/… ) | **BLOCK** |
| `dependency-change` | WARN (→ BLOCK if advisory-cited) |
| `new-outbound-domain` | WARN |

A maintainer adds the **`security-reviewed`** label to clear a block — the only path (no `--admin` bypass; CI is read-only and can't self-clear).

## Why

The 2026-05-27 fleet message relayed a **real** CVE (`CVE-2026-48710`, Starlette host-header auth bypass) but the actual instruction was *"run the BadHost scanner against both services."* The malice was in the **remediation action**, not the claim — a "real CVE?" check passes. The only thing that catches that is gating the action in the diff and refusing to auto-merge without a human.

## ⛓️ Sequencing lock

**Do not enable auto-merge / soak on any repo until `security-guard` is a _required_ status check there.** Today no repo has required checks, so the backstop must go required *before* autonomy is switched on. Details + the `gh api` command + cross-repo caller snippet in `docs/SECURITY-GUARD.md`.

## Testing

Smoke-tested locally against fixtures: every rule fires, exit 1 blocks, `security-reviewed` label → exit 0, fleet-critical scoping limited to manifest files.

## Note — this PR will block itself ✅

Because it edits `.github/workflows/**` and the body cites `CVE-2026-48710`, `security-guard` will (correctly) **BLOCK this very PR** — a live demonstration. Clear it with the `security-reviewed` label after review.

## Scope

Layer 2 of a 3-layer autonomy guardrail (ingress / Frontier runtime / **Trailhead**). Layers 0 and 1 are tracked as follow-ons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)