### PR TITLE
feat(phase-a): close ops artifacts + B1 submission gate

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -155,6 +155,10 @@ inputs:
     description: "Agent remediation brief in PR comments: off, collapsed (default for agent PRs), or expanded. Omit to use .trailhead.yml gate.agent_brief or provenance-based default."
     required: false
     default: ""
+  submission-gate:
+    description: "Enable Gate 1 agent submission checks (mock placeholders, artifact integrity, secrets, etc.). Default off; also enable via .trailhead.yml submission.enabled."
+    required: false
+    default: "false"
   security-gate:
     description: "Enable GitHub Code Scanning alert integration as a risk factor. Set to 'false' to disable."
     required: false

--- a/app/src/submission-engine.ts
+++ b/app/src/submission-engine.ts
@@ -1,0 +1,226 @@
+// Gate 1 — agent submission quality (Phase B1).
+// Pure module: no @actions/*, octokit, or Node I/O.
+
+import type { RepoConfig, SubmissionCheckResult } from "./types.js";
+import { SubmissionCheckCode } from "./types.js";
+
+export type { SubmissionCheckCode, SubmissionCheckResult } from "./types.js";
+
+/** All Gate 1 check codes — keep in sync with A8 fixture manifest. */
+export const SUBMISSION_CHECK_CODES = SubmissionCheckCode.options;
+
+export interface SubmissionFileInfo {
+  filename: string;
+  patch?: string;
+  status?: string;
+}
+
+export interface SubmissionEngineOptions {
+  files: SubmissionFileInfo[];
+  repoConfig?: RepoConfig | null;
+  /** When true, enable Komatik-specific checks (SOUL paths, etc.). */
+  komatikInstance?: boolean;
+  mode?: "warn" | "block";
+}
+
+const MOCK_PLACEHOLDER_PATTERNS = [
+  /\bTODO\s*\(\s*mock\s*\)/i,
+  /\bFIXME\s*\(\s*mock\s*\)/i,
+  /\bMOCK_[A-Z0-9_]+\b/,
+  /\bfakeImplementation\b/,
+  /\bstubResponse\s*\(/i,
+];
+
+const SECRET_PATTERNS = [
+  /\bsk_live_[A-Za-z0-9]{10,}\b/,
+  /\bsk_test_[A-Za-z0-9]{10,}\b/,
+  /\bghp_[A-Za-z0-9]{20,}\b/,
+  /\bAKIA[0-9A-Z]{16}\b/,
+];
+
+const DESTRUCTIVE_SQL_PATTERNS = [
+  /\bDROP\s+TABLE\b/i,
+  /\bTRUNCATE\s+TABLE\b/i,
+  /\bDROP\s+COLUMN\b/i,
+];
+
+const DEFAULT_STALE_TERMS = ["deployguard", "DeployGuard"];
+
+function addedLines(patch: string | undefined): string[] {
+  if (!patch) return [];
+  return patch
+    .split("\n")
+    .filter((line) => line.startsWith("+") && !line.startsWith("+++"))
+    .map((line) => line.slice(1));
+}
+
+function scanAddedContent(
+  files: SubmissionFileInfo[],
+  predicate: (line: string, filename: string) => boolean,
+): string[] {
+  const hits: string[] = [];
+  for (const file of files) {
+    for (const line of addedLines(file.patch)) {
+      if (predicate(line, file.filename)) hits.push(file.filename);
+    }
+  }
+  return [...new Set(hits)];
+}
+
+function detectMockPlaceholder(
+  files: SubmissionFileInfo[],
+): SubmissionCheckResult | null {
+  const hits = scanAddedContent(files, (line) =>
+    MOCK_PLACEHOLDER_PATTERNS.some((re) => re.test(line)),
+  );
+  if (hits.length === 0) return null;
+  return {
+    code: "mock_placeholder",
+    severity: "blocking",
+    title: "Mock placeholder in production path",
+    detail: `Found mock/TODO placeholder patterns in ${hits.join(", ")}. Replace stubs before review.`,
+    files: hits,
+    suggested_action: "Remove mock placeholders and implement real behavior.",
+    autofix_eligible: false,
+  };
+}
+
+function detectSecrets(files: SubmissionFileInfo[]): SubmissionCheckResult | null {
+  const hits = scanAddedContent(files, (line) =>
+    SECRET_PATTERNS.some((re) => re.test(line)),
+  );
+  if (hits.length === 0) return null;
+  return {
+    code: "secrets",
+    severity: "blocking",
+    title: "Potential secret in diff",
+    detail: `Added lines match secret patterns in ${hits.join(", ")}. Rotate any exposed credential.`,
+    files: hits,
+    suggested_action:
+      "Remove secrets from source; use environment variables or a secret manager.",
+    autofix_eligible: false,
+  };
+}
+
+function detectDestructiveSql(files: SubmissionFileInfo[]): SubmissionCheckResult | null {
+  const sqlFiles = files.filter((f) => /\.sql$/i.test(f.filename));
+  const hits = scanAddedContent(sqlFiles, (line) =>
+    DESTRUCTIVE_SQL_PATTERNS.some((re) => re.test(line)),
+  );
+  if (hits.length === 0) return null;
+  return {
+    code: "destructive_sql",
+    severity: "blocking",
+    title: "Destructive SQL in migration",
+    detail: `Added SQL contains destructive statements in ${hits.join(", ")}.`,
+    files: hits,
+    suggested_action:
+      "Use additive migrations; avoid DROP/TRUNCATE without explicit human approval.",
+    autofix_eligible: false,
+  };
+}
+
+function detectContextFreshness(
+  files: SubmissionFileInfo[],
+  staleTerms: string[],
+): SubmissionCheckResult | null {
+  if (staleTerms.length === 0) return null;
+  const hits = scanAddedContent(files, (line) =>
+    staleTerms.some((term) => line.toLowerCase().includes(term.toLowerCase())),
+  );
+  if (hits.length === 0) return null;
+  return {
+    code: "context_freshness",
+    severity: "warn",
+    title: "Stale naming or deprecated terms",
+    detail: `Added lines reference deprecated terms (${staleTerms.join(", ")}) in ${hits.join(", ")}.`,
+    files: hits,
+    suggested_action:
+      "Update naming to match current product vocabulary (see BRAND.md / repo docs).",
+    autofix_eligible: true,
+  };
+}
+
+function detectPathFormat(files: SubmissionFileInfo[]): SubmissionCheckResult | null {
+  const hits = files
+    .map((f) => f.filename)
+    .filter(
+      (name) => /^komatik-agents\/agents\//.test(name) || /\/agents\/agents\//.test(name),
+    );
+  if (hits.length === 0) return null;
+  return {
+    code: "path_format",
+    severity: "warn",
+    title: "Suspicious agent path prefix",
+    detail: `Files use repo-name prefix in internal paths: ${hits.join(", ")}.`,
+    files: hits,
+    suggested_action:
+      "Use agents/<agent-id>/... not <repo>/agents/... for agent workspace paths.",
+    autofix_eligible: false,
+  };
+}
+
+function detectArtifactIntegrity(
+  files: SubmissionFileInfo[],
+): SubmissionCheckResult | null {
+  const prPaths = new Set(files.map((f) => f.filename.replace(/\\/g, "/")));
+  const referenced = new Set<string>();
+
+  const pathRefPattern =
+    /(?:^|\s|['"`])([\w@./-]+\.(?:ts|tsx|js|jsx|md|sql|yml|yaml|json))(?:['"`]|\s|:)/g;
+
+  for (const file of files) {
+    for (const line of addedLines(file.patch)) {
+      if (!/(?:import|from|require|see|fix|update)\s/i.test(line)) continue;
+      for (const match of line.matchAll(pathRefPattern)) {
+        const candidate = match[1]?.replace(/^\.\//, "");
+        if (!candidate || candidate.includes("*")) continue;
+        if (!prPaths.has(candidate) && !candidate.startsWith("node:")) {
+          referenced.add(candidate);
+        }
+      }
+    }
+  }
+
+  if (referenced.size === 0) return null;
+  const missing = [...referenced].slice(0, 8);
+  return {
+    code: "artifact_integrity",
+    severity: "blocking",
+    title: "Referenced files missing from PR",
+    detail: `Added lines reference paths not in this PR: ${missing.join(", ")}${referenced.size > 8 ? "…" : ""}.`,
+    files: missing,
+    suggested_action:
+      "Include the referenced files in this PR or fix hallucinated paths.",
+    autofix_eligible: false,
+  };
+}
+
+export function runSubmissionGate(
+  options: SubmissionEngineOptions,
+): SubmissionCheckResult[] {
+  const { files, repoConfig, komatikInstance = false } = options;
+  if (files.length === 0) return [];
+
+  const staleTerms =
+    repoConfig?.submission?.stale_terms ?? (komatikInstance ? DEFAULT_STALE_TERMS : []);
+
+  const checks: Array<SubmissionCheckResult | null> = [
+    detectMockPlaceholder(files),
+    detectSecrets(files),
+    detectDestructiveSql(files),
+    detectArtifactIntegrity(files),
+    detectContextFreshness(files, staleTerms),
+    komatikInstance ? detectPathFormat(files) : null,
+  ];
+
+  return checks.filter((check): check is SubmissionCheckResult => check !== null);
+}
+
+export function submissionGateShouldBlock(
+  checks: SubmissionCheckResult[],
+  mode: "warn" | "block" = "block",
+): boolean {
+  if (mode !== "block") return false;
+  return checks.some((check) => check.severity === "blocking");
+}

--- a/app/src/submission-remediation.ts
+++ b/app/src/submission-remediation.ts
@@ -1,27 +1,12 @@
-// Submission-gate remediation (Phase B preview).
-// Maps agent submission check results to RemediationFix entries so fleet
-// fixtures can exercise failure modes before submission-engine.ts lands.
+// Submission-gate remediation mapping (Phase B).
+// Maps submission-engine check results to RemediationFix entries.
 
 import { RemediationFix as RemediationFixSchema } from "./types.js";
-import type { RemediationFix, RemediationSeverity } from "./types.js";
+import type { RemediationFix } from "./types.js";
+import type { SubmissionCheckResult } from "./submission-engine.js";
 
-export const SUBMISSION_CHECK_CODES = [
-  "artifact_integrity",
-  "mock_placeholder",
-  "context_freshness",
-] as const;
-
-export type SubmissionCheckCode = (typeof SUBMISSION_CHECK_CODES)[number];
-
-export interface SubmissionCheckResult {
-  code: SubmissionCheckCode;
-  severity: RemediationSeverity;
-  title: string;
-  detail: string;
-  files?: string[];
-  suggested_action?: string;
-  autofix_eligible?: boolean;
-}
+export type { SubmissionCheckResult } from "./submission-engine.js";
+export { SubmissionCheckCode, SUBMISSION_CHECK_CODES } from "./submission-engine.js";
 
 export function deriveSubmissionFixes(
   checks: SubmissionCheckResult[] | undefined,

--- a/cloud/src/app.test.ts
+++ b/cloud/src/app.test.ts
@@ -1,9 +1,9 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { createCloudApp } from "./app.js";
 import type { ApiKeyRecord } from "./types.js";
 
 const seedKeys: ApiKeyRecord[] = [
-  { orgId: "komatik", orgName: "Komatik", key: "thk_test_key" },
+  { keyId: "seed-komatik", orgId: "komatik", orgName: "Komatik", key: "thk_test_key" },
 ];
 
 function authHeaders(key = "thk_test_key"): Record<string, string> {
@@ -31,7 +31,11 @@ function sampleEvaluation(id = "eval-1") {
 }
 
 describe("Trailhead Cloud API", () => {
-  const app = createCloudApp({ seedKeys });
+  let app: ReturnType<typeof createCloudApp>;
+
+  beforeEach(() => {
+    app = createCloudApp({ seedKeys });
+  });
 
   it("rejects unauthenticated requests", async () => {
     const res = await app.request("/v1/evaluations", { method: "GET" });

--- a/cloud/src/digest-cron.ts
+++ b/cloud/src/digest-cron.ts
@@ -1,0 +1,93 @@
+import type { CloudStore } from "./types.js";
+
+export interface DigestCronOptions {
+  store: CloudStore;
+  intervalHours?: number;
+  digestDays?: number;
+  /** Bearer token used for internal deliver calls when org keys are not iterated. */
+  deliverForOrgIds?: string[];
+}
+
+async function deliverForOrg(
+  store: CloudStore,
+  orgId: string,
+  days: number,
+): Promise<{ repo: string; status: number }[]> {
+  const settings = store.getOrgSettings(orgId);
+  if (!settings.digest?.enabled || !settings.digest.destination) return [];
+
+  const { buildTuningDigestV1 } = await import("./tuning-digest.js");
+  const fpThreshold = (settings.digest.fpThreshold ?? 15) / 100;
+  const repos = store.listRepos(orgId);
+  const delivered: Array<{ repo: string; status: number }> = [];
+
+  for (const repo of repos) {
+    const digest = buildTuningDigestV1({
+      repoId: repo.fullName,
+      evaluations: store.listAllEvaluations(orgId),
+      feedback: store.listFeedback(orgId, repo.fullName),
+      downgrades: store.listDetectorDowngrades(orgId),
+      days,
+      fpThreshold,
+    });
+    const response = await fetch(settings.digest.destination, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(digest),
+      signal: AbortSignal.timeout(10_000),
+    });
+    delivered.push({ repo: repo.fullName, status: response.status });
+  }
+
+  return delivered;
+}
+
+export function startDigestCron(options: DigestCronOptions): () => void {
+  const intervalHours = options.intervalHours ?? 24;
+  const digestDays = options.digestDays ?? 7;
+  const orgIds = options.deliverForOrgIds ?? [];
+
+  const tick = async () => {
+    for (const orgId of orgIds) {
+      try {
+        const delivered = await deliverForOrg(options.store, orgId, digestDays);
+        console.log(
+          JSON.stringify({
+            level: "info",
+            msg: "digest cron delivered",
+            orgId,
+            count: delivered.length,
+            ts: new Date().toISOString(),
+          }),
+        );
+      } catch (error) {
+        console.error(
+          JSON.stringify({
+            level: "error",
+            msg: "digest cron failed",
+            orgId,
+            error: String(error),
+            ts: new Date().toISOString(),
+          }),
+        );
+      }
+    }
+  };
+
+  const intervalMs = Math.max(intervalHours, 1) * 3_600_000;
+  const timer = setInterval(() => {
+    void tick();
+  }, intervalMs);
+
+  console.log(
+    JSON.stringify({
+      level: "info",
+      msg: "digest cron started",
+      intervalHours,
+      orgIds,
+      ts: new Date().toISOString(),
+    }),
+  );
+
+  return () => clearInterval(timer);
+}

--- a/cloud/src/server.ts
+++ b/cloud/src/server.ts
@@ -1,8 +1,12 @@
 import { serve } from "@hono/node-server";
-import { createDefaultCloudApp } from "./app.js";
+import { createCloudApp } from "./app.js";
+import { startDigestCron } from "./digest-cron.js";
+import { createMemoryStore, parseSeedKeys } from "./store.js";
 
 const port = parseInt(process.env.PORT ?? "3101", 10);
-const app = createDefaultCloudApp();
+const seedKeys = parseSeedKeys(process.env.TRAILHEAD_CLOUD_API_KEYS);
+const store = createMemoryStore(seedKeys);
+const app = createCloudApp({ seedKeys, store });
 
 console.log(
   JSON.stringify({
@@ -13,5 +17,18 @@ console.log(
     ts: new Date().toISOString(),
   }),
 );
+
+if (process.env.TRAILHEAD_CLOUD_DIGEST_CRON === "1") {
+  const orgIds = [...new Set(seedKeys.map((k) => k.orgId))];
+  const intervalHours = parseInt(
+    process.env.TRAILHEAD_CLOUD_DIGEST_INTERVAL_HOURS ?? "24",
+    10,
+  );
+  startDigestCron({
+    store,
+    intervalHours,
+    deliverForOrgIds: orgIds,
+  });
+}
 
 serve({ fetch: app.fetch, port });

--- a/cloud/src/store.ts
+++ b/cloud/src/store.ts
@@ -17,18 +17,6 @@ import type { PlanTier } from "./billing.js";
 export function createMemoryStore(seedKeys: ApiKeyRecord[] = []): CloudStore {
   const keys = new Map<string, ApiKeyRecord>();
   const managedKeys = new Map<string, ManagedApiKey>();
-  for (const record of seedKeys) {
-    keys.set(record.key, record);
-    managedKeys.set(record.keyId, {
-      id: record.keyId,
-      orgId: record.orgId,
-      key: record.key,
-      label: record.label ?? "Seed key",
-      keyPreview: maskApiKey(record.key),
-      createdAt: new Date().toISOString(),
-      revokedAt: null,
-    });
-  }
 
   const orgs = new Map<string, OrgRecord>();
   const orgSettings = new Map<string, OrgSettings>();
@@ -60,6 +48,20 @@ export function createMemoryStore(seedKeys: ApiKeyRecord[] = []): CloudStore {
       });
     }
     return org;
+  }
+
+  for (const record of seedKeys) {
+    keys.set(record.key, record);
+    managedKeys.set(record.keyId, {
+      id: record.keyId,
+      orgId: record.orgId,
+      key: record.key,
+      label: record.label ?? "Seed key",
+      keyPreview: maskApiKey(record.key),
+      createdAt: new Date().toISOString(),
+      revokedAt: null,
+    });
+    ensureOrg(record.orgId, record.orgName);
   }
 
   function getSettings(orgId: string): OrgSettings {

--- a/cloud/src/tuning-digest.ts
+++ b/cloud/src/tuning-digest.ts
@@ -89,7 +89,7 @@ export interface AutoDowngradeCandidate {
 
 function inWindow(iso: string, start: Date, end: Date): boolean {
   const ts = new Date(iso).getTime();
-  return ts >= start.getTime() && ts < end.getTime();
+  return ts >= start.getTime() && ts <= end.getTime();
 }
 
 function median(values: number[]): number | null {

--- a/dist/index.js
+++ b/dist/index.js
@@ -40632,6 +40632,23 @@ const MatchedContext = objectType({
     environment: stringType().optional(),
 });
 const RemediationSeverity = enumType(["blocking", "warn", "advisory"]);
+const SubmissionCheckCode = enumType([
+    "artifact_integrity",
+    "mock_placeholder",
+    "context_freshness",
+    "destructive_sql",
+    "secrets",
+    "path_format",
+]);
+const SubmissionCheckResult = objectType({
+    code: SubmissionCheckCode,
+    severity: RemediationSeverity,
+    title: stringType(),
+    detail: stringType(),
+    files: arrayType(stringType()).default([]),
+    suggested_action: stringType().optional(),
+    autofix_eligible: booleanType().default(false),
+});
 const RemediationAutofixClass = enumType([
     "format",
     "lint",
@@ -40744,6 +40761,7 @@ const GateEvaluation = objectType({
     storePersisted: booleanType().optional(),
     remediation: Remediation.optional(),
     agentBriefMode: AgentBriefMode.optional(),
+    submissionChecks: arrayType(SubmissionCheckResult).optional(),
     cross_repo_impact: objectType({
         services: arrayType(objectType({
             serviceName: stringType(),
@@ -40854,12 +40872,18 @@ const TuningConfig = objectType({
     digest_webhook_url: stringType().url().optional(),
     fp_threshold: numberType().min(0).max(1).default(0.15),
 });
+const SubmissionConfig = objectType({
+    enabled: booleanType().default(false),
+    mode: enumType(["warn", "block"]).default("block"),
+    stale_terms: arrayType(stringType()).optional(),
+});
 const RepoConfig = objectType({
     schema_version: numberType().int().positive().default(1),
     gate: GateConfig.default({}),
     remediation: RemediationConfig.optional(),
     override: OverrideConfig.optional(),
     tuning: TuningConfig.optional(),
+    submission: SubmissionConfig.optional(),
     contexts: arrayType(TrailheadContext).default([]),
     sensitivity: objectType({
         high: arrayType(stringType()).default([]),
@@ -41513,6 +41537,10 @@ const KNOWN_TOP_LEVEL_KEYS = new Set([
     "canary",
     "escalation",
     "policies",
+    "remediation",
+    "override",
+    "tuning",
+    "submission",
 ]);
 function warnUnknownTopLevelKeys(raw, configPath) {
     if (!raw || typeof raw !== "object" || Array.isArray(raw))
@@ -42428,16 +42456,181 @@ function pickLatestPreviousEvaluation(rows, excludeEvaluationId) {
     return null;
 }
 
-;// CONCATENATED MODULE: ./src/submission-remediation.ts
-// Submission-gate remediation (Phase B preview).
-// Maps agent submission check results to RemediationFix entries so fleet
-// fixtures can exercise failure modes before submission-engine.ts lands.
+;// CONCATENATED MODULE: ./src/submission-engine.ts
+// Gate 1 — agent submission quality (Phase B1).
+// Pure module: no @actions/*, octokit, or Node I/O.
 
-const SUBMISSION_CHECK_CODES = (/* unused pure expression or super */ null && ([
-    "artifact_integrity",
-    "mock_placeholder",
-    "context_freshness",
-]));
+/** All Gate 1 check codes — keep in sync with A8 fixture manifest. */
+const SUBMISSION_CHECK_CODES = SubmissionCheckCode.options;
+const MOCK_PLACEHOLDER_PATTERNS = [
+    /\bTODO\s*\(\s*mock\s*\)/i,
+    /\bFIXME\s*\(\s*mock\s*\)/i,
+    /\bMOCK_[A-Z0-9_]+\b/,
+    /\bfakeImplementation\b/,
+    /\bstubResponse\s*\(/i,
+];
+const SECRET_PATTERNS = [
+    /\bsk_live_[A-Za-z0-9]{10,}\b/,
+    /\bsk_test_[A-Za-z0-9]{10,}\b/,
+    /\bghp_[A-Za-z0-9]{20,}\b/,
+    /\bAKIA[0-9A-Z]{16}\b/,
+];
+const DESTRUCTIVE_SQL_PATTERNS = [
+    /\bDROP\s+TABLE\b/i,
+    /\bTRUNCATE\s+TABLE\b/i,
+    /\bDROP\s+COLUMN\b/i,
+];
+const DEFAULT_STALE_TERMS = ["deployguard", "DeployGuard"];
+function addedLines(patch) {
+    if (!patch)
+        return [];
+    return patch
+        .split("\n")
+        .filter((line) => line.startsWith("+") && !line.startsWith("+++"))
+        .map((line) => line.slice(1));
+}
+function scanAddedContent(files, predicate) {
+    const hits = [];
+    for (const file of files) {
+        for (const line of addedLines(file.patch)) {
+            if (predicate(line, file.filename))
+                hits.push(file.filename);
+        }
+    }
+    return [...new Set(hits)];
+}
+function detectMockPlaceholder(files) {
+    const hits = scanAddedContent(files, (line) => MOCK_PLACEHOLDER_PATTERNS.some((re) => re.test(line)));
+    if (hits.length === 0)
+        return null;
+    return {
+        code: "mock_placeholder",
+        severity: "blocking",
+        title: "Mock placeholder in production path",
+        detail: `Found mock/TODO placeholder patterns in ${hits.join(", ")}. Replace stubs before review.`,
+        files: hits,
+        suggested_action: "Remove mock placeholders and implement real behavior.",
+        autofix_eligible: false,
+    };
+}
+function detectSecrets(files) {
+    const hits = scanAddedContent(files, (line) => SECRET_PATTERNS.some((re) => re.test(line)));
+    if (hits.length === 0)
+        return null;
+    return {
+        code: "secrets",
+        severity: "blocking",
+        title: "Potential secret in diff",
+        detail: `Added lines match secret patterns in ${hits.join(", ")}. Rotate any exposed credential.`,
+        files: hits,
+        suggested_action: "Remove secrets from source; use environment variables or a secret manager.",
+        autofix_eligible: false,
+    };
+}
+function detectDestructiveSql(files) {
+    const sqlFiles = files.filter((f) => /\.sql$/i.test(f.filename));
+    const hits = scanAddedContent(sqlFiles, (line) => DESTRUCTIVE_SQL_PATTERNS.some((re) => re.test(line)));
+    if (hits.length === 0)
+        return null;
+    return {
+        code: "destructive_sql",
+        severity: "blocking",
+        title: "Destructive SQL in migration",
+        detail: `Added SQL contains destructive statements in ${hits.join(", ")}.`,
+        files: hits,
+        suggested_action: "Use additive migrations; avoid DROP/TRUNCATE without explicit human approval.",
+        autofix_eligible: false,
+    };
+}
+function detectContextFreshness(files, staleTerms) {
+    if (staleTerms.length === 0)
+        return null;
+    const hits = scanAddedContent(files, (line) => staleTerms.some((term) => line.toLowerCase().includes(term.toLowerCase())));
+    if (hits.length === 0)
+        return null;
+    return {
+        code: "context_freshness",
+        severity: "warn",
+        title: "Stale naming or deprecated terms",
+        detail: `Added lines reference deprecated terms (${staleTerms.join(", ")}) in ${hits.join(", ")}.`,
+        files: hits,
+        suggested_action: "Update naming to match current product vocabulary (see BRAND.md / repo docs).",
+        autofix_eligible: true,
+    };
+}
+function detectPathFormat(files) {
+    const hits = files
+        .map((f) => f.filename)
+        .filter((name) => /^komatik-agents\/agents\//.test(name) || /\/agents\/agents\//.test(name));
+    if (hits.length === 0)
+        return null;
+    return {
+        code: "path_format",
+        severity: "warn",
+        title: "Suspicious agent path prefix",
+        detail: `Files use repo-name prefix in internal paths: ${hits.join(", ")}.`,
+        files: hits,
+        suggested_action: "Use agents/<agent-id>/... not <repo>/agents/... for agent workspace paths.",
+        autofix_eligible: false,
+    };
+}
+function detectArtifactIntegrity(files) {
+    const prPaths = new Set(files.map((f) => f.filename.replace(/\\/g, "/")));
+    const referenced = new Set();
+    const pathRefPattern = /(?:^|\s|['"`])([\w@./-]+\.(?:ts|tsx|js|jsx|md|sql|yml|yaml|json))(?:['"`]|\s|:)/g;
+    for (const file of files) {
+        for (const line of addedLines(file.patch)) {
+            if (!/(?:import|from|require|see|fix|update)\s/i.test(line))
+                continue;
+            for (const match of line.matchAll(pathRefPattern)) {
+                const candidate = match[1]?.replace(/^\.\//, "");
+                if (!candidate || candidate.includes("*"))
+                    continue;
+                if (!prPaths.has(candidate) && !candidate.startsWith("node:")) {
+                    referenced.add(candidate);
+                }
+            }
+        }
+    }
+    if (referenced.size === 0)
+        return null;
+    const missing = [...referenced].slice(0, 8);
+    return {
+        code: "artifact_integrity",
+        severity: "blocking",
+        title: "Referenced files missing from PR",
+        detail: `Added lines reference paths not in this PR: ${missing.join(", ")}${referenced.size > 8 ? "…" : ""}.`,
+        files: missing,
+        suggested_action: "Include the referenced files in this PR or fix hallucinated paths.",
+        autofix_eligible: false,
+    };
+}
+function runSubmissionGate(options) {
+    const { files, repoConfig, komatikInstance = false } = options;
+    if (files.length === 0)
+        return [];
+    const staleTerms = repoConfig?.submission?.stale_terms ?? (komatikInstance ? DEFAULT_STALE_TERMS : []);
+    const checks = [
+        detectMockPlaceholder(files),
+        detectSecrets(files),
+        detectDestructiveSql(files),
+        detectArtifactIntegrity(files),
+        detectContextFreshness(files, staleTerms),
+        komatikInstance ? detectPathFormat(files) : null,
+    ];
+    return checks.filter((check) => check !== null);
+}
+function submissionGateShouldBlock(checks, mode = "block") {
+    if (mode !== "block")
+        return false;
+    return checks.some((check) => check.severity === "blocking");
+}
+
+;// CONCATENATED MODULE: ./src/submission-remediation.ts
+// Submission-gate remediation mapping (Phase B).
+// Maps submission-engine check results to RemediationFix entries.
+
+
 function deriveSubmissionFixes(checks) {
     if (!checks || checks.length === 0)
         return [];
@@ -43213,6 +43406,7 @@ function applyLabelOverrideToEvaluation(evaluation, audit) {
 }
 
 ;// CONCATENATED MODULE: ./src/gate.ts
+
 
 
 
@@ -44450,6 +44644,20 @@ async function evaluateGate(config, commitSha, prNumber) {
     if (agentPolicy?.findings.length) {
         policyFindings.push(...agentPolicy.findings);
     }
+    let submissionChecks = [];
+    const submissionMode = repoConfig?.submission?.mode ?? "block";
+    const submissionEnabled = config.submissionGate === true || repoConfig?.submission?.enabled === true;
+    if (submissionEnabled && files.length > 0) {
+        submissionChecks = runSubmissionGate({
+            files,
+            repoConfig,
+            komatikInstance: process.env.KOMATIK_INSTANCE === "true",
+            mode: submissionMode,
+        });
+        if (submissionChecks.length > 0) {
+            policyFindings.push(`Submission gate: ${submissionChecks.length} finding(s).`);
+        }
+    }
     const sessionCorrelation = await detectSessionCorrelation({
         prNumber,
         token: config.githubToken,
@@ -44494,7 +44702,9 @@ async function evaluateGate(config, commitSha, prNumber) {
         (sessionCorrelation &&
             sessionCfg &&
             sessionCorrelation.burstCount >= sessionCfg.threshold &&
-            sessionCfg.mode === "block")
+            sessionCfg.mode === "block") ||
+        (submissionChecks.length > 0 &&
+            submissionGateShouldBlock(submissionChecks, submissionMode))
         ? "block"
         : baselineDecision;
     if (ciIntegrity.blockingPatterns.length > 0) {
@@ -44591,6 +44801,7 @@ async function evaluateGate(config, commitSha, prNumber) {
         trust_profile: trustProfile,
         gateMode,
         context: matchedContext?.matched,
+        submissionChecks: submissionChecks.length > 0 ? submissionChecks : undefined,
         cross_repo_impact: crossRepoImpact.services.length > 0
             ? {
                 services: crossRepoImpact.services.map((service) => ({
@@ -44735,6 +44946,7 @@ async function evaluateGate(config, commitSha, prNumber) {
             previousEvaluation,
             maxLoopRounds: remediationSettings?.max_loop_rounds ?? 3,
             agentProvenance: isAgentProvenanceType(localEvaluation.pr?.provenance?.type ?? "unknown"),
+            submissionChecks,
         });
     }
     return localEvaluation;
@@ -47362,6 +47574,7 @@ async function run() {
             ciManifest,
             ciManifestPath: ciManifestPath || undefined,
             agentBrief,
+            submissionGate: getInput("submission-gate") === "true",
         };
         if (policyOverride?.changes.riskThreshold !== undefined) {
             config.riskThreshold = policyOverride.changes.riskThreshold;

--- a/docs/komatik-hosted-store.md
+++ b/docs/komatik-hosted-store.md
@@ -60,7 +60,7 @@ Reference copy for Trailhead Cloud hosted tier: `cloud/migrations/002_loop_bookk
 
 ## Fleet rollout status (May 2026)
 
-**A6 complete** for active consumers — pinned `@v4.3.0`, store URL on `/api/trailhead/store`:
+**A6 complete** for active DORA satellites — pinned `@v4.3.3`, store URL on `/api/trailhead/store`:
 
 | Repo                                                       | Status                                                                     |
 | ---------------------------------------------------------- | -------------------------------------------------------------------------- |
@@ -69,8 +69,8 @@ Reference copy for Trailhead Cloud hosted tier: `cloud/migrations/002_loop_bookk
 
 **Pending:**
 
-- [Komatik #2014](https://github.com/KomatikAI/komatik/pull/2014) — store persistence + GET API
-- [Trailhead #236](https://github.com/KomatikAI/trailhead/pull/236) — komatik list read path → tag **v4.3.1**, re-pin fleet
+- [Komatik migration](../runbooks/KOMATIK-A5-STORE-MIGRATION.md) — `agent_provenance_id` column + store mapper update
+- Strict-agent preset on remaining Base Camp repos — `scripts/batch-strict-preset-prs.mjs` (#229)
 
 ## Deployment rules (mandatory)
 
@@ -85,3 +85,4 @@ If prod was changed out-of-band, reconcile by renaming the local migration file 
 - [Evaluation storage](./evaluation-storage.md)
 - [Roadmap v4.3 Phase A](./roadmap-v4.3-agent-autonomy.md)
 - `scripts/batch-v4.3-rollout-prs.mjs` — fleet pin + store URL batch PRs
+- `scripts/batch-strict-preset-prs.mjs` — strict-agent `.trailhead.yml` preset (#229)

--- a/docs/komatik-migrations/20260529180000_trailhead_a5_agent_provenance.sql
+++ b/docs/komatik-migrations/20260529180000_trailhead_a5_agent_provenance.sql
@@ -1,0 +1,38 @@
+-- A5 tuning digest — Komatik hosted store (trailhead_evaluations)
+-- Copy into Komatik/supabase/migrations/ via PR. Do NOT apply via MCP to prod.
+--
+-- Trailhead reference: cloud/migrations/003_tuning_digest_a5.sql
+-- Runbook: docs/runbooks/KOMATIK-A5-STORE-MIGRATION.md
+
+ALTER TABLE public.trailhead_evaluations
+  ADD COLUMN IF NOT EXISTS agent_provenance_id text;
+
+CREATE INDEX IF NOT EXISTS idx_trailhead_evals_agent_provenance
+  ON public.trailhead_evaluations (agent_provenance_id, created_at DESC)
+  WHERE agent_provenance_id IS NOT NULL;
+
+COMMENT ON COLUMN public.trailhead_evaluations.agent_provenance_id IS
+  'Denormalised pr.provenance.source for agent group-by (Trailhead A5).';
+
+-- Best-effort backfill from pr JSONB
+UPDATE public.trailhead_evaluations
+SET agent_provenance_id = COALESCE(
+  pr->'provenance'->>'source',
+  substring(pr->>'headRef' from '^agent/([^/]+)/')
+)
+WHERE agent_provenance_id IS NULL
+  AND pr IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS public.trailhead_detector_downgrades (
+  detector_code text PRIMARY KEY,
+  downgraded_at timestamptz NOT NULL DEFAULT now(),
+  fp_rate_at_trigger numeric NOT NULL,
+  tuning_issue_url text,
+  reverted_at timestamptz,
+  reverted_by text
+);
+
+ALTER TABLE public.trailhead_detector_downgrades ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "service role only" ON public.trailhead_detector_downgrades
+  FOR ALL TO service_role USING (true) WITH CHECK (true);

--- a/docs/runbooks/KOMATIK-A5-STORE-MIGRATION.md
+++ b/docs/runbooks/KOMATIK-A5-STORE-MIGRATION.md
@@ -1,0 +1,59 @@
+# Komatik PR — A5 store migration (`agent_provenance_id`)
+
+> **Do not** apply this migration via Supabase MCP against production.
+> Ship through **Komatik PR → merge → deploy** only.
+
+## What this enables
+
+- `agent_provenance_id` column on `trailhead_evaluations` (from Trailhead `buildEvaluationStoreRow`)
+- Per-agent analytics and tuning digest group-by in Komatik / Trailhead Cloud
+- Optional `trailhead_detector_downgrades` audit table for auto-downgrade (Cloud in-memory tier already works standalone)
+
+## Steps
+
+1. Copy SQL from [`docs/komatik-migrations/20260529180000_trailhead_a5_agent_provenance.sql`](../komatik-migrations/20260529180000_trailhead_a5_agent_provenance.sql) into `Komatik/supabase/migrations/` with a new timestamp if needed.
+
+2. Update `platform/web/lib/trailhead/evaluation-store.ts` — add to `mapEvaluationStoreRow`:
+
+   ```typescript
+   agent_provenance_id:
+     pick(body, "agentProvenanceId", "agent_provenance_id") ?? null,
+   ```
+
+3. Merge Komatik PR → verify Vercel deploy → confirm Migration Drift Check green.
+
+4. Subscribe digest webhook (Komatik or Trailhead Cloud):
+
+   ```http
+   PUT /v1/digest/subscribe
+   Authorization: Bearer <trailhead-api-key>
+
+   {
+     "enabled": true,
+     "channel": "webhook",
+     "destination": "https://hooks.slack.com/services/...",
+     "fpThreshold": 15
+   }
+   ```
+
+5. Schedule daily delivery (Cloud env or external cron):
+
+   ```http
+   POST /v1/digest/tuning/deliver?days=7
+   Authorization: Bearer <trailhead-api-key>
+   ```
+
+   Cloud server: set `TRAILHEAD_CLOUD_DIGEST_CRON=1` and `TRAILHEAD_CLOUD_DIGEST_INTERVAL_HOURS=24`.
+
+## Verification
+
+```bash
+# After an agent PR gate run on a fleet repo:
+curl -s "https://komatik.ai/api/trailhead/evaluations?repo_id=KomatikAI/cairn&pr_number=N&limit=1" \
+  -H "Authorization: Bearer $INTERNAL_API_SECRET" | jq '.evaluations[0].agent_provenance_id'
+```
+
+## Related
+
+- [komatik-hosted-store.md](../komatik-hosted-store.md)
+- [tuning-digest-spec.md](../../cloud/docs/tuning-digest-spec.md)

--- a/mcp/src/submission-engine.ts
+++ b/mcp/src/submission-engine.ts
@@ -1,0 +1,226 @@
+// Gate 1 — agent submission quality (Phase B1).
+// Pure module: no @actions/*, octokit, or Node I/O.
+
+import type { RepoConfig, SubmissionCheckResult } from "./types.js";
+import { SubmissionCheckCode } from "./types.js";
+
+export type { SubmissionCheckCode, SubmissionCheckResult } from "./types.js";
+
+/** All Gate 1 check codes — keep in sync with A8 fixture manifest. */
+export const SUBMISSION_CHECK_CODES = SubmissionCheckCode.options;
+
+export interface SubmissionFileInfo {
+  filename: string;
+  patch?: string;
+  status?: string;
+}
+
+export interface SubmissionEngineOptions {
+  files: SubmissionFileInfo[];
+  repoConfig?: RepoConfig | null;
+  /** When true, enable Komatik-specific checks (SOUL paths, etc.). */
+  komatikInstance?: boolean;
+  mode?: "warn" | "block";
+}
+
+const MOCK_PLACEHOLDER_PATTERNS = [
+  /\bTODO\s*\(\s*mock\s*\)/i,
+  /\bFIXME\s*\(\s*mock\s*\)/i,
+  /\bMOCK_[A-Z0-9_]+\b/,
+  /\bfakeImplementation\b/,
+  /\bstubResponse\s*\(/i,
+];
+
+const SECRET_PATTERNS = [
+  /\bsk_live_[A-Za-z0-9]{10,}\b/,
+  /\bsk_test_[A-Za-z0-9]{10,}\b/,
+  /\bghp_[A-Za-z0-9]{20,}\b/,
+  /\bAKIA[0-9A-Z]{16}\b/,
+];
+
+const DESTRUCTIVE_SQL_PATTERNS = [
+  /\bDROP\s+TABLE\b/i,
+  /\bTRUNCATE\s+TABLE\b/i,
+  /\bDROP\s+COLUMN\b/i,
+];
+
+const DEFAULT_STALE_TERMS = ["deployguard", "DeployGuard"];
+
+function addedLines(patch: string | undefined): string[] {
+  if (!patch) return [];
+  return patch
+    .split("\n")
+    .filter((line) => line.startsWith("+") && !line.startsWith("+++"))
+    .map((line) => line.slice(1));
+}
+
+function scanAddedContent(
+  files: SubmissionFileInfo[],
+  predicate: (line: string, filename: string) => boolean,
+): string[] {
+  const hits: string[] = [];
+  for (const file of files) {
+    for (const line of addedLines(file.patch)) {
+      if (predicate(line, file.filename)) hits.push(file.filename);
+    }
+  }
+  return [...new Set(hits)];
+}
+
+function detectMockPlaceholder(
+  files: SubmissionFileInfo[],
+): SubmissionCheckResult | null {
+  const hits = scanAddedContent(files, (line) =>
+    MOCK_PLACEHOLDER_PATTERNS.some((re) => re.test(line)),
+  );
+  if (hits.length === 0) return null;
+  return {
+    code: "mock_placeholder",
+    severity: "blocking",
+    title: "Mock placeholder in production path",
+    detail: `Found mock/TODO placeholder patterns in ${hits.join(", ")}. Replace stubs before review.`,
+    files: hits,
+    suggested_action: "Remove mock placeholders and implement real behavior.",
+    autofix_eligible: false,
+  };
+}
+
+function detectSecrets(files: SubmissionFileInfo[]): SubmissionCheckResult | null {
+  const hits = scanAddedContent(files, (line) =>
+    SECRET_PATTERNS.some((re) => re.test(line)),
+  );
+  if (hits.length === 0) return null;
+  return {
+    code: "secrets",
+    severity: "blocking",
+    title: "Potential secret in diff",
+    detail: `Added lines match secret patterns in ${hits.join(", ")}. Rotate any exposed credential.`,
+    files: hits,
+    suggested_action:
+      "Remove secrets from source; use environment variables or a secret manager.",
+    autofix_eligible: false,
+  };
+}
+
+function detectDestructiveSql(files: SubmissionFileInfo[]): SubmissionCheckResult | null {
+  const sqlFiles = files.filter((f) => /\.sql$/i.test(f.filename));
+  const hits = scanAddedContent(sqlFiles, (line) =>
+    DESTRUCTIVE_SQL_PATTERNS.some((re) => re.test(line)),
+  );
+  if (hits.length === 0) return null;
+  return {
+    code: "destructive_sql",
+    severity: "blocking",
+    title: "Destructive SQL in migration",
+    detail: `Added SQL contains destructive statements in ${hits.join(", ")}.`,
+    files: hits,
+    suggested_action:
+      "Use additive migrations; avoid DROP/TRUNCATE without explicit human approval.",
+    autofix_eligible: false,
+  };
+}
+
+function detectContextFreshness(
+  files: SubmissionFileInfo[],
+  staleTerms: string[],
+): SubmissionCheckResult | null {
+  if (staleTerms.length === 0) return null;
+  const hits = scanAddedContent(files, (line) =>
+    staleTerms.some((term) => line.toLowerCase().includes(term.toLowerCase())),
+  );
+  if (hits.length === 0) return null;
+  return {
+    code: "context_freshness",
+    severity: "warn",
+    title: "Stale naming or deprecated terms",
+    detail: `Added lines reference deprecated terms (${staleTerms.join(", ")}) in ${hits.join(", ")}.`,
+    files: hits,
+    suggested_action:
+      "Update naming to match current product vocabulary (see BRAND.md / repo docs).",
+    autofix_eligible: true,
+  };
+}
+
+function detectPathFormat(files: SubmissionFileInfo[]): SubmissionCheckResult | null {
+  const hits = files
+    .map((f) => f.filename)
+    .filter(
+      (name) => /^komatik-agents\/agents\//.test(name) || /\/agents\/agents\//.test(name),
+    );
+  if (hits.length === 0) return null;
+  return {
+    code: "path_format",
+    severity: "warn",
+    title: "Suspicious agent path prefix",
+    detail: `Files use repo-name prefix in internal paths: ${hits.join(", ")}.`,
+    files: hits,
+    suggested_action:
+      "Use agents/<agent-id>/... not <repo>/agents/... for agent workspace paths.",
+    autofix_eligible: false,
+  };
+}
+
+function detectArtifactIntegrity(
+  files: SubmissionFileInfo[],
+): SubmissionCheckResult | null {
+  const prPaths = new Set(files.map((f) => f.filename.replace(/\\/g, "/")));
+  const referenced = new Set<string>();
+
+  const pathRefPattern =
+    /(?:^|\s|['"`])([\w@./-]+\.(?:ts|tsx|js|jsx|md|sql|yml|yaml|json))(?:['"`]|\s|:)/g;
+
+  for (const file of files) {
+    for (const line of addedLines(file.patch)) {
+      if (!/(?:import|from|require|see|fix|update)\s/i.test(line)) continue;
+      for (const match of line.matchAll(pathRefPattern)) {
+        const candidate = match[1]?.replace(/^\.\//, "");
+        if (!candidate || candidate.includes("*")) continue;
+        if (!prPaths.has(candidate) && !candidate.startsWith("node:")) {
+          referenced.add(candidate);
+        }
+      }
+    }
+  }
+
+  if (referenced.size === 0) return null;
+  const missing = [...referenced].slice(0, 8);
+  return {
+    code: "artifact_integrity",
+    severity: "blocking",
+    title: "Referenced files missing from PR",
+    detail: `Added lines reference paths not in this PR: ${missing.join(", ")}${referenced.size > 8 ? "…" : ""}.`,
+    files: missing,
+    suggested_action:
+      "Include the referenced files in this PR or fix hallucinated paths.",
+    autofix_eligible: false,
+  };
+}
+
+export function runSubmissionGate(
+  options: SubmissionEngineOptions,
+): SubmissionCheckResult[] {
+  const { files, repoConfig, komatikInstance = false } = options;
+  if (files.length === 0) return [];
+
+  const staleTerms =
+    repoConfig?.submission?.stale_terms ?? (komatikInstance ? DEFAULT_STALE_TERMS : []);
+
+  const checks: Array<SubmissionCheckResult | null> = [
+    detectMockPlaceholder(files),
+    detectSecrets(files),
+    detectDestructiveSql(files),
+    detectArtifactIntegrity(files),
+    detectContextFreshness(files, staleTerms),
+    komatikInstance ? detectPathFormat(files) : null,
+  ];
+
+  return checks.filter((check): check is SubmissionCheckResult => check !== null);
+}
+
+export function submissionGateShouldBlock(
+  checks: SubmissionCheckResult[],
+  mode: "warn" | "block" = "block",
+): boolean {
+  if (mode !== "block") return false;
+  return checks.some((check) => check.severity === "blocking");
+}

--- a/mcp/src/submission-remediation.ts
+++ b/mcp/src/submission-remediation.ts
@@ -1,27 +1,12 @@
-// Submission-gate remediation (Phase B preview).
-// Maps agent submission check results to RemediationFix entries so fleet
-// fixtures can exercise failure modes before submission-engine.ts lands.
+// Submission-gate remediation mapping (Phase B).
+// Maps submission-engine check results to RemediationFix entries.
 
 import { RemediationFix as RemediationFixSchema } from "./types.js";
-import type { RemediationFix, RemediationSeverity } from "./types.js";
+import type { RemediationFix } from "./types.js";
+import type { SubmissionCheckResult } from "./submission-engine.js";
 
-export const SUBMISSION_CHECK_CODES = [
-  "artifact_integrity",
-  "mock_placeholder",
-  "context_freshness",
-] as const;
-
-export type SubmissionCheckCode = (typeof SUBMISSION_CHECK_CODES)[number];
-
-export interface SubmissionCheckResult {
-  code: SubmissionCheckCode;
-  severity: RemediationSeverity;
-  title: string;
-  detail: string;
-  files?: string[];
-  suggested_action?: string;
-  autofix_eligible?: boolean;
-}
+export type { SubmissionCheckResult } from "./submission-engine.js";
+export { SubmissionCheckCode, SUBMISSION_CHECK_CODES } from "./submission-engine.js";
 
 export function deriveSubmissionFixes(
   checks: SubmissionCheckResult[] | undefined,

--- a/presets/trailhead-strict-agents.yml
+++ b/presets/trailhead-strict-agents.yml
@@ -1,0 +1,43 @@
+# Strict-agent preset for Phase A fleet rollout (#229).
+# Merge into .trailhead.yml or adopt wholesale on repos without existing policy.
+
+schema_version: 2
+
+gate:
+  mode: release-ready
+  agent_brief: collapsed
+
+thresholds:
+  risk: 60
+  warn: 40
+
+policies:
+  agent_prs:
+    enabled: true
+    risk_threshold: 40
+    strict_on_unknown_provenance: true
+    require_code_owner_approval: true
+  ci_integrity:
+    mode: block
+  workflow_security:
+    mode: block
+  prompt_injection:
+    mode: block
+  pr_scope:
+    mode: warn
+    max_files: 30
+    max_changes: 1500
+  duplicate_logic:
+    mode: warn
+
+remediation:
+  enabled: true
+  max_loop_rounds: 5
+
+override:
+  enabled: true
+  max_per_week: 5
+
+tuning:
+  auto_downgrade: true
+  fp_threshold: 0.15

--- a/scripts/batch-strict-preset-prs.mjs
+++ b/scripts/batch-strict-preset-prs.mjs
@@ -1,0 +1,261 @@
+#!/usr/bin/env node
+/**
+ * A6 / #229 — adopt strict-agent preset (.trailhead.yml) across Base Camp repos.
+ *
+ * Skips repos that already have policies.agent_prs.enabled: true.
+ * Does not modify workflow pins (see batch-v4.3-rollout-prs.mjs).
+ *
+ * Usage:
+ *   node scripts/batch-strict-preset-prs.mjs
+ *   node scripts/batch-strict-preset-prs.mjs --apply
+ *   node scripts/batch-strict-preset-prs.mjs --only=Komatik,shieldcheck
+ */
+
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const ORG = "KomatikAI";
+const BRANCH = "cursor/trailhead-strict-agents-preset";
+const CONFIG_PATH = ".trailhead.yml";
+const PRESET_PATH = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "presets",
+  "trailhead-strict-agents.yml",
+);
+const PRESET_CONTENT = readFileSync(PRESET_PATH, "utf8");
+
+/** 21-repo fleet minus retired/archived and this repo. */
+const REPOS = [
+  { name: "Komatik", base: "dev" },
+  { name: "komatik-agents", base: "main" },
+  { name: "komatik-base-camp", base: "dev" },
+  { name: "daydream-studio", base: "dev" },
+  { name: "storyboard-studio", base: "dev" },
+  { name: "shieldcheck", base: "dev" },
+  { name: "reviewflow", base: "dev" },
+  { name: "mcp-brokerage", base: "dev" },
+  { name: "rescue-engineering", base: "dev" },
+  { name: "shadow-ai-governance", base: "dev" },
+  { name: "komatik-yggdrasil", base: "dev" },
+  { name: "Bored", base: "dev" },
+  { name: "cairn", base: "dev" },
+  { name: "frontier", base: "dev" },
+  { name: "kindling", base: "dev" },
+  { name: "pack", base: "dev" },
+  { name: "slipstream", base: "dev" },
+  { name: "sundog", base: "dev" },
+  { name: "trace", base: "dev" },
+];
+
+const args = new Set(process.argv.slice(2));
+const apply = args.has("--apply");
+const onlyArg = process.argv.find((a) => a.startsWith("--only="));
+const onlyList = onlyArg
+  ? new Set(
+      onlyArg
+        .replace("--only=", "")
+        .split(",")
+        .map((s) => s.trim()),
+    )
+  : null;
+
+function gh(ghArgs) {
+  return execFileSync("gh", ghArgs, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+function tryGh(ghArgs) {
+  try {
+    return { ok: true, out: gh(ghArgs) };
+  } catch (err) {
+    return { ok: false, err: err.stderr?.toString?.() || err.message || String(err) };
+  }
+}
+
+function getFile(name, ref, filePath) {
+  const res = tryGh([
+    "api",
+    `repos/${ORG}/${name}/contents/${filePath}?ref=${ref}`,
+    "--jq",
+    "{sha: .sha, content: .content}",
+  ]);
+  if (!res.ok) return null;
+  const { sha, content } = JSON.parse(res.out);
+  return {
+    sha,
+    content: Buffer.from(content, "base64").toString("utf8"),
+    path: filePath,
+  };
+}
+
+function hasStrictAgentPreset(content) {
+  return (
+    /agent_prs:\s*\n[\s\S]*?enabled:\s*true/.test(content) &&
+    /risk_threshold:\s*40/.test(content)
+  );
+}
+
+function planRepo(repo) {
+  const meta = JSON.parse(
+    gh(["api", `repos/${ORG}/${repo.name}`, "--jq", "{archived: .archived}"]),
+  );
+  if (meta.archived) {
+    return { skip: true, reason: "archived" };
+  }
+
+  const existing = getFile(repo.name, repo.base, CONFIG_PATH);
+  if (existing && hasStrictAgentPreset(existing.content)) {
+    return { skip: true, reason: "strict preset already present", base: repo.base };
+  }
+
+  return {
+    skip: false,
+    base: repo.base,
+    existing,
+    content: PRESET_CONTENT,
+    action: existing ? "replace" : "create",
+  };
+}
+
+function prBody(name, plan) {
+  return [
+    "## Summary",
+    "",
+    "Adopt the Trailhead **strict-agent** preset for Phase A coach mode.",
+    "",
+    "## What changes",
+    "",
+    plan.action === "create"
+      ? `- Add \`${CONFIG_PATH}\` from [\`presets/trailhead-strict-agents.yml\`](https://github.com/KomatikAI/trailhead/blob/main/presets/trailhead-strict-agents.yml)`
+      : `- Replace \`${CONFIG_PATH}\` with the fleet strict-agent preset (prior config was minimal or missing agent_prs)`,
+    "",
+    "Key settings: `agent_prs.risk_threshold: 40`, blocking CI/workflow/prompt policies, remediation loop (5 rounds), override cap.",
+    "",
+    "## Rollback",
+    "",
+    "Revert this PR to restore the previous `.trailhead.yml`.",
+  ].join("\n");
+}
+
+function applyRepo(repo, plan) {
+  const baseSha = gh([
+    "api",
+    `repos/${ORG}/${repo.name}/git/ref/heads/${plan.base}`,
+    "--jq",
+    ".object.sha",
+  ]);
+
+  if (
+    !tryGh([
+      "api",
+      `repos/${ORG}/${repo.name}/git/ref/heads/${BRANCH}`,
+      "--jq",
+      ".object.sha",
+    ]).ok
+  ) {
+    const created = tryGh([
+      "api",
+      `repos/${ORG}/${repo.name}/git/refs`,
+      "-f",
+      `ref=refs/heads/${BRANCH}`,
+      "-f",
+      `sha=${baseSha}`,
+    ]);
+    if (!created.ok && !/Reference already exists/.test(created.err)) {
+      throw new Error(`branch create: ${created.err}`);
+    }
+  }
+
+  const payload = {
+    message: "chore(trailhead): adopt strict-agent preset (Phase A)",
+    content: Buffer.from(plan.content).toString("base64"),
+    branch: BRANCH,
+  };
+  if (plan.existing?.sha) payload.sha = plan.existing.sha;
+
+  gh([
+    "api",
+    "-X",
+    "PUT",
+    `repos/${ORG}/${repo.name}/contents/${CONFIG_PATH}`,
+    "-f",
+    `message=${payload.message}`,
+    "-f",
+    `content=${payload.content}`,
+    "-f",
+    `branch=${BRANCH}`,
+    ...(payload.sha ? ["-f", `sha=${payload.sha}`] : []),
+  ]);
+
+  const existingPr = tryGh([
+    "pr",
+    "list",
+    "--repo",
+    `${ORG}/${repo.name}`,
+    "--head",
+    BRANCH,
+    "--state",
+    "open",
+    "--json",
+    "url",
+    "--jq",
+    ".[0].url",
+  ]);
+  if (existingPr.ok && existingPr.out) return existingPr.out;
+
+  return gh([
+    "pr",
+    "create",
+    "--repo",
+    `${ORG}/${repo.name}`,
+    "--base",
+    plan.base,
+    "--head",
+    BRANCH,
+    "--title",
+    "chore(trailhead): adopt strict-agent preset (Phase A)",
+    "--body",
+    prBody(repo.name, plan),
+  ]);
+}
+
+const targets = REPOS.filter((r) => !onlyList || onlyList.has(r.name));
+let planned = 0;
+let opened = 0;
+const prUrls = [];
+
+for (const repo of targets) {
+  const plan = planRepo(repo);
+  if (plan.skip) {
+    console.log(`SKIP ${repo.name}: ${plan.reason}`);
+    continue;
+  }
+  planned += 1;
+  if (!apply) {
+    console.log(`PLAN ${repo.name} (base=${plan.base}): ${plan.action} ${CONFIG_PATH}`);
+    continue;
+  }
+  try {
+    const url = applyRepo(repo, plan);
+    opened += 1;
+    prUrls.push({ repo: repo.name, url });
+    console.log(`OK ${repo.name}: ${url}`);
+  } catch (err) {
+    console.error(`FAIL ${repo.name}: ${err.message || err}`);
+  }
+}
+
+console.log("\n--- Summary ---");
+console.log(`Mode:       ${apply ? "APPLY" : "DRY-RUN"}`);
+console.log(`Repos:      ${targets.length}`);
+console.log(`Planned:    ${planned}`);
+console.log(`Opened:     ${opened}`);
+if (prUrls.length) {
+  console.log("\n--- PRs ---");
+  for (const { repo, url } of prUrls) console.log(`${repo}: ${url}`);
+}

--- a/scripts/copy-shared-src.mjs
+++ b/scripts/copy-shared-src.mjs
@@ -35,6 +35,7 @@ const sharedFiles = [
   "remediation.ts",
   "loop-bookkeeping.ts",
   "submission-remediation.ts",
+  "submission-engine.ts",
   "remediation-lanes.ts",
   "trailhead-events.ts",
 ];

--- a/src/__tests__/fixtures/agent-failures/manifest.json
+++ b/src/__tests__/fixtures/agent-failures/manifest.json
@@ -14,7 +14,10 @@
   "coveredSubmissionCodes": [
     "artifact_integrity",
     "mock_placeholder",
-    "context_freshness"
+    "context_freshness",
+    "destructive_sql",
+    "secrets",
+    "path_format"
   ],
   "coveredRiskFactors": [
     "test_coverage",

--- a/src/__tests__/remediation.test.ts
+++ b/src/__tests__/remediation.test.ts
@@ -353,6 +353,7 @@ describe("buildRemediation", () => {
             title: "Mock leak",
             detail: "TODO(mock) in handler",
             files: ["src/handler.ts"],
+            autofix_eligible: false,
           },
         ],
         agentProvenance: true,

--- a/src/__tests__/submission-engine.test.ts
+++ b/src/__tests__/submission-engine.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { runSubmissionGate, submissionGateShouldBlock } from "../submission-engine.js";
+
+describe("submission-engine", () => {
+  it("blocks on mock placeholder patterns", () => {
+    const checks = runSubmissionGate({
+      files: [
+        {
+          filename: "src/handler.ts",
+          patch: "@@\n+export function run() { // TODO(mock) return {}; }\n",
+        },
+      ],
+    });
+    expect(checks.some((c) => c.code === "mock_placeholder")).toBe(true);
+    expect(submissionGateShouldBlock(checks)).toBe(true);
+  });
+
+  it("warns on stale naming terms when configured", () => {
+    const checks = runSubmissionGate({
+      files: [
+        {
+          filename: "README.md",
+          patch: "@@\n+Uses DeployGuard for gating.\n",
+        },
+      ],
+      komatikInstance: true,
+    });
+    const stale = checks.find((c) => c.code === "context_freshness");
+    expect(stale?.severity).toBe("warn");
+    expect(submissionGateShouldBlock(checks)).toBe(false);
+  });
+
+  it("blocks on destructive SQL", () => {
+    const checks = runSubmissionGate({
+      files: [
+        {
+          filename: "supabase/migrations/001.sql",
+          patch: "@@\n+DROP TABLE users;\n",
+        },
+      ],
+    });
+    expect(checks.some((c) => c.code === "destructive_sql")).toBe(true);
+  });
+
+  it("blocks when added lines reference missing files", () => {
+    const checks = runSubmissionGate({
+      files: [
+        {
+          filename: "src/index.ts",
+          patch: "@@\n+import { trust } from './trust.ts';\n",
+        },
+      ],
+    });
+    expect(checks.some((c) => c.code === "artifact_integrity")).toBe(true);
+  });
+});

--- a/src/__tests__/submission-remediation.test.ts
+++ b/src/__tests__/submission-remediation.test.ts
@@ -10,6 +10,7 @@ describe("deriveSubmissionFixes", () => {
         title: "Phantom file",
         detail: "Missing from diff",
         files: ["src/missing.ts"],
+        autofix_eligible: false,
       },
     ]);
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -29,6 +29,10 @@ const KNOWN_TOP_LEVEL_KEYS = new Set([
   "canary",
   "escalation",
   "policies",
+  "remediation",
+  "override",
+  "tuning",
+  "submission",
 ]);
 
 function warnUnknownTopLevelKeys(raw: unknown, configPath: string): void {

--- a/src/gate.ts
+++ b/src/gate.ts
@@ -65,6 +65,8 @@ import {
   hasOverrideLabel,
   resolveLabelOverride,
 } from "./override.js";
+import { runSubmissionGate, submissionGateShouldBlock } from "./submission-engine.js";
+import type { SubmissionCheckResult } from "./types.js";
 
 export {
   isSensitiveFile,
@@ -1716,6 +1718,22 @@ export async function evaluateGate(
     policyFindings.push(...agentPolicy.findings);
   }
 
+  let submissionChecks: SubmissionCheckResult[] = [];
+  const submissionMode = repoConfig?.submission?.mode ?? "block";
+  const submissionEnabled =
+    config.submissionGate === true || repoConfig?.submission?.enabled === true;
+  if (submissionEnabled && files.length > 0) {
+    submissionChecks = runSubmissionGate({
+      files,
+      repoConfig,
+      komatikInstance: process.env.KOMATIK_INSTANCE === "true",
+      mode: submissionMode,
+    });
+    if (submissionChecks.length > 0) {
+      policyFindings.push(`Submission gate: ${submissionChecks.length} finding(s).`);
+    }
+  }
+
   const sessionCorrelation = await detectSessionCorrelation({
     prNumber,
     token: config.githubToken,
@@ -1767,7 +1785,9 @@ export async function evaluateGate(
     (sessionCorrelation &&
       sessionCfg &&
       sessionCorrelation.burstCount >= sessionCfg.threshold &&
-      sessionCfg.mode === "block")
+      sessionCfg.mode === "block") ||
+    (submissionChecks.length > 0 &&
+      submissionGateShouldBlock(submissionChecks, submissionMode))
       ? ("block" as GateDecision)
       : baselineDecision;
 
@@ -1891,6 +1911,7 @@ export async function evaluateGate(
     trust_profile: trustProfile,
     gateMode,
     context: matchedContext?.matched,
+    submissionChecks: submissionChecks.length > 0 ? submissionChecks : undefined,
     cross_repo_impact:
       crossRepoImpact.services.length > 0
         ? {
@@ -2050,6 +2071,7 @@ export async function evaluateGate(
       agentProvenance: isAgentProvenanceType(
         localEvaluation.pr?.provenance?.type ?? "unknown",
       ),
+      submissionChecks,
     });
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -285,6 +285,7 @@ async function run(): Promise<void> {
       ciManifest,
       ciManifestPath: ciManifestPath || undefined,
       agentBrief,
+      submissionGate: core.getInput("submission-gate") === "true",
     };
 
     if (policyOverride?.changes.riskThreshold !== undefined) {

--- a/src/submission-engine.ts
+++ b/src/submission-engine.ts
@@ -1,0 +1,226 @@
+// Gate 1 — agent submission quality (Phase B1).
+// Pure module: no @actions/*, octokit, or Node I/O.
+
+import type { RepoConfig, SubmissionCheckResult } from "./types.js";
+import { SubmissionCheckCode } from "./types.js";
+
+export type { SubmissionCheckCode, SubmissionCheckResult } from "./types.js";
+
+/** All Gate 1 check codes — keep in sync with A8 fixture manifest. */
+export const SUBMISSION_CHECK_CODES = SubmissionCheckCode.options;
+
+export interface SubmissionFileInfo {
+  filename: string;
+  patch?: string;
+  status?: string;
+}
+
+export interface SubmissionEngineOptions {
+  files: SubmissionFileInfo[];
+  repoConfig?: RepoConfig | null;
+  /** When true, enable Komatik-specific checks (SOUL paths, etc.). */
+  komatikInstance?: boolean;
+  mode?: "warn" | "block";
+}
+
+const MOCK_PLACEHOLDER_PATTERNS = [
+  /\bTODO\s*\(\s*mock\s*\)/i,
+  /\bFIXME\s*\(\s*mock\s*\)/i,
+  /\bMOCK_[A-Z0-9_]+\b/,
+  /\bfakeImplementation\b/,
+  /\bstubResponse\s*\(/i,
+];
+
+const SECRET_PATTERNS = [
+  /\bsk_live_[A-Za-z0-9]{10,}\b/,
+  /\bsk_test_[A-Za-z0-9]{10,}\b/,
+  /\bghp_[A-Za-z0-9]{20,}\b/,
+  /\bAKIA[0-9A-Z]{16}\b/,
+];
+
+const DESTRUCTIVE_SQL_PATTERNS = [
+  /\bDROP\s+TABLE\b/i,
+  /\bTRUNCATE\s+TABLE\b/i,
+  /\bDROP\s+COLUMN\b/i,
+];
+
+const DEFAULT_STALE_TERMS = ["deployguard", "DeployGuard"];
+
+function addedLines(patch: string | undefined): string[] {
+  if (!patch) return [];
+  return patch
+    .split("\n")
+    .filter((line) => line.startsWith("+") && !line.startsWith("+++"))
+    .map((line) => line.slice(1));
+}
+
+function scanAddedContent(
+  files: SubmissionFileInfo[],
+  predicate: (line: string, filename: string) => boolean,
+): string[] {
+  const hits: string[] = [];
+  for (const file of files) {
+    for (const line of addedLines(file.patch)) {
+      if (predicate(line, file.filename)) hits.push(file.filename);
+    }
+  }
+  return [...new Set(hits)];
+}
+
+function detectMockPlaceholder(
+  files: SubmissionFileInfo[],
+): SubmissionCheckResult | null {
+  const hits = scanAddedContent(files, (line) =>
+    MOCK_PLACEHOLDER_PATTERNS.some((re) => re.test(line)),
+  );
+  if (hits.length === 0) return null;
+  return {
+    code: "mock_placeholder",
+    severity: "blocking",
+    title: "Mock placeholder in production path",
+    detail: `Found mock/TODO placeholder patterns in ${hits.join(", ")}. Replace stubs before review.`,
+    files: hits,
+    suggested_action: "Remove mock placeholders and implement real behavior.",
+    autofix_eligible: false,
+  };
+}
+
+function detectSecrets(files: SubmissionFileInfo[]): SubmissionCheckResult | null {
+  const hits = scanAddedContent(files, (line) =>
+    SECRET_PATTERNS.some((re) => re.test(line)),
+  );
+  if (hits.length === 0) return null;
+  return {
+    code: "secrets",
+    severity: "blocking",
+    title: "Potential secret in diff",
+    detail: `Added lines match secret patterns in ${hits.join(", ")}. Rotate any exposed credential.`,
+    files: hits,
+    suggested_action:
+      "Remove secrets from source; use environment variables or a secret manager.",
+    autofix_eligible: false,
+  };
+}
+
+function detectDestructiveSql(files: SubmissionFileInfo[]): SubmissionCheckResult | null {
+  const sqlFiles = files.filter((f) => /\.sql$/i.test(f.filename));
+  const hits = scanAddedContent(sqlFiles, (line) =>
+    DESTRUCTIVE_SQL_PATTERNS.some((re) => re.test(line)),
+  );
+  if (hits.length === 0) return null;
+  return {
+    code: "destructive_sql",
+    severity: "blocking",
+    title: "Destructive SQL in migration",
+    detail: `Added SQL contains destructive statements in ${hits.join(", ")}.`,
+    files: hits,
+    suggested_action:
+      "Use additive migrations; avoid DROP/TRUNCATE without explicit human approval.",
+    autofix_eligible: false,
+  };
+}
+
+function detectContextFreshness(
+  files: SubmissionFileInfo[],
+  staleTerms: string[],
+): SubmissionCheckResult | null {
+  if (staleTerms.length === 0) return null;
+  const hits = scanAddedContent(files, (line) =>
+    staleTerms.some((term) => line.toLowerCase().includes(term.toLowerCase())),
+  );
+  if (hits.length === 0) return null;
+  return {
+    code: "context_freshness",
+    severity: "warn",
+    title: "Stale naming or deprecated terms",
+    detail: `Added lines reference deprecated terms (${staleTerms.join(", ")}) in ${hits.join(", ")}.`,
+    files: hits,
+    suggested_action:
+      "Update naming to match current product vocabulary (see BRAND.md / repo docs).",
+    autofix_eligible: true,
+  };
+}
+
+function detectPathFormat(files: SubmissionFileInfo[]): SubmissionCheckResult | null {
+  const hits = files
+    .map((f) => f.filename)
+    .filter(
+      (name) => /^komatik-agents\/agents\//.test(name) || /\/agents\/agents\//.test(name),
+    );
+  if (hits.length === 0) return null;
+  return {
+    code: "path_format",
+    severity: "warn",
+    title: "Suspicious agent path prefix",
+    detail: `Files use repo-name prefix in internal paths: ${hits.join(", ")}.`,
+    files: hits,
+    suggested_action:
+      "Use agents/<agent-id>/... not <repo>/agents/... for agent workspace paths.",
+    autofix_eligible: false,
+  };
+}
+
+function detectArtifactIntegrity(
+  files: SubmissionFileInfo[],
+): SubmissionCheckResult | null {
+  const prPaths = new Set(files.map((f) => f.filename.replace(/\\/g, "/")));
+  const referenced = new Set<string>();
+
+  const pathRefPattern =
+    /(?:^|\s|['"`])([\w@./-]+\.(?:ts|tsx|js|jsx|md|sql|yml|yaml|json))(?:['"`]|\s|:)/g;
+
+  for (const file of files) {
+    for (const line of addedLines(file.patch)) {
+      if (!/(?:import|from|require|see|fix|update)\s/i.test(line)) continue;
+      for (const match of line.matchAll(pathRefPattern)) {
+        const candidate = match[1]?.replace(/^\.\//, "");
+        if (!candidate || candidate.includes("*")) continue;
+        if (!prPaths.has(candidate) && !candidate.startsWith("node:")) {
+          referenced.add(candidate);
+        }
+      }
+    }
+  }
+
+  if (referenced.size === 0) return null;
+  const missing = [...referenced].slice(0, 8);
+  return {
+    code: "artifact_integrity",
+    severity: "blocking",
+    title: "Referenced files missing from PR",
+    detail: `Added lines reference paths not in this PR: ${missing.join(", ")}${referenced.size > 8 ? "…" : ""}.`,
+    files: missing,
+    suggested_action:
+      "Include the referenced files in this PR or fix hallucinated paths.",
+    autofix_eligible: false,
+  };
+}
+
+export function runSubmissionGate(
+  options: SubmissionEngineOptions,
+): SubmissionCheckResult[] {
+  const { files, repoConfig, komatikInstance = false } = options;
+  if (files.length === 0) return [];
+
+  const staleTerms =
+    repoConfig?.submission?.stale_terms ?? (komatikInstance ? DEFAULT_STALE_TERMS : []);
+
+  const checks: Array<SubmissionCheckResult | null> = [
+    detectMockPlaceholder(files),
+    detectSecrets(files),
+    detectDestructiveSql(files),
+    detectArtifactIntegrity(files),
+    detectContextFreshness(files, staleTerms),
+    komatikInstance ? detectPathFormat(files) : null,
+  ];
+
+  return checks.filter((check): check is SubmissionCheckResult => check !== null);
+}
+
+export function submissionGateShouldBlock(
+  checks: SubmissionCheckResult[],
+  mode: "warn" | "block" = "block",
+): boolean {
+  if (mode !== "block") return false;
+  return checks.some((check) => check.severity === "blocking");
+}

--- a/src/submission-remediation.ts
+++ b/src/submission-remediation.ts
@@ -1,27 +1,12 @@
-// Submission-gate remediation (Phase B preview).
-// Maps agent submission check results to RemediationFix entries so fleet
-// fixtures can exercise failure modes before submission-engine.ts lands.
+// Submission-gate remediation mapping (Phase B).
+// Maps submission-engine check results to RemediationFix entries.
 
 import { RemediationFix as RemediationFixSchema } from "./types.js";
-import type { RemediationFix, RemediationSeverity } from "./types.js";
+import type { RemediationFix } from "./types.js";
+import type { SubmissionCheckResult } from "./submission-engine.js";
 
-export const SUBMISSION_CHECK_CODES = [
-  "artifact_integrity",
-  "mock_placeholder",
-  "context_freshness",
-] as const;
-
-export type SubmissionCheckCode = (typeof SUBMISSION_CHECK_CODES)[number];
-
-export interface SubmissionCheckResult {
-  code: SubmissionCheckCode;
-  severity: RemediationSeverity;
-  title: string;
-  detail: string;
-  files?: string[];
-  suggested_action?: string;
-  autofix_eligible?: boolean;
-}
+export type { SubmissionCheckResult } from "./submission-engine.js";
+export { SubmissionCheckCode, SUBMISSION_CHECK_CODES } from "./submission-engine.js";
 
 export function deriveSubmissionFixes(
   checks: SubmissionCheckResult[] | undefined,

--- a/src/types.ts
+++ b/src/types.ts
@@ -95,6 +95,27 @@ export type MatchedContext = z.infer<typeof MatchedContext>;
 export const RemediationSeverity = z.enum(["blocking", "warn", "advisory"]);
 export type RemediationSeverity = z.infer<typeof RemediationSeverity>;
 
+export const SubmissionCheckCode = z.enum([
+  "artifact_integrity",
+  "mock_placeholder",
+  "context_freshness",
+  "destructive_sql",
+  "secrets",
+  "path_format",
+]);
+export type SubmissionCheckCode = z.infer<typeof SubmissionCheckCode>;
+
+export const SubmissionCheckResult = z.object({
+  code: SubmissionCheckCode,
+  severity: RemediationSeverity,
+  title: z.string(),
+  detail: z.string(),
+  files: z.array(z.string()).default([]),
+  suggested_action: z.string().optional(),
+  autofix_eligible: z.boolean().default(false),
+});
+export type SubmissionCheckResult = z.infer<typeof SubmissionCheckResult>;
+
 export const RemediationAutofixClass = z.enum([
   "format",
   "lint",
@@ -224,6 +245,7 @@ export const GateEvaluation = z.object({
   storePersisted: z.boolean().optional(),
   remediation: Remediation.optional(),
   agentBriefMode: AgentBriefMode.optional(),
+  submissionChecks: z.array(SubmissionCheckResult).optional(),
   cross_repo_impact: z
     .object({
       services: z.array(
@@ -377,12 +399,20 @@ export const TuningConfig = z.object({
 });
 export type TuningConfig = z.infer<typeof TuningConfig>;
 
+export const SubmissionConfig = z.object({
+  enabled: z.boolean().default(false),
+  mode: z.enum(["warn", "block"]).default("block"),
+  stale_terms: z.array(z.string()).optional(),
+});
+export type SubmissionConfig = z.infer<typeof SubmissionConfig>;
+
 export const RepoConfig = z.object({
   schema_version: z.number().int().positive().default(1),
   gate: GateConfig.default({}),
   remediation: RemediationConfig.optional(),
   override: OverrideConfig.optional(),
   tuning: TuningConfig.optional(),
+  submission: SubmissionConfig.optional(),
   contexts: z.array(TrailheadContext).default([]),
   sensitivity: z
     .object({
@@ -511,6 +541,7 @@ export interface TrailheadConfig {
   ciManifest?: CiManifest | null;
   ciManifestPath?: string;
   agentBrief?: AgentBriefMode;
+  submissionGate?: boolean;
 }
 
 export interface TestRepairResult {


### PR DESCRIPTION
## Summary
- **Phase A closure:** Komatik A5 store migration SQL + runbook, strict-agent preset (`presets/trailhead-strict-agents.yml`), batch rollout script (`scripts/batch-strict-preset-prs.mjs`), Cloud digest cron (`TRAILHEAD_CLOUD_DIGEST_CRON=1`), hosted-store doc refresh (v4.3.3 fleet status).
- **Phase B1 (preview):** `submission-engine.ts` with six Gate 1 checks (mock placeholders, secrets, destructive SQL, artifact integrity, context freshness, Komatik path format); optional `submission-gate` action input + `.trailhead.yml submission` config; wired into `evaluateGate` blocking + remediation `submission.*` fix codes.
- **Cloud test hardening:** per-test app isolation, seed org bootstrap, inclusive digest time window (fixes same-ms flake).

## Test plan
- [x] `npm test` — 654 root tests
- [x] `npm run lint` — ESLint + tsc
- [x] `npm run build` — ncc bundle + committed `dist/`
- [x] `cd cloud && npx vitest run` — 27 cloud tests

## Ops follow-ups (not in this PR)
- Komatik PR: apply `docs/komatik-migrations/20260529180000_trailhead_a5_agent_provenance.sql` per runbook
- Dry-run then apply: `node scripts/batch-strict-preset-prs.mjs --apply` for #229
- Enable digest cron in Cloud prod when webhook destination is configured


Made with [Cursor](https://cursor.com)