### PR TITLE
feat(override): trailhead-override label escape valve (A7)

### DIFF
--- a/app/src/loop-bookkeeping.ts
+++ b/app/src/loop-bookkeeping.ts
@@ -1,0 +1,47 @@
+// Pure loop bookkeeping helpers — no framework dependencies.
+
+import type { GateEvaluation, Remediation } from "./types.js";
+
+export type PreviousEvaluationSnapshot = Pick<GateEvaluation, "id" | "remediation">;
+
+export function resolveLoopRound(
+  previous: PreviousEvaluationSnapshot | null | undefined,
+): number {
+  if (!previous) return 0;
+  return (previous.remediation?.loop_round ?? 0) + 1;
+}
+
+export function parseAgentIdFromHeadRef(headRef: string | undefined): string | null {
+  if (!headRef) return null;
+  const match = headRef.match(/^agent\/([a-z0-9-]+)\//);
+  return match?.[1] ?? null;
+}
+
+export function parsePreviousEvaluationRow(
+  row: unknown,
+): PreviousEvaluationSnapshot | null {
+  if (!row || typeof row !== "object") return null;
+  const record = row as Record<string, unknown>;
+  const id = typeof record.id === "string" ? record.id : null;
+  if (!id) return null;
+
+  let remediation: Remediation | undefined;
+  if (record.remediation && typeof record.remediation === "object") {
+    remediation = record.remediation as Remediation;
+  }
+
+  return { id, remediation };
+}
+
+export function pickLatestPreviousEvaluation(
+  rows: unknown[],
+  excludeEvaluationId?: string,
+): PreviousEvaluationSnapshot | null {
+  for (const row of rows) {
+    const parsed = parsePreviousEvaluationRow(row);
+    if (!parsed) continue;
+    if (excludeEvaluationId && parsed.id === excludeEvaluationId) continue;
+    return parsed;
+  }
+  return null;
+}

--- a/app/src/remediation.ts
+++ b/app/src/remediation.ts
@@ -8,6 +8,7 @@
 
 import type { z } from "zod";
 import { RemediationFix as RemediationFixSchema } from "./types.js";
+import { resolveLoopRound } from "./loop-bookkeeping.js";
 import type {
   AgentBriefMode,
   GateEvaluation,
@@ -331,7 +332,7 @@ export function buildRemediation(input: BuildRemediationInput): Remediation {
   const advisory_count = dedupedFixes.filter((f) => f.severity === "advisory").length;
   const autofix_eligible_count = dedupedFixes.filter((f) => f.autofix_eligible).length;
 
-  const loopRound = input.loopRound ?? (input.previousEvaluation ? 1 : 0);
+  const loopRound = input.loopRound ?? resolveLoopRound(input.previousEvaluation);
   const maxLoopRounds = input.maxLoopRounds ?? 3;
   const releaseReady =
     input.evaluation.releaseReady ??

--- a/app/src/trailhead-events.ts
+++ b/app/src/trailhead-events.ts
@@ -11,6 +11,7 @@ export const TRAILHEAD_EVENT_TYPES = [
   "trailhead.warn_high_risk",
   "trailhead.ready",
   "trailhead.loop_exceeded",
+  "trailhead.override_applied",
 ] as const;
 export type TrailheadEventType = (typeof TRAILHEAD_EVENT_TYPES)[number];
 
@@ -65,6 +66,10 @@ export function resolveTrailheadEventTypes(
 
   if (evaluation.remediation?.next_action === "max_rounds_exceeded") {
     events.push("trailhead.loop_exceeded");
+  }
+
+  if (evaluation.policyOverride?.source === "label") {
+    events.push("trailhead.override_applied");
   }
 
   return events;

--- a/dist/index.js
+++ b/dist/index.js
@@ -40674,6 +40674,24 @@ const Remediation = objectType({
     fixes_introduced: arrayType(stringType()).default([]),
     next_action: RemediationNextAction,
 });
+const PolicyOverrideChanges = objectType({
+    failMode: enumType(["open", "closed"]).optional(),
+    riskThreshold: numberType().min(0).max(100).optional(),
+    warnThreshold: numberType().min(0).max(100).optional(),
+    releaseReady: literalType(true).optional(),
+});
+const PolicyOverrideAudit = objectType({
+    source: enumType(["workflow", "label"]).default("workflow"),
+    owner: stringType(),
+    reason: stringType(),
+    linkedTicket: stringType(),
+    expiresAt: stringType(),
+    appliedAt: stringType(),
+    changes: PolicyOverrideChanges.default({}),
+    preOverrideDecision: GateDecision.optional(),
+    preOverrideReleaseReady: booleanType().optional(),
+    preOverrideReasons: arrayType(stringType()).optional(),
+});
 const GateEvaluation = objectType({
     id: stringType(),
     repoId: stringType(),
@@ -40712,18 +40730,10 @@ const GateEvaluation = objectType({
         reason: stringType(),
     })
         .optional(),
-    policyOverride: objectType({
-        owner: stringType(),
-        reason: stringType(),
-        linkedTicket: stringType(),
-        expiresAt: stringType(),
-        appliedAt: stringType(),
-        changes: objectType({
-            failMode: enumType(["open", "closed"]).optional(),
-            riskThreshold: numberType().min(0).max(100).optional(),
-            warnThreshold: numberType().min(0).max(100).optional(),
-        })
-            .default({}),
+    policyOverride: PolicyOverrideAudit.optional(),
+    labelOverrideFeedback: objectType({
+        status: enumType(["applied", "rejected"]),
+        message: stringType(),
     })
         .optional(),
     releaseReady: booleanType().optional(),
@@ -40835,10 +40845,15 @@ const RemediationConfig = objectType({
     enabled: booleanType().default(true),
     max_loop_rounds: numberType().int().min(0).default(3),
 });
+const OverrideConfig = objectType({
+    enabled: booleanType().default(true),
+    max_per_week: numberType().int().min(1).default(5),
+});
 const RepoConfig = objectType({
     schema_version: numberType().int().positive().default(1),
     gate: GateConfig.default({}),
     remediation: RemediationConfig.optional(),
+    override: OverrideConfig.optional(),
     contexts: arrayType(TrailheadContext).default([]),
     sensitivity: objectType({
         high: arrayType(stringType()).default([]),
@@ -42940,8 +42955,179 @@ async function fetchPreviousEvaluationForPr(params) {
         return null;
     }
 }
+function isLabelOverrideRow(row) {
+    const raw = row.policy_override ?? row.policyOverride;
+    if (!raw || typeof raw !== "object")
+        return false;
+    const source = raw.source;
+    return source === "label";
+}
+function rowCreatedAtMs(row) {
+    const createdAt = row.created_at ?? row.createdAt;
+    if (typeof createdAt !== "string")
+        return null;
+    const parsed = Date.parse(createdAt);
+    return Number.isNaN(parsed) ? null : parsed;
+}
+async function countRecentLabelOverrides(params) {
+    const windowDays = params.windowDays ?? 7;
+    const windowMs = windowDays * 24 * 60 * 60 * 1000;
+    const cutoff = Date.now() - windowMs;
+    const listUrls = [];
+    if (params.storeUrl) {
+        const cloudUrl = resolveCloudListUrl(params.storeUrl);
+        const komatikUrl = resolveKomatikListUrl(params.storeUrl);
+        if (cloudUrl)
+            listUrls.push(cloudUrl);
+        if (komatikUrl)
+            listUrls.push(komatikUrl);
+    }
+    for (const listUrl of listUrls) {
+        try {
+            const url = new URL(listUrl);
+            url.searchParams.set("repo_id", params.repoId);
+            url.searchParams.set("limit", "100");
+            const response = await fetch(url.toString(), {
+                method: "GET",
+                headers: buildAuthHeaders(params),
+                signal: AbortSignal.timeout(LOOKUP_TIMEOUT_MS),
+            });
+            if (!response.ok)
+                continue;
+            const body = (await response.json());
+            if (!Array.isArray(body.evaluations))
+                continue;
+            let count = 0;
+            for (const row of body.evaluations) {
+                if (!row || typeof row !== "object")
+                    continue;
+                const record = row;
+                if (!isLabelOverrideRow(record))
+                    continue;
+                const createdAtMs = rowCreatedAtMs(record);
+                if (createdAtMs !== null && createdAtMs < cutoff)
+                    continue;
+                count += 1;
+            }
+            return count;
+        }
+        catch {
+            // Try next store URL.
+        }
+    }
+    return null;
+}
+
+;// CONCATENATED MODULE: ./src/override.ts
+const OVERRIDE_LABEL = "trailhead-override";
+const OVERRIDE_COMMENT_PATTERN = /^trailhead-override:\s*(.+)/im;
+function hasOverrideLabel(labels) {
+    return labels.some((label) => label.toLowerCase() === OVERRIDE_LABEL);
+}
+function parseOverrideComment(comments) {
+    for (let index = comments.length - 1; index >= 0; index -= 1) {
+        const comment = comments[index];
+        const match = comment.body.trim().match(OVERRIDE_COMMENT_PATTERN);
+        if (!match?.[1]?.trim())
+            continue;
+        return {
+            reason: match[1].trim(),
+            author: comment.author?.trim() || "unknown",
+        };
+    }
+    return null;
+}
+function buildLabelOverrideAudit(input) {
+    const appliedAt = new Date().toISOString();
+    const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+    return {
+        source: "label",
+        owner: input.parsed.author,
+        reason: input.parsed.reason,
+        linkedTicket: `override:pr#${input.prNumber}`,
+        expiresAt,
+        appliedAt,
+        changes: { releaseReady: true },
+        preOverrideDecision: input.gateDecision,
+        preOverrideReleaseReady: input.releaseResult.releaseReady,
+        preOverrideReasons: input.releaseResult.reasons.length > 0
+            ? [...input.releaseResult.reasons]
+            : undefined,
+    };
+}
+function formatOverrideRejectionMessage(code) {
+    switch (code) {
+        case "missing_reason":
+            return ("The `trailhead-override` label is present but no valid override reason was found. " +
+                "Add a PR comment starting with `trailhead-override: <your reason>` " +
+                "(for example: `trailhead-override: emergency hotfix for prod outage`). " +
+                "The gate will re-evaluate on the next run after the comment is posted.");
+        case "disabled":
+            return ("The `trailhead-override` label is present but label overrides are disabled " +
+                "in this repo's `.trailhead.yml` (`override.enabled: false`).");
+        case "cap_exceeded":
+            return ("The `trailhead-override` label is present but this repo has reached its weekly " +
+                "override cap. File an issue in [KomatikAI/trailhead](https://github.com/KomatikAI/trailhead) " +
+                "linking this PR and the override pattern before applying another override.");
+        case "not_needed":
+            return "The `trailhead-override` label is present but release is already ready — no override applied.";
+        default: {
+            const _exhaustive = code;
+            return _exhaustive;
+        }
+    }
+}
+function resolveLabelOverride(input) {
+    if (!hasOverrideLabel(input.labels)) {
+        return { kind: "none" };
+    }
+    if (!input.config.enabled) {
+        return {
+            kind: "rejected",
+            code: "disabled",
+            message: formatOverrideRejectionMessage("disabled"),
+        };
+    }
+    if (input.releaseResult.releaseReady) {
+        return { kind: "none" };
+    }
+    const parsed = parseOverrideComment(input.comments);
+    if (!parsed) {
+        return {
+            kind: "rejected",
+            code: "missing_reason",
+            message: formatOverrideRejectionMessage("missing_reason"),
+        };
+    }
+    if (input.recentOverrideCount !== null &&
+        input.recentOverrideCount >= input.config.maxPerWeek) {
+        return {
+            kind: "rejected",
+            code: "cap_exceeded",
+            message: formatOverrideRejectionMessage("cap_exceeded"),
+        };
+    }
+    return {
+        kind: "applied",
+        audit: buildLabelOverrideAudit({
+            parsed,
+            prNumber: input.prNumber,
+            releaseResult: input.releaseResult,
+            gateDecision: input.gateDecision,
+        }),
+    };
+}
+function applyLabelOverrideToEvaluation(evaluation, audit) {
+    return {
+        ...evaluation,
+        releaseReady: true,
+        releaseReadyReasons: undefined,
+        policyOverride: audit,
+    };
+}
 
 ;// CONCATENATED MODULE: ./src/gate.ts
+
 
 
 
@@ -43943,6 +44129,76 @@ function getPrMatchContext() {
         labels: (pr?.labels ?? []).map((l) => l.name ?? "").filter(Boolean),
     };
 }
+async function fetchPrCommentsForOverride(prNumber, token) {
+    try {
+        const octokit = getOctokit(token);
+        const { owner, repo } = github_context.repo;
+        const { data: comments } = await octokit.rest.issues.listComments({
+            owner,
+            repo,
+            issue_number: prNumber,
+            per_page: 100,
+        });
+        return comments.map((comment) => ({
+            body: comment.body ?? "",
+            author: comment.user?.login ?? undefined,
+        }));
+    }
+    catch (error) {
+        core_debug(`Failed to fetch PR comments for override: ${error}`);
+        return [];
+    }
+}
+async function applyLabelOverrideIfNeeded(input) {
+    const overrideSettings = input.repoConfig?.override ?? {
+        enabled: true,
+        max_per_week: 5,
+    };
+    const comments = await fetchPrCommentsForOverride(input.prNumber, input.githubToken);
+    const recentOverrideCount = await countRecentLabelOverrides({
+        repoId: input.evaluation.repoId,
+        storeUrl: input.config.evaluationStoreUrl,
+        apiKey: input.config.trailheadApiKey,
+    });
+    if (recentOverrideCount === null) {
+        warning("Could not verify weekly override cap — proceeding without cap enforcement.");
+    }
+    const outcome = resolveLabelOverride({
+        labels: input.prMatchCtx.labels,
+        comments,
+        config: {
+            enabled: overrideSettings.enabled,
+            maxPerWeek: overrideSettings.max_per_week,
+        },
+        recentOverrideCount,
+        releaseResult: input.releaseResult,
+        gateDecision: input.gateDecision,
+        prNumber: input.prNumber,
+    });
+    if (outcome.kind === "applied") {
+        warning(`Label override applied by ${outcome.audit.owner}: ${outcome.audit.reason}`);
+        return {
+            ...applyLabelOverrideToEvaluation(input.evaluation, outcome.audit),
+            labelOverrideFeedback: {
+                status: "applied",
+                message: `Release override applied by \`${outcome.audit.owner}\`.`,
+            },
+        };
+    }
+    if (outcome.kind === "rejected") {
+        warning(`Label override rejected: ${outcome.message}`);
+        await postOverrideRejectionComment(input.prNumber, outcome.message, input.githubToken);
+        return {
+            ...input.evaluation,
+            policyFindings: [...(input.evaluation.policyFindings ?? []), outcome.message],
+            labelOverrideFeedback: {
+                status: "rejected",
+                message: outcome.message,
+            },
+        };
+    }
+    return input.evaluation;
+}
 // ---------------------------------------------------------------------------
 // Main evaluation entry point
 // ---------------------------------------------------------------------------
@@ -44329,6 +44585,18 @@ async function evaluateGate(config, commitSha, prNumber) {
         securityBlocked,
     });
     localEvaluation = applyReleaseReadyToEvaluation(localEvaluation, releaseResult, gateMode);
+    if (prNumber && config.githubToken && hasOverrideLabel(prMatchCtx.labels)) {
+        localEvaluation = await applyLabelOverrideIfNeeded({
+            evaluation: localEvaluation,
+            config,
+            repoConfig,
+            prMatchCtx,
+            prNumber,
+            releaseResult,
+            gateDecision,
+            githubToken: config.githubToken,
+        });
+    }
     if (config.apiKey) {
         const apiResponse = await callGateApi(config, localEvaluation);
         if (apiResponse) {
@@ -44390,6 +44658,42 @@ async function evaluateGate(config, commitSha, prNumber) {
 // ---------------------------------------------------------------------------
 // PR comment posting
 // ---------------------------------------------------------------------------
+async function postOverrideRejectionComment(prNumber, message, token) {
+    try {
+        const octokit = getOctokit(token);
+        const { owner, repo } = github_context.repo;
+        const MARKER = "<!-- trailhead-override-feedback -->";
+        const body = `${MARKER}\n` +
+            `### Trailhead override rejected\n\n` +
+            `${message}\n\n` +
+            `_This comment is updated automatically when the \`trailhead-override\` label is present._`;
+        const { data: comments } = await octokit.rest.issues.listComments({
+            owner,
+            repo,
+            issue_number: prNumber,
+            per_page: 100,
+        });
+        const existing = comments.find((comment) => comment.body?.includes(MARKER));
+        if (existing) {
+            await octokit.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+            });
+            return;
+        }
+        await octokit.rest.issues.createComment({
+            owner,
+            repo,
+            issue_number: prNumber,
+            body,
+        });
+    }
+    catch (error) {
+        core_debug(`Failed to post override rejection comment: ${error}`);
+    }
+}
 async function postPrComment(report, prNumber, token) {
     try {
         const octokit = getOctokit(token);
@@ -44838,16 +45142,26 @@ function formatGateReport(evaluation, riskThreshold) {
     }
     if (evaluation.policyOverride) {
         const override = evaluation.policyOverride;
-        const changes = [];
-        if (override.changes.failMode)
-            changes.push(`fail-mode=${override.changes.failMode}`);
-        if (override.changes.riskThreshold !== undefined) {
-            changes.push(`risk-threshold=${override.changes.riskThreshold}`);
+        if (override.source === "label") {
+            lines.push(`### Release Override (\`trailhead-override\`)`, ``, `- Author: \`${override.owner}\``, `- Reason: ${override.reason}`, `- Applied: \`${override.appliedAt}\``, `- Expires: \`${override.expiresAt}\``, `- Pre-override decision: \`${override.preOverrideDecision ?? evaluation.gateDecision}\``, `- Pre-override release ready: \`${override.preOverrideReleaseReady ?? false}\``, ...(override.preOverrideReasons && override.preOverrideReasons.length > 0
+                ? [
+                    `- Pre-override blockers:`,
+                    ...override.preOverrideReasons.map((reason) => `  - ${reason}`),
+                ]
+                : []), ``);
         }
-        if (override.changes.warnThreshold !== undefined) {
-            changes.push(`warn-threshold=${override.changes.warnThreshold}`);
+        else {
+            const changes = [];
+            if (override.changes.failMode)
+                changes.push(`fail-mode=${override.changes.failMode}`);
+            if (override.changes.riskThreshold !== undefined) {
+                changes.push(`risk-threshold=${override.changes.riskThreshold}`);
+            }
+            if (override.changes.warnThreshold !== undefined) {
+                changes.push(`warn-threshold=${override.changes.warnThreshold}`);
+            }
+            lines.push(`### Policy Override`, ``, `- Owner: \`${override.owner}\``, `- Ticket: \`${override.linkedTicket}\``, `- Reason: ${override.reason}`, `- Expires: \`${override.expiresAt}\``, `- Changes: ${changes.length > 0 ? changes.join(", ") : "none"}`, ``);
         }
-        lines.push(`### Policy Override`, ``, `- Owner: \`${override.owner}\``, `- Ticket: \`${override.linkedTicket}\``, `- Reason: ${override.reason}`, `- Expires: \`${override.expiresAt}\``, `- Changes: ${changes.length > 0 ? changes.join(", ") : "none"}`, ``);
     }
     if (evaluation.riskFactors.length > 0) {
         lines.push(`<details><summary><strong>Risk Factor Breakdown</strong> (${evaluation.riskFactors.length} factors)</summary>`, ``);
@@ -44897,6 +45211,7 @@ const TRAILHEAD_EVENT_TYPES = (/* unused pure expression or super */ null && ([
     "trailhead.warn_high_risk",
     "trailhead.ready",
     "trailhead.loop_exceeded",
+    "trailhead.override_applied",
 ]));
 function parseWebhookEvents(input) {
     return new Set(input
@@ -44925,6 +45240,9 @@ function resolveTrailheadEventTypes(evaluation, options = {}) {
     }
     if (evaluation.remediation?.next_action === "max_rounds_exceeded") {
         events.push("trailhead.loop_exceeded");
+    }
+    if (evaluation.policyOverride?.source === "label") {
+        events.push("trailhead.override_applied");
     }
     return events;
 }
@@ -45025,6 +45343,7 @@ function buildTrailheadEventPayload(evaluation, event, prUrl) {
         nextAction: evaluation.remediation?.next_action,
         loopRound: evaluation.remediation?.loop_round,
         maxLoopRounds: evaluation.remediation?.max_loop_rounds,
+        policyOverride: evaluation.policyOverride,
         timestamp: new Date().toISOString(),
     };
 }
@@ -45177,6 +45496,7 @@ function buildEvaluationStoreRow(evaluation) {
         fixes_resolved: remediation?.fixes_resolved ?? [],
         fixes_introduced: remediation?.fixes_introduced ?? [],
         pr: evaluation.pr ?? null,
+        policy_override: evaluation.policyOverride ?? null,
     };
 }
 async function storeEvaluation(url, evaluation, options = {}) {
@@ -46782,6 +47102,7 @@ function resolvePolicyOverride() {
         throw new PolicyOverrideError(`Override expired at ${expiresAt}. Extend expiry before applying.`);
     }
     return {
+        source: "workflow",
         owner,
         reason,
         linkedTicket,
@@ -46951,7 +47272,7 @@ async function run() {
         const prNumber = context.payload.pull_request?.number;
         info(`Evaluating deployment gate for ${commitSha.substring(0, 7)}`);
         const evaluation = await evaluateGate(config, commitSha, prNumber);
-        if (policyOverride) {
+        if (policyOverride && !evaluation.policyOverride) {
             evaluation.policyOverride = policyOverride;
         }
         setOutput("health-score", evaluation.healthScore.toString());

--- a/mcp/src/loop-bookkeeping.ts
+++ b/mcp/src/loop-bookkeeping.ts
@@ -1,0 +1,47 @@
+// Pure loop bookkeeping helpers — no framework dependencies.
+
+import type { GateEvaluation, Remediation } from "./types.js";
+
+export type PreviousEvaluationSnapshot = Pick<GateEvaluation, "id" | "remediation">;
+
+export function resolveLoopRound(
+  previous: PreviousEvaluationSnapshot | null | undefined,
+): number {
+  if (!previous) return 0;
+  return (previous.remediation?.loop_round ?? 0) + 1;
+}
+
+export function parseAgentIdFromHeadRef(headRef: string | undefined): string | null {
+  if (!headRef) return null;
+  const match = headRef.match(/^agent\/([a-z0-9-]+)\//);
+  return match?.[1] ?? null;
+}
+
+export function parsePreviousEvaluationRow(
+  row: unknown,
+): PreviousEvaluationSnapshot | null {
+  if (!row || typeof row !== "object") return null;
+  const record = row as Record<string, unknown>;
+  const id = typeof record.id === "string" ? record.id : null;
+  if (!id) return null;
+
+  let remediation: Remediation | undefined;
+  if (record.remediation && typeof record.remediation === "object") {
+    remediation = record.remediation as Remediation;
+  }
+
+  return { id, remediation };
+}
+
+export function pickLatestPreviousEvaluation(
+  rows: unknown[],
+  excludeEvaluationId?: string,
+): PreviousEvaluationSnapshot | null {
+  for (const row of rows) {
+    const parsed = parsePreviousEvaluationRow(row);
+    if (!parsed) continue;
+    if (excludeEvaluationId && parsed.id === excludeEvaluationId) continue;
+    return parsed;
+  }
+  return null;
+}

--- a/mcp/src/remediation.ts
+++ b/mcp/src/remediation.ts
@@ -8,6 +8,7 @@
 
 import type { z } from "zod";
 import { RemediationFix as RemediationFixSchema } from "./types.js";
+import { resolveLoopRound } from "./loop-bookkeeping.js";
 import type {
   AgentBriefMode,
   GateEvaluation,
@@ -331,7 +332,7 @@ export function buildRemediation(input: BuildRemediationInput): Remediation {
   const advisory_count = dedupedFixes.filter((f) => f.severity === "advisory").length;
   const autofix_eligible_count = dedupedFixes.filter((f) => f.autofix_eligible).length;
 
-  const loopRound = input.loopRound ?? (input.previousEvaluation ? 1 : 0);
+  const loopRound = input.loopRound ?? resolveLoopRound(input.previousEvaluation);
   const maxLoopRounds = input.maxLoopRounds ?? 3;
   const releaseReady =
     input.evaluation.releaseReady ??

--- a/mcp/src/trailhead-events.ts
+++ b/mcp/src/trailhead-events.ts
@@ -11,6 +11,7 @@ export const TRAILHEAD_EVENT_TYPES = [
   "trailhead.warn_high_risk",
   "trailhead.ready",
   "trailhead.loop_exceeded",
+  "trailhead.override_applied",
 ] as const;
 export type TrailheadEventType = (typeof TRAILHEAD_EVENT_TYPES)[number];
 
@@ -65,6 +66,10 @@ export function resolveTrailheadEventTypes(
 
   if (evaluation.remediation?.next_action === "max_rounds_exceeded") {
     events.push("trailhead.loop_exceeded");
+  }
+
+  if (evaluation.policyOverride?.source === "label") {
+    events.push("trailhead.override_applied");
   }
 
   return events;

--- a/src/__tests__/override.test.ts
+++ b/src/__tests__/override.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from "vitest";
+import {
+  hasOverrideLabel,
+  parseOverrideComment,
+  resolveLabelOverride,
+  buildLabelOverrideAudit,
+  formatOverrideRejectionMessage,
+} from "../override.js";
+
+describe("hasOverrideLabel", () => {
+  it("matches trailhead-override case-insensitively", () => {
+    expect(hasOverrideLabel(["Trailhead-Override"])).toBe(true);
+    expect(hasOverrideLabel(["bug"])).toBe(false);
+  });
+});
+
+describe("parseOverrideComment", () => {
+  it("extracts the most recent valid override reason", () => {
+    expect(
+      parseOverrideComment([
+        { body: "trailhead-override: first reason", author: "alice" },
+        { body: "Looks good to me", author: "bob" },
+        { body: "trailhead-override: latest reason", author: "carol" },
+      ]),
+    ).toEqual({
+      reason: "latest reason",
+      author: "carol",
+    });
+  });
+
+  it("accepts leading whitespace on the override line", () => {
+    expect(
+      parseOverrideComment([
+        {
+          body: "  trailhead-override: emergency hotfix for prod outage",
+          author: "david",
+        },
+      ]),
+    ).toEqual({
+      reason: "emergency hotfix for prod outage",
+      author: "david",
+    });
+  });
+
+  it("returns null when label comment is missing or empty", () => {
+    expect(
+      parseOverrideComment([{ body: "trailhead-override:", author: "alice" }]),
+    ).toBeNull();
+    expect(
+      parseOverrideComment([{ body: "please override this", author: "alice" }]),
+    ).toBeNull();
+  });
+});
+
+describe("resolveLabelOverride", () => {
+  const blockedRelease = {
+    releaseReady: false,
+    reasons: ["Risk/policy gate decision is BLOCK"],
+  };
+
+  it("applies override when label and reason are present", () => {
+    const outcome = resolveLabelOverride({
+      labels: ["trailhead-override"],
+      comments: [{ body: "trailhead-override: approved by on-call", author: "david" }],
+      config: { enabled: true, maxPerWeek: 5 },
+      recentOverrideCount: 1,
+      releaseResult: blockedRelease,
+      gateDecision: "block",
+      prNumber: 42,
+    });
+
+    expect(outcome.kind).toBe("applied");
+    if (outcome.kind !== "applied") return;
+    expect(outcome.audit.source).toBe("label");
+    expect(outcome.audit.reason).toBe("approved by on-call");
+    expect(outcome.audit.changes.releaseReady).toBe(true);
+    expect(outcome.audit.preOverrideDecision).toBe("block");
+  });
+
+  it("rejects when reason comment is missing", () => {
+    const outcome = resolveLabelOverride({
+      labels: ["trailhead-override"],
+      comments: [],
+      config: { enabled: true, maxPerWeek: 5 },
+      recentOverrideCount: 0,
+      releaseResult: blockedRelease,
+      gateDecision: "block",
+      prNumber: 42,
+    });
+
+    expect(outcome).toEqual({
+      kind: "rejected",
+      code: "missing_reason",
+      message: formatOverrideRejectionMessage("missing_reason"),
+    });
+  });
+
+  it("rejects when weekly cap is exceeded", () => {
+    const outcome = resolveLabelOverride({
+      labels: ["trailhead-override"],
+      comments: [{ body: "trailhead-override: one more", author: "david" }],
+      config: { enabled: true, maxPerWeek: 5 },
+      recentOverrideCount: 5,
+      releaseResult: blockedRelease,
+      gateDecision: "block",
+      prNumber: 42,
+    });
+
+    expect(outcome.kind).toBe("rejected");
+    if (outcome.kind !== "rejected") return;
+    expect(outcome.code).toBe("cap_exceeded");
+  });
+
+  it("no-ops when release is already ready", () => {
+    const outcome = resolveLabelOverride({
+      labels: ["trailhead-override"],
+      comments: [{ body: "trailhead-override: unnecessary", author: "david" }],
+      config: { enabled: true, maxPerWeek: 5 },
+      recentOverrideCount: 0,
+      releaseResult: { releaseReady: true, reasons: [] },
+      gateDecision: "allow",
+      prNumber: 42,
+    });
+
+    expect(outcome).toEqual({ kind: "none" });
+  });
+});
+
+describe("buildLabelOverrideAudit", () => {
+  it("captures pre-override state for audit trail", () => {
+    const audit = buildLabelOverrideAudit({
+      parsed: { reason: "hotfix", author: "david" },
+      prNumber: 99,
+      releaseResult: { releaseReady: false, reasons: ["CI failed"] },
+      gateDecision: "block",
+    });
+
+    expect(audit.owner).toBe("david");
+    expect(audit.linkedTicket).toBe("override:pr#99");
+    expect(audit.preOverrideReleaseReady).toBe(false);
+    expect(audit.preOverrideReasons).toEqual(["CI failed"]);
+  });
+});

--- a/src/__tests__/trailhead-events.test.ts
+++ b/src/__tests__/trailhead-events.test.ts
@@ -79,6 +79,27 @@ describe("resolveTrailheadEventTypes", () => {
     );
     expect(events).toContain("trailhead.loop_exceeded");
   });
+
+  it("emits trailhead.override_applied for label policy overrides", () => {
+    const events = resolveTrailheadEventTypes(
+      evaluation({
+        gateDecision: "block",
+        releaseReady: true,
+        policyOverride: {
+          source: "label",
+          owner: "david",
+          reason: "approved hotfix",
+          linkedTicket: "override:pr#42",
+          expiresAt: "2026-06-01T00:00:00.000Z",
+          appliedAt: "2026-05-28T00:00:00.000Z",
+          changes: { releaseReady: true },
+          preOverrideDecision: "block",
+          preOverrideReleaseReady: false,
+        },
+      }),
+    );
+    expect(events).toContain("trailhead.override_applied");
+  });
 });
 
 describe("resolveWebhookDeliveries", () => {

--- a/src/evaluation-history.ts
+++ b/src/evaluation-history.ts
@@ -16,7 +16,11 @@ export interface FetchPreviousEvaluationParams {
   vercelBypass?: string;
 }
 
-function buildAuthHeaders(params: FetchPreviousEvaluationParams): Record<string, string> {
+function buildAuthHeaders(params: {
+  apiKey?: string;
+  storeSecret?: string;
+  vercelBypass?: string;
+}): Record<string, string> {
   const headers: Record<string, string> = { Accept: "application/json" };
   const secret = params.storeSecret ?? process.env.EVALUATION_STORE_SECRET;
   if (secret) {
@@ -186,4 +190,72 @@ export async function fetchPreviousEvaluationForPr(
   } catch {
     return null;
   }
+}
+
+function isLabelOverrideRow(row: Record<string, unknown>): boolean {
+  const raw = row.policy_override ?? row.policyOverride;
+  if (!raw || typeof raw !== "object") return false;
+  const source = (raw as Record<string, unknown>).source;
+  return source === "label";
+}
+
+function rowCreatedAtMs(row: Record<string, unknown>): number | null {
+  const createdAt = row.created_at ?? row.createdAt;
+  if (typeof createdAt !== "string") return null;
+  const parsed = Date.parse(createdAt);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+export async function countRecentLabelOverrides(params: {
+  repoId: string;
+  storeUrl?: string;
+  apiKey?: string;
+  storeSecret?: string;
+  vercelBypass?: string;
+  windowDays?: number;
+}): Promise<number | null> {
+  const windowDays = params.windowDays ?? 7;
+  const windowMs = windowDays * 24 * 60 * 60 * 1000;
+  const cutoff = Date.now() - windowMs;
+
+  const listUrls: string[] = [];
+  if (params.storeUrl) {
+    const cloudUrl = resolveCloudListUrl(params.storeUrl);
+    const komatikUrl = resolveKomatikListUrl(params.storeUrl);
+    if (cloudUrl) listUrls.push(cloudUrl);
+    if (komatikUrl) listUrls.push(komatikUrl);
+  }
+
+  for (const listUrl of listUrls) {
+    try {
+      const url = new URL(listUrl);
+      url.searchParams.set("repo_id", params.repoId);
+      url.searchParams.set("limit", "100");
+
+      const response = await fetch(url.toString(), {
+        method: "GET",
+        headers: buildAuthHeaders(params),
+        signal: AbortSignal.timeout(LOOKUP_TIMEOUT_MS),
+      });
+      if (!response.ok) continue;
+
+      const body = (await response.json()) as { evaluations?: unknown[] };
+      if (!Array.isArray(body.evaluations)) continue;
+
+      let count = 0;
+      for (const row of body.evaluations) {
+        if (!row || typeof row !== "object") continue;
+        const record = row as Record<string, unknown>;
+        if (!isLabelOverrideRow(record)) continue;
+        const createdAtMs = rowCreatedAtMs(record);
+        if (createdAtMs !== null && createdAtMs < cutoff) continue;
+        count += 1;
+      }
+      return count;
+    } catch {
+      // Try next store URL.
+    }
+  }
+
+  return null;
 }

--- a/src/gate.ts
+++ b/src/gate.ts
@@ -1466,7 +1466,11 @@ async function applyLabelOverrideIfNeeded(input: {
 
   if (outcome.kind === "rejected") {
     core.warning(`Label override rejected: ${outcome.message}`);
-    await postOverrideRejectionComment(input.prNumber, outcome.message, input.githubToken);
+    await postOverrideRejectionComment(
+      input.prNumber,
+      outcome.message,
+      input.githubToken,
+    );
     return {
       ...input.evaluation,
       policyFindings: [...(input.evaluation.policyFindings ?? []), outcome.message],

--- a/src/gate.ts
+++ b/src/gate.ts
@@ -55,7 +55,15 @@ import {
   formatAgentBrief,
   resolveAgentBriefMode,
 } from "./remediation.js";
-import { fetchPreviousEvaluationForPr } from "./evaluation-history.js";
+import {
+  fetchPreviousEvaluationForPr,
+  countRecentLabelOverrides,
+} from "./evaluation-history.js";
+import {
+  applyLabelOverrideToEvaluation,
+  hasOverrideLabel,
+  resolveLabelOverride,
+} from "./override.js";
 
 export {
   isSensitiveFile,
@@ -1380,6 +1388,98 @@ function getPrMatchContext(): PrMatchContext {
   };
 }
 
+async function fetchPrCommentsForOverride(
+  prNumber: number,
+  token: string,
+): Promise<Array<{ body: string; author?: string }>> {
+  try {
+    const octokit = github.getOctokit(token);
+    const { owner, repo } = github.context.repo;
+    const { data: comments } = await octokit.rest.issues.listComments({
+      owner,
+      repo,
+      issue_number: prNumber,
+      per_page: 100,
+    });
+    return comments.map((comment) => ({
+      body: comment.body ?? "",
+      author: comment.user?.login ?? undefined,
+    }));
+  } catch (error) {
+    core.debug(`Failed to fetch PR comments for override: ${error}`);
+    return [];
+  }
+}
+
+async function applyLabelOverrideIfNeeded(input: {
+  evaluation: GateEvaluation;
+  config: TrailheadConfig;
+  repoConfig: RepoConfig | null;
+  prMatchCtx: PrMatchContext;
+  prNumber: number;
+  releaseResult: ReturnType<typeof computeReleaseReady>;
+  gateDecision: GateDecision;
+  githubToken: string;
+}): Promise<GateEvaluation> {
+  const overrideSettings = input.repoConfig?.override ?? {
+    enabled: true,
+    max_per_week: 5,
+  };
+
+  const comments = await fetchPrCommentsForOverride(input.prNumber, input.githubToken);
+  const recentOverrideCount = await countRecentLabelOverrides({
+    repoId: input.evaluation.repoId,
+    storeUrl: input.config.evaluationStoreUrl,
+    apiKey: input.config.trailheadApiKey,
+  });
+  if (recentOverrideCount === null) {
+    core.warning(
+      "Could not verify weekly override cap — proceeding without cap enforcement.",
+    );
+  }
+
+  const outcome = resolveLabelOverride({
+    labels: input.prMatchCtx.labels,
+    comments,
+    config: {
+      enabled: overrideSettings.enabled,
+      maxPerWeek: overrideSettings.max_per_week,
+    },
+    recentOverrideCount,
+    releaseResult: input.releaseResult,
+    gateDecision: input.gateDecision,
+    prNumber: input.prNumber,
+  });
+
+  if (outcome.kind === "applied") {
+    core.warning(
+      `Label override applied by ${outcome.audit.owner}: ${outcome.audit.reason}`,
+    );
+    return {
+      ...applyLabelOverrideToEvaluation(input.evaluation, outcome.audit),
+      labelOverrideFeedback: {
+        status: "applied",
+        message: `Release override applied by \`${outcome.audit.owner}\`.`,
+      },
+    };
+  }
+
+  if (outcome.kind === "rejected") {
+    core.warning(`Label override rejected: ${outcome.message}`);
+    await postOverrideRejectionComment(input.prNumber, outcome.message, input.githubToken);
+    return {
+      ...input.evaluation,
+      policyFindings: [...(input.evaluation.policyFindings ?? []), outcome.message],
+      labelOverrideFeedback: {
+        status: "rejected",
+        message: outcome.message,
+      },
+    };
+  }
+
+  return input.evaluation;
+}
+
 // ---------------------------------------------------------------------------
 // Main evaluation entry point
 // ---------------------------------------------------------------------------
@@ -1876,6 +1976,19 @@ export async function evaluateGate(
     gateMode,
   );
 
+  if (prNumber && config.githubToken && hasOverrideLabel(prMatchCtx.labels)) {
+    localEvaluation = await applyLabelOverrideIfNeeded({
+      evaluation: localEvaluation,
+      config,
+      repoConfig,
+      prMatchCtx,
+      prNumber,
+      releaseResult,
+      gateDecision,
+      githubToken: config.githubToken,
+    });
+  }
+
   if (config.apiKey) {
     const apiResponse = await callGateApi(config, localEvaluation);
     if (apiResponse) {
@@ -1942,6 +2055,50 @@ export async function evaluateGate(
 // ---------------------------------------------------------------------------
 // PR comment posting
 // ---------------------------------------------------------------------------
+
+export async function postOverrideRejectionComment(
+  prNumber: number,
+  message: string,
+  token: string,
+): Promise<void> {
+  try {
+    const octokit = github.getOctokit(token);
+    const { owner, repo } = github.context.repo;
+    const MARKER = "<!-- trailhead-override-feedback -->";
+    const body =
+      `${MARKER}\n` +
+      `### Trailhead override rejected\n\n` +
+      `${message}\n\n` +
+      `_This comment is updated automatically when the \`trailhead-override\` label is present._`;
+
+    const { data: comments } = await octokit.rest.issues.listComments({
+      owner,
+      repo,
+      issue_number: prNumber,
+      per_page: 100,
+    });
+    const existing = comments.find((comment) => comment.body?.includes(MARKER));
+
+    if (existing) {
+      await octokit.rest.issues.updateComment({
+        owner,
+        repo,
+        comment_id: existing.id,
+        body,
+      });
+      return;
+    }
+
+    await octokit.rest.issues.createComment({
+      owner,
+      repo,
+      issue_number: prNumber,
+      body,
+    });
+  } catch (error) {
+    core.debug(`Failed to post override rejection comment: ${error}`);
+  }
+}
 
 export async function postPrComment(
   report: string,
@@ -2556,24 +2713,45 @@ export function formatGateReport(
 
   if (evaluation.policyOverride) {
     const override = evaluation.policyOverride;
-    const changes: string[] = [];
-    if (override.changes.failMode) changes.push(`fail-mode=${override.changes.failMode}`);
-    if (override.changes.riskThreshold !== undefined) {
-      changes.push(`risk-threshold=${override.changes.riskThreshold}`);
+    if (override.source === "label") {
+      lines.push(
+        `### Release Override (\`trailhead-override\`)`,
+        ``,
+        `- Author: \`${override.owner}\``,
+        `- Reason: ${override.reason}`,
+        `- Applied: \`${override.appliedAt}\``,
+        `- Expires: \`${override.expiresAt}\``,
+        `- Pre-override decision: \`${override.preOverrideDecision ?? evaluation.gateDecision}\``,
+        `- Pre-override release ready: \`${override.preOverrideReleaseReady ?? false}\``,
+        ...(override.preOverrideReasons && override.preOverrideReasons.length > 0
+          ? [
+              `- Pre-override blockers:`,
+              ...override.preOverrideReasons.map((reason) => `  - ${reason}`),
+            ]
+          : []),
+        ``,
+      );
+    } else {
+      const changes: string[] = [];
+      if (override.changes.failMode)
+        changes.push(`fail-mode=${override.changes.failMode}`);
+      if (override.changes.riskThreshold !== undefined) {
+        changes.push(`risk-threshold=${override.changes.riskThreshold}`);
+      }
+      if (override.changes.warnThreshold !== undefined) {
+        changes.push(`warn-threshold=${override.changes.warnThreshold}`);
+      }
+      lines.push(
+        `### Policy Override`,
+        ``,
+        `- Owner: \`${override.owner}\``,
+        `- Ticket: \`${override.linkedTicket}\``,
+        `- Reason: ${override.reason}`,
+        `- Expires: \`${override.expiresAt}\``,
+        `- Changes: ${changes.length > 0 ? changes.join(", ") : "none"}`,
+        ``,
+      );
     }
-    if (override.changes.warnThreshold !== undefined) {
-      changes.push(`warn-threshold=${override.changes.warnThreshold}`);
-    }
-    lines.push(
-      `### Policy Override`,
-      ``,
-      `- Owner: \`${override.owner}\``,
-      `- Ticket: \`${override.linkedTicket}\``,
-      `- Reason: ${override.reason}`,
-      `- Expires: \`${override.expiresAt}\``,
-      `- Changes: ${changes.length > 0 ? changes.join(", ") : "none"}`,
-      ``,
-    );
   }
 
   if (evaluation.riskFactors.length > 0) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,26 +26,13 @@ import { fetchCodeScanningAlerts, formatSecuritySection } from "./security.js";
 import { resolveEvaluationStoreUrl } from "./cloud-config.js";
 import { resolveCiManifests } from "./ci-external.js";
 import { computeRolloutReadiness } from "./rollout-readiness.js";
-import type { TrailheadConfig, TestRepairResult } from "./types.js";
+import type { TrailheadConfig, TestRepairResult, PolicyOverrideAudit } from "./types.js";
 
 class PolicyOverrideError extends Error {
   constructor(message: string) {
     super(message);
     this.name = "PolicyOverrideError";
   }
-}
-
-interface PolicyOverrideAudit {
-  owner: string;
-  reason: string;
-  linkedTicket: string;
-  expiresAt: string;
-  appliedAt: string;
-  changes: {
-    failMode?: "open" | "closed";
-    riskThreshold?: number;
-    warnThreshold?: number;
-  };
 }
 
 function parseEvaluationStoreRetries(raw: string): number {
@@ -128,6 +115,7 @@ function resolvePolicyOverride(): PolicyOverrideAudit | null {
   }
 
   return {
+    source: "workflow",
     owner,
     reason,
     linkedTicket,
@@ -321,7 +309,7 @@ async function run(): Promise<void> {
     core.info(`Evaluating deployment gate for ${commitSha.substring(0, 7)}`);
 
     const evaluation = await evaluateGate(config, commitSha, prNumber);
-    if (policyOverride) {
+    if (policyOverride && !evaluation.policyOverride) {
       evaluation.policyOverride = policyOverride;
     }
 

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -105,6 +105,7 @@ function buildTrailheadEventPayload(
     nextAction: evaluation.remediation?.next_action,
     loopRound: evaluation.remediation?.loop_round,
     maxLoopRounds: evaluation.remediation?.max_loop_rounds,
+    policyOverride: evaluation.policyOverride,
     timestamp: new Date().toISOString(),
   };
 }
@@ -319,6 +320,7 @@ export function buildEvaluationStoreRow(
     fixes_resolved: remediation?.fixes_resolved ?? [],
     fixes_introduced: remediation?.fixes_introduced ?? [],
     pr: evaluation.pr ?? null,
+    policy_override: evaluation.policyOverride ?? null,
   };
 }
 

--- a/src/override.ts
+++ b/src/override.ts
@@ -1,0 +1,173 @@
+import type { GateDecision, GateEvaluation, PolicyOverrideAudit } from "./types.js";
+import type { ReleaseReadyResult } from "./release-ready.js";
+
+export const OVERRIDE_LABEL = "trailhead-override";
+export const OVERRIDE_COMMENT_PATTERN = /^trailhead-override:\s*(.+)/im;
+
+export interface PrComment {
+  body: string;
+  author?: string;
+}
+
+export interface OverrideConfig {
+  enabled: boolean;
+  maxPerWeek: number;
+}
+
+export interface ParsedOverrideComment {
+  reason: string;
+  author: string;
+}
+
+export type LabelOverrideRejectionCode =
+  | "missing_reason"
+  | "disabled"
+  | "cap_exceeded"
+  | "not_needed";
+
+export type LabelOverrideOutcome =
+  | { kind: "none" }
+  | { kind: "applied"; audit: PolicyOverrideAudit }
+  | { kind: "rejected"; code: LabelOverrideRejectionCode; message: string };
+
+export function hasOverrideLabel(labels: string[]): boolean {
+  return labels.some((label) => label.toLowerCase() === OVERRIDE_LABEL);
+}
+
+export function parseOverrideComment(
+  comments: PrComment[],
+): ParsedOverrideComment | null {
+  for (let index = comments.length - 1; index >= 0; index -= 1) {
+    const comment = comments[index];
+    const match = comment.body.trim().match(OVERRIDE_COMMENT_PATTERN);
+    if (!match?.[1]?.trim()) continue;
+    return {
+      reason: match[1].trim(),
+      author: comment.author?.trim() || "unknown",
+    };
+  }
+  return null;
+}
+
+export function buildLabelOverrideAudit(input: {
+  parsed: ParsedOverrideComment;
+  prNumber: number;
+  releaseResult: ReleaseReadyResult;
+  gateDecision: GateDecision;
+}): PolicyOverrideAudit {
+  const appliedAt = new Date().toISOString();
+  const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+
+  return {
+    source: "label",
+    owner: input.parsed.author,
+    reason: input.parsed.reason,
+    linkedTicket: `override:pr#${input.prNumber}`,
+    expiresAt,
+    appliedAt,
+    changes: { releaseReady: true },
+    preOverrideDecision: input.gateDecision,
+    preOverrideReleaseReady: input.releaseResult.releaseReady,
+    preOverrideReasons:
+      input.releaseResult.reasons.length > 0
+        ? [...input.releaseResult.reasons]
+        : undefined,
+  };
+}
+
+export function formatOverrideRejectionMessage(code: LabelOverrideRejectionCode): string {
+  switch (code) {
+    case "missing_reason":
+      return (
+        "The `trailhead-override` label is present but no valid override reason was found. " +
+        "Add a PR comment starting with `trailhead-override: <your reason>` " +
+        "(for example: `trailhead-override: emergency hotfix for prod outage`). " +
+        "The gate will re-evaluate on the next run after the comment is posted."
+      );
+    case "disabled":
+      return (
+        "The `trailhead-override` label is present but label overrides are disabled " +
+        "in this repo's `.trailhead.yml` (`override.enabled: false`)."
+      );
+    case "cap_exceeded":
+      return (
+        "The `trailhead-override` label is present but this repo has reached its weekly " +
+        "override cap. File an issue in [KomatikAI/trailhead](https://github.com/KomatikAI/trailhead) " +
+        "linking this PR and the override pattern before applying another override."
+      );
+    case "not_needed":
+      return "The `trailhead-override` label is present but release is already ready — no override applied.";
+    default: {
+      const _exhaustive: never = code;
+      return _exhaustive;
+    }
+  }
+}
+
+export function resolveLabelOverride(input: {
+  labels: string[];
+  comments: PrComment[];
+  config: OverrideConfig;
+  recentOverrideCount: number | null;
+  releaseResult: ReleaseReadyResult;
+  gateDecision: GateDecision;
+  prNumber: number;
+}): LabelOverrideOutcome {
+  if (!hasOverrideLabel(input.labels)) {
+    return { kind: "none" };
+  }
+
+  if (!input.config.enabled) {
+    return {
+      kind: "rejected",
+      code: "disabled",
+      message: formatOverrideRejectionMessage("disabled"),
+    };
+  }
+
+  if (input.releaseResult.releaseReady) {
+    return { kind: "none" };
+  }
+
+  const parsed = parseOverrideComment(input.comments);
+  if (!parsed) {
+    return {
+      kind: "rejected",
+      code: "missing_reason",
+      message: formatOverrideRejectionMessage("missing_reason"),
+    };
+  }
+
+  if (
+    input.recentOverrideCount !== null &&
+    input.recentOverrideCount >= input.config.maxPerWeek
+  ) {
+    return {
+      kind: "rejected",
+      code: "cap_exceeded",
+      message: formatOverrideRejectionMessage("cap_exceeded"),
+    };
+  }
+
+  return {
+    kind: "applied",
+    audit: buildLabelOverrideAudit({
+      parsed,
+      prNumber: input.prNumber,
+      releaseResult: input.releaseResult,
+      gateDecision: input.gateDecision,
+    }),
+  };
+}
+
+export function applyLabelOverrideToEvaluation(
+  evaluation: GateEvaluation,
+  audit: PolicyOverrideAudit,
+): GateEvaluation {
+  return {
+    ...evaluation,
+    releaseReady: true,
+    releaseReadyReasons: undefined,
+    policyOverride: audit,
+  };
+}

--- a/src/trailhead-events.ts
+++ b/src/trailhead-events.ts
@@ -11,6 +11,7 @@ export const TRAILHEAD_EVENT_TYPES = [
   "trailhead.warn_high_risk",
   "trailhead.ready",
   "trailhead.loop_exceeded",
+  "trailhead.override_applied",
 ] as const;
 export type TrailheadEventType = (typeof TRAILHEAD_EVENT_TYPES)[number];
 
@@ -65,6 +66,10 @@ export function resolveTrailheadEventTypes(
 
   if (evaluation.remediation?.next_action === "max_rounds_exceeded") {
     events.push("trailhead.loop_exceeded");
+  }
+
+  if (evaluation.policyOverride?.source === "label") {
+    events.push("trailhead.override_applied");
   }
 
   return events;

--- a/src/types.ts
+++ b/src/types.ts
@@ -145,6 +145,28 @@ export const Remediation = z.object({
 });
 export type Remediation = z.infer<typeof Remediation>;
 
+export const PolicyOverrideChanges = z.object({
+  failMode: z.enum(["open", "closed"]).optional(),
+  riskThreshold: z.number().min(0).max(100).optional(),
+  warnThreshold: z.number().min(0).max(100).optional(),
+  releaseReady: z.literal(true).optional(),
+});
+export type PolicyOverrideChanges = z.infer<typeof PolicyOverrideChanges>;
+
+export const PolicyOverrideAudit = z.object({
+  source: z.enum(["workflow", "label"]).default("workflow"),
+  owner: z.string(),
+  reason: z.string(),
+  linkedTicket: z.string(),
+  expiresAt: z.string(),
+  appliedAt: z.string(),
+  changes: PolicyOverrideChanges.default({}),
+  preOverrideDecision: GateDecision.optional(),
+  preOverrideReleaseReady: z.boolean().optional(),
+  preOverrideReasons: z.array(z.string()).optional(),
+});
+export type PolicyOverrideAudit = z.infer<typeof PolicyOverrideAudit>;
+
 export const GateEvaluation = z.object({
   id: z.string(),
   repoId: z.string(),
@@ -187,20 +209,11 @@ export const GateEvaluation = z.object({
       reason: z.string(),
     })
     .optional(),
-  policyOverride: z
+  policyOverride: PolicyOverrideAudit.optional(),
+  labelOverrideFeedback: z
     .object({
-      owner: z.string(),
-      reason: z.string(),
-      linkedTicket: z.string(),
-      expiresAt: z.string(),
-      appliedAt: z.string(),
-      changes: z
-        .object({
-          failMode: z.enum(["open", "closed"]).optional(),
-          riskThreshold: z.number().min(0).max(100).optional(),
-          warnThreshold: z.number().min(0).max(100).optional(),
-        })
-        .default({}),
+      status: z.enum(["applied", "rejected"]),
+      message: z.string(),
     })
     .optional(),
   releaseReady: z.boolean().optional(),
@@ -351,10 +364,17 @@ export const RemediationConfig = z.object({
 });
 export type RemediationConfig = z.infer<typeof RemediationConfig>;
 
+export const OverrideConfig = z.object({
+  enabled: z.boolean().default(true),
+  max_per_week: z.number().int().min(1).default(5),
+});
+export type OverrideConfig = z.infer<typeof OverrideConfig>;
+
 export const RepoConfig = z.object({
   schema_version: z.number().int().positive().default(1),
   gate: GateConfig.default({}),
   remediation: RemediationConfig.optional(),
+  override: OverrideConfig.optional(),
   contexts: z.array(TrailheadContext).default([]),
   sensitivity: z
     .object({


### PR DESCRIPTION
## Summary
- Adds the **A7 label override** flow: `trailhead-override` label + required `trailhead-override: <reason>` PR comment forces `release_ready: true` with a full audit trail
- Rejects invalid overrides (missing reason, disabled in config, weekly cap exceeded) with a dedicated PR feedback comment
- Persists `policyOverride` to the evaluation store, emits `trailhead.override_applied` webhook, and documents override in gate reports
- Configurable via `.trailhead.yml` `override.max_per_week` (default 5) and `override.enabled`

Closes #230

## Test plan
- [x] `npm run lint`
- [x] `npm test` (622 passing)
- [x] `npm run build` (dist committed)
- [ ] Manual: blocked PR → add label + reason comment → re-run gate → Release Ready passes with audit section
- [ ] Manual: label without reason comment → rejection comment posted, gate stays blocked
- [ ] Manual: subscribe webhook to `trailhead.override_applied` and verify payload includes `policyOverride`


Made with [Cursor](https://cursor.com)