### PR TITLE
feat(cloud): A5 tuning digest + agent stats

### DIFF
--- a/cloud/migrations/003_tuning_digest_a5.sql
+++ b/cloud/migrations/003_tuning_digest_a5.sql
@@ -1,0 +1,36 @@
+-- A5 tuning digest — agent provenance + detector downgrade audit
+-- Trailhead Cloud reference migration.
+-- Komatik fleet store: apply equivalent via Komatik PR (never MCP prod DDL).
+
+ALTER TABLE trailhead_evaluations
+  ADD COLUMN IF NOT EXISTS agent_provenance_id text;
+
+CREATE INDEX IF NOT EXISTS idx_trailhead_evals_agent_provenance
+  ON trailhead_evaluations (agent_provenance_id, created_at DESC)
+  WHERE agent_provenance_id IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS trailhead_detector_downgrades (
+  detector_code text PRIMARY KEY,
+  downgraded_at timestamptz NOT NULL DEFAULT now(),
+  fp_rate_at_trigger numeric NOT NULL,
+  tuning_issue_url text,
+  reverted_at timestamptz,
+  reverted_by text
+);
+
+ALTER TABLE trailhead_detector_downgrades ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "service role only" ON trailhead_detector_downgrades
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+COMMENT ON COLUMN trailhead_evaluations.agent_provenance_id IS
+  'Denormalised pr.provenance.source for fast agent group-by (A5).';
+
+-- Best-effort backfill from pr JSONB
+UPDATE trailhead_evaluations
+SET agent_provenance_id = COALESCE(
+  pr->'provenance'->>'source',
+  substring(pr->>'headRef' from '^agent/([^/]+)/')
+)
+WHERE agent_provenance_id IS NULL
+  AND pr IS NOT NULL;

--- a/cloud/src/app.test.ts
+++ b/cloud/src/app.test.ts
@@ -273,4 +273,85 @@ describe("Trailhead Cloud API", () => {
     });
     expect(res.status).toBe(403);
   });
+
+  it("returns tuning digest v1 for a repo", async () => {
+    await app.request("/v1/evaluations", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({
+        ...sampleEvaluation("tuning-1"),
+        gateDecision: "warn",
+        agentProvenanceId: "frontend-dev",
+        remediation: {
+          fixes: [{ code: "risk.test_coverage", severity: "warn" }],
+        },
+        pr: { headRef: "agent/frontend-dev/fix-nav" },
+      }),
+    });
+
+    const res = await app.request(
+      "/v1/digest/tuning?repo_id=KomatikAI/trailhead&days=30",
+      { headers: authHeaders() },
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { schema: string; totals: { agent_prs: number } };
+    expect(body.schema).toBe("trailhead.tuning-digest.v1");
+    expect(body.totals.agent_prs).toBeGreaterThan(0);
+  });
+
+  it("returns per-agent recent evaluations", async () => {
+    await app.request("/v1/evaluations", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({
+        ...sampleEvaluation("agent-1"),
+        releaseReady: true,
+        agentProvenanceId: "frontend-dev",
+        remediation: { loop_round: 2, next_action: "ready_to_merge" },
+      }),
+    });
+
+    const res = await app.request("/v1/agents/frontend-dev/recent-evaluations?days=30", {
+      headers: authHeaders(),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { agent_id: string; evaluations: number };
+    expect(body.agent_id).toBe("frontend-dev");
+    expect(body.evaluations).toBeGreaterThan(0);
+  });
+
+  it("runs auto-downgrade when FP threshold exceeded", async () => {
+    for (let i = 0; i < 10; i += 1) {
+      await app.request("/v1/evaluations", {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify({
+          ...sampleEvaluation(`ad-${i}`),
+          gateDecision: "warn",
+          remediation: {
+            fixes: [{ code: "policy.duplicate_logic", severity: "warn" }],
+          },
+        }),
+      });
+    }
+    for (let i = 0; i < 6; i += 1) {
+      await app.request("/v1/feedback", {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify({
+          detector: "policy.duplicate_logic",
+          disposition: "false_positive",
+          repo: "KomatikAI/trailhead",
+        }),
+      });
+    }
+
+    const res = await app.request("/v1/tuning/auto-downgrade/run", {
+      method: "POST",
+      headers: authHeaders(),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { count: number };
+    expect(body.count).toBeGreaterThan(0);
+  });
 });

--- a/cloud/src/app.ts
+++ b/cloud/src/app.ts
@@ -8,6 +8,12 @@ import {
   generateTuningYaml,
   recommendPolicyTuning,
 } from "./feedback-core.js";
+import {
+  buildAgentRecentEvaluations,
+  buildTuningDigestV1,
+  evaluateAutoDowngradeCandidates,
+  type DetectorDowngradeRecord,
+} from "./tuning-digest.js";
 import { createMemoryStore, parseSeedKeys } from "./store.js";
 import type { ApiKeyRecord, CloudStore, RateLimitState } from "./types.js";
 import {
@@ -297,8 +303,27 @@ export function createCloudApp(options: CloudAppOptions = {}): Hono {
   app.get("/v1/digest/preview", (c) => {
     const orgId = c.get("orgId") as string;
     const orgName = c.get("orgName") as string;
+    const repoId = c.req.query("repo_id") || undefined;
+    const schema = c.req.query("schema") ?? "legacy";
     const settings = store.getOrgSettings(orgId);
     const fpThreshold = settings.digest?.fpThreshold ?? 15;
+
+    if (schema === "v1" && repoId) {
+      const digest = buildTuningDigestV1({
+        repoId,
+        evaluations: store.listAllEvaluations(orgId),
+        feedback: store.listFeedback(orgId, repoId),
+        downgrades: store.listDetectorDowngrades(orgId),
+        fpThreshold: fpThreshold / 100,
+      });
+      return c.json({
+        enabled: settings.digest?.enabled ?? false,
+        channel: settings.digest?.channel ?? null,
+        destination: settings.digest?.destination ?? null,
+        ...digest,
+      });
+    }
+
     const noise = aggregateDetectorNoise(store.listFeedback(orgId), { fpThreshold });
     const digest = buildDigestPayload(noise, orgName);
     return c.json({
@@ -307,6 +332,125 @@ export function createCloudApp(options: CloudAppOptions = {}): Hono {
       destination: settings.digest?.destination ?? null,
       ...digest,
     });
+  });
+
+  app.get("/v1/digest/tuning", (c) => {
+    const orgId = c.get("orgId") as string;
+    const repoId = c.req.query("repo_id");
+    if (!repoId) {
+      return c.json({ error: "repo_id query parameter is required" }, 400);
+    }
+    const daysRaw = c.req.query("days");
+    const days = daysRaw ? parseInt(daysRaw, 10) : 7;
+    const settings = store.getOrgSettings(orgId);
+    const fpThreshold = (settings.digest?.fpThreshold ?? 15) / 100;
+    const digest = buildTuningDigestV1({
+      repoId,
+      evaluations: store.listAllEvaluations(orgId),
+      feedback: store.listFeedback(orgId, repoId),
+      downgrades: store.listDetectorDowngrades(orgId),
+      days: Number.isFinite(days) && days > 0 ? days : 7,
+      fpThreshold,
+    });
+    return c.json(digest);
+  });
+
+  app.post("/v1/digest/tuning/deliver", async (c) => {
+    const orgId = c.get("orgId") as string;
+    const settings = store.getOrgSettings(orgId);
+    if (!settings.digest?.enabled || !settings.digest.destination) {
+      return c.json({ error: "digest not configured — subscribe first" }, 400);
+    }
+
+    const daysRaw = c.req.query("days");
+    const days = daysRaw ? parseInt(daysRaw, 10) : 7;
+    const fpThreshold = (settings.digest.fpThreshold ?? 15) / 100;
+    const repos = store.listRepos(orgId);
+    const delivered: Array<{ repo: string; status: number }> = [];
+
+    for (const repo of repos) {
+      const digest = buildTuningDigestV1({
+        repoId: repo.fullName,
+        evaluations: store.listAllEvaluations(orgId),
+        feedback: store.listFeedback(orgId, repo.fullName),
+        downgrades: store.listDetectorDowngrades(orgId),
+        days: Number.isFinite(days) && days > 0 ? days : 7,
+        fpThreshold,
+      });
+      const response = await fetch(settings.digest.destination, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(digest),
+        signal: AbortSignal.timeout(10_000),
+      });
+      delivered.push({ repo: repo.fullName, status: response.status });
+    }
+
+    return c.json({ delivered, count: delivered.length });
+  });
+
+  app.get("/v1/agents/:agentId/recent-evaluations", (c) => {
+    const orgId = c.get("orgId") as string;
+    const agentId = c.req.param("agentId");
+    const repoId = c.req.query("repo_id") || undefined;
+    const daysRaw = c.req.query("days");
+    const days = daysRaw ? parseInt(daysRaw, 10) : 30;
+    const stats = buildAgentRecentEvaluations({
+      agentId,
+      evaluations: store.listAllEvaluations(orgId),
+      repoId,
+      days: Number.isFinite(days) && days > 0 ? days : 30,
+    });
+    return c.json(stats);
+  });
+
+  app.post("/v1/tuning/auto-downgrade/run", async (c) => {
+    const orgId = c.get("orgId") as string;
+    const settings = store.getOrgSettings(orgId);
+    if (settings.tuning?.autoDowngrade === false) {
+      return c.json({ skipped: true, reason: "auto_downgrade disabled for org" });
+    }
+
+    const daysRaw = c.req.query("days");
+    const days = daysRaw ? parseInt(daysRaw, 10) : 7;
+    const fpThreshold = (store.getOrgSettings(orgId).digest?.fpThreshold ?? 15) / 100;
+    const candidates = evaluateAutoDowngradeCandidates({
+      evaluations: store.listAllEvaluations(orgId),
+      feedback: store.listFeedback(orgId),
+      downgrades: store.listDetectorDowngrades(orgId),
+      days: Number.isFinite(days) && days > 0 ? days : 7,
+      fpThreshold,
+    });
+
+    const applied: DetectorDowngradeRecord[] = [];
+    for (const candidate of candidates) {
+      const record: DetectorDowngradeRecord = {
+        detectorCode: candidate.detector,
+        downgradedAt: new Date().toISOString(),
+        fpRateAtTrigger: candidate.fpRate,
+        tuningIssueUrl: `https://github.com/KomatikAI/trailhead/issues/new?title=${encodeURIComponent(`[tune] detector ${candidate.detector} auto-downgraded (FP rate ${Math.round(candidate.fpRate * 100)}%)`)}`,
+      };
+      store.recordDetectorDowngrade(orgId, record);
+      applied.push(record);
+
+      const destination = settings.digest?.destination;
+      if (destination) {
+        await fetch(destination, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            event: "trailhead.detector_auto_downgraded",
+            detector: candidate.detector,
+            fp_rate: candidate.fpRate,
+            emissions: candidate.emissions,
+            tuning_issue: record.tuningIssueUrl,
+          }),
+          signal: AbortSignal.timeout(10_000),
+        }).catch(() => undefined);
+      }
+    }
+
+    return c.json({ applied, count: applied.length });
   });
 
   app.get("/v1/org/settings", (c) => {

--- a/cloud/src/store.ts
+++ b/cloud/src/store.ts
@@ -38,6 +38,10 @@ export function createMemoryStore(seedKeys: ApiKeyRecord[] = []): CloudStore {
   const deployEvents: Array<{ orgId: string; payload: DeployEventPayload }> = [];
   const feedback: DetectorFeedbackRecord[] = [];
   const usageByOrgMonth = new Map<string, number>();
+  const detectorDowngrades = new Map<
+    string,
+    Map<string, import("./tuning-digest.js").DetectorDowngradeRecord>
+  >();
 
   function ensureOrg(orgId: string, orgName: string): OrgRecord {
     const existing = orgs.get(orgId);
@@ -152,6 +156,13 @@ export function createMemoryStore(seedKeys: ApiKeyRecord[] = []): CloudStore {
         ...payload,
         orgId,
         receivedAt,
+        agentProvenanceId:
+          typeof payload.agentProvenanceId === "string"
+            ? payload.agentProvenanceId
+            : typeof (payload as { agent_provenance_id?: string }).agent_provenance_id ===
+                "string"
+              ? (payload as { agent_provenance_id: string }).agent_provenance_id
+              : undefined,
       };
       evaluations.set(stored.id, stored);
       idempotency.set(`${orgId}:${idem}`, stored.id);
@@ -278,6 +289,34 @@ export function createMemoryStore(seedKeys: ApiKeyRecord[] = []): CloudStore {
       orgId: string,
     ): Array<{ orgId: string; payload: DeployEventPayload }> {
       return deployEvents.filter((e) => e.orgId === orgId);
+    },
+
+    listDetectorDowngrades(orgId: string) {
+      const rows = detectorDowngrades.get(orgId);
+      return rows ? [...rows.values()] : [];
+    },
+
+    recordDetectorDowngrade(orgId, record) {
+      let orgRows = detectorDowngrades.get(orgId);
+      if (!orgRows) {
+        orgRows = new Map();
+        detectorDowngrades.set(orgId, orgRows);
+      }
+      orgRows.set(record.detectorCode, record);
+      return record;
+    },
+
+    revertDetectorDowngrade(orgId, detectorCode, revertedBy) {
+      const orgRows = detectorDowngrades.get(orgId);
+      const existing = orgRows?.get(detectorCode);
+      if (!existing || existing.revertedAt) return null;
+      const next = {
+        ...existing,
+        revertedAt: new Date().toISOString(),
+        revertedBy,
+      };
+      orgRows!.set(detectorCode, next);
+      return next;
     },
   };
 }

--- a/cloud/src/store.ts
+++ b/cloud/src/store.ts
@@ -152,17 +152,17 @@ export function createMemoryStore(seedKeys: ApiKeyRecord[] = []): CloudStore {
       }
 
       const receivedAt = new Date().toISOString();
+      const agentFromPayload =
+        typeof payload.agentProvenanceId === "string"
+          ? payload.agentProvenanceId
+          : typeof (payload as Record<string, unknown>).agent_provenance_id === "string"
+            ? ((payload as Record<string, unknown>).agent_provenance_id as string)
+            : undefined;
       const stored: StoredEvaluation = {
         ...payload,
         orgId,
         receivedAt,
-        agentProvenanceId:
-          typeof payload.agentProvenanceId === "string"
-            ? payload.agentProvenanceId
-            : typeof (payload as { agent_provenance_id?: string }).agent_provenance_id ===
-                "string"
-              ? (payload as { agent_provenance_id: string }).agent_provenance_id
-              : undefined,
+        agentProvenanceId: agentFromPayload,
       };
       evaluations.set(stored.id, stored);
       idempotency.set(`${orgId}:${idem}`, stored.id);

--- a/cloud/src/tuning-digest.test.ts
+++ b/cloud/src/tuning-digest.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildAgentRecentEvaluations,
+  buildTuningDigestV1,
+  evaluateAutoDowngradeCandidates,
+} from "./tuning-digest.js";
+import type { DetectorFeedbackRecord } from "./feedback-core.js";
+import type { StoredEvaluation } from "./types.js";
+
+function evalRow(overrides: Partial<StoredEvaluation> = {}): StoredEvaluation {
+  return {
+    id: "e1",
+    orgId: "komatik",
+    repoId: "KomatikAI/trailhead",
+    commitSha: "abc",
+    healthScore: 100,
+    riskScore: 40,
+    gateDecision: "warn",
+    healthChecks: [],
+    riskFactors: [],
+    evaluationMs: 10,
+    receivedAt: "2026-05-20T12:00:00.000Z",
+    prNumber: 42,
+    ...overrides,
+  };
+}
+
+function feedback(
+  overrides: Partial<DetectorFeedbackRecord> = {},
+): DetectorFeedbackRecord {
+  return {
+    id: "fb-1",
+    orgId: "komatik",
+    detector: "policy.duplicate_logic",
+    disposition: "false_positive",
+    repo: "KomatikAI/trailhead",
+    timestamp: "2026-05-20T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("tuning-digest", () => {
+  it("builds v1 digest with detector FP rates", () => {
+    const evaluations = [
+      evalRow({
+        id: "1",
+        gateDecision: "warn",
+        remediation: {
+          fixes: [{ code: "policy.duplicate_logic", severity: "warn" }],
+        },
+        pr: {
+          headRef: "agent/frontend-dev/fix",
+          provenance: { type: "claude", confidence: 0.9, source: "frontend-dev" },
+        },
+      }),
+      evalRow({
+        id: "2",
+        gateDecision: "block",
+        remediation: {
+          fixes: [{ code: "policy.duplicate_logic", severity: "blocking" }],
+        },
+      }),
+    ];
+    const feedbackRows = Array.from({ length: 6 }, (_, i) => feedback({ id: `fp-${i}` }));
+
+    const digest = buildTuningDigestV1({
+      repoId: "KomatikAI/trailhead",
+      evaluations,
+      feedback: feedbackRows,
+      downgrades: [],
+      now: new Date("2026-05-22"),
+    });
+
+    expect(digest.schema).toBe("trailhead.tuning-digest.v1");
+    expect(digest.totals.evaluations).toBe(2);
+    expect(digest.totals.agent_prs).toBe(1);
+    const detector = digest.detectors.find((d) => d.code === "policy.duplicate_logic");
+    expect(detector?.fp_rate).toBe(3);
+    expect(detector?.status).toBe("noisy");
+  });
+
+  it("returns agent recent evaluations with trust signal", () => {
+    const evaluations = Array.from({ length: 12 }, (_, i) =>
+      evalRow({
+        id: `a-${i}`,
+        gateDecision: i % 3 === 0 ? "block" : "allow",
+        releaseReady: i % 3 !== 0,
+        agentProvenanceId: "frontend-dev",
+        remediation: {
+          loop_round: 2,
+          next_action: i % 3 !== 0 ? "ready_to_merge" : "fix_and_retry",
+          fixes: [{ code: "risk.test_coverage" }],
+        },
+      }),
+    );
+
+    const stats = buildAgentRecentEvaluations({
+      agentId: "frontend-dev",
+      evaluations,
+      now: new Date("2026-05-22"),
+    });
+
+    expect(stats.evaluations).toBe(12);
+    expect(stats.trust_signal_v1).toBe("converging");
+    expect(stats.top_detectors[0]?.code).toBe("risk.test_coverage");
+  });
+
+  it("flags auto-downgrade candidates at fleet threshold", () => {
+    const evaluations = Array.from({ length: 12 }, (_, i) =>
+      evalRow({
+        id: `d-${i}`,
+        gateDecision: i < 2 ? "block" : "warn",
+        remediation: {
+          fixes: [{ code: "policy.duplicate_logic", severity: "warn" }],
+        },
+      }),
+    );
+    const feedbackRows = Array.from({ length: 6 }, (_, i) => feedback({ id: `fp-${i}` }));
+
+    const candidates = evaluateAutoDowngradeCandidates({
+      evaluations,
+      feedback: feedbackRows,
+      downgrades: [],
+      now: new Date("2026-05-22"),
+      minEmissions: 10,
+      fpThreshold: 0.15,
+    });
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].detector).toBe("policy.duplicate_logic");
+    expect(candidates[0].fpRate).toBeGreaterThanOrEqual(0.15);
+  });
+});

--- a/cloud/src/tuning-digest.ts
+++ b/cloud/src/tuning-digest.ts
@@ -1,0 +1,534 @@
+import type { DetectorFeedbackRecord } from "./feedback-core.js";
+import type { StoredEvaluation } from "./types.js";
+
+export interface TuningDigestWindow {
+  start: string;
+  end: string;
+  days: number;
+}
+
+export interface TuningDigestDetectorRow {
+  code: string;
+  blocked: number;
+  warned: number;
+  fixed_after_remediation: number;
+  fp_signals: number;
+  fp_rate: number;
+  status: "ok" | "auto_downgraded" | "noisy";
+  downgraded_at?: string;
+}
+
+export interface TuningDigestAgentRow {
+  agent_id: string;
+  prs: number;
+  ready: number;
+  blocked: number;
+  abandoned: number;
+  median_rounds_to_ready: number | null;
+  sensitive_path_violations: number;
+  trust_signal: "converging" | "flailing" | "quiet";
+}
+
+export interface TuningDigestPayload {
+  schema: "trailhead.tuning-digest.v1";
+  repo: string;
+  window: TuningDigestWindow;
+  totals: {
+    evaluations: number;
+    block: number;
+    warn: number;
+    allow: number;
+    overrides: number;
+    agent_prs: number;
+  };
+  detectors: TuningDigestDetectorRow[];
+  agents: TuningDigestAgentRow[];
+  overrides: Array<{
+    pr_url?: string;
+    author?: string;
+    reason?: string;
+    pre_decision?: string;
+  }>;
+  auto_downgrades_last_7d: Array<{
+    detector: string;
+    downgraded_at: string;
+    fp_rate_at_trigger: number;
+    tuning_issue?: string;
+  }>;
+}
+
+export interface AgentRecentEvaluationsPayload {
+  agent_id: string;
+  window_days: number;
+  evaluations: number;
+  decisions: { allow: number; warn: number; block: number };
+  ready_without_human: number;
+  median_rounds_to_ready: number | null;
+  p95_rounds_to_ready: number | null;
+  sensitive_path_violations: number;
+  top_detectors: Array<{ code: string; count: number }>;
+  trust_signal_v1: "converging" | "flailing" | "quiet";
+}
+
+export interface DetectorDowngradeRecord {
+  detectorCode: string;
+  downgradedAt: string;
+  fpRateAtTrigger: number;
+  tuningIssueUrl?: string;
+  revertedAt?: string;
+  revertedBy?: string;
+}
+
+export interface AutoDowngradeCandidate {
+  detector: string;
+  fpRate: number;
+  emissions: number;
+  fpSignals: number;
+  alreadyDowngraded: boolean;
+}
+
+function inWindow(iso: string, start: Date, end: Date): boolean {
+  const ts = new Date(iso).getTime();
+  return ts >= start.getTime() && ts < end.getTime();
+}
+
+function median(values: number[]): number | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? Math.round(((sorted[mid - 1] + sorted[mid]) / 2) * 10) / 10
+    : sorted[mid];
+}
+
+function percentile(values: number[], p: number): number | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const idx = Math.ceil((p / 100) * sorted.length) - 1;
+  return sorted[Math.max(0, idx)];
+}
+
+export function resolveAgentProvenanceId(row: StoredEvaluation): string | null {
+  const direct =
+    (row as { agentProvenanceId?: string; agent_provenance_id?: string })
+      .agentProvenanceId ?? (row as { agent_provenance_id?: string }).agent_provenance_id;
+  if (typeof direct === "string" && direct.trim()) return direct.trim();
+
+  const pr = row.pr as
+    | { headRef?: string; provenance?: { source?: string; type?: string } }
+    | undefined;
+  if (pr?.provenance?.source?.trim()) return pr.provenance.source.trim();
+  if (pr?.headRef) {
+    const match = pr.headRef.match(/^agent\/([a-z0-9-]+)\//i);
+    if (match?.[1]) return match[1];
+  }
+  if (pr?.provenance?.type && pr.provenance.type !== "human") {
+    return pr.provenance.type;
+  }
+  return null;
+}
+
+export function extractDetectorCodes(row: StoredEvaluation): string[] {
+  const codes = new Set<string>();
+  const remediation = row.remediation as { fixes?: Array<{ code: string }> } | undefined;
+  for (const fix of remediation?.fixes ?? []) {
+    if (fix.code) codes.add(fix.code);
+  }
+  for (const factor of row.riskFactors ?? []) {
+    if (typeof factor === "object" && factor !== null && "type" in factor) {
+      const type = String((factor as { type: string }).type);
+      if (type) codes.add(`risk.${type}`);
+    }
+  }
+  const policyOverride = row.policyOverride ?? row.policy_override;
+  if (policyOverride) {
+    codes.add("policy.override");
+  }
+  return [...codes];
+}
+
+function filterEvaluations(
+  rows: StoredEvaluation[],
+  options: { repoId?: string; days: number; now?: Date },
+): StoredEvaluation[] {
+  const now = options.now ?? new Date();
+  const start = new Date(now.getTime() - options.days * 86_400_000);
+  return rows.filter(
+    (row) =>
+      inWindow(row.receivedAt, start, now) &&
+      (!options.repoId || row.repoId === options.repoId),
+  );
+}
+
+function filterFeedback(
+  rows: DetectorFeedbackRecord[],
+  options: { repoId?: string; days: number; now?: Date },
+): DetectorFeedbackRecord[] {
+  const now = options.now ?? new Date();
+  const start = new Date(now.getTime() - options.days * 86_400_000);
+  return rows.filter(
+    (row) =>
+      inWindow(row.timestamp, start, now) &&
+      (!options.repoId || !row.repo || row.repo === options.repoId),
+  );
+}
+
+export function buildTuningDigestV1(args: {
+  repoId: string;
+  evaluations: StoredEvaluation[];
+  feedback: DetectorFeedbackRecord[];
+  downgrades: DetectorDowngradeRecord[];
+  days?: number;
+  now?: Date;
+  fpThreshold?: number;
+}): TuningDigestPayload {
+  const days = args.days ?? 7;
+  const now = args.now ?? new Date();
+  const start = new Date(now.getTime() - days * 86_400_000);
+  const fpThreshold = args.fpThreshold ?? 0.15;
+  const window: TuningDigestWindow = {
+    start: start.toISOString(),
+    end: now.toISOString(),
+    days,
+  };
+
+  const evalRows = filterEvaluations(args.evaluations, {
+    repoId: args.repoId,
+    days,
+    now,
+  });
+  const feedbackRows = filterFeedback(args.feedback, {
+    repoId: args.repoId,
+    days,
+    now,
+  });
+
+  const downgradeByCode = new Map(
+    args.downgrades.filter((d) => !d.revertedAt).map((d) => [d.detectorCode, d] as const),
+  );
+
+  const detectorStats = new Map<
+    string,
+    { blocked: number; warned: number; fixed: number }
+  >();
+  const agentStats = new Map<
+    string,
+    {
+      prs: Set<number>;
+      ready: number;
+      blocked: number;
+      abandoned: number;
+      rounds: number[];
+      sensitive: number;
+    }
+  >();
+
+  let block = 0;
+  let warn = 0;
+  let allow = 0;
+  let overrides = 0;
+  let agentPrs = 0;
+
+  const overridesList: TuningDigestPayload["overrides"] = [];
+
+  for (const row of evalRows) {
+    if (row.gateDecision === "block") block += 1;
+    else if (row.gateDecision === "warn") warn += 1;
+    else allow += 1;
+
+    const agentId = resolveAgentProvenanceId(row);
+    if (agentId) agentPrs += 1;
+
+    const policyOverride = row.policyOverride ?? row.policy_override;
+    if (policyOverride) {
+      overrides += 1;
+      const audit = policyOverride as {
+        author?: string;
+        reason?: string;
+        preDecision?: string;
+        pre_decision?: string;
+      };
+      overridesList.push({
+        author: audit.author,
+        reason: audit.reason,
+        pre_decision: audit.preDecision ?? audit.pre_decision,
+        pr_url: row.prNumber
+          ? `https://github.com/${row.repoId}/pull/${row.prNumber}`
+          : undefined,
+      });
+    }
+
+    const codes = extractDetectorCodes(row);
+    for (const code of codes) {
+      const stat = detectorStats.get(code) ?? { blocked: 0, warned: 0, fixed: 0 };
+      if (row.gateDecision === "block") stat.blocked += 1;
+      else if (row.gateDecision === "warn") stat.warned += 1;
+      const remediation = row.remediation as
+        | { fixes_resolved?: unknown[]; next_action?: string }
+        | undefined;
+      if (
+        (remediation?.fixes_resolved?.length ?? 0) > 0 ||
+        remediation?.next_action === "ready_to_merge"
+      ) {
+        stat.fixed += 1;
+      }
+      detectorStats.set(code, stat);
+    }
+
+    if (agentId && row.prNumber !== undefined) {
+      const bucket = agentStats.get(agentId) ?? {
+        prs: new Set<number>(),
+        ready: 0,
+        blocked: 0,
+        abandoned: 0,
+        rounds: [],
+        sensitive: 0,
+      };
+      bucket.prs.add(row.prNumber);
+      const remediation = row.remediation as
+        | { loop_round?: number; next_action?: string }
+        | undefined;
+      if (row.releaseReady === true || remediation?.next_action === "ready_to_merge") {
+        bucket.ready += 1;
+        if (typeof remediation?.loop_round === "number") {
+          bucket.rounds.push(remediation.loop_round);
+        }
+      } else if (row.gateDecision === "block") {
+        bucket.blocked += 1;
+      } else if (remediation?.next_action === "max_rounds_exceeded") {
+        bucket.abandoned += 1;
+      }
+      if (codes.includes("risk.sensitive_files")) bucket.sensitive += 1;
+      agentStats.set(agentId, bucket);
+    }
+  }
+
+  const fpByDetector = new Map<string, number>();
+  for (const fb of feedbackRows) {
+    if (fb.disposition !== "false_positive") continue;
+    fpByDetector.set(fb.detector, (fpByDetector.get(fb.detector) ?? 0) + 1);
+  }
+
+  const detectors: TuningDigestDetectorRow[] = [...detectorStats.entries()]
+    .map(([code, stat]) => {
+      const emissions = stat.blocked + stat.warned;
+      const fp_signals = fpByDetector.get(code) ?? 0;
+      const fp_rate =
+        emissions > 0 ? Math.round((fp_signals / emissions) * 1000) / 1000 : 0;
+      const downgrade = downgradeByCode.get(code);
+      let status: TuningDigestDetectorRow["status"] = "ok";
+      if (downgrade) status = "auto_downgraded";
+      else if (fp_rate >= fpThreshold) status = "noisy";
+
+      return {
+        code,
+        blocked: stat.blocked,
+        warned: stat.warned,
+        fixed_after_remediation: stat.fixed,
+        fp_signals,
+        fp_rate,
+        status,
+        downgraded_at: downgrade?.downgradedAt,
+      };
+    })
+    .sort((a, b) => b.fp_rate - a.fp_rate || b.blocked - a.blocked);
+
+  const agents: TuningDigestAgentRow[] = [...agentStats.entries()]
+    .map(([agent_id, stat]) => {
+      const evalCount = stat.ready + stat.blocked + stat.abandoned;
+      const readyRate = evalCount > 0 ? stat.ready / evalCount : 0;
+      const med = median(stat.rounds);
+      let trust_signal: TuningDigestAgentRow["trust_signal"] = "quiet";
+      if (evalCount >= 10) {
+        if (readyRate >= 0.6) trust_signal = "converging";
+        else if (med !== null && med > 3) trust_signal = "flailing";
+        else trust_signal = "converging";
+      }
+      return {
+        agent_id,
+        prs: stat.prs.size,
+        ready: stat.ready,
+        blocked: stat.blocked,
+        abandoned: stat.abandoned,
+        median_rounds_to_ready: med,
+        sensitive_path_violations: stat.sensitive,
+        trust_signal,
+      };
+    })
+    .sort((a, b) => a.agent_id.localeCompare(b.agent_id));
+
+  const auto_downgrades_last_7d = args.downgrades
+    .filter((d) => inWindow(d.downgradedAt, start, now) && !d.revertedAt)
+    .map((d) => ({
+      detector: d.detectorCode,
+      downgraded_at: d.downgradedAt,
+      fp_rate_at_trigger: d.fpRateAtTrigger,
+      tuning_issue: d.tuningIssueUrl,
+    }));
+
+  return {
+    schema: "trailhead.tuning-digest.v1",
+    repo: args.repoId,
+    window,
+    totals: {
+      evaluations: evalRows.length,
+      block,
+      warn,
+      allow,
+      overrides,
+      agent_prs: agentPrs,
+    },
+    detectors,
+    agents,
+    overrides: overridesList.slice(0, 10),
+    auto_downgrades_last_7d,
+  };
+}
+
+export function buildAgentRecentEvaluations(args: {
+  agentId: string;
+  evaluations: StoredEvaluation[];
+  days?: number;
+  now?: Date;
+  repoId?: string;
+}): AgentRecentEvaluationsPayload {
+  const days = args.days ?? 30;
+  const now = args.now ?? new Date();
+  const rows = filterEvaluations(args.evaluations, {
+    repoId: args.repoId,
+    days,
+    now,
+  }).filter((row) => resolveAgentProvenanceId(row) === args.agentId);
+
+  const decisions = { allow: 0, warn: 0, block: 0 };
+  let ready_without_human = 0;
+  const rounds: number[] = [];
+  let sensitive_path_violations = 0;
+  const detectorCounts = new Map<string, number>();
+
+  for (const row of rows) {
+    if (row.gateDecision === "allow") decisions.allow += 1;
+    else if (row.gateDecision === "warn") decisions.warn += 1;
+    else decisions.block += 1;
+
+    const remediation = row.remediation as
+      | { loop_round?: number; next_action?: string }
+      | undefined;
+    if (row.releaseReady === true || remediation?.next_action === "ready_to_merge") {
+      ready_without_human += 1;
+      if (typeof remediation?.loop_round === "number") {
+        rounds.push(remediation.loop_round);
+      }
+    }
+
+    const codes = extractDetectorCodes(row);
+    if (codes.includes("risk.sensitive_files")) sensitive_path_violations += 1;
+    for (const code of codes) {
+      detectorCounts.set(code, (detectorCounts.get(code) ?? 0) + 1);
+    }
+  }
+
+  const evaluations = rows.length;
+  const med = median(rounds);
+  const p95 = percentile(rounds, 95);
+
+  let trust_signal_v1: AgentRecentEvaluationsPayload["trust_signal_v1"] = "quiet";
+  if (evaluations >= 10) {
+    const readyRate = evaluations > 0 ? ready_without_human / evaluations : 0;
+    if (readyRate >= 0.6) trust_signal_v1 = "converging";
+    else if (med !== null && med > 3) trust_signal_v1 = "flailing";
+    else trust_signal_v1 = "converging";
+  }
+
+  const top_detectors = [...detectorCounts.entries()]
+    .map(([code, count]) => ({ code, count }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 10);
+
+  return {
+    agent_id: args.agentId,
+    window_days: days,
+    evaluations,
+    decisions,
+    ready_without_human,
+    median_rounds_to_ready: med,
+    p95_rounds_to_ready: p95,
+    sensitive_path_violations,
+    top_detectors,
+    trust_signal_v1,
+  };
+}
+
+export function evaluateAutoDowngradeCandidates(args: {
+  evaluations: StoredEvaluation[];
+  feedback: DetectorFeedbackRecord[];
+  downgrades: DetectorDowngradeRecord[];
+  days?: number;
+  now?: Date;
+  fpThreshold?: number;
+  minEmissions?: number;
+}): AutoDowngradeCandidate[] {
+  const days = args.days ?? 7;
+  const now = args.now ?? new Date();
+  const fpThreshold = args.fpThreshold ?? 0.15;
+  const minEmissions = args.minEmissions ?? 10;
+
+  const activeDowngrades = new Set(
+    args.downgrades.filter((d) => !d.revertedAt).map((d) => d.detectorCode),
+  );
+
+  const emissionsByCode = new Map<string, number>();
+  for (const row of filterEvaluations(args.evaluations, { days, now })) {
+    for (const code of extractDetectorCodes(row)) {
+      emissionsByCode.set(code, (emissionsByCode.get(code) ?? 0) + 1);
+    }
+  }
+
+  const fleetDetectors = new Map<
+    string,
+    { blocked: number; warned: number; fp_signals: number }
+  >();
+  for (const row of filterEvaluations(args.evaluations, { days, now })) {
+    for (const code of extractDetectorCodes(row)) {
+      const stat = fleetDetectors.get(code) ?? {
+        blocked: 0,
+        warned: 0,
+        fp_signals: 0,
+      };
+      if (row.gateDecision === "block") stat.blocked += 1;
+      else if (row.gateDecision === "warn") stat.warned += 1;
+      fleetDetectors.set(code, stat);
+    }
+  }
+  for (const fb of filterFeedback(args.feedback, { days, now })) {
+    if (fb.disposition !== "false_positive") continue;
+    const stat = fleetDetectors.get(fb.detector) ?? {
+      blocked: 0,
+      warned: 0,
+      fp_signals: 0,
+    };
+    stat.fp_signals += 1;
+    fleetDetectors.set(fb.detector, stat);
+  }
+
+  return [...fleetDetectors.entries()]
+    .map(([detector, stat]) => {
+      const emissions = stat.blocked + stat.warned;
+      const fpRate =
+        emissions > 0 ? Math.round((stat.fp_signals / emissions) * 1000) / 1000 : 0;
+      return {
+        detector,
+        fpRate,
+        emissions,
+        fpSignals: stat.fp_signals,
+        alreadyDowngraded: activeDowngrades.has(detector),
+      };
+    })
+    .filter(
+      (row) =>
+        row.emissions >= minEmissions &&
+        row.fpRate >= fpThreshold &&
+        !row.alreadyDowngraded,
+    )
+    .sort((a, b) => b.fpRate - a.fpRate);
+}

--- a/cloud/src/types.ts
+++ b/cloud/src/types.ts
@@ -60,7 +60,7 @@ export type FeedbackPayload = z.infer<typeof FeedbackPayload>;
 
 export const DigestSubscribePayload = z.object({
   enabled: z.boolean(),
-  channel: z.enum(["slack", "email"]),
+  channel: z.enum(["slack", "email", "webhook"]),
   destination: z.string().min(3),
   fpThreshold: z.number().min(0).max(100).default(15),
 });
@@ -85,6 +85,7 @@ export type OrgSettingsPatch = z.infer<typeof OrgSettingsPatch>;
 export interface StoredEvaluation extends EvaluationPayload {
   orgId: string;
   receivedAt: string;
+  agentProvenanceId?: string;
 }
 
 export interface OrgRecord {
@@ -105,9 +106,12 @@ export interface OrgSettings {
   };
   digest?: {
     enabled: boolean;
-    channel: "slack" | "email";
+    channel: "slack" | "email" | "webhook";
     destination: string;
     fpThreshold: number;
+  };
+  tuning?: {
+    autoDowngrade: boolean;
   };
 }
 
@@ -181,6 +185,18 @@ export interface CloudStore {
   listManagedKeys(orgId: string): ManagedApiKey[];
   createApiKey(orgId: string, label?: string): { key: ManagedApiKey; secret: string };
   revokeApiKey(orgId: string, keyId: string): boolean;
+  listDetectorDowngrades(
+    orgId: string,
+  ): import("./tuning-digest.js").DetectorDowngradeRecord[];
+  recordDetectorDowngrade(
+    orgId: string,
+    record: import("./tuning-digest.js").DetectorDowngradeRecord,
+  ): import("./tuning-digest.js").DetectorDowngradeRecord;
+  revertDetectorDowngrade(
+    orgId: string,
+    detectorCode: string,
+    revertedBy: string,
+  ): import("./tuning-digest.js").DetectorDowngradeRecord | null;
 }
 
 export interface RateLimitState {

--- a/dist/index.js
+++ b/dist/index.js
@@ -40849,11 +40849,17 @@ const OverrideConfig = objectType({
     enabled: booleanType().default(true),
     max_per_week: numberType().int().min(1).default(5),
 });
+const TuningConfig = objectType({
+    auto_downgrade: booleanType().default(true),
+    digest_webhook_url: stringType().url().optional(),
+    fp_threshold: numberType().min(0).max(1).default(0.15),
+});
 const RepoConfig = objectType({
     schema_version: numberType().int().positive().default(1),
     gate: GateConfig.default({}),
     remediation: RemediationConfig.optional(),
     override: OverrideConfig.optional(),
+    tuning: TuningConfig.optional(),
     contexts: arrayType(TrailheadContext).default([]),
     sensitivity: objectType({
         high: arrayType(stringType()).default([]),
@@ -45280,6 +45286,27 @@ function formatGateReport(evaluation, riskThreshold) {
     return lines.join("\n");
 }
 
+;// CONCATENATED MODULE: ./src/agent-provenance.ts
+/** Denormalised agent id for evaluation store group-by (A5). */
+function resolveAgentProvenanceId(evaluation) {
+    const pr = evaluation.pr;
+    if (!pr)
+        return null;
+    const source = pr.provenance?.source?.trim();
+    if (source)
+        return source;
+    const headRef = pr.headRef;
+    if (headRef) {
+        const match = headRef.match(/^agent\/([a-z0-9-]+)\//i);
+        if (match?.[1])
+            return match[1];
+    }
+    const type = pr.provenance?.type;
+    if (type && type !== "human")
+        return type;
+    return null;
+}
+
 ;// CONCATENATED MODULE: ./src/trailhead-events.ts
 // Pure Trailhead semantic event resolution — no framework dependencies.
 // Maps gate evaluations to coordinator-friendly webhook event types.
@@ -45341,6 +45368,7 @@ function evaluationMatchesTrailheadEvent(evaluation, event, options = {}) {
 }
 
 ;// CONCATENATED MODULE: ./src/notify.ts
+
 
 
 
@@ -45575,6 +45603,7 @@ function buildEvaluationStoreRow(evaluation) {
         fixes_introduced: remediation?.fixes_introduced ?? [],
         pr: evaluation.pr ?? null,
         policy_override: evaluation.policyOverride ?? null,
+        agent_provenance_id: resolveAgentProvenanceId(evaluation),
     };
 }
 async function storeEvaluation(url, evaluation, options = {}) {

--- a/scripts/batch-v4.3-rollout-prs.mjs
+++ b/scripts/batch-v4.3-rollout-prs.mjs
@@ -1,13 +1,13 @@
 #!/usr/bin/env node
 /**
- * A6 fleet rollout: pin Trailhead v4.3.2+ + migrate evaluation store URL.
+ * A6 fleet rollout: pin Trailhead v4.3.3+ + migrate evaluation store URL.
  *
  * Repos still on legacy deployguard store endpoint — active fleet only (see docs/komatik-hosted-store.md):
  *   cairn, frontier, kindling, pack, slipstream, sundog, trace
  * Excluded (retired/archived, trace absorbed): drift, floe, traverse, watchtower
  *
  * Deploy rule: Komatik schema/routes via PR only — never apply_migration to prod via MCP.
- *   1. Bump action ref → KomatikAI/trailhead@v4.3.2 (explicit tag, NOT @v4)
+ *   1. Bump action ref → KomatikAI/trailhead@v4.3.3 (explicit tag, NOT @v4)
  *   2. Flip evaluation-store-url → .../api/trailhead/store
  *
  * Workflow file: `.github/workflows/trailhead.yml` or `deployguard.yml` (legacy filename).
@@ -19,19 +19,19 @@
  *   node scripts/batch-v4.3-rollout-prs.mjs --only=kindling,sundog
  *   node scripts/batch-v4.3-rollout-prs.mjs --skip-missing-workflow
  *
- * Override release pin: TRAILHEAD_ROLLOUT_VERSION=4.3.2 node scripts/...
+ * Override release pin: TRAILHEAD_ROLLOUT_VERSION=4.3.3 node scripts/...
  */
 
 import { execFileSync } from "node:child_process";
 
 const ORG = "KomatikAI";
 const ACTION_REPO = "KomatikAI/trailhead";
-const BRANCH = "cursor/trailhead-v4.3.0-a6-rollout";
+const BRANCH = "cursor/trailhead-v4.3.3-a6-rollout";
 const WORKFLOW_CANDIDATES = [
   ".github/workflows/trailhead.yml",
   ".github/workflows/deployguard.yml",
 ];
-const TARGET_VERSION = process.env.TRAILHEAD_ROLLOUT_VERSION || "4.3.2";
+const TARGET_VERSION = process.env.TRAILHEAD_ROLLOUT_VERSION || "4.3.3";
 const TARGET_REF = `@v${TARGET_VERSION}`; // @v4.3.0
 const LEGACY_STORE = "/api/deployguard/store";
 const CANONICAL_STORE = "/api/trailhead/store";

--- a/src/__tests__/agent-provenance.test.ts
+++ b/src/__tests__/agent-provenance.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { resolveAgentProvenanceId } from "../agent-provenance.js";
+import type { GateEvaluation } from "../types.js";
+
+function evaluation(pr: GateEvaluation["pr"]): Pick<GateEvaluation, "pr"> {
+  return { pr };
+}
+
+describe("resolveAgentProvenanceId", () => {
+  it("prefers provenance.source", () => {
+    expect(
+      resolveAgentProvenanceId(
+        evaluation({
+          headRef: "agent/frontend-dev/fix-nav",
+          provenance: { type: "claude", confidence: 0.9, source: "frontend-dev" },
+        }),
+      ),
+    ).toBe("frontend-dev");
+  });
+
+  it("parses agent branch headRef", () => {
+    expect(
+      resolveAgentProvenanceId(
+        evaluation({
+          headRef: "agent/pipeline-ops/db-health",
+          provenance: { type: "unknown", confidence: 0.5 },
+        }),
+      ),
+    ).toBe("pipeline-ops");
+  });
+
+  it("falls back to non-human provenance type", () => {
+    expect(
+      resolveAgentProvenanceId(
+        evaluation({
+          provenance: { type: "claude", confidence: 0.8 },
+        }),
+      ),
+    ).toBe("claude");
+  });
+
+  it("returns null for human PRs", () => {
+    expect(
+      resolveAgentProvenanceId(
+        evaluation({
+          provenance: { type: "human", confidence: 1 },
+        }),
+      ),
+    ).toBeNull();
+  });
+});

--- a/src/agent-provenance.ts
+++ b/src/agent-provenance.ts
@@ -1,0 +1,23 @@
+import type { GateEvaluation } from "./types.js";
+
+/** Denormalised agent id for evaluation store group-by (A5). */
+export function resolveAgentProvenanceId(
+  evaluation: Pick<GateEvaluation, "pr">,
+): string | null {
+  const pr = evaluation.pr;
+  if (!pr) return null;
+
+  const source = pr.provenance?.source?.trim();
+  if (source) return source;
+
+  const headRef = pr.headRef;
+  if (headRef) {
+    const match = headRef.match(/^agent\/([a-z0-9-]+)\//i);
+    if (match?.[1]) return match[1];
+  }
+
+  const type = pr.provenance?.type;
+  if (type && type !== "human") return type;
+
+  return null;
+}

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -1,6 +1,7 @@
 import * as core from "@actions/core";
 import * as github from "@actions/github";
 import type { GateEvaluation } from "./types.js";
+import { resolveAgentProvenanceId } from "./agent-provenance.js";
 import {
   resolveWebhookDeliveries,
   type ResolveTrailheadEventsOptions,
@@ -321,6 +322,7 @@ export function buildEvaluationStoreRow(
     fixes_introduced: remediation?.fixes_introduced ?? [],
     pr: evaluation.pr ?? null,
     policy_override: evaluation.policyOverride ?? null,
+    agent_provenance_id: resolveAgentProvenanceId(evaluation),
   };
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -370,11 +370,19 @@ export const OverrideConfig = z.object({
 });
 export type OverrideConfig = z.infer<typeof OverrideConfig>;
 
+export const TuningConfig = z.object({
+  auto_downgrade: z.boolean().default(true),
+  digest_webhook_url: z.string().url().optional(),
+  fp_threshold: z.number().min(0).max(1).default(0.15),
+});
+export type TuningConfig = z.infer<typeof TuningConfig>;
+
 export const RepoConfig = z.object({
   schema_version: z.number().int().positive().default(1),
   gate: GateConfig.default({}),
   remediation: RemediationConfig.optional(),
   override: OverrideConfig.optional(),
+  tuning: TuningConfig.optional(),
   contexts: z.array(TrailheadContext).default([]),
   sensitivity: z
     .object({


### PR DESCRIPTION
## Summary
- Adds `agent_provenance_id` to evaluation store payloads (denormalised from `pr.provenance.source`)
- Cloud tuning digest v1 (`trailhead.tuning-digest.v1`) with per-repo detector FP rates, agent rollup, and override summary
- `GET /v1/agents/:agentId/recent-evaluations` rolling stats + trust signal stub
- `POST /v1/digest/tuning/deliver` daily digest webhook delivery
- `POST /v1/tuning/auto-downgrade/run` fleet-wide block→warn when FP ≥15% with ≥10 emissions
- SQL migration `003_tuning_digest_a5.sql` for Cloud/Komatik reference
- Batch rollout script default pin bumped to `@v4.3.3` for post-release fleet re-pin

Closes #228 (Epic A5)

## Test plan
- [x] Root: 650 tests passing (incl. agent-provenance)
- [x] Cloud: 27 tests passing (tuning digest + auto-downgrade E2E)
- [ ] Komatik migration PR for `agent_provenance_id` column (separate deploy)

Made with [Cursor](https://cursor.com)