### PR TITLE
feat(remediation): lane-aware next_action for agent PRs

### DIFF
--- a/app/src/remediation-lanes.ts
+++ b/app/src/remediation-lanes.ts
@@ -1,0 +1,75 @@
+// Lane classification for remediation next_action routing (v4.3 agent autonomy).
+// Red-lane findings require human review; yellow-lane (routine) findings loop to the agent.
+
+import type { RemediationFix, RemediationNextAction } from "./types.js";
+
+/** Fix codes that always require human review for agent-provenance PRs. */
+export const RED_LANE_FIX_CODES = new Set([
+  "submission.artifact_integrity",
+  "submission.mock_placeholder",
+  "policy.workflow_security",
+  "policy.prompt_injection",
+  "policy.ci_integrity",
+  "policy.finding",
+  "security.code_scanning",
+  "risk.sensitive_files",
+  "risk.supply_chain",
+]);
+
+/** Routine (yellow-lane) fix codes — agent should fix_and_retry. */
+export const ROUTINE_FIX_CODES = new Set([
+  "risk.test_coverage",
+  "submission.context_freshness",
+  "policy.pr_scope",
+  "policy.duplicate_logic",
+  "ci.failed",
+  "ci.missing",
+]);
+
+export type RemediationLane = "red" | "yellow" | "unknown";
+
+export function classifyFixLane(code: string): RemediationLane {
+  if (RED_LANE_FIX_CODES.has(code)) return "red";
+  if (ROUTINE_FIX_CODES.has(code)) return "yellow";
+  return "unknown";
+}
+
+export function hasRedLaneFindings(fixes: RemediationFix[]): boolean {
+  return fixes.some((fix) => classifyFixLane(fix.code) === "red");
+}
+
+export function isAgentProvenanceType(provenanceType: string | undefined): boolean {
+  return provenanceType !== undefined && provenanceType !== "human";
+}
+
+export function computeNextAction(args: {
+  releaseReady: boolean;
+  blockingCount: number;
+  warnCount: number;
+  advisoryCount: number;
+  loopRound: number;
+  maxLoopRounds: number;
+  redLane?: boolean;
+  agentProvenance?: boolean;
+  fixes: RemediationFix[];
+}): RemediationNextAction {
+  const redLane = args.redLane === true || hasRedLaneFindings(args.fixes);
+
+  if (args.releaseReady) {
+    return redLane ? "human_review_required" : "ready_to_merge";
+  }
+
+  if (args.agentProvenance) {
+    if (redLane) return "human_review_required";
+    if (args.loopRound >= args.maxLoopRounds) return "max_rounds_exceeded";
+    if (args.blockingCount > 0 || args.warnCount > 0 || args.advisoryCount > 0) {
+      return "fix_and_retry";
+    }
+    return "human_review_required";
+  }
+
+  // Human-provenance PRs — preserve legacy behavior.
+  if (args.blockingCount === 0) return "human_review_required";
+  if (args.loopRound >= args.maxLoopRounds) return "max_rounds_exceeded";
+  return "fix_and_retry";
+}

--- a/app/src/remediation.ts
+++ b/app/src/remediation.ts
@@ -11,13 +11,21 @@ import { RemediationFix as RemediationFixSchema } from "./types.js";
 import { resolveLoopRound } from "./loop-bookkeeping.js";
 import { deriveSubmissionFixes } from "./submission-remediation.js";
 import type { SubmissionCheckResult } from "./submission-remediation.js";
+import { computeNextAction } from "./remediation-lanes.js";
+export {
+  RED_LANE_FIX_CODES,
+  ROUTINE_FIX_CODES,
+  classifyFixLane,
+  hasRedLaneFindings,
+  isAgentProvenanceType,
+  computeNextAction,
+} from "./remediation-lanes.js";
 import type {
   AgentBriefMode,
   GateEvaluation,
   PrProvenance,
   Remediation,
   RemediationAutofixClass,
-  RemediationNextAction,
   RemediationSeverity,
   RiskFactor,
 } from "./types.js";
@@ -272,25 +280,6 @@ function diffFixCodes(
   return { resolved, introduced };
 }
 
-function computeNextAction(args: {
-  releaseReady: boolean;
-  blockingCount: number;
-  loopRound: number;
-  maxLoopRounds: number;
-  redLane?: boolean;
-}): RemediationNextAction {
-  if (args.releaseReady) {
-    return args.redLane ? "human_review_required" : "ready_to_merge";
-  }
-  if (args.blockingCount === 0) {
-    return "human_review_required";
-  }
-  if (args.loopRound >= args.maxLoopRounds) {
-    return "max_rounds_exceeded";
-  }
-  return "fix_and_retry";
-}
-
 export function buildRemediation(input: BuildRemediationInput): Remediation {
   const fixes: RemediationFix[] = [];
 
@@ -350,8 +339,12 @@ export function buildRemediation(input: BuildRemediationInput): Remediation {
   const next_action = computeNextAction({
     releaseReady,
     blockingCount: blocking_count,
+    warnCount: warn_count,
+    advisoryCount: advisory_count,
     loopRound,
     maxLoopRounds,
+    agentProvenance: input.agentProvenance,
+    fixes: dedupedFixes,
   });
 
   return {

--- a/dist/index.js
+++ b/dist/index.js
@@ -42446,6 +42446,66 @@ function deriveSubmissionFixes(checks) {
     }));
 }
 
+;// CONCATENATED MODULE: ./src/remediation-lanes.ts
+// Lane classification for remediation next_action routing (v4.3 agent autonomy).
+// Red-lane findings require human review; yellow-lane (routine) findings loop to the agent.
+/** Fix codes that always require human review for agent-provenance PRs. */
+const RED_LANE_FIX_CODES = new Set([
+    "submission.artifact_integrity",
+    "submission.mock_placeholder",
+    "policy.workflow_security",
+    "policy.prompt_injection",
+    "policy.ci_integrity",
+    "policy.finding",
+    "security.code_scanning",
+    "risk.sensitive_files",
+    "risk.supply_chain",
+]);
+/** Routine (yellow-lane) fix codes — agent should fix_and_retry. */
+const ROUTINE_FIX_CODES = new Set([
+    "risk.test_coverage",
+    "submission.context_freshness",
+    "policy.pr_scope",
+    "policy.duplicate_logic",
+    "ci.failed",
+    "ci.missing",
+]);
+function classifyFixLane(code) {
+    if (RED_LANE_FIX_CODES.has(code))
+        return "red";
+    if (ROUTINE_FIX_CODES.has(code))
+        return "yellow";
+    return "unknown";
+}
+function hasRedLaneFindings(fixes) {
+    return fixes.some((fix) => classifyFixLane(fix.code) === "red");
+}
+function isAgentProvenanceType(provenanceType) {
+    return provenanceType !== undefined && provenanceType !== "human";
+}
+function computeNextAction(args) {
+    const redLane = args.redLane === true || hasRedLaneFindings(args.fixes);
+    if (args.releaseReady) {
+        return redLane ? "human_review_required" : "ready_to_merge";
+    }
+    if (args.agentProvenance) {
+        if (redLane)
+            return "human_review_required";
+        if (args.loopRound >= args.maxLoopRounds)
+            return "max_rounds_exceeded";
+        if (args.blockingCount > 0 || args.warnCount > 0 || args.advisoryCount > 0) {
+            return "fix_and_retry";
+        }
+        return "human_review_required";
+    }
+    // Human-provenance PRs — preserve legacy behavior.
+    if (args.blockingCount === 0)
+        return "human_review_required";
+    if (args.loopRound >= args.maxLoopRounds)
+        return "max_rounds_exceeded";
+    return "fix_and_retry";
+}
+
 ;// CONCATENATED MODULE: ./src/remediation.ts
 // Pure remediation derivation — no framework dependencies.
 // Maps gate findings (risk factors, CI failures, policy violations, release-ready
@@ -42454,6 +42514,8 @@ function deriveSubmissionFixes(checks) {
 // Shared across the GitHub Action, MCP server, and GitHub App via the existing
 // prebuild copy pattern. Keep this module free of @actions/*, octokit, and Node
 // runtime imports so it stays portable.
+
+
 
 
 
@@ -42658,18 +42720,6 @@ function diffFixCodes(current, previous) {
     }
     return { resolved, introduced };
 }
-function computeNextAction(args) {
-    if (args.releaseReady) {
-        return args.redLane ? "human_review_required" : "ready_to_merge";
-    }
-    if (args.blockingCount === 0) {
-        return "human_review_required";
-    }
-    if (args.loopRound >= args.maxLoopRounds) {
-        return "max_rounds_exceeded";
-    }
-    return "fix_and_retry";
-}
 function buildRemediation(input) {
     const fixes = [];
     for (const factor of input.evaluation.riskFactors ?? []) {
@@ -42718,8 +42768,12 @@ function buildRemediation(input) {
     const next_action = computeNextAction({
         releaseReady,
         blockingCount: blocking_count,
+        warnCount: warn_count,
+        advisoryCount: advisory_count,
         loopRound,
         maxLoopRounds,
+        agentProvenance: input.agentProvenance,
+        fixes: dedupedFixes,
     });
     return {
         schema: "trailhead.remediation.v1",
@@ -43822,9 +43876,6 @@ async function detectSessionCorrelation(params) {
         return null;
     }
 }
-function isAgentProvenanceType(type) {
-    return type !== "human";
-}
 async function enforceAgentPrPolicies(params) {
     const policy = params.repoConfig?.policies?.agent_prs;
     if (!policy?.enabled || !params.prNumber || !params.token)
@@ -44677,6 +44728,7 @@ async function evaluateGate(config, commitSha, prNumber) {
             },
             previousEvaluation,
             maxLoopRounds: remediationSettings?.max_loop_rounds ?? 3,
+            agentProvenance: isAgentProvenanceType(localEvaluation.pr?.provenance?.type ?? "unknown"),
         });
     }
     return localEvaluation;

--- a/mcp/src/remediation-lanes.ts
+++ b/mcp/src/remediation-lanes.ts
@@ -1,0 +1,75 @@
+// Lane classification for remediation next_action routing (v4.3 agent autonomy).
+// Red-lane findings require human review; yellow-lane (routine) findings loop to the agent.
+
+import type { RemediationFix, RemediationNextAction } from "./types.js";
+
+/** Fix codes that always require human review for agent-provenance PRs. */
+export const RED_LANE_FIX_CODES = new Set([
+  "submission.artifact_integrity",
+  "submission.mock_placeholder",
+  "policy.workflow_security",
+  "policy.prompt_injection",
+  "policy.ci_integrity",
+  "policy.finding",
+  "security.code_scanning",
+  "risk.sensitive_files",
+  "risk.supply_chain",
+]);
+
+/** Routine (yellow-lane) fix codes — agent should fix_and_retry. */
+export const ROUTINE_FIX_CODES = new Set([
+  "risk.test_coverage",
+  "submission.context_freshness",
+  "policy.pr_scope",
+  "policy.duplicate_logic",
+  "ci.failed",
+  "ci.missing",
+]);
+
+export type RemediationLane = "red" | "yellow" | "unknown";
+
+export function classifyFixLane(code: string): RemediationLane {
+  if (RED_LANE_FIX_CODES.has(code)) return "red";
+  if (ROUTINE_FIX_CODES.has(code)) return "yellow";
+  return "unknown";
+}
+
+export function hasRedLaneFindings(fixes: RemediationFix[]): boolean {
+  return fixes.some((fix) => classifyFixLane(fix.code) === "red");
+}
+
+export function isAgentProvenanceType(provenanceType: string | undefined): boolean {
+  return provenanceType !== undefined && provenanceType !== "human";
+}
+
+export function computeNextAction(args: {
+  releaseReady: boolean;
+  blockingCount: number;
+  warnCount: number;
+  advisoryCount: number;
+  loopRound: number;
+  maxLoopRounds: number;
+  redLane?: boolean;
+  agentProvenance?: boolean;
+  fixes: RemediationFix[];
+}): RemediationNextAction {
+  const redLane = args.redLane === true || hasRedLaneFindings(args.fixes);
+
+  if (args.releaseReady) {
+    return redLane ? "human_review_required" : "ready_to_merge";
+  }
+
+  if (args.agentProvenance) {
+    if (redLane) return "human_review_required";
+    if (args.loopRound >= args.maxLoopRounds) return "max_rounds_exceeded";
+    if (args.blockingCount > 0 || args.warnCount > 0 || args.advisoryCount > 0) {
+      return "fix_and_retry";
+    }
+    return "human_review_required";
+  }
+
+  // Human-provenance PRs — preserve legacy behavior.
+  if (args.blockingCount === 0) return "human_review_required";
+  if (args.loopRound >= args.maxLoopRounds) return "max_rounds_exceeded";
+  return "fix_and_retry";
+}

--- a/mcp/src/remediation.ts
+++ b/mcp/src/remediation.ts
@@ -11,13 +11,21 @@ import { RemediationFix as RemediationFixSchema } from "./types.js";
 import { resolveLoopRound } from "./loop-bookkeeping.js";
 import { deriveSubmissionFixes } from "./submission-remediation.js";
 import type { SubmissionCheckResult } from "./submission-remediation.js";
+import { computeNextAction } from "./remediation-lanes.js";
+export {
+  RED_LANE_FIX_CODES,
+  ROUTINE_FIX_CODES,
+  classifyFixLane,
+  hasRedLaneFindings,
+  isAgentProvenanceType,
+  computeNextAction,
+} from "./remediation-lanes.js";
 import type {
   AgentBriefMode,
   GateEvaluation,
   PrProvenance,
   Remediation,
   RemediationAutofixClass,
-  RemediationNextAction,
   RemediationSeverity,
   RiskFactor,
 } from "./types.js";
@@ -272,25 +280,6 @@ function diffFixCodes(
   return { resolved, introduced };
 }
 
-function computeNextAction(args: {
-  releaseReady: boolean;
-  blockingCount: number;
-  loopRound: number;
-  maxLoopRounds: number;
-  redLane?: boolean;
-}): RemediationNextAction {
-  if (args.releaseReady) {
-    return args.redLane ? "human_review_required" : "ready_to_merge";
-  }
-  if (args.blockingCount === 0) {
-    return "human_review_required";
-  }
-  if (args.loopRound >= args.maxLoopRounds) {
-    return "max_rounds_exceeded";
-  }
-  return "fix_and_retry";
-}
-
 export function buildRemediation(input: BuildRemediationInput): Remediation {
   const fixes: RemediationFix[] = [];
 
@@ -350,8 +339,12 @@ export function buildRemediation(input: BuildRemediationInput): Remediation {
   const next_action = computeNextAction({
     releaseReady,
     blockingCount: blocking_count,
+    warnCount: warn_count,
+    advisoryCount: advisory_count,
     loopRound,
     maxLoopRounds,
+    agentProvenance: input.agentProvenance,
+    fixes: dedupedFixes,
   });
 
   return {

--- a/scripts/copy-shared-src.mjs
+++ b/scripts/copy-shared-src.mjs
@@ -35,6 +35,7 @@ const sharedFiles = [
   "remediation.ts",
   "loop-bookkeeping.ts",
   "submission-remediation.ts",
+  "remediation-lanes.ts",
   "trailhead-events.ts",
 ];
 

--- a/src/__tests__/agent-failure-fixtures.test.ts
+++ b/src/__tests__/agent-failure-fixtures.test.ts
@@ -35,7 +35,7 @@ interface RemediationScenario {
   id: string;
   kind: "remediation";
   description?: string;
-  input: BuildRemediationInput;
+  input: BuildRemediationInput & { agentProvenance?: boolean };
 }
 
 interface RemediationSequenceScenario {
@@ -44,7 +44,7 @@ interface RemediationSequenceScenario {
   description?: string;
   steps: Array<{
     label: string;
-    input: BuildRemediationInput;
+    input: BuildRemediationInput & { agentProvenance?: boolean };
     expectedFile: string;
   }>;
 }
@@ -142,7 +142,10 @@ describe("A8 fleet agent failure fixtures", () => {
         const expected = loadJson<RemediationExpected>(
           path.join(fixturesRoot, fixtureId, "remediation.expected.json"),
         );
-        const remediation = buildRemediation(scenario.input);
+        const remediation = buildRemediation({
+          ...scenario.input,
+          agentProvenance: scenario.input.agentProvenance ?? true,
+        });
         assertRemediationMatches(remediation, expected, fixtureId);
       });
       continue;
@@ -156,6 +159,7 @@ describe("A8 fleet agent failure fixtures", () => {
           const remediation = buildRemediation({
             ...step.input,
             previousEvaluation: previous,
+            agentProvenance: step.input.agentProvenance ?? true,
           });
           const expected = loadJson<RemediationExpected>(
             path.join(fixturesRoot, fixtureId, step.expectedFile),

--- a/src/__tests__/fixtures/agent-failures/missing-test-warn/remediation.expected.json
+++ b/src/__tests__/fixtures/agent-failures/missing-test-warn/remediation.expected.json
@@ -5,7 +5,7 @@
   "advisory_count": 0,
   "loop_round": 0,
   "max_loop_rounds": 5,
-  "next_action": "human_review_required",
+  "next_action": "fix_and_retry",
   "fix_codes": [{ "code": "risk.test_coverage", "severity": "warn" }],
   "fixes_introduced": ["risk.test_coverage"],
   "fixes_resolved": []

--- a/src/__tests__/fixtures/agent-failures/mock-placeholder/remediation.expected.json
+++ b/src/__tests__/fixtures/agent-failures/mock-placeholder/remediation.expected.json
@@ -5,7 +5,7 @@
   "advisory_count": 0,
   "loop_round": 0,
   "max_loop_rounds": 5,
-  "next_action": "fix_and_retry",
+  "next_action": "human_review_required",
   "fix_codes": [{ "code": "submission.mock_placeholder", "severity": "blocking" }],
   "fixes_introduced": ["submission.mock_placeholder"],
   "fixes_resolved": []

--- a/src/__tests__/fixtures/agent-failures/multi-fix/remediation.expected.json
+++ b/src/__tests__/fixtures/agent-failures/multi-fix/remediation.expected.json
@@ -5,7 +5,7 @@
   "advisory_count": 0,
   "loop_round": 0,
   "max_loop_rounds": 5,
-  "next_action": "fix_and_retry",
+  "next_action": "human_review_required",
   "fix_codes": [
     { "code": "ci.failed", "severity": "blocking" },
     { "code": "risk.sensitive_files", "severity": "warn" },

--- a/src/__tests__/fixtures/agent-failures/phantom-file/remediation.expected.json
+++ b/src/__tests__/fixtures/agent-failures/phantom-file/remediation.expected.json
@@ -5,7 +5,7 @@
   "advisory_count": 0,
   "loop_round": 0,
   "max_loop_rounds": 5,
-  "next_action": "fix_and_retry",
+  "next_action": "human_review_required",
   "fix_codes": [{ "code": "submission.artifact_integrity", "severity": "blocking" }],
   "fixes_introduced": ["submission.artifact_integrity"],
   "fixes_resolved": []

--- a/src/__tests__/fixtures/agent-failures/stale-naming/remediation.expected.json
+++ b/src/__tests__/fixtures/agent-failures/stale-naming/remediation.expected.json
@@ -5,7 +5,7 @@
   "advisory_count": 0,
   "loop_round": 0,
   "max_loop_rounds": 5,
-  "next_action": "human_review_required",
+  "next_action": "fix_and_retry",
   "fix_codes": [{ "code": "submission.context_freshness", "severity": "warn" }],
   "fixes_introduced": ["submission.context_freshness"],
   "fixes_resolved": []

--- a/src/__tests__/remediation-lanes.test.ts
+++ b/src/__tests__/remediation-lanes.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "vitest";
+import {
+  classifyFixLane,
+  computeNextAction,
+  hasRedLaneFindings,
+  isAgentProvenanceType,
+} from "../remediation-lanes.js";
+import type { RemediationFix } from "../types.js";
+
+function fix(
+  code: string,
+  severity: RemediationFix["severity"] = "blocking",
+): RemediationFix {
+  return {
+    code,
+    severity,
+    title: code,
+    detail: "detail",
+    files: [],
+    autofix_eligible: false,
+  };
+}
+
+describe("classifyFixLane", () => {
+  it("marks dangerous submission and policy codes as red", () => {
+    expect(classifyFixLane("submission.mock_placeholder")).toBe("red");
+    expect(classifyFixLane("submission.artifact_integrity")).toBe("red");
+    expect(classifyFixLane("risk.sensitive_files")).toBe("red");
+  });
+
+  it("marks routine codes as yellow", () => {
+    expect(classifyFixLane("risk.test_coverage")).toBe("yellow");
+    expect(classifyFixLane("submission.context_freshness")).toBe("yellow");
+    expect(classifyFixLane("ci.failed")).toBe("yellow");
+  });
+});
+
+describe("isAgentProvenanceType", () => {
+  it("treats non-human automation as agent provenance", () => {
+    expect(isAgentProvenanceType("claude")).toBe(true);
+    expect(isAgentProvenanceType("unknown")).toBe(true);
+    expect(isAgentProvenanceType("human")).toBe(false);
+    expect(isAgentProvenanceType(undefined)).toBe(false);
+  });
+});
+
+describe("computeNextAction agent lane routing", () => {
+  it("routes routine warn-only findings to fix_and_retry for agents", () => {
+    expect(
+      computeNextAction({
+        releaseReady: false,
+        blockingCount: 0,
+        warnCount: 1,
+        advisoryCount: 0,
+        loopRound: 0,
+        maxLoopRounds: 5,
+        agentProvenance: true,
+        fixes: [fix("risk.test_coverage", "warn")],
+      }),
+    ).toBe("fix_and_retry");
+  });
+
+  it("routes red-lane findings to human_review_required for agents", () => {
+    expect(
+      computeNextAction({
+        releaseReady: false,
+        blockingCount: 1,
+        warnCount: 0,
+        advisoryCount: 0,
+        loopRound: 0,
+        maxLoopRounds: 5,
+        agentProvenance: true,
+        fixes: [fix("submission.mock_placeholder")],
+      }),
+    ).toBe("human_review_required");
+  });
+
+  it("routes routine blocking findings to fix_and_retry for agents", () => {
+    expect(
+      computeNextAction({
+        releaseReady: false,
+        blockingCount: 1,
+        warnCount: 0,
+        advisoryCount: 0,
+        loopRound: 0,
+        maxLoopRounds: 5,
+        agentProvenance: true,
+        fixes: [fix("risk.test_coverage")],
+      }),
+    ).toBe("fix_and_retry");
+  });
+
+  it("keeps human warn-only PRs on human_review_required (legacy)", () => {
+    expect(
+      computeNextAction({
+        releaseReady: false,
+        blockingCount: 0,
+        warnCount: 1,
+        advisoryCount: 0,
+        loopRound: 0,
+        maxLoopRounds: 5,
+        agentProvenance: false,
+        fixes: [fix("risk.test_coverage", "warn")],
+      }),
+    ).toBe("human_review_required");
+  });
+
+  it("requires human review when release-ready but red-lane findings remain", () => {
+    expect(
+      computeNextAction({
+        releaseReady: true,
+        blockingCount: 0,
+        warnCount: 1,
+        advisoryCount: 0,
+        loopRound: 2,
+        maxLoopRounds: 5,
+        agentProvenance: true,
+        fixes: [fix("risk.sensitive_files", "warn")],
+      }),
+    ).toBe("human_review_required");
+    expect(hasRedLaneFindings([fix("risk.sensitive_files", "warn")])).toBe(true);
+  });
+});

--- a/src/__tests__/remediation.test.ts
+++ b/src/__tests__/remediation.test.ts
@@ -322,11 +322,45 @@ describe("buildRemediation", () => {
         }),
         loopRound: 1,
         maxLoopRounds: 5,
+        agentProvenance: true,
       });
       expect(remediation.next_action).toBe("fix_and_retry");
     });
 
-    it("returns human_review_required when not release-ready but no blockers", () => {
+    it("returns fix_and_retry for agent warn-only routine findings", () => {
+      const remediation = buildRemediation({
+        evaluation: evaluationFixture({
+          gateDecision: "warn",
+          releaseReady: false,
+          riskFactors: [factor("test_coverage", 45, { missing_tests: ["src/foo.ts"] })],
+        }),
+        agentProvenance: true,
+      });
+      expect(remediation.next_action).toBe("fix_and_retry");
+    });
+
+    it("returns human_review_required for agent red-lane findings", () => {
+      const remediation = buildRemediation({
+        evaluation: evaluationFixture({
+          gateDecision: "block",
+          releaseReady: false,
+          riskFactors: [],
+        }),
+        submissionChecks: [
+          {
+            code: "mock_placeholder",
+            severity: "blocking",
+            title: "Mock leak",
+            detail: "TODO(mock) in handler",
+            files: ["src/handler.ts"],
+          },
+        ],
+        agentProvenance: true,
+      });
+      expect(remediation.next_action).toBe("human_review_required");
+    });
+
+    it("returns human_review_required when not release-ready but no blockers (human PR)", () => {
       const remediation = buildRemediation({
         evaluation: evaluationFixture({
           gateDecision: "warn",

--- a/src/gate.ts
+++ b/src/gate.ts
@@ -54,6 +54,7 @@ import {
   buildRemediation,
   formatAgentBrief,
   resolveAgentBriefMode,
+  isAgentProvenanceType,
 } from "./remediation.js";
 import {
   fetchPreviousEvaluationForPr,
@@ -978,10 +979,6 @@ interface AgentPolicyEnforcementResult {
   adjustedRiskThreshold?: number;
   forceBlock: boolean;
   findings: string[];
-}
-
-function isAgentProvenanceType(type: PrProvenance["type"]): boolean {
-  return type !== "human";
 }
 
 async function enforceAgentPrPolicies(params: {
@@ -2050,6 +2047,9 @@ export async function evaluateGate(
       },
       previousEvaluation,
       maxLoopRounds: remediationSettings?.max_loop_rounds ?? 3,
+      agentProvenance: isAgentProvenanceType(
+        localEvaluation.pr?.provenance?.type ?? "unknown",
+      ),
     });
   }
 

--- a/src/remediation-lanes.ts
+++ b/src/remediation-lanes.ts
@@ -1,0 +1,75 @@
+// Lane classification for remediation next_action routing (v4.3 agent autonomy).
+// Red-lane findings require human review; yellow-lane (routine) findings loop to the agent.
+
+import type { RemediationFix, RemediationNextAction } from "./types.js";
+
+/** Fix codes that always require human review for agent-provenance PRs. */
+export const RED_LANE_FIX_CODES = new Set([
+  "submission.artifact_integrity",
+  "submission.mock_placeholder",
+  "policy.workflow_security",
+  "policy.prompt_injection",
+  "policy.ci_integrity",
+  "policy.finding",
+  "security.code_scanning",
+  "risk.sensitive_files",
+  "risk.supply_chain",
+]);
+
+/** Routine (yellow-lane) fix codes — agent should fix_and_retry. */
+export const ROUTINE_FIX_CODES = new Set([
+  "risk.test_coverage",
+  "submission.context_freshness",
+  "policy.pr_scope",
+  "policy.duplicate_logic",
+  "ci.failed",
+  "ci.missing",
+]);
+
+export type RemediationLane = "red" | "yellow" | "unknown";
+
+export function classifyFixLane(code: string): RemediationLane {
+  if (RED_LANE_FIX_CODES.has(code)) return "red";
+  if (ROUTINE_FIX_CODES.has(code)) return "yellow";
+  return "unknown";
+}
+
+export function hasRedLaneFindings(fixes: RemediationFix[]): boolean {
+  return fixes.some((fix) => classifyFixLane(fix.code) === "red");
+}
+
+export function isAgentProvenanceType(provenanceType: string | undefined): boolean {
+  return provenanceType !== undefined && provenanceType !== "human";
+}
+
+export function computeNextAction(args: {
+  releaseReady: boolean;
+  blockingCount: number;
+  warnCount: number;
+  advisoryCount: number;
+  loopRound: number;
+  maxLoopRounds: number;
+  redLane?: boolean;
+  agentProvenance?: boolean;
+  fixes: RemediationFix[];
+}): RemediationNextAction {
+  const redLane = args.redLane === true || hasRedLaneFindings(args.fixes);
+
+  if (args.releaseReady) {
+    return redLane ? "human_review_required" : "ready_to_merge";
+  }
+
+  if (args.agentProvenance) {
+    if (redLane) return "human_review_required";
+    if (args.loopRound >= args.maxLoopRounds) return "max_rounds_exceeded";
+    if (args.blockingCount > 0 || args.warnCount > 0 || args.advisoryCount > 0) {
+      return "fix_and_retry";
+    }
+    return "human_review_required";
+  }
+
+  // Human-provenance PRs — preserve legacy behavior.
+  if (args.blockingCount === 0) return "human_review_required";
+  if (args.loopRound >= args.maxLoopRounds) return "max_rounds_exceeded";
+  return "fix_and_retry";
+}

--- a/src/remediation.ts
+++ b/src/remediation.ts
@@ -11,13 +11,21 @@ import { RemediationFix as RemediationFixSchema } from "./types.js";
 import { resolveLoopRound } from "./loop-bookkeeping.js";
 import { deriveSubmissionFixes } from "./submission-remediation.js";
 import type { SubmissionCheckResult } from "./submission-remediation.js";
+import { computeNextAction } from "./remediation-lanes.js";
+export {
+  RED_LANE_FIX_CODES,
+  ROUTINE_FIX_CODES,
+  classifyFixLane,
+  hasRedLaneFindings,
+  isAgentProvenanceType,
+  computeNextAction,
+} from "./remediation-lanes.js";
 import type {
   AgentBriefMode,
   GateEvaluation,
   PrProvenance,
   Remediation,
   RemediationAutofixClass,
-  RemediationNextAction,
   RemediationSeverity,
   RiskFactor,
 } from "./types.js";
@@ -272,25 +280,6 @@ function diffFixCodes(
   return { resolved, introduced };
 }
 
-function computeNextAction(args: {
-  releaseReady: boolean;
-  blockingCount: number;
-  loopRound: number;
-  maxLoopRounds: number;
-  redLane?: boolean;
-}): RemediationNextAction {
-  if (args.releaseReady) {
-    return args.redLane ? "human_review_required" : "ready_to_merge";
-  }
-  if (args.blockingCount === 0) {
-    return "human_review_required";
-  }
-  if (args.loopRound >= args.maxLoopRounds) {
-    return "max_rounds_exceeded";
-  }
-  return "fix_and_retry";
-}
-
 export function buildRemediation(input: BuildRemediationInput): Remediation {
   const fixes: RemediationFix[] = [];
 
@@ -350,8 +339,12 @@ export function buildRemediation(input: BuildRemediationInput): Remediation {
   const next_action = computeNextAction({
     releaseReady,
     blockingCount: blocking_count,
+    warnCount: warn_count,
+    advisoryCount: advisory_count,
     loopRound,
     maxLoopRounds,
+    agentProvenance: input.agentProvenance,
+    fixes: dedupedFixes,
   });
 
   return {


### PR DESCRIPTION
## Summary
- Adds `remediation-lanes.ts` to route agent PR `next_action` by finding severity lane
- Red-lane (dangerous) findings → `human_review_required`; routine yellow-lane → `fix_and_retry`
- Human PRs keep legacy `blocking_count` behavior
- Updates A8 fixture golden expectations and adds unit tests

Follow-up to #240 — that merge landed before this commit was included.

## Test plan
- [x] `npm test` — 646 passing
- [x] Fixture expectations updated for phantom-file, mock-placeholder, multi-fix, missing-test-warn, stale-naming

Made with [Cursor](https://cursor.com)