### PR TITLE
feat(v4.4.0): Phase B — Gate 1 engine, autofix allowlist, trust scoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to Trailhead will be documented in this file.
 
 ## Unreleased
 
+## [4.4.0] - 2026-05-29
+
+### Added — Phase B (Fixer / Gate 1 extraction)
+
+- **B1 Gate 1 engine** — `src/submission-engine.ts` + `src/submission-checks/` ports 15 checks from `komatik-agents` (secrets, destructive SQL, RLS, auth routes, syntax validity with optional `@swc/core` or bracket fallback, import resolution, mock placeholders, etc.). Action input `submission-gate: "true"` and `.trailhead.yml` `submission.enabled`. Komatik-only checks gated on `KOMATIK_INSTANCE=true`.
+- **B2 Autofix allowlist** — `src/fixer-core.ts` red-lane globs + allowlisted autofix classes; `app/src/fixer.ts` plans one fix per round (dry-run in v4.4.0; git write in follow-up App PR).
+- **B3 Trust scoring** — `src/trust-score.ts` computes fast-track / standard / probation profiles; `evaluateGate` reads `TRAILHEAD_AGENT_TRUST_JSON` and extends `trust_profile` with `score`, `profile`, `factors`.
+- **B4 dogfood wiring** — `presets/trailhead-strict-agents.yml` enables `submission.enabled`; `examples/agent-submission-fixture/` for external repos. Komatik `komatik-agents` CI flip to enforce mode is a separate PR after FP metrics.
+
+### Changed
+
+- **`scripts/copy-shared-src.mjs`** — copies `fixer-core`, `trust-score`, and `submission-checks/` into `app/` and `mcp/`.
+
 ## [4.3.3] - 2026-05-29
 
 ### Added — Phase A completion (A5–A8, A7)

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trailhead-app",
-  "version": "4.3.3",
+  "version": "4.4.0",
   "private": true,
   "type": "module",
   "description": "Trailhead GitHub App — Deployment Protection Rule webhook handler",

--- a/app/src/fixer-core.ts
+++ b/app/src/fixer-core.ts
@@ -35,17 +35,39 @@ export interface AutofixPlan {
   blocked: Array<{ fix: RemediationFix; reason: string }>;
 }
 
+function escapeRegexChar(ch: string): string {
+  return /[\\^$+?.()|{}[\]]/.test(ch) ? `\\${ch}` : ch;
+}
+
+function globToRegex(glob: string): RegExp {
+  let src = "^";
+  for (let i = 0; i < glob.length; i++) {
+    const c = glob[i]!;
+    if (c === "*") {
+      if (glob[i + 1] === "*") {
+        src += ".*";
+        i++;
+      } else {
+        src += "[^/]*";
+      }
+    } else if (c === ".") {
+      src += "\\.";
+    } else {
+      src += escapeRegexChar(c);
+    }
+  }
+  src += "$";
+  return new RegExp(src);
+}
+
 function matchesGlob(path: string, glob: string): boolean {
   const normalized = path.replace(/\\/g, "/");
   if (glob.endsWith("/**")) {
-    const prefix = glob.slice(0, -3);
-    return normalized.includes(prefix.replace(/\*\*/g, ""));
+    const prefix = glob.slice(0, -3).replace(/\*\*/g, "");
+    return normalized.includes(prefix);
   }
   if (glob.includes("*")) {
-    const re = new RegExp(
-      `^${glob.replace(/\*\*/g, ".*").replace(/\*/g, "[^/]*").replace(/\./g, "\\.")}$`,
-    );
-    return re.test(normalized);
+    return globToRegex(glob).test(normalized);
   }
   return normalized.includes(glob);
 }

--- a/app/src/fixer-core.ts
+++ b/app/src/fixer-core.ts
@@ -42,7 +42,7 @@ function escapeRegexChar(ch: string): string {
 function globToRegex(glob: string): RegExp {
   let src = "^";
   for (let i = 0; i < glob.length; i++) {
-    const c = glob[i]!;
+    const c = glob.charAt(i);
     if (c === "*") {
       if (glob[i + 1] === "*") {
         src += ".*";

--- a/app/src/fixer-core.ts
+++ b/app/src/fixer-core.ts
@@ -1,0 +1,100 @@
+// Phase B2 — autofix allowlist (pure module; execution lives in app/fixer.ts).
+
+import type { RemediationAutofixClass, RemediationFix } from "./types.js";
+
+export const RED_LANE_GLOBS = [
+  "**/migrations/**",
+  "**/*.sql",
+  "**/rls/**",
+  "src/auth/**",
+  "app/**/auth/**",
+  ".github/workflows/**",
+  "agents/*/SOUL.md",
+  "src/risk-engine.ts",
+  "**/secrets/**",
+  "**/payments/**",
+];
+
+const ALLOWED_AUTOFIX_CLASSES = new Set<RemediationAutofixClass>([
+  "format",
+  "lint",
+  "import-fix",
+  "test-scaffold",
+  "doc-update",
+  "dependency-bump",
+]);
+
+export interface AutofixPlanItem {
+  fix: RemediationFix;
+  files: string[];
+  autofix_class: RemediationAutofixClass;
+}
+
+export interface AutofixPlan {
+  items: AutofixPlanItem[];
+  blocked: Array<{ fix: RemediationFix; reason: string }>;
+}
+
+function matchesGlob(path: string, glob: string): boolean {
+  const normalized = path.replace(/\\/g, "/");
+  if (glob.endsWith("/**")) {
+    const prefix = glob.slice(0, -3);
+    return normalized.includes(prefix.replace(/\*\*/g, ""));
+  }
+  if (glob.includes("*")) {
+    const re = new RegExp(
+      `^${glob.replace(/\*\*/g, ".*").replace(/\*/g, "[^/]*").replace(/\./g, "\\.")}$`,
+    );
+    return re.test(normalized);
+  }
+  return normalized.includes(glob);
+}
+
+export function isRedLanePath(filePath: string): boolean {
+  const normalized = filePath.replace(/\\/g, "/");
+  return RED_LANE_GLOBS.some((glob) => matchesGlob(normalized, glob));
+}
+
+export function isAutofixClassAllowed(autofixClass: RemediationAutofixClass): boolean {
+  return ALLOWED_AUTOFIX_CLASSES.has(autofixClass);
+}
+
+export function buildAutofixPlan(fixes: RemediationFix[]): AutofixPlan {
+  const items: AutofixPlanItem[] = [];
+  const blocked: AutofixPlan["blocked"] = [];
+
+  for (const fix of fixes) {
+    if (!fix.autofix_eligible || !fix.autofix_class) continue;
+
+    if (!isAutofixClassAllowed(fix.autofix_class)) {
+      blocked.push({
+        fix,
+        reason: `Autofix class not allowlisted: ${fix.autofix_class}`,
+      });
+      continue;
+    }
+
+    const touchFiles = fix.files.length > 0 ? fix.files : ["."];
+    const redLane = touchFiles.filter(isRedLanePath);
+    if (redLane.length > 0) {
+      blocked.push({
+        fix,
+        reason: `Red-lane paths forbid autofix: ${redLane.join(", ")}`,
+      });
+      continue;
+    }
+
+    items.push({
+      fix,
+      files: touchFiles,
+      autofix_class: fix.autofix_class,
+    });
+  }
+
+  return { items, blocked };
+}
+
+/** Max one fix commit per gate round (Phase B2). */
+export function selectAutofixCommit(plan: AutofixPlan): AutofixPlanItem | null {
+  return plan.items[0] ?? null;
+}

--- a/app/src/fixer.ts
+++ b/app/src/fixer.ts
@@ -1,0 +1,78 @@
+/**
+ * Trailhead fixer — commits allowlisted autofixes to a PR branch (Phase B2).
+ * Requires GitHub App `contents: write` on the target repo.
+ */
+
+import type { AutofixPlanItem } from "./fixer-core.js";
+import { buildAutofixPlan, selectAutofixCommit } from "./fixer-core.js";
+import type { RemediationFix } from "../types.js";
+
+export interface FixerCommitResult {
+  committed: boolean;
+  evaluationId?: string;
+  autofixClass?: string;
+  files?: string[];
+  message?: string;
+  skippedReason?: string;
+}
+
+export interface FixerOptions {
+  fixes: RemediationFix[];
+  evaluationId: string;
+  trustAutofixEnabled?: boolean;
+  /** When true, compute plan only — no git write. */
+  dryRun?: boolean;
+}
+
+export function planAutofix(options: FixerOptions): {
+  selected: AutofixPlanItem | null;
+  blockedCount: number;
+} {
+  if (options.trustAutofixEnabled === false) {
+    return { selected: null, blockedCount: 0 };
+  }
+
+  const plan = buildAutofixPlan(options.fixes);
+  return {
+    selected: selectAutofixCommit(plan),
+    blockedCount: plan.blocked.length,
+  };
+}
+
+/**
+ * Apply at most one autofix commit for this evaluation round.
+ * GitHub write path is wired in a follow-up App handler PR.
+ */
+export async function applyAutofixRound(
+  options: FixerOptions,
+): Promise<FixerCommitResult> {
+  const { selected, blockedCount } = planAutofix(options);
+
+  if (!selected) {
+    return {
+      committed: false,
+      skippedReason:
+        blockedCount > 0
+          ? "All autofix candidates blocked (red lane or disallowed class)"
+          : "No autofix-eligible fixes in remediation payload",
+    };
+  }
+
+  if (options.dryRun) {
+    return {
+      committed: false,
+      evaluationId: options.evaluationId,
+      autofixClass: selected.autofix_class,
+      files: selected.files,
+      message: `[trailhead-fixer] dry-run: would apply ${selected.autofix_class}`,
+    };
+  }
+
+  return {
+    committed: false,
+    evaluationId: options.evaluationId,
+    autofixClass: selected.autofix_class,
+    files: selected.files,
+    skippedReason: "Fixer git write not yet enabled — dry-run only in v4.4.0",
+  };
+}

--- a/app/src/fixer.ts
+++ b/app/src/fixer.ts
@@ -5,7 +5,7 @@
 
 import type { AutofixPlanItem } from "./fixer-core.js";
 import { buildAutofixPlan, selectAutofixCommit } from "./fixer-core.js";
-import type { RemediationFix } from "../types.js";
+import type { RemediationFix } from "./types.js";
 
 export interface FixerCommitResult {
   committed: boolean;

--- a/app/src/submission-checks/detectors.ts
+++ b/app/src/submission-checks/detectors.ts
@@ -1,0 +1,632 @@
+// Gate 1 detectors — ported from komatik-agents agent-gate-checks (patch/content based).
+
+import type { SubmissionCheckResult } from "../types.js";
+import type { SubmissionCheckContext, SubmissionFileInfo } from "./types.js";
+import {
+  addedLines,
+  extensionOf,
+  fileContent,
+  isTestPath,
+  lineCountFromPatch,
+  normalizePath,
+  scanAddedContent,
+} from "./helpers.js";
+
+export const OLD_NAME_PATTERNS: Array<{
+  oldName: string;
+  newName: string;
+  pattern: RegExp;
+}> = [
+  { oldName: "DeployGuard", newName: "Trailhead", pattern: /\bDeployGuard\b/g },
+  { oldName: "Daydream Studio", newName: "Sundog", pattern: /\bDaydream Studio\b/g },
+  {
+    oldName: "Storyboard Studio",
+    newName: "Kindling",
+    pattern: /\bStoryboard Studio\b/g,
+  },
+  { oldName: "Cognitive Debt", newName: "Drift", pattern: /\bCognitive Debt\b/g },
+  { oldName: "cognitive-debt", newName: "Drift", pattern: /\bcognitive-debt\b/g },
+];
+
+const MOCK_PATTERNS = [
+  /\bTODO\s*\(\s*mock\s*\)/i,
+  /\bFIXME\s*\(\s*mock\s*\)/i,
+  /\bMOCK_[A-Z0-9_]+\b/,
+  /\bfakeImplementation\b/,
+  /\bstubResponse\s*\(/i,
+  /\b(?:generate|create|build|get)(?:Mock|Fake|Dummy|Sample)\w*/g,
+  /\b(?:mockData|fakeData|sampleData|dummyData|testData)\b/g,
+  /\bTODO:\s*implement\b/gi,
+  /\bFIXME\b/g,
+  /\bplaceholder\b/gi,
+  /\blorem ipsum\b/gi,
+];
+
+const SECRET_PATTERNS: Array<{ name: string; pattern: RegExp }> = [
+  { name: "AWS access key", pattern: /\bAKIA[0-9A-Z]{16}\b/g },
+  { name: "GitHub token", pattern: /\bgh[pousr]_[A-Za-z0-9_]{20,}\b/g },
+  { name: "Stripe live key", pattern: /\bsk_live_[A-Za-z0-9]{10,}\b/g },
+  { name: "Stripe test key", pattern: /\bsk_test_[A-Za-z0-9]{10,}\b/g },
+  { name: "Private key block", pattern: /-----BEGIN [A-Z ]+PRIVATE KEY-----/g },
+  {
+    name: "Generic API key assignment",
+    pattern: /api[_-]?key\s*[:=]\s*['"][A-Za-z0-9_-]{32,}['"]/gi,
+  },
+];
+
+const HARDCODED_ENV_PATTERNS: Array<{ name: string; pattern: RegExp }> = [
+  { name: "localhost with port", pattern: /(?:['"`])localhost:\d{2,5}(?:['"`])/g },
+  {
+    name: "hardcoded private IP",
+    pattern:
+      /(?:['"`])(?:10\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.(?:1[6-9]|2\d|3[01])\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3})(?::\d+)?(?:['"`])/g,
+  },
+];
+
+const NODE_BUILTINS = new Set([
+  "assert",
+  "async_hooks",
+  "buffer",
+  "child_process",
+  "cluster",
+  "console",
+  "constants",
+  "crypto",
+  "dgram",
+  "dns",
+  "events",
+  "fs",
+  "http",
+  "http2",
+  "https",
+  "module",
+  "net",
+  "os",
+  "path",
+  "process",
+  "stream",
+  "url",
+  "util",
+  "zlib",
+]);
+
+function result(
+  partial: Omit<SubmissionCheckResult, "autofix_eligible"> & {
+    autofix_eligible?: boolean;
+  },
+): SubmissionCheckResult {
+  return { autofix_eligible: false, ...partial };
+}
+
+export function detectMockPlaceholder(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const hits = scanAddedContent(ctx.files, (line, filename) => {
+    if (isTestPath(filename)) return false;
+    if (/\.(md|txt)$/i.test(filename)) return false;
+    return MOCK_PATTERNS.some((re) => {
+      re.lastIndex = 0;
+      return re.test(line);
+    });
+  });
+  if (hits.length === 0) return null;
+  return result({
+    code: "mock_placeholder",
+    severity: "blocking",
+    title: "Mock placeholder in production path",
+    detail: `Found mock/TODO placeholder patterns in ${hits.join(", ")}.`,
+    files: hits,
+    suggested_action: "Remove mock placeholders and implement real behavior.",
+  });
+}
+
+export function detectSecrets(ctx: SubmissionCheckContext): SubmissionCheckResult | null {
+  const hits = scanAddedContent(ctx.files, (line) =>
+    SECRET_PATTERNS.some((entry) => {
+      entry.pattern.lastIndex = 0;
+      return entry.pattern.test(line);
+    }),
+  );
+  if (hits.length === 0) return null;
+  return result({
+    code: "secrets",
+    severity: "blocking",
+    title: "Potential secret in diff",
+    detail: `Added lines match secret patterns in ${hits.join(", ")}.`,
+    files: hits,
+    suggested_action: "Remove secrets; use environment variables or a secret manager.",
+  });
+}
+
+export function detectDestructiveSql(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const sqlFiles = ctx.files.filter((f) => extensionOf(f.filename) === ".sql");
+  const hits = scanAddedContent(sqlFiles, (line) =>
+    /\b(DROP\s+TABLE|TRUNCATE|DELETE\s+FROM(?![^\n]*\bWHERE\b))/i.test(line),
+  );
+  if (hits.length === 0) return null;
+  return result({
+    code: "destructive_sql",
+    severity: "blocking",
+    title: "Destructive SQL in migration",
+    detail: `Added SQL contains destructive statements in ${hits.join(", ")}.`,
+    files: hits,
+    suggested_action:
+      "Use additive migrations; avoid DROP/TRUNCATE without human approval.",
+  });
+}
+
+export function detectArtifactIntegrity(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const referenced = new Set<string>();
+  const pathRefPattern =
+    /(?:^|\s|['"`])([\w@./-]+\.(?:ts|tsx|js|jsx|md|sql|yml|yaml|json))(?:['"`]|\s|:)/g;
+
+  for (const file of ctx.files) {
+    for (const line of addedLines(file.patch)) {
+      if (!/(?:import|from|require|see|fix|update)\s/i.test(line)) continue;
+      for (const match of line.matchAll(pathRefPattern)) {
+        const candidate = match[1]?.replace(/^\.\//, "");
+        if (!candidate || candidate.includes("*")) continue;
+        if (!ctx.prPaths.has(candidate) && !candidate.startsWith("node:")) {
+          referenced.add(candidate);
+        }
+      }
+    }
+  }
+
+  if (referenced.size === 0) return null;
+  const missing = [...referenced].slice(0, 8);
+  return result({
+    code: "artifact_integrity",
+    severity: "blocking",
+    title: "Referenced files missing from PR",
+    detail: `Added lines reference paths not in this PR: ${missing.join(", ")}${referenced.size > 8 ? "…" : ""}.`,
+    files: missing,
+    suggested_action: "Include referenced files or fix hallucinated paths.",
+  });
+}
+
+function isNamingAllowlisted(filename: string, line: string): boolean {
+  const trimmed = line.trim();
+  if (/^import\s|^from\s|require\(/.test(trimmed)) return true;
+  if (/\.sql$/i.test(filename)) return true;
+  if (/(?:^|\/)migrations\//.test(filename)) return true;
+  if (/(?:^|\/)memory\//.test(filename)) return true;
+  if (/RESEARCH\.md$|BRAND\.md$|CHANGELOG\.md$/.test(filename)) return true;
+  if (/^\[.*\]\(.*\)/.test(trimmed)) return true;
+  return false;
+}
+
+export function detectContextFreshness(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  if (ctx.staleTerms.length === 0 && !ctx.komatikInstance) return null;
+
+  const hits: string[] = [];
+  for (const file of ctx.files) {
+    for (const line of addedLines(file.patch)) {
+      if (isNamingAllowlisted(file.filename, line)) continue;
+
+      const terms = ctx.staleTerms.length > 0 ? ctx.staleTerms : [];
+      for (const term of terms) {
+        if (line.toLowerCase().includes(term.toLowerCase())) hits.push(file.filename);
+      }
+
+      if (ctx.komatikInstance) {
+        for (const entry of OLD_NAME_PATTERNS) {
+          entry.pattern.lastIndex = 0;
+          if (entry.pattern.test(line)) hits.push(file.filename);
+        }
+      }
+    }
+  }
+
+  const unique = [...new Set(hits)];
+  if (unique.length === 0) return null;
+  return result({
+    code: "context_freshness",
+    severity: "warn",
+    title: "Stale naming or deprecated terms",
+    detail: `Added lines reference deprecated terms in ${unique.join(", ")}.`,
+    files: unique,
+    suggested_action: "Update naming to current product vocabulary (see BRAND.md).",
+    autofix_eligible: true,
+  });
+}
+
+export function detectPathFormat(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  if (!ctx.komatikInstance) return null;
+  const hits = ctx.files
+    .map((f) => normalizePath(f.filename))
+    .filter(
+      (name) =>
+        /^komatik-agents\/agents\//.test(name) ||
+        /\/agents\/agents\//.test(name) ||
+        (!/^agents\/[a-z][a-z0-9-]*\/suggestions\//.test(name) &&
+          /\/suggestions\//.test(name) &&
+          !name.startsWith("agents/")),
+    );
+  if (hits.length === 0) return null;
+  return result({
+    code: "path_format",
+    severity: "warn",
+    title: "Suspicious agent suggestion path",
+    detail: `Paths should match agents/<id>/suggestions/<project>/… — found: ${hits.join(", ")}.`,
+    files: hits,
+    suggested_action: "Use canonical agent suggestion paths without repo prefix.",
+  });
+}
+
+export function detectHardcodedEnv(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const hits = scanAddedContent(ctx.files, (line, filename) => {
+    if (/\.(md|txt)$/i.test(filename)) return false;
+    if (/^\s*\/\/|^\s*\*|^\s*#/.test(line)) return false;
+    return HARDCODED_ENV_PATTERNS.some((entry) => {
+      entry.pattern.lastIndex = 0;
+      return entry.pattern.test(line);
+    });
+  });
+  if (hits.length === 0) return null;
+  return result({
+    code: "hardcoded_env",
+    severity: "blocking",
+    title: "Hardcoded environment value",
+    detail: `Added lines contain hardcoded localhost/IP patterns in ${hits.join(", ")}.`,
+    files: hits,
+    suggested_action:
+      "Use environment variables or configuration instead of hardcoded hosts.",
+  });
+}
+
+export function detectLargeFile(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const hits = ctx.files
+    .filter((file) => {
+      const lines =
+        typeof file.content === "string"
+          ? file.content.split("\n").length
+          : lineCountFromPatch(file.patch);
+      return lines > ctx.maxFileLines;
+    })
+    .map((f) => f.filename);
+  if (hits.length === 0) return null;
+  return result({
+    code: "large_file",
+    severity: "warn",
+    title: "Large file in PR",
+    detail: `Files exceed ${ctx.maxFileLines} lines: ${hits.join(", ")}.`,
+    files: hits,
+    suggested_action: "Split large changes into smaller PRs.",
+  });
+}
+
+function extractRelativeImports(content: string): string[] {
+  const imports: string[] = [];
+  const patterns = [
+    /\bimport\s+(?:type\s+)?(?:[^'"]+\s+from\s+)?['"](\.\.?[^'"]+)['"]/g,
+    /\brequire\(\s*['"](\.\.?[^'"]+)['"]\s*\)/g,
+  ];
+  for (const pattern of patterns) {
+    for (const match of content.matchAll(pattern)) {
+      if (match[1]) imports.push(match[1]);
+    }
+  }
+  return imports;
+}
+
+function resolveRelativeImport(
+  fromFile: string,
+  specifier: string,
+  prPaths: Set<string>,
+): boolean {
+  const clean = specifier.split("?")[0].split("#")[0];
+  const baseDir = normalizePath(fromFile).split("/").slice(0, -1);
+  const segments = clean.replace(/^\.\//, "").split("/");
+  for (const segment of segments) {
+    if (segment === "..") baseDir.pop();
+    else if (segment !== ".") baseDir.push(segment);
+  }
+  const resolved = baseDir.join("/");
+  const candidates = [
+    resolved,
+    `${resolved}.ts`,
+    `${resolved}.tsx`,
+    `${resolved}.js`,
+    `${resolved}.jsx`,
+    `${resolved}/index.ts`,
+    `${resolved}/index.js`,
+  ];
+  return candidates.some((c) => prPaths.has(c));
+}
+
+export function detectImportResolution(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const codeExts = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"]);
+  const hits: string[] = [];
+
+  for (const file of ctx.files) {
+    if (!codeExts.has(extensionOf(file.filename))) continue;
+    const content = fileContent(file);
+    for (const specifier of extractRelativeImports(content)) {
+      if (!resolveRelativeImport(file.filename, specifier, ctx.prPaths)) {
+        hits.push(file.filename);
+        break;
+      }
+    }
+  }
+
+  if (hits.length === 0) return null;
+  return result({
+    code: "import_resolution",
+    severity: "blocking",
+    title: "Unresolved relative import",
+    detail: `Relative imports could not be resolved within this PR: ${[...new Set(hits)].join(", ")}.`,
+    files: [...new Set(hits)],
+    suggested_action: "Add missing files to the PR or fix import paths.",
+  });
+}
+
+export function detectRlsNewTables(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const sqlFiles = ctx.files.filter((f) => extensionOf(f.filename) === ".sql");
+  const corpus = sqlFiles.map((f) => fileContent(f)).join("\n");
+  const hits: string[] = [];
+  const createTable =
+    /\bCREATE\s+(?!TEMP(?:ORARY)?\s+)TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?((?:"?[A-Za-z_][\w$]*"?\.)?"?[A-Za-z_][\w$]*"?)/gi;
+
+  for (const file of sqlFiles) {
+    const content = fileContent(file);
+    for (const match of content.matchAll(createTable)) {
+      const table = match[1]?.replace(/"/g, "") ?? "";
+      const pattern = new RegExp(
+        `ALTER\\s+TABLE\\s+(?:ONLY\\s+)?["']?${table.split(".").pop()}["']?\\s+ENABLE\\s+ROW\\s+LEVEL\\s+SECURITY`,
+        "i",
+      );
+      if (!pattern.test(corpus)) hits.push(file.filename);
+    }
+  }
+
+  if (hits.length === 0) return null;
+  return result({
+    code: "rls_new_tables",
+    severity: "blocking",
+    title: "New table missing RLS",
+    detail: `CREATE TABLE without ENABLE ROW LEVEL SECURITY in ${[...new Set(hits)].join(", ")}.`,
+    files: [...new Set(hits)],
+    suggested_action:
+      "Add ALTER TABLE ... ENABLE ROW LEVEL SECURITY for every new table.",
+  });
+}
+
+function isRouteAllowlisted(path: string, allowlist: string[]): boolean {
+  return allowlist.some((entry) => path.includes(entry.replace(/^\//, "")));
+}
+
+export function detectAuthRouteAuth(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const routePattern =
+    /(?:^|\/)(?:app\/api\/.+\/route|pages\/api\/.+)\.(?:ts|tsx|js|jsx)$/;
+  const authPattern =
+    /\b(getUser|getSession|getServerSession|auth|requireAuth|withAuth)\s*\(/;
+  const hits: string[] = [];
+
+  for (const file of ctx.files) {
+    const normalized = normalizePath(file.filename);
+    if (!routePattern.test(normalized)) continue;
+    if (isRouteAllowlisted(normalized, ctx.authRouteAllowlist)) continue;
+    if (!authPattern.test(fileContent(file))) hits.push(normalized);
+  }
+
+  if (hits.length === 0) return null;
+  return result({
+    code: "auth_route_auth",
+    severity: "blocking",
+    title: "API route missing auth check",
+    detail: `Routes appear to lack session/user verification: ${hits.join(", ")}.`,
+    files: hits,
+    suggested_action: "Verify authenticated user before handling the request.",
+  });
+}
+
+function packageNameFromSpecifier(specifier: string): string {
+  if (specifier.startsWith("@")) return specifier.split("/").slice(0, 2).join("/");
+  return specifier.split("/")[0];
+}
+
+function isNodeBuiltin(specifier: string): boolean {
+  const bare = specifier.startsWith("node:") ? specifier.slice(5) : specifier;
+  return NODE_BUILTINS.has(bare.split("/")[0]);
+}
+
+export function detectExternalPackageDeps(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  if (ctx.declaredPackages.size === 0) return null;
+  const codeExts = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"]);
+  const hits: string[] = [];
+
+  for (const file of ctx.files) {
+    if (!codeExts.has(extensionOf(file.filename))) continue;
+    const importPattern = /\b(?:import|from|require)\s*(?:\([^)]*|\(?)?['"]([^'"]+)['"]/g;
+    for (const match of fileContent(file).matchAll(importPattern)) {
+      const specifier = match[1];
+      if (!specifier || specifier.startsWith(".") || specifier.startsWith("@/")) continue;
+      if (isNodeBuiltin(specifier)) continue;
+      const pkg = packageNameFromSpecifier(specifier);
+      if (!ctx.declaredPackages.has(pkg)) hits.push(`${file.filename} → ${pkg}`);
+    }
+  }
+
+  if (hits.length === 0) return null;
+  return result({
+    code: "external_package_deps",
+    severity: "warn",
+    title: "Undeclared package import",
+    detail: hits.slice(0, 6).join("; "),
+    files: [...new Set(hits.map((h) => h.split(" → ")[0]))],
+    suggested_action: "Add the package to package.json or remove the import.",
+  });
+}
+
+export function detectSqlSyntaxBasic(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const hits: string[] = [];
+  for (const file of ctx.files.filter((f) => extensionOf(f.filename) === ".sql")) {
+    const content = fileContent(file);
+    const stripped = content.replace(/--[^\n]*/g, "").replace(/\/\*[\s\S]*?\*\//g, "");
+    const beginCount = (stripped.match(/\bBEGIN\b/gi) || []).length;
+    const endCount = (stripped.match(/\bEND\b\s*;/gi) || []).length;
+    if (beginCount > 0 && endCount === 0) hits.push(file.filename);
+    else if (endCount > beginCount) hits.push(file.filename);
+  }
+  if (hits.length === 0) return null;
+  return result({
+    code: "sql_syntax_basic",
+    severity: "blocking",
+    title: "SQL block balance issue",
+    detail: `Possible unmatched BEGIN/END in ${hits.join(", ")}.`,
+    files: hits,
+    suggested_action: "Fix PL/pgSQL block structure before merging.",
+  });
+}
+
+type SwcParseSync = (code: string, options: Record<string, unknown>) => unknown;
+
+let cachedSwcParse: SwcParseSync | null | undefined;
+
+function getSwcParse(): SwcParseSync | null {
+  if (cachedSwcParse !== undefined) return cachedSwcParse;
+  try {
+    // Optional — install @swc/core locally for full parse; Action uses bracket fallback.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const swc = require("@swc/core") as { parseSync: SwcParseSync };
+    cachedSwcParse = swc.parseSync;
+  } catch {
+    cachedSwcParse = null;
+  }
+  return cachedSwcParse;
+}
+
+function basicBracketBalance(content: string): string | null {
+  let braces = 0;
+  let parens = 0;
+  let brackets = 0;
+  for (const ch of content) {
+    if (ch === "{") braces += 1;
+    if (ch === "}") braces -= 1;
+    if (ch === "(") parens += 1;
+    if (ch === ")") parens -= 1;
+    if (ch === "[") brackets += 1;
+    if (ch === "]") brackets -= 1;
+    if (braces < 0 || parens < 0 || brackets < 0) return "Unbalanced brackets/parens";
+  }
+  if (braces !== 0 || parens !== 0 || brackets !== 0) {
+    return "Unclosed brackets/parens in diff hunk";
+  }
+  return null;
+}
+
+function parserOptionsFor(file: SubmissionFileInfo): Record<string, unknown> {
+  const ext = extensionOf(file.filename);
+  const isTs = ext === ".ts" || ext === ".tsx";
+  return {
+    syntax: isTs ? "typescript" : "ecmascript",
+    tsx: ext === ".tsx",
+    jsx: ext === ".jsx",
+    decorators: true,
+    dynamicImport: true,
+  };
+}
+
+export function detectSyntaxValidity(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const errors: Array<{ file: string; message: string }> = [];
+  const codeExts = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"]);
+  const swcParse = getSwcParse();
+
+  for (const file of ctx.files) {
+    const ext = extensionOf(file.filename);
+    const content = fileContent(file);
+    if (!content.trim()) continue;
+
+    try {
+      if (codeExts.has(ext)) {
+        if (swcParse) {
+          swcParse(content, parserOptionsFor(file));
+        } else {
+          const balance = basicBracketBalance(content);
+          if (balance) throw new Error(balance);
+        }
+      } else if (ext === ".json") {
+        JSON.parse(content);
+      }
+    } catch (error) {
+      errors.push({
+        file: file.filename,
+        message: error instanceof Error ? error.message.split("\n")[0] : String(error),
+      });
+    }
+  }
+
+  if (errors.length === 0) return null;
+  return result({
+    code: "syntax_validity",
+    severity: "blocking",
+    title: "Syntax error in changed file",
+    detail: errors.map((e) => `${e.file}: ${e.message}`).join("; "),
+    files: errors.map((e) => e.file),
+    suggested_action: "Fix parse errors before resubmitting.",
+  });
+}
+
+export function detectSoulIntegrity(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  if (!ctx.komatikInstance) return null;
+  const hits = ctx.files
+    .map((f) => normalizePath(f.filename))
+    .filter((name) => /^agents\/[a-z][a-z0-9-]*\/SOUL\.md$/.test(name));
+  if (hits.length === 0) return null;
+  return result({
+    code: "soul_integrity",
+    severity: "blocking",
+    title: "Agent SOUL.md modified",
+    detail: `SOUL changes require human review: ${hits.join(", ")}.`,
+    files: hits,
+    suggested_action: "Revert SOUL.md changes or request explicit human approval.",
+  });
+}
+
+export function runAllDetectors(ctx: SubmissionCheckContext): SubmissionCheckResult[] {
+  const checks = [
+    detectMockPlaceholder(ctx),
+    detectSecrets(ctx),
+    detectDestructiveSql(ctx),
+    detectSyntaxValidity(ctx),
+    detectImportResolution(ctx),
+    detectRlsNewTables(ctx),
+    detectAuthRouteAuth(ctx),
+    detectHardcodedEnv(ctx),
+    detectExternalPackageDeps(ctx),
+    detectSqlSyntaxBasic(ctx),
+    detectLargeFile(ctx),
+    detectArtifactIntegrity(ctx),
+    detectContextFreshness(ctx),
+    detectSoulIntegrity(ctx),
+    detectPathFormat(ctx),
+  ];
+  return checks.filter((check): check is SubmissionCheckResult => check !== null);
+}

--- a/app/src/submission-checks/helpers.ts
+++ b/app/src/submission-checks/helpers.ts
@@ -1,0 +1,83 @@
+// Shared helpers for Gate 1 submission checks (pure, no I/O).
+
+import type { SubmissionFileInfo } from "./types.js";
+
+export function normalizePath(filePath: string): string {
+  return filePath.replace(/\\/g, "/").replace(/^\.\//, "");
+}
+
+export function extensionOf(filename: string): string {
+  const base = normalizePath(filename);
+  const idx = base.lastIndexOf(".");
+  return idx >= 0 ? base.slice(idx).toLowerCase() : "";
+}
+
+export function addedLines(patch: string | undefined): string[] {
+  if (!patch) return [];
+  return patch
+    .split("\n")
+    .filter((line) => line.startsWith("+") && !line.startsWith("+++"))
+    .map((line) => line.slice(1));
+}
+
+/** Approximate post-change file body from a unified diff hunk (context + additions). */
+export function effectiveContentFromPatch(patch: string | undefined): string {
+  if (!patch) return "";
+  return patch
+    .split("\n")
+    .filter(
+      (line) =>
+        !line.startsWith("@@") && !line.startsWith("---") && !line.startsWith("+++"),
+    )
+    .filter((line) => !line.startsWith("-"))
+    .map((line) => (line.startsWith("+") || line.startsWith(" ") ? line.slice(1) : line))
+    .join("\n");
+}
+
+export function fileContent(file: SubmissionFileInfo): string {
+  if (typeof file.content === "string") return file.content;
+  return effectiveContentFromPatch(file.patch);
+}
+
+export function lineCountFromPatch(patch: string | undefined): number {
+  const content = effectiveContentFromPatch(patch);
+  if (!content) return 0;
+  return content.split("\n").length;
+}
+
+export function scanAddedContent(
+  files: SubmissionFileInfo[],
+  predicate: (line: string, filename: string) => boolean,
+): string[] {
+  const hits: string[] = [];
+  for (const file of files) {
+    for (const line of addedLines(file.patch)) {
+      if (predicate(line, file.filename)) hits.push(file.filename);
+    }
+  }
+  return [...new Set(hits)];
+}
+
+export function scanFileContent(
+  files: SubmissionFileInfo[],
+  predicate: (line: string, filename: string, lineNo: number) => boolean,
+): Array<{ file: string; line: number }> {
+  const hits: Array<{ file: string; line: number }> = [];
+  for (const file of files) {
+    const lines = fileContent(file).split("\n");
+    lines.forEach((line, index) => {
+      if (predicate(line, file.filename, index + 1)) {
+        hits.push({ file: file.filename, line: index + 1 });
+      }
+    });
+  }
+  return hits;
+}
+
+export function prPathSet(files: SubmissionFileInfo[]): Set<string> {
+  return new Set(files.map((f) => normalizePath(f.filename)));
+}
+
+export function isTestPath(filename: string): boolean {
+  return /\/__tests__\/|\/test\/|\/fixtures\/|\.test\.|\.spec\./.test(filename);
+}

--- a/app/src/submission-checks/types.ts
+++ b/app/src/submission-checks/types.ts
@@ -1,0 +1,18 @@
+export interface SubmissionFileInfo {
+  filename: string;
+  patch?: string;
+  status?: string;
+  /** Full file content when fetched by the gate (optional). */
+  content?: string;
+  additions?: number;
+}
+
+export interface SubmissionCheckContext {
+  files: SubmissionFileInfo[];
+  prPaths: Set<string>;
+  komatikInstance: boolean;
+  staleTerms: string[];
+  authRouteAllowlist: string[];
+  maxFileLines: number;
+  declaredPackages: Set<string>;
+}

--- a/app/src/submission-engine.ts
+++ b/app/src/submission-engine.ts
@@ -1,220 +1,60 @@
 // Gate 1 — agent submission quality (Phase B1).
 // Pure module: no @actions/*, octokit, or Node I/O.
 
-import type { RepoConfig, SubmissionCheckResult } from "./types.js";
+import { runAllDetectors } from "./submission-checks/detectors.js";
+import type { SubmissionCheckContext } from "./submission-checks/types.js";
+import { prPathSet } from "./submission-checks/helpers.js";
 import { SubmissionCheckCode } from "./types.js";
+import type { RepoConfig, SubmissionCheckResult } from "./types.js";
 
+export type { SubmissionFileInfo } from "./submission-checks/types.js";
 export type { SubmissionCheckCode, SubmissionCheckResult } from "./types.js";
 
 /** All Gate 1 check codes — keep in sync with A8 fixture manifest. */
 export const SUBMISSION_CHECK_CODES = SubmissionCheckCode.options;
 
-export interface SubmissionFileInfo {
-  filename: string;
-  patch?: string;
-  status?: string;
-}
-
-export interface SubmissionEngineOptions {
-  files: SubmissionFileInfo[];
-  repoConfig?: RepoConfig | null;
-  /** When true, enable Komatik-specific checks (SOUL paths, etc.). */
-  komatikInstance?: boolean;
-  mode?: "warn" | "block";
-}
-
-const MOCK_PLACEHOLDER_PATTERNS = [
-  /\bTODO\s*\(\s*mock\s*\)/i,
-  /\bFIXME\s*\(\s*mock\s*\)/i,
-  /\bMOCK_[A-Z0-9_]+\b/,
-  /\bfakeImplementation\b/,
-  /\bstubResponse\s*\(/i,
-];
-
-const SECRET_PATTERNS = [
-  /\bsk_live_[A-Za-z0-9]{10,}\b/,
-  /\bsk_test_[A-Za-z0-9]{10,}\b/,
-  /\bghp_[A-Za-z0-9]{20,}\b/,
-  /\bAKIA[0-9A-Z]{16}\b/,
-];
-
-const DESTRUCTIVE_SQL_PATTERNS = [
-  /\bDROP\s+TABLE\b/i,
-  /\bTRUNCATE\s+TABLE\b/i,
-  /\bDROP\s+COLUMN\b/i,
-];
-
 const DEFAULT_STALE_TERMS = ["deployguard", "DeployGuard"];
 
-function addedLines(patch: string | undefined): string[] {
-  if (!patch) return [];
-  return patch
-    .split("\n")
-    .filter((line) => line.startsWith("+") && !line.startsWith("+++"))
-    .map((line) => line.slice(1));
+const DEFAULT_AUTH_ROUTE_ALLOWLIST = [
+  "/api/auth/",
+  "/api/webhooks/",
+  "/api/health/",
+  "/api/metrics/",
+];
+
+export interface SubmissionEngineOptions {
+  files: import("./submission-checks/types.js").SubmissionFileInfo[];
+  repoConfig?: RepoConfig | null;
+  komatikInstance?: boolean;
+  mode?: "warn" | "block";
+  /** Declared npm package names from root package.json (optional). */
+  declaredPackages?: string[];
 }
 
-function scanAddedContent(
-  files: SubmissionFileInfo[],
-  predicate: (line: string, filename: string) => boolean,
-): string[] {
-  const hits: string[] = [];
-  for (const file of files) {
-    for (const line of addedLines(file.patch)) {
-      if (predicate(line, file.filename)) hits.push(file.filename);
-    }
-  }
-  return [...new Set(hits)];
-}
+function buildContext(options: SubmissionEngineOptions): SubmissionCheckContext {
+  const { files, repoConfig, komatikInstance = false } = options;
+  const staleTerms =
+    repoConfig?.submission?.stale_terms ?? (komatikInstance ? DEFAULT_STALE_TERMS : []);
 
-function detectMockPlaceholder(
-  files: SubmissionFileInfo[],
-): SubmissionCheckResult | null {
-  const hits = scanAddedContent(files, (line) =>
-    MOCK_PLACEHOLDER_PATTERNS.some((re) => re.test(line)),
-  );
-  if (hits.length === 0) return null;
+  const declared = new Set(options.declaredPackages ?? []);
+
   return {
-    code: "mock_placeholder",
-    severity: "blocking",
-    title: "Mock placeholder in production path",
-    detail: `Found mock/TODO placeholder patterns in ${hits.join(", ")}. Replace stubs before review.`,
-    files: hits,
-    suggested_action: "Remove mock placeholders and implement real behavior.",
-    autofix_eligible: false,
-  };
-}
-
-function detectSecrets(files: SubmissionFileInfo[]): SubmissionCheckResult | null {
-  const hits = scanAddedContent(files, (line) =>
-    SECRET_PATTERNS.some((re) => re.test(line)),
-  );
-  if (hits.length === 0) return null;
-  return {
-    code: "secrets",
-    severity: "blocking",
-    title: "Potential secret in diff",
-    detail: `Added lines match secret patterns in ${hits.join(", ")}. Rotate any exposed credential.`,
-    files: hits,
-    suggested_action:
-      "Remove secrets from source; use environment variables or a secret manager.",
-    autofix_eligible: false,
-  };
-}
-
-function detectDestructiveSql(files: SubmissionFileInfo[]): SubmissionCheckResult | null {
-  const sqlFiles = files.filter((f) => /\.sql$/i.test(f.filename));
-  const hits = scanAddedContent(sqlFiles, (line) =>
-    DESTRUCTIVE_SQL_PATTERNS.some((re) => re.test(line)),
-  );
-  if (hits.length === 0) return null;
-  return {
-    code: "destructive_sql",
-    severity: "blocking",
-    title: "Destructive SQL in migration",
-    detail: `Added SQL contains destructive statements in ${hits.join(", ")}.`,
-    files: hits,
-    suggested_action:
-      "Use additive migrations; avoid DROP/TRUNCATE without explicit human approval.",
-    autofix_eligible: false,
-  };
-}
-
-function detectContextFreshness(
-  files: SubmissionFileInfo[],
-  staleTerms: string[],
-): SubmissionCheckResult | null {
-  if (staleTerms.length === 0) return null;
-  const hits = scanAddedContent(files, (line) =>
-    staleTerms.some((term) => line.toLowerCase().includes(term.toLowerCase())),
-  );
-  if (hits.length === 0) return null;
-  return {
-    code: "context_freshness",
-    severity: "warn",
-    title: "Stale naming or deprecated terms",
-    detail: `Added lines reference deprecated terms (${staleTerms.join(", ")}) in ${hits.join(", ")}.`,
-    files: hits,
-    suggested_action:
-      "Update naming to match current product vocabulary (see BRAND.md / repo docs).",
-    autofix_eligible: true,
-  };
-}
-
-function detectPathFormat(files: SubmissionFileInfo[]): SubmissionCheckResult | null {
-  const hits = files
-    .map((f) => f.filename)
-    .filter(
-      (name) => /^komatik-agents\/agents\//.test(name) || /\/agents\/agents\//.test(name),
-    );
-  if (hits.length === 0) return null;
-  return {
-    code: "path_format",
-    severity: "warn",
-    title: "Suspicious agent path prefix",
-    detail: `Files use repo-name prefix in internal paths: ${hits.join(", ")}.`,
-    files: hits,
-    suggested_action:
-      "Use agents/<agent-id>/... not <repo>/agents/... for agent workspace paths.",
-    autofix_eligible: false,
-  };
-}
-
-function detectArtifactIntegrity(
-  files: SubmissionFileInfo[],
-): SubmissionCheckResult | null {
-  const prPaths = new Set(files.map((f) => f.filename.replace(/\\/g, "/")));
-  const referenced = new Set<string>();
-
-  const pathRefPattern =
-    /(?:^|\s|['"`])([\w@./-]+\.(?:ts|tsx|js|jsx|md|sql|yml|yaml|json))(?:['"`]|\s|:)/g;
-
-  for (const file of files) {
-    for (const line of addedLines(file.patch)) {
-      if (!/(?:import|from|require|see|fix|update)\s/i.test(line)) continue;
-      for (const match of line.matchAll(pathRefPattern)) {
-        const candidate = match[1]?.replace(/^\.\//, "");
-        if (!candidate || candidate.includes("*")) continue;
-        if (!prPaths.has(candidate) && !candidate.startsWith("node:")) {
-          referenced.add(candidate);
-        }
-      }
-    }
-  }
-
-  if (referenced.size === 0) return null;
-  const missing = [...referenced].slice(0, 8);
-  return {
-    code: "artifact_integrity",
-    severity: "blocking",
-    title: "Referenced files missing from PR",
-    detail: `Added lines reference paths not in this PR: ${missing.join(", ")}${referenced.size > 8 ? "…" : ""}.`,
-    files: missing,
-    suggested_action:
-      "Include the referenced files in this PR or fix hallucinated paths.",
-    autofix_eligible: false,
+    files,
+    prPaths: prPathSet(files),
+    komatikInstance,
+    staleTerms,
+    authRouteAllowlist:
+      repoConfig?.submission?.auth_route_allowlist ?? DEFAULT_AUTH_ROUTE_ALLOWLIST,
+    maxFileLines: repoConfig?.submission?.max_file_lines ?? 1000,
+    declaredPackages: declared,
   };
 }
 
 export function runSubmissionGate(
   options: SubmissionEngineOptions,
 ): SubmissionCheckResult[] {
-  const { files, repoConfig, komatikInstance = false } = options;
-  if (files.length === 0) return [];
-
-  const staleTerms =
-    repoConfig?.submission?.stale_terms ?? (komatikInstance ? DEFAULT_STALE_TERMS : []);
-
-  const checks: Array<SubmissionCheckResult | null> = [
-    detectMockPlaceholder(files),
-    detectSecrets(files),
-    detectDestructiveSql(files),
-    detectArtifactIntegrity(files),
-    detectContextFreshness(files, staleTerms),
-    komatikInstance ? detectPathFormat(files) : null,
-  ];
-
-  return checks.filter((check): check is SubmissionCheckResult => check !== null);
+  if (options.files.length === 0) return [];
+  return runAllDetectors(buildContext(options));
 }
 
 export function submissionGateShouldBlock(

--- a/app/src/submission-remediation.ts
+++ b/app/src/submission-remediation.ts
@@ -22,6 +22,10 @@ export function deriveSubmissionFixes(
       files: check.files ?? [],
       suggested_action: check.suggested_action,
       autofix_eligible: check.autofix_eligible ?? false,
+      autofix_class:
+        check.autofix_eligible && check.code === "context_freshness"
+          ? "doc-update"
+          : undefined,
     }),
   );
 }

--- a/app/src/trust-score.ts
+++ b/app/src/trust-score.ts
@@ -1,0 +1,147 @@
+// Phase B3 — dynamic agent trust scoring (pure module).
+
+export type TrustProfileName = "fast-track" | "standard" | "probation";
+
+export interface AgentTrustMetrics {
+  evaluations: number;
+  releaseReadyCount: number;
+  revertCount: number;
+  humanReviewRequiredCount: number;
+  policyViolationCount: number;
+  sensitivePathViolationCount: number;
+  /** Sum of loop rounds for PRs that reached release_ready. */
+  remediationRoundsToReady: number[];
+}
+
+export interface AgentTrustResult {
+  score: number;
+  profile: TrustProfileName;
+  factors: {
+    release_ready_rate: number;
+    revert_rate: number;
+    human_review_required_rate: number;
+    remediation_efficiency: number;
+    policy_violation_rate: number;
+    sensitive_path_violation_rate: number;
+  };
+  thresholdDelta: number;
+  autofixEnabled: boolean;
+}
+
+const WEIGHTS = {
+  release_ready_rate: 0.3,
+  revert_resistance: 0.2,
+  human_free_rate: 0.2,
+  remediation_efficiency: 0.15,
+  policy_violation_penalty: 0.075,
+  sensitive_path_penalty: 0.075,
+};
+
+function rate(numerator: number, denominator: number): number {
+  if (denominator <= 0) return 0;
+  return numerator / denominator;
+}
+
+function remediationEfficiency(rounds: number[]): number {
+  if (rounds.length === 0) return 0.5;
+  const avg = rounds.reduce((a, b) => a + b, 0) / rounds.length;
+  return Math.max(0, Math.min(1, 1 - (avg - 1) / 4));
+}
+
+export function computeAgentTrustScore(metrics: AgentTrustMetrics): AgentTrustResult {
+  const n = Math.max(metrics.evaluations, 0);
+  const releaseReadyRate = rate(metrics.releaseReadyCount, n);
+  const revertRate = rate(metrics.revertCount, n);
+  const humanReviewRate = rate(metrics.humanReviewRequiredCount, n);
+  const policyViolationRate = rate(metrics.policyViolationCount, n);
+  const sensitiveRate = rate(metrics.sensitivePathViolationCount, n);
+  const remEff = remediationEfficiency(metrics.remediationRoundsToReady);
+
+  const factors = {
+    release_ready_rate: releaseReadyRate,
+    revert_rate: revertRate,
+    human_review_required_rate: humanReviewRate,
+    remediation_efficiency: remEff,
+    policy_violation_rate: policyViolationRate,
+    sensitive_path_violation_rate: sensitiveRate,
+  };
+
+  const score = Math.max(
+    0,
+    Math.min(
+      1,
+      WEIGHTS.release_ready_rate * releaseReadyRate +
+        WEIGHTS.revert_resistance * (1 - revertRate) +
+        WEIGHTS.human_free_rate * (1 - humanReviewRate) +
+        WEIGHTS.remediation_efficiency * remEff -
+        WEIGHTS.policy_violation_penalty * policyViolationRate -
+        WEIGHTS.sensitive_path_penalty * sensitiveRate,
+    ),
+  );
+
+  let profile: TrustProfileName = "standard";
+  if (score >= 0.85) profile = "fast-track";
+  else if (score < 0.6) profile = "probation";
+
+  const thresholdDelta =
+    profile === "fast-track" ? 10 : profile === "probation" ? -10 : 0;
+
+  return {
+    score: Math.round(score * 1000) / 1000,
+    profile,
+    factors,
+    thresholdDelta,
+    autofixEnabled: profile !== "probation",
+  };
+}
+
+export function strictnessFromTrust(
+  trust: AgentTrustResult | null,
+  riskScore: number,
+): {
+  strictness: "baseline" | "elevated" | "strict";
+  reason: string;
+  score?: number;
+  profile?: TrustProfileName;
+  factors?: AgentTrustResult["factors"];
+} {
+  if (!trust) {
+    return riskScore >= 75
+      ? {
+          strictness: "strict",
+          reason: "Automated provenance with high composite risk score",
+        }
+      : {
+          strictness: "elevated",
+          reason: "Automated provenance with elevated review requirements",
+        };
+  }
+
+  if (trust.profile === "probation") {
+    return {
+      strictness: "strict",
+      reason: `Agent trust score ${trust.score} — probation (human review required)`,
+      score: trust.score,
+      profile: trust.profile,
+      factors: trust.factors,
+    };
+  }
+
+  if (trust.profile === "fast-track" && riskScore < 60) {
+    return {
+      strictness: "baseline",
+      reason: `Agent trust score ${trust.score} — fast-track profile`,
+      score: trust.score,
+      profile: trust.profile,
+      factors: trust.factors,
+    };
+  }
+
+  return {
+    strictness: riskScore >= 75 ? "strict" : "elevated",
+    reason: `Agent trust score ${trust.score} (${trust.profile})`,
+    score: trust.score,
+    profile: trust.profile,
+    factors: trust.factors,
+  };
+}

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@komatikai/trailhead",
-  "version": "4.3.3",
+  "version": "4.4.0",
   "description": "Trailhead CLI — setup wizard and utilities for the Trailhead deployment gate",
   "type": "module",
   "bin": {

--- a/cloud/package.json
+++ b/cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trailhead-cloud",
-  "version": "4.3.3",
+  "version": "4.4.0",
   "private": true,
   "type": "module",
   "description": "Trailhead Cloud API — evaluation store, org/repo registry, deploy events",

--- a/dist/index.js
+++ b/dist/index.js
@@ -28617,6 +28617,14 @@ module.exports = {
 
 /***/ }),
 
+/***/ 9922:
+/***/ ((module) => {
+
+module.exports = eval("require")("@swc/core");
+
+
+/***/ }),
+
 /***/ 2613:
 /***/ ((module) => {
 
@@ -40639,6 +40647,15 @@ const SubmissionCheckCode = enumType([
     "destructive_sql",
     "secrets",
     "path_format",
+    "syntax_validity",
+    "import_resolution",
+    "rls_new_tables",
+    "auth_route_auth",
+    "hardcoded_env",
+    "external_package_deps",
+    "sql_syntax_basic",
+    "large_file",
+    "soul_integrity",
 ]);
 const SubmissionCheckResult = objectType({
     code: SubmissionCheckCode,
@@ -40745,6 +40762,9 @@ const GateEvaluation = objectType({
     trust_profile: objectType({
         strictness: enumType(["baseline", "elevated", "strict"]),
         reason: stringType(),
+        score: numberType().min(0).max(1).optional(),
+        profile: enumType(["fast-track", "standard", "probation"]).optional(),
+        factors: recordType(numberType()).optional(),
     })
         .optional(),
     policyOverride: PolicyOverrideAudit.optional(),
@@ -40876,6 +40896,8 @@ const SubmissionConfig = objectType({
     enabled: booleanType().default(false),
     mode: enumType(["warn", "block"]).default("block"),
     stale_terms: arrayType(stringType()).optional(),
+    auth_route_allowlist: arrayType(stringType()).optional(),
+    max_file_lines: numberType().int().positive().optional(),
 });
 const RepoConfig = objectType({
     schema_version: numberType().int().positive().default(1),
@@ -42456,31 +42478,16 @@ function pickLatestPreviousEvaluation(rows, excludeEvaluationId) {
     return null;
 }
 
-;// CONCATENATED MODULE: ./src/submission-engine.ts
-// Gate 1 — agent submission quality (Phase B1).
-// Pure module: no @actions/*, octokit, or Node I/O.
-
-/** All Gate 1 check codes — keep in sync with A8 fixture manifest. */
-const SUBMISSION_CHECK_CODES = SubmissionCheckCode.options;
-const MOCK_PLACEHOLDER_PATTERNS = [
-    /\bTODO\s*\(\s*mock\s*\)/i,
-    /\bFIXME\s*\(\s*mock\s*\)/i,
-    /\bMOCK_[A-Z0-9_]+\b/,
-    /\bfakeImplementation\b/,
-    /\bstubResponse\s*\(/i,
-];
-const SECRET_PATTERNS = [
-    /\bsk_live_[A-Za-z0-9]{10,}\b/,
-    /\bsk_test_[A-Za-z0-9]{10,}\b/,
-    /\bghp_[A-Za-z0-9]{20,}\b/,
-    /\bAKIA[0-9A-Z]{16}\b/,
-];
-const DESTRUCTIVE_SQL_PATTERNS = [
-    /\bDROP\s+TABLE\b/i,
-    /\bTRUNCATE\s+TABLE\b/i,
-    /\bDROP\s+COLUMN\b/i,
-];
-const DEFAULT_STALE_TERMS = ["deployguard", "DeployGuard"];
+;// CONCATENATED MODULE: ./src/submission-checks/helpers.ts
+// Shared helpers for Gate 1 submission checks (pure, no I/O).
+function normalizePath(filePath) {
+    return filePath.replace(/\\/g, "/").replace(/^\.\//, "");
+}
+function extensionOf(filename) {
+    const base = normalizePath(filename);
+    const idx = base.lastIndexOf(".");
+    return idx >= 0 ? base.slice(idx).toLowerCase() : "";
+}
 function addedLines(patch) {
     if (!patch)
         return [];
@@ -42488,6 +42495,28 @@ function addedLines(patch) {
         .split("\n")
         .filter((line) => line.startsWith("+") && !line.startsWith("+++"))
         .map((line) => line.slice(1));
+}
+/** Approximate post-change file body from a unified diff hunk (context + additions). */
+function effectiveContentFromPatch(patch) {
+    if (!patch)
+        return "";
+    return patch
+        .split("\n")
+        .filter((line) => !line.startsWith("@@") && !line.startsWith("---") && !line.startsWith("+++"))
+        .filter((line) => !line.startsWith("-"))
+        .map((line) => (line.startsWith("+") || line.startsWith(" ") ? line.slice(1) : line))
+        .join("\n");
+}
+function fileContent(file) {
+    if (typeof file.content === "string")
+        return file.content;
+    return effectiveContentFromPatch(file.patch);
+}
+function lineCountFromPatch(patch) {
+    const content = effectiveContentFromPatch(patch);
+    if (!content)
+        return 0;
+    return content.split("\n").length;
 }
 function scanAddedContent(files, predicate) {
     const hits = [];
@@ -42499,86 +42528,155 @@ function scanAddedContent(files, predicate) {
     }
     return [...new Set(hits)];
 }
-function detectMockPlaceholder(files) {
-    const hits = scanAddedContent(files, (line) => MOCK_PLACEHOLDER_PATTERNS.some((re) => re.test(line)));
+function scanFileContent(files, predicate) {
+    const hits = [];
+    for (const file of files) {
+        const lines = fileContent(file).split("\n");
+        lines.forEach((line, index) => {
+            if (predicate(line, file.filename, index + 1)) {
+                hits.push({ file: file.filename, line: index + 1 });
+            }
+        });
+    }
+    return hits;
+}
+function prPathSet(files) {
+    return new Set(files.map((f) => normalizePath(f.filename)));
+}
+function isTestPath(filename) {
+    return /\/__tests__\/|\/test\/|\/fixtures\/|\.test\.|\.spec\./.test(filename);
+}
+
+;// CONCATENATED MODULE: ./src/submission-checks/detectors.ts
+// Gate 1 detectors — ported from komatik-agents agent-gate-checks (patch/content based).
+
+const OLD_NAME_PATTERNS = [
+    { oldName: "DeployGuard", newName: "Trailhead", pattern: /\bDeployGuard\b/g },
+    { oldName: "Daydream Studio", newName: "Sundog", pattern: /\bDaydream Studio\b/g },
+    {
+        oldName: "Storyboard Studio",
+        newName: "Kindling",
+        pattern: /\bStoryboard Studio\b/g,
+    },
+    { oldName: "Cognitive Debt", newName: "Drift", pattern: /\bCognitive Debt\b/g },
+    { oldName: "cognitive-debt", newName: "Drift", pattern: /\bcognitive-debt\b/g },
+];
+const MOCK_PATTERNS = [
+    /\bTODO\s*\(\s*mock\s*\)/i,
+    /\bFIXME\s*\(\s*mock\s*\)/i,
+    /\bMOCK_[A-Z0-9_]+\b/,
+    /\bfakeImplementation\b/,
+    /\bstubResponse\s*\(/i,
+    /\b(?:generate|create|build|get)(?:Mock|Fake|Dummy|Sample)\w*/g,
+    /\b(?:mockData|fakeData|sampleData|dummyData|testData)\b/g,
+    /\bTODO:\s*implement\b/gi,
+    /\bFIXME\b/g,
+    /\bplaceholder\b/gi,
+    /\blorem ipsum\b/gi,
+];
+const SECRET_PATTERNS = [
+    { name: "AWS access key", pattern: /\bAKIA[0-9A-Z]{16}\b/g },
+    { name: "GitHub token", pattern: /\bgh[pousr]_[A-Za-z0-9_]{20,}\b/g },
+    { name: "Stripe live key", pattern: /\bsk_live_[A-Za-z0-9]{10,}\b/g },
+    { name: "Stripe test key", pattern: /\bsk_test_[A-Za-z0-9]{10,}\b/g },
+    { name: "Private key block", pattern: /-----BEGIN [A-Z ]+PRIVATE KEY-----/g },
+    {
+        name: "Generic API key assignment",
+        pattern: /api[_-]?key\s*[:=]\s*['"][A-Za-z0-9_-]{32,}['"]/gi,
+    },
+];
+const HARDCODED_ENV_PATTERNS = [
+    { name: "localhost with port", pattern: /(?:['"`])localhost:\d{2,5}(?:['"`])/g },
+    {
+        name: "hardcoded private IP",
+        pattern: /(?:['"`])(?:10\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.(?:1[6-9]|2\d|3[01])\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3})(?::\d+)?(?:['"`])/g,
+    },
+];
+const NODE_BUILTINS = new Set([
+    "assert",
+    "async_hooks",
+    "buffer",
+    "child_process",
+    "cluster",
+    "console",
+    "constants",
+    "crypto",
+    "dgram",
+    "dns",
+    "events",
+    "fs",
+    "http",
+    "http2",
+    "https",
+    "module",
+    "net",
+    "os",
+    "path",
+    "process",
+    "stream",
+    "url",
+    "util",
+    "zlib",
+]);
+function result(partial) {
+    return { autofix_eligible: false, ...partial };
+}
+function detectMockPlaceholder(ctx) {
+    const hits = scanAddedContent(ctx.files, (line, filename) => {
+        if (isTestPath(filename))
+            return false;
+        if (/\.(md|txt)$/i.test(filename))
+            return false;
+        return MOCK_PATTERNS.some((re) => {
+            re.lastIndex = 0;
+            return re.test(line);
+        });
+    });
     if (hits.length === 0)
         return null;
-    return {
+    return result({
         code: "mock_placeholder",
         severity: "blocking",
         title: "Mock placeholder in production path",
-        detail: `Found mock/TODO placeholder patterns in ${hits.join(", ")}. Replace stubs before review.`,
+        detail: `Found mock/TODO placeholder patterns in ${hits.join(", ")}.`,
         files: hits,
         suggested_action: "Remove mock placeholders and implement real behavior.",
-        autofix_eligible: false,
-    };
+    });
 }
-function detectSecrets(files) {
-    const hits = scanAddedContent(files, (line) => SECRET_PATTERNS.some((re) => re.test(line)));
+function detectSecrets(ctx) {
+    const hits = scanAddedContent(ctx.files, (line) => SECRET_PATTERNS.some((entry) => {
+        entry.pattern.lastIndex = 0;
+        return entry.pattern.test(line);
+    }));
     if (hits.length === 0)
         return null;
-    return {
+    return result({
         code: "secrets",
         severity: "blocking",
         title: "Potential secret in diff",
-        detail: `Added lines match secret patterns in ${hits.join(", ")}. Rotate any exposed credential.`,
+        detail: `Added lines match secret patterns in ${hits.join(", ")}.`,
         files: hits,
-        suggested_action: "Remove secrets from source; use environment variables or a secret manager.",
-        autofix_eligible: false,
-    };
+        suggested_action: "Remove secrets; use environment variables or a secret manager.",
+    });
 }
-function detectDestructiveSql(files) {
-    const sqlFiles = files.filter((f) => /\.sql$/i.test(f.filename));
-    const hits = scanAddedContent(sqlFiles, (line) => DESTRUCTIVE_SQL_PATTERNS.some((re) => re.test(line)));
+function detectDestructiveSql(ctx) {
+    const sqlFiles = ctx.files.filter((f) => extensionOf(f.filename) === ".sql");
+    const hits = scanAddedContent(sqlFiles, (line) => /\b(DROP\s+TABLE|TRUNCATE|DELETE\s+FROM(?![^\n]*\bWHERE\b))/i.test(line));
     if (hits.length === 0)
         return null;
-    return {
+    return result({
         code: "destructive_sql",
         severity: "blocking",
         title: "Destructive SQL in migration",
         detail: `Added SQL contains destructive statements in ${hits.join(", ")}.`,
         files: hits,
-        suggested_action: "Use additive migrations; avoid DROP/TRUNCATE without explicit human approval.",
-        autofix_eligible: false,
-    };
+        suggested_action: "Use additive migrations; avoid DROP/TRUNCATE without human approval.",
+    });
 }
-function detectContextFreshness(files, staleTerms) {
-    if (staleTerms.length === 0)
-        return null;
-    const hits = scanAddedContent(files, (line) => staleTerms.some((term) => line.toLowerCase().includes(term.toLowerCase())));
-    if (hits.length === 0)
-        return null;
-    return {
-        code: "context_freshness",
-        severity: "warn",
-        title: "Stale naming or deprecated terms",
-        detail: `Added lines reference deprecated terms (${staleTerms.join(", ")}) in ${hits.join(", ")}.`,
-        files: hits,
-        suggested_action: "Update naming to match current product vocabulary (see BRAND.md / repo docs).",
-        autofix_eligible: true,
-    };
-}
-function detectPathFormat(files) {
-    const hits = files
-        .map((f) => f.filename)
-        .filter((name) => /^komatik-agents\/agents\//.test(name) || /\/agents\/agents\//.test(name));
-    if (hits.length === 0)
-        return null;
-    return {
-        code: "path_format",
-        severity: "warn",
-        title: "Suspicious agent path prefix",
-        detail: `Files use repo-name prefix in internal paths: ${hits.join(", ")}.`,
-        files: hits,
-        suggested_action: "Use agents/<agent-id>/... not <repo>/agents/... for agent workspace paths.",
-        autofix_eligible: false,
-    };
-}
-function detectArtifactIntegrity(files) {
-    const prPaths = new Set(files.map((f) => f.filename.replace(/\\/g, "/")));
+function detectArtifactIntegrity(ctx) {
     const referenced = new Set();
     const pathRefPattern = /(?:^|\s|['"`])([\w@./-]+\.(?:ts|tsx|js|jsx|md|sql|yml|yaml|json))(?:['"`]|\s|:)/g;
-    for (const file of files) {
+    for (const file of ctx.files) {
         for (const line of addedLines(file.patch)) {
             if (!/(?:import|from|require|see|fix|update)\s/i.test(line))
                 continue;
@@ -42586,7 +42684,7 @@ function detectArtifactIntegrity(files) {
                 const candidate = match[1]?.replace(/^\.\//, "");
                 if (!candidate || candidate.includes("*"))
                     continue;
-                if (!prPaths.has(candidate) && !candidate.startsWith("node:")) {
+                if (!ctx.prPaths.has(candidate) && !candidate.startsWith("node:")) {
                     referenced.add(candidate);
                 }
             }
@@ -42595,30 +42693,469 @@ function detectArtifactIntegrity(files) {
     if (referenced.size === 0)
         return null;
     const missing = [...referenced].slice(0, 8);
-    return {
+    return result({
         code: "artifact_integrity",
         severity: "blocking",
         title: "Referenced files missing from PR",
         detail: `Added lines reference paths not in this PR: ${missing.join(", ")}${referenced.size > 8 ? "…" : ""}.`,
         files: missing,
-        suggested_action: "Include the referenced files in this PR or fix hallucinated paths.",
-        autofix_eligible: false,
+        suggested_action: "Include referenced files or fix hallucinated paths.",
+    });
+}
+function isNamingAllowlisted(filename, line) {
+    const trimmed = line.trim();
+    if (/^import\s|^from\s|require\(/.test(trimmed))
+        return true;
+    if (/\.sql$/i.test(filename))
+        return true;
+    if (/(?:^|\/)migrations\//.test(filename))
+        return true;
+    if (/(?:^|\/)memory\//.test(filename))
+        return true;
+    if (/RESEARCH\.md$|BRAND\.md$|CHANGELOG\.md$/.test(filename))
+        return true;
+    if (/^\[.*\]\(.*\)/.test(trimmed))
+        return true;
+    return false;
+}
+function detectContextFreshness(ctx) {
+    if (ctx.staleTerms.length === 0 && !ctx.komatikInstance)
+        return null;
+    const hits = [];
+    for (const file of ctx.files) {
+        for (const line of addedLines(file.patch)) {
+            if (isNamingAllowlisted(file.filename, line))
+                continue;
+            const terms = ctx.staleTerms.length > 0 ? ctx.staleTerms : [];
+            for (const term of terms) {
+                if (line.toLowerCase().includes(term.toLowerCase()))
+                    hits.push(file.filename);
+            }
+            if (ctx.komatikInstance) {
+                for (const entry of OLD_NAME_PATTERNS) {
+                    entry.pattern.lastIndex = 0;
+                    if (entry.pattern.test(line))
+                        hits.push(file.filename);
+                }
+            }
+        }
+    }
+    const unique = [...new Set(hits)];
+    if (unique.length === 0)
+        return null;
+    return result({
+        code: "context_freshness",
+        severity: "warn",
+        title: "Stale naming or deprecated terms",
+        detail: `Added lines reference deprecated terms in ${unique.join(", ")}.`,
+        files: unique,
+        suggested_action: "Update naming to current product vocabulary (see BRAND.md).",
+        autofix_eligible: true,
+    });
+}
+function detectPathFormat(ctx) {
+    if (!ctx.komatikInstance)
+        return null;
+    const hits = ctx.files
+        .map((f) => normalizePath(f.filename))
+        .filter((name) => /^komatik-agents\/agents\//.test(name) ||
+        /\/agents\/agents\//.test(name) ||
+        (!/^agents\/[a-z][a-z0-9-]*\/suggestions\//.test(name) &&
+            /\/suggestions\//.test(name) &&
+            !name.startsWith("agents/")));
+    if (hits.length === 0)
+        return null;
+    return result({
+        code: "path_format",
+        severity: "warn",
+        title: "Suspicious agent suggestion path",
+        detail: `Paths should match agents/<id>/suggestions/<project>/… — found: ${hits.join(", ")}.`,
+        files: hits,
+        suggested_action: "Use canonical agent suggestion paths without repo prefix.",
+    });
+}
+function detectHardcodedEnv(ctx) {
+    const hits = scanAddedContent(ctx.files, (line, filename) => {
+        if (/\.(md|txt)$/i.test(filename))
+            return false;
+        if (/^\s*\/\/|^\s*\*|^\s*#/.test(line))
+            return false;
+        return HARDCODED_ENV_PATTERNS.some((entry) => {
+            entry.pattern.lastIndex = 0;
+            return entry.pattern.test(line);
+        });
+    });
+    if (hits.length === 0)
+        return null;
+    return result({
+        code: "hardcoded_env",
+        severity: "blocking",
+        title: "Hardcoded environment value",
+        detail: `Added lines contain hardcoded localhost/IP patterns in ${hits.join(", ")}.`,
+        files: hits,
+        suggested_action: "Use environment variables or configuration instead of hardcoded hosts.",
+    });
+}
+function detectLargeFile(ctx) {
+    const hits = ctx.files
+        .filter((file) => {
+        const lines = typeof file.content === "string"
+            ? file.content.split("\n").length
+            : lineCountFromPatch(file.patch);
+        return lines > ctx.maxFileLines;
+    })
+        .map((f) => f.filename);
+    if (hits.length === 0)
+        return null;
+    return result({
+        code: "large_file",
+        severity: "warn",
+        title: "Large file in PR",
+        detail: `Files exceed ${ctx.maxFileLines} lines: ${hits.join(", ")}.`,
+        files: hits,
+        suggested_action: "Split large changes into smaller PRs.",
+    });
+}
+function extractRelativeImports(content) {
+    const imports = [];
+    const patterns = [
+        /\bimport\s+(?:type\s+)?(?:[^'"]+\s+from\s+)?['"](\.\.?[^'"]+)['"]/g,
+        /\brequire\(\s*['"](\.\.?[^'"]+)['"]\s*\)/g,
+    ];
+    for (const pattern of patterns) {
+        for (const match of content.matchAll(pattern)) {
+            if (match[1])
+                imports.push(match[1]);
+        }
+    }
+    return imports;
+}
+function resolveRelativeImport(fromFile, specifier, prPaths) {
+    const clean = specifier.split("?")[0].split("#")[0];
+    const baseDir = normalizePath(fromFile).split("/").slice(0, -1);
+    const segments = clean.replace(/^\.\//, "").split("/");
+    for (const segment of segments) {
+        if (segment === "..")
+            baseDir.pop();
+        else if (segment !== ".")
+            baseDir.push(segment);
+    }
+    const resolved = baseDir.join("/");
+    const candidates = [
+        resolved,
+        `${resolved}.ts`,
+        `${resolved}.tsx`,
+        `${resolved}.js`,
+        `${resolved}.jsx`,
+        `${resolved}/index.ts`,
+        `${resolved}/index.js`,
+    ];
+    return candidates.some((c) => prPaths.has(c));
+}
+function detectImportResolution(ctx) {
+    const codeExts = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"]);
+    const hits = [];
+    for (const file of ctx.files) {
+        if (!codeExts.has(extensionOf(file.filename)))
+            continue;
+        const content = fileContent(file);
+        for (const specifier of extractRelativeImports(content)) {
+            if (!resolveRelativeImport(file.filename, specifier, ctx.prPaths)) {
+                hits.push(file.filename);
+                break;
+            }
+        }
+    }
+    if (hits.length === 0)
+        return null;
+    return result({
+        code: "import_resolution",
+        severity: "blocking",
+        title: "Unresolved relative import",
+        detail: `Relative imports could not be resolved within this PR: ${[...new Set(hits)].join(", ")}.`,
+        files: [...new Set(hits)],
+        suggested_action: "Add missing files to the PR or fix import paths.",
+    });
+}
+function detectRlsNewTables(ctx) {
+    const sqlFiles = ctx.files.filter((f) => extensionOf(f.filename) === ".sql");
+    const corpus = sqlFiles.map((f) => fileContent(f)).join("\n");
+    const hits = [];
+    const createTable = /\bCREATE\s+(?!TEMP(?:ORARY)?\s+)TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?((?:"?[A-Za-z_][\w$]*"?\.)?"?[A-Za-z_][\w$]*"?)/gi;
+    for (const file of sqlFiles) {
+        const content = fileContent(file);
+        for (const match of content.matchAll(createTable)) {
+            const table = match[1]?.replace(/"/g, "") ?? "";
+            const pattern = new RegExp(`ALTER\\s+TABLE\\s+(?:ONLY\\s+)?["']?${table.split(".").pop()}["']?\\s+ENABLE\\s+ROW\\s+LEVEL\\s+SECURITY`, "i");
+            if (!pattern.test(corpus))
+                hits.push(file.filename);
+        }
+    }
+    if (hits.length === 0)
+        return null;
+    return result({
+        code: "rls_new_tables",
+        severity: "blocking",
+        title: "New table missing RLS",
+        detail: `CREATE TABLE without ENABLE ROW LEVEL SECURITY in ${[...new Set(hits)].join(", ")}.`,
+        files: [...new Set(hits)],
+        suggested_action: "Add ALTER TABLE ... ENABLE ROW LEVEL SECURITY for every new table.",
+    });
+}
+function isRouteAllowlisted(path, allowlist) {
+    return allowlist.some((entry) => path.includes(entry.replace(/^\//, "")));
+}
+function detectAuthRouteAuth(ctx) {
+    const routePattern = /(?:^|\/)(?:app\/api\/.+\/route|pages\/api\/.+)\.(?:ts|tsx|js|jsx)$/;
+    const authPattern = /\b(getUser|getSession|getServerSession|auth|requireAuth|withAuth)\s*\(/;
+    const hits = [];
+    for (const file of ctx.files) {
+        const normalized = normalizePath(file.filename);
+        if (!routePattern.test(normalized))
+            continue;
+        if (isRouteAllowlisted(normalized, ctx.authRouteAllowlist))
+            continue;
+        if (!authPattern.test(fileContent(file)))
+            hits.push(normalized);
+    }
+    if (hits.length === 0)
+        return null;
+    return result({
+        code: "auth_route_auth",
+        severity: "blocking",
+        title: "API route missing auth check",
+        detail: `Routes appear to lack session/user verification: ${hits.join(", ")}.`,
+        files: hits,
+        suggested_action: "Verify authenticated user before handling the request.",
+    });
+}
+function packageNameFromSpecifier(specifier) {
+    if (specifier.startsWith("@"))
+        return specifier.split("/").slice(0, 2).join("/");
+    return specifier.split("/")[0];
+}
+function isNodeBuiltin(specifier) {
+    const bare = specifier.startsWith("node:") ? specifier.slice(5) : specifier;
+    return NODE_BUILTINS.has(bare.split("/")[0]);
+}
+function detectExternalPackageDeps(ctx) {
+    if (ctx.declaredPackages.size === 0)
+        return null;
+    const codeExts = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"]);
+    const hits = [];
+    for (const file of ctx.files) {
+        if (!codeExts.has(extensionOf(file.filename)))
+            continue;
+        const importPattern = /\b(?:import|from|require)\s*(?:\([^)]*|\(?)?['"]([^'"]+)['"]/g;
+        for (const match of fileContent(file).matchAll(importPattern)) {
+            const specifier = match[1];
+            if (!specifier || specifier.startsWith(".") || specifier.startsWith("@/"))
+                continue;
+            if (isNodeBuiltin(specifier))
+                continue;
+            const pkg = packageNameFromSpecifier(specifier);
+            if (!ctx.declaredPackages.has(pkg))
+                hits.push(`${file.filename} → ${pkg}`);
+        }
+    }
+    if (hits.length === 0)
+        return null;
+    return result({
+        code: "external_package_deps",
+        severity: "warn",
+        title: "Undeclared package import",
+        detail: hits.slice(0, 6).join("; "),
+        files: [...new Set(hits.map((h) => h.split(" → ")[0]))],
+        suggested_action: "Add the package to package.json or remove the import.",
+    });
+}
+function detectSqlSyntaxBasic(ctx) {
+    const hits = [];
+    for (const file of ctx.files.filter((f) => extensionOf(f.filename) === ".sql")) {
+        const content = fileContent(file);
+        const stripped = content.replace(/--[^\n]*/g, "").replace(/\/\*[\s\S]*?\*\//g, "");
+        const beginCount = (stripped.match(/\bBEGIN\b/gi) || []).length;
+        const endCount = (stripped.match(/\bEND\b\s*;/gi) || []).length;
+        if (beginCount > 0 && endCount === 0)
+            hits.push(file.filename);
+        else if (endCount > beginCount)
+            hits.push(file.filename);
+    }
+    if (hits.length === 0)
+        return null;
+    return result({
+        code: "sql_syntax_basic",
+        severity: "blocking",
+        title: "SQL block balance issue",
+        detail: `Possible unmatched BEGIN/END in ${hits.join(", ")}.`,
+        files: hits,
+        suggested_action: "Fix PL/pgSQL block structure before merging.",
+    });
+}
+let cachedSwcParse;
+function getSwcParse() {
+    if (cachedSwcParse !== undefined)
+        return cachedSwcParse;
+    try {
+        // Optional — install @swc/core locally for full parse; Action uses bracket fallback.
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const swc = __nccwpck_require__(9922);
+        cachedSwcParse = swc.parseSync;
+    }
+    catch {
+        cachedSwcParse = null;
+    }
+    return cachedSwcParse;
+}
+function basicBracketBalance(content) {
+    let braces = 0;
+    let parens = 0;
+    let brackets = 0;
+    for (const ch of content) {
+        if (ch === "{")
+            braces += 1;
+        if (ch === "}")
+            braces -= 1;
+        if (ch === "(")
+            parens += 1;
+        if (ch === ")")
+            parens -= 1;
+        if (ch === "[")
+            brackets += 1;
+        if (ch === "]")
+            brackets -= 1;
+        if (braces < 0 || parens < 0 || brackets < 0)
+            return "Unbalanced brackets/parens";
+    }
+    if (braces !== 0 || parens !== 0 || brackets !== 0) {
+        return "Unclosed brackets/parens in diff hunk";
+    }
+    return null;
+}
+function parserOptionsFor(file) {
+    const ext = extensionOf(file.filename);
+    const isTs = ext === ".ts" || ext === ".tsx";
+    return {
+        syntax: isTs ? "typescript" : "ecmascript",
+        tsx: ext === ".tsx",
+        jsx: ext === ".jsx",
+        decorators: true,
+        dynamicImport: true,
+    };
+}
+function detectSyntaxValidity(ctx) {
+    const errors = [];
+    const codeExts = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"]);
+    const swcParse = getSwcParse();
+    for (const file of ctx.files) {
+        const ext = extensionOf(file.filename);
+        const content = fileContent(file);
+        if (!content.trim())
+            continue;
+        try {
+            if (codeExts.has(ext)) {
+                if (swcParse) {
+                    swcParse(content, parserOptionsFor(file));
+                }
+                else {
+                    const balance = basicBracketBalance(content);
+                    if (balance)
+                        throw new Error(balance);
+                }
+            }
+            else if (ext === ".json") {
+                JSON.parse(content);
+            }
+        }
+        catch (error) {
+            errors.push({
+                file: file.filename,
+                message: error instanceof Error ? error.message.split("\n")[0] : String(error),
+            });
+        }
+    }
+    if (errors.length === 0)
+        return null;
+    return result({
+        code: "syntax_validity",
+        severity: "blocking",
+        title: "Syntax error in changed file",
+        detail: errors.map((e) => `${e.file}: ${e.message}`).join("; "),
+        files: errors.map((e) => e.file),
+        suggested_action: "Fix parse errors before resubmitting.",
+    });
+}
+function detectSoulIntegrity(ctx) {
+    if (!ctx.komatikInstance)
+        return null;
+    const hits = ctx.files
+        .map((f) => normalizePath(f.filename))
+        .filter((name) => /^agents\/[a-z][a-z0-9-]*\/SOUL\.md$/.test(name));
+    if (hits.length === 0)
+        return null;
+    return result({
+        code: "soul_integrity",
+        severity: "blocking",
+        title: "Agent SOUL.md modified",
+        detail: `SOUL changes require human review: ${hits.join(", ")}.`,
+        files: hits,
+        suggested_action: "Revert SOUL.md changes or request explicit human approval.",
+    });
+}
+function runAllDetectors(ctx) {
+    const checks = [
+        detectMockPlaceholder(ctx),
+        detectSecrets(ctx),
+        detectDestructiveSql(ctx),
+        detectSyntaxValidity(ctx),
+        detectImportResolution(ctx),
+        detectRlsNewTables(ctx),
+        detectAuthRouteAuth(ctx),
+        detectHardcodedEnv(ctx),
+        detectExternalPackageDeps(ctx),
+        detectSqlSyntaxBasic(ctx),
+        detectLargeFile(ctx),
+        detectArtifactIntegrity(ctx),
+        detectContextFreshness(ctx),
+        detectSoulIntegrity(ctx),
+        detectPathFormat(ctx),
+    ];
+    return checks.filter((check) => check !== null);
+}
+
+;// CONCATENATED MODULE: ./src/submission-engine.ts
+// Gate 1 — agent submission quality (Phase B1).
+// Pure module: no @actions/*, octokit, or Node I/O.
+
+
+
+/** All Gate 1 check codes — keep in sync with A8 fixture manifest. */
+const SUBMISSION_CHECK_CODES = SubmissionCheckCode.options;
+const DEFAULT_STALE_TERMS = ["deployguard", "DeployGuard"];
+const DEFAULT_AUTH_ROUTE_ALLOWLIST = [
+    "/api/auth/",
+    "/api/webhooks/",
+    "/api/health/",
+    "/api/metrics/",
+];
+function buildContext(options) {
+    const { files, repoConfig, komatikInstance = false } = options;
+    const staleTerms = repoConfig?.submission?.stale_terms ?? (komatikInstance ? DEFAULT_STALE_TERMS : []);
+    const declared = new Set(options.declaredPackages ?? []);
+    return {
+        files,
+        prPaths: prPathSet(files),
+        komatikInstance,
+        staleTerms,
+        authRouteAllowlist: repoConfig?.submission?.auth_route_allowlist ?? DEFAULT_AUTH_ROUTE_ALLOWLIST,
+        maxFileLines: repoConfig?.submission?.max_file_lines ?? 1000,
+        declaredPackages: declared,
     };
 }
 function runSubmissionGate(options) {
-    const { files, repoConfig, komatikInstance = false } = options;
-    if (files.length === 0)
+    if (options.files.length === 0)
         return [];
-    const staleTerms = repoConfig?.submission?.stale_terms ?? (komatikInstance ? DEFAULT_STALE_TERMS : []);
-    const checks = [
-        detectMockPlaceholder(files),
-        detectSecrets(files),
-        detectDestructiveSql(files),
-        detectArtifactIntegrity(files),
-        detectContextFreshness(files, staleTerms),
-        komatikInstance ? detectPathFormat(files) : null,
-    ];
-    return checks.filter((check) => check !== null);
+    return runAllDetectors(buildContext(options));
 }
 function submissionGateShouldBlock(checks, mode = "block") {
     if (mode !== "block")
@@ -42642,6 +43179,9 @@ function deriveSubmissionFixes(checks) {
         files: check.files ?? [],
         suggested_action: check.suggested_action,
         autofix_eligible: check.autofix_eligible ?? false,
+        autofix_class: check.autofix_eligible && check.code === "context_freshness"
+            ? "doc-update"
+            : undefined,
     }));
 }
 
@@ -43405,7 +43945,104 @@ function applyLabelOverrideToEvaluation(evaluation, audit) {
     };
 }
 
+;// CONCATENATED MODULE: ./src/trust-score.ts
+// Phase B3 — dynamic agent trust scoring (pure module).
+const WEIGHTS = {
+    release_ready_rate: 0.3,
+    revert_resistance: 0.2,
+    human_free_rate: 0.2,
+    remediation_efficiency: 0.15,
+    policy_violation_penalty: 0.075,
+    sensitive_path_penalty: 0.075,
+};
+function rate(numerator, denominator) {
+    if (denominator <= 0)
+        return 0;
+    return numerator / denominator;
+}
+function remediationEfficiency(rounds) {
+    if (rounds.length === 0)
+        return 0.5;
+    const avg = rounds.reduce((a, b) => a + b, 0) / rounds.length;
+    return Math.max(0, Math.min(1, 1 - (avg - 1) / 4));
+}
+function computeAgentTrustScore(metrics) {
+    const n = Math.max(metrics.evaluations, 0);
+    const releaseReadyRate = rate(metrics.releaseReadyCount, n);
+    const revertRate = rate(metrics.revertCount, n);
+    const humanReviewRate = rate(metrics.humanReviewRequiredCount, n);
+    const policyViolationRate = rate(metrics.policyViolationCount, n);
+    const sensitiveRate = rate(metrics.sensitivePathViolationCount, n);
+    const remEff = remediationEfficiency(metrics.remediationRoundsToReady);
+    const factors = {
+        release_ready_rate: releaseReadyRate,
+        revert_rate: revertRate,
+        human_review_required_rate: humanReviewRate,
+        remediation_efficiency: remEff,
+        policy_violation_rate: policyViolationRate,
+        sensitive_path_violation_rate: sensitiveRate,
+    };
+    const score = Math.max(0, Math.min(1, WEIGHTS.release_ready_rate * releaseReadyRate +
+        WEIGHTS.revert_resistance * (1 - revertRate) +
+        WEIGHTS.human_free_rate * (1 - humanReviewRate) +
+        WEIGHTS.remediation_efficiency * remEff -
+        WEIGHTS.policy_violation_penalty * policyViolationRate -
+        WEIGHTS.sensitive_path_penalty * sensitiveRate));
+    let profile = "standard";
+    if (score >= 0.85)
+        profile = "fast-track";
+    else if (score < 0.6)
+        profile = "probation";
+    const thresholdDelta = profile === "fast-track" ? 10 : profile === "probation" ? -10 : 0;
+    return {
+        score: Math.round(score * 1000) / 1000,
+        profile,
+        factors,
+        thresholdDelta,
+        autofixEnabled: profile !== "probation",
+    };
+}
+function strictnessFromTrust(trust, riskScore) {
+    if (!trust) {
+        return riskScore >= 75
+            ? {
+                strictness: "strict",
+                reason: "Automated provenance with high composite risk score",
+            }
+            : {
+                strictness: "elevated",
+                reason: "Automated provenance with elevated review requirements",
+            };
+    }
+    if (trust.profile === "probation") {
+        return {
+            strictness: "strict",
+            reason: `Agent trust score ${trust.score} — probation (human review required)`,
+            score: trust.score,
+            profile: trust.profile,
+            factors: trust.factors,
+        };
+    }
+    if (trust.profile === "fast-track" && riskScore < 60) {
+        return {
+            strictness: "baseline",
+            reason: `Agent trust score ${trust.score} — fast-track profile`,
+            score: trust.score,
+            profile: trust.profile,
+            factors: trust.factors,
+        };
+    }
+    return {
+        strictness: riskScore >= 75 ? "strict" : "elevated",
+        reason: `Agent trust score ${trust.score} (${trust.profile})`,
+        score: trust.score,
+        profile: trust.profile,
+        factors: trust.factors,
+    };
+}
+
 ;// CONCATENATED MODULE: ./src/gate.ts
+
 
 
 
@@ -43424,6 +44061,46 @@ function applyLabelOverrideToEvaluation(evaluation, audit) {
 // Re-export sensitivityWeight with the RepoConfig-compatible signature
 function gate_sensitivityWeight(filename, repoConfig) {
     return sensitivityWeightShared(filename, repoConfig ?? null);
+}
+function parseDeclaredPackages(raw) {
+    if (!raw?.trim())
+        return undefined;
+    try {
+        const parsed = JSON.parse(raw);
+        if (Array.isArray(parsed)) {
+            return parsed.filter((entry) => typeof entry === "string");
+        }
+    }
+    catch {
+        return raw
+            .split(",")
+            .map((entry) => entry.trim())
+            .filter(Boolean);
+    }
+    return undefined;
+}
+function parseAgentTrustMetrics(raw) {
+    if (!raw?.trim())
+        return null;
+    try {
+        const parsed = JSON.parse(raw);
+        if (typeof parsed.evaluations !== "number")
+            return null;
+        return {
+            evaluations: parsed.evaluations,
+            releaseReadyCount: parsed.releaseReadyCount ?? 0,
+            revertCount: parsed.revertCount ?? 0,
+            humanReviewRequiredCount: parsed.humanReviewRequiredCount ?? 0,
+            policyViolationCount: parsed.policyViolationCount ?? 0,
+            sensitivePathViolationCount: parsed.sensitivePathViolationCount ?? 0,
+            remediationRoundsToReady: Array.isArray(parsed.remediationRoundsToReady)
+                ? parsed.remediationRoundsToReady.filter((n) => typeof n === "number")
+                : [],
+        };
+    }
+    catch {
+        return null;
+    }
 }
 // ---------------------------------------------------------------------------
 // PR diff fetching via @actions/github
@@ -44649,10 +45326,15 @@ async function evaluateGate(config, commitSha, prNumber) {
     const submissionEnabled = config.submissionGate === true || repoConfig?.submission?.enabled === true;
     if (submissionEnabled && files.length > 0) {
         submissionChecks = runSubmissionGate({
-            files,
+            files: files.map((f) => ({
+                filename: f.filename,
+                patch: f.patch,
+                additions: f.additions,
+            })),
             repoConfig,
             komatikInstance: process.env.KOMATIK_INSTANCE === "true",
             mode: submissionMode,
+            declaredPackages: parseDeclaredPackages(process.env.TRAILHEAD_DECLARED_PACKAGES),
         });
         if (submissionChecks.length > 0) {
             policyFindings.push(`Submission gate: ${submissionChecks.length} finding(s).`);
@@ -44753,15 +45435,14 @@ async function evaluateGate(config, commitSha, prNumber) {
         policyFindings.push(`Escalation configured with ${escalationStatus.target_count} target(s); acknowledge within ${escalationStatus.acknowledge_sla_minutes} minutes.`);
     }
     const trustProfile = provenance?.type && provenance.type !== "human"
-        ? riskScore >= 75
-            ? {
-                strictness: "strict",
-                reason: "Automated provenance with high composite risk score",
+        ? (() => {
+            const metrics = parseAgentTrustMetrics(process.env.TRAILHEAD_AGENT_TRUST_JSON);
+            const trust = metrics ? computeAgentTrustScore(metrics) : null;
+            if (trust && trust.thresholdDelta !== 0) {
+                adjustedRiskThreshold = Math.max(0, Math.min(100, adjustedRiskThreshold + trust.thresholdDelta));
             }
-            : {
-                strictness: "elevated",
-                reason: "Automated provenance with elevated review requirements",
-            }
+            return strictnessFromTrust(trust, riskScore);
+        })()
         : {
             strictness: "baseline",
             reason: "Human provenance or unknown automation signals",

--- a/dist/licenses.txt
+++ b/dist/licenses.txt
@@ -243,6 +243,16 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
+@vercel/ncc
+MIT
+Copyright 2018 ZEIT, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 before-after-hook
 Apache-2.0
                                  Apache License

--- a/examples/agent-submission-fixture/.trailhead.yml
+++ b/examples/agent-submission-fixture/.trailhead.yml
@@ -1,0 +1,19 @@
+# Example Gate 1 policy for external agent fleets (non-Komatik).
+schema_version: 2
+
+submission:
+  enabled: true
+  mode: block
+  max_file_lines: 1000
+  auth_route_allowlist:
+    - /api/auth/
+    - /api/webhooks/
+    - /api/health/
+
+gate:
+  mode: release-ready
+  agent_brief: collapsed
+
+remediation:
+  enabled: true
+  max_loop_rounds: 3

--- a/examples/agent-submission-fixture/README.md
+++ b/examples/agent-submission-fixture/README.md
@@ -1,0 +1,61 @@
+# Agent submission fixture (Gate 1)
+
+Minimal non-Komatik example showing **Gate 1** agent submission checks via the Trailhead Action.
+
+Gate 1 validates PR diffs for agent-quality issues (secrets, destructive SQL, missing RLS, auth on API routes, syntax, etc.) before the deploy gate runs.
+
+## Enable in your repo
+
+1. Add `.trailhead.yml` (or merge the snippet below).
+2. Wire the Action with `submission-gate: "true"`.
+
+```yaml
+# .trailhead.yml
+schema_version: 2
+
+submission:
+  enabled: true
+  mode: block # or warn while tuning false-positive rate
+
+gate:
+  mode: release-ready
+  agent_brief: collapsed
+```
+
+```yaml
+# .github/workflows/trailhead.yml (snippet)
+- uses: KomatikAI/trailhead@v4
+  with:
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+    submission-gate: "true"
+```
+
+## Komatik fleet only
+
+Set `KOMATIK_INSTANCE: "true"` in the workflow env to enable SOUL integrity and DeployGuard stale-term checks. External repos should omit this.
+
+## Trust scoring (optional)
+
+Pass rolling agent metrics via `TRAILHEAD_AGENT_TRUST_JSON` until hosted trust lookup ships:
+
+```json
+{
+  "evaluations": 20,
+  "releaseReadyCount": 18,
+  "revertCount": 0,
+  "humanReviewRequiredCount": 2,
+  "policyViolationCount": 0,
+  "sensitivePathViolationCount": 0,
+  "remediationRoundsToReady": [1, 1, 2, 1]
+}
+```
+
+## Local self-test
+
+Run the engine against sample patches in this directory:
+
+```bash
+npm test -- submission-engine
+```
+
+See `src/__tests__/submission-engine.test.ts` for programmatic examples.

--- a/examples/agent-submission-fixture/trailhead-workflow.snippet.yml
+++ b/examples/agent-submission-fixture/trailhead-workflow.snippet.yml
@@ -1,0 +1,22 @@
+# Copy into .github/workflows/ — validates agent PR quality (Gate 1) + release readiness.
+name: Trailhead
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      checks: write
+    steps:
+      - uses: KomatikAI/trailhead@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          submission-gate: "true"
+        env:
+          # Optional: trust metrics JSON until Cloud nightly compute (B3 follow-up)
+          # TRAILHEAD_AGENT_TRUST_JSON: ${{ secrets.TRAILHEAD_AGENT_TRUST_JSON }}

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trailhead/mcp-server",
-  "version": "4.3.3",
+  "version": "4.4.0",
   "private": true,
   "description": "MCP server exposing Trailhead deployment gate — health checks, risk scoring, DORA metrics, and policy enforcement as tools",
   "type": "module",

--- a/mcp/src/fixer-core.ts
+++ b/mcp/src/fixer-core.ts
@@ -35,17 +35,39 @@ export interface AutofixPlan {
   blocked: Array<{ fix: RemediationFix; reason: string }>;
 }
 
+function escapeRegexChar(ch: string): string {
+  return /[\\^$+?.()|{}[\]]/.test(ch) ? `\\${ch}` : ch;
+}
+
+function globToRegex(glob: string): RegExp {
+  let src = "^";
+  for (let i = 0; i < glob.length; i++) {
+    const c = glob[i]!;
+    if (c === "*") {
+      if (glob[i + 1] === "*") {
+        src += ".*";
+        i++;
+      } else {
+        src += "[^/]*";
+      }
+    } else if (c === ".") {
+      src += "\\.";
+    } else {
+      src += escapeRegexChar(c);
+    }
+  }
+  src += "$";
+  return new RegExp(src);
+}
+
 function matchesGlob(path: string, glob: string): boolean {
   const normalized = path.replace(/\\/g, "/");
   if (glob.endsWith("/**")) {
-    const prefix = glob.slice(0, -3);
-    return normalized.includes(prefix.replace(/\*\*/g, ""));
+    const prefix = glob.slice(0, -3).replace(/\*\*/g, "");
+    return normalized.includes(prefix);
   }
   if (glob.includes("*")) {
-    const re = new RegExp(
-      `^${glob.replace(/\*\*/g, ".*").replace(/\*/g, "[^/]*").replace(/\./g, "\\.")}$`,
-    );
-    return re.test(normalized);
+    return globToRegex(glob).test(normalized);
   }
   return normalized.includes(glob);
 }

--- a/mcp/src/fixer-core.ts
+++ b/mcp/src/fixer-core.ts
@@ -42,7 +42,7 @@ function escapeRegexChar(ch: string): string {
 function globToRegex(glob: string): RegExp {
   let src = "^";
   for (let i = 0; i < glob.length; i++) {
-    const c = glob[i]!;
+    const c = glob.charAt(i);
     if (c === "*") {
       if (glob[i + 1] === "*") {
         src += ".*";

--- a/mcp/src/fixer-core.ts
+++ b/mcp/src/fixer-core.ts
@@ -1,0 +1,100 @@
+// Phase B2 — autofix allowlist (pure module; execution lives in app/fixer.ts).
+
+import type { RemediationAutofixClass, RemediationFix } from "./types.js";
+
+export const RED_LANE_GLOBS = [
+  "**/migrations/**",
+  "**/*.sql",
+  "**/rls/**",
+  "src/auth/**",
+  "app/**/auth/**",
+  ".github/workflows/**",
+  "agents/*/SOUL.md",
+  "src/risk-engine.ts",
+  "**/secrets/**",
+  "**/payments/**",
+];
+
+const ALLOWED_AUTOFIX_CLASSES = new Set<RemediationAutofixClass>([
+  "format",
+  "lint",
+  "import-fix",
+  "test-scaffold",
+  "doc-update",
+  "dependency-bump",
+]);
+
+export interface AutofixPlanItem {
+  fix: RemediationFix;
+  files: string[];
+  autofix_class: RemediationAutofixClass;
+}
+
+export interface AutofixPlan {
+  items: AutofixPlanItem[];
+  blocked: Array<{ fix: RemediationFix; reason: string }>;
+}
+
+function matchesGlob(path: string, glob: string): boolean {
+  const normalized = path.replace(/\\/g, "/");
+  if (glob.endsWith("/**")) {
+    const prefix = glob.slice(0, -3);
+    return normalized.includes(prefix.replace(/\*\*/g, ""));
+  }
+  if (glob.includes("*")) {
+    const re = new RegExp(
+      `^${glob.replace(/\*\*/g, ".*").replace(/\*/g, "[^/]*").replace(/\./g, "\\.")}$`,
+    );
+    return re.test(normalized);
+  }
+  return normalized.includes(glob);
+}
+
+export function isRedLanePath(filePath: string): boolean {
+  const normalized = filePath.replace(/\\/g, "/");
+  return RED_LANE_GLOBS.some((glob) => matchesGlob(normalized, glob));
+}
+
+export function isAutofixClassAllowed(autofixClass: RemediationAutofixClass): boolean {
+  return ALLOWED_AUTOFIX_CLASSES.has(autofixClass);
+}
+
+export function buildAutofixPlan(fixes: RemediationFix[]): AutofixPlan {
+  const items: AutofixPlanItem[] = [];
+  const blocked: AutofixPlan["blocked"] = [];
+
+  for (const fix of fixes) {
+    if (!fix.autofix_eligible || !fix.autofix_class) continue;
+
+    if (!isAutofixClassAllowed(fix.autofix_class)) {
+      blocked.push({
+        fix,
+        reason: `Autofix class not allowlisted: ${fix.autofix_class}`,
+      });
+      continue;
+    }
+
+    const touchFiles = fix.files.length > 0 ? fix.files : ["."];
+    const redLane = touchFiles.filter(isRedLanePath);
+    if (redLane.length > 0) {
+      blocked.push({
+        fix,
+        reason: `Red-lane paths forbid autofix: ${redLane.join(", ")}`,
+      });
+      continue;
+    }
+
+    items.push({
+      fix,
+      files: touchFiles,
+      autofix_class: fix.autofix_class,
+    });
+  }
+
+  return { items, blocked };
+}
+
+/** Max one fix commit per gate round (Phase B2). */
+export function selectAutofixCommit(plan: AutofixPlan): AutofixPlanItem | null {
+  return plan.items[0] ?? null;
+}

--- a/mcp/src/submission-checks/detectors.ts
+++ b/mcp/src/submission-checks/detectors.ts
@@ -1,0 +1,632 @@
+// Gate 1 detectors — ported from komatik-agents agent-gate-checks (patch/content based).
+
+import type { SubmissionCheckResult } from "../types.js";
+import type { SubmissionCheckContext, SubmissionFileInfo } from "./types.js";
+import {
+  addedLines,
+  extensionOf,
+  fileContent,
+  isTestPath,
+  lineCountFromPatch,
+  normalizePath,
+  scanAddedContent,
+} from "./helpers.js";
+
+export const OLD_NAME_PATTERNS: Array<{
+  oldName: string;
+  newName: string;
+  pattern: RegExp;
+}> = [
+  { oldName: "DeployGuard", newName: "Trailhead", pattern: /\bDeployGuard\b/g },
+  { oldName: "Daydream Studio", newName: "Sundog", pattern: /\bDaydream Studio\b/g },
+  {
+    oldName: "Storyboard Studio",
+    newName: "Kindling",
+    pattern: /\bStoryboard Studio\b/g,
+  },
+  { oldName: "Cognitive Debt", newName: "Drift", pattern: /\bCognitive Debt\b/g },
+  { oldName: "cognitive-debt", newName: "Drift", pattern: /\bcognitive-debt\b/g },
+];
+
+const MOCK_PATTERNS = [
+  /\bTODO\s*\(\s*mock\s*\)/i,
+  /\bFIXME\s*\(\s*mock\s*\)/i,
+  /\bMOCK_[A-Z0-9_]+\b/,
+  /\bfakeImplementation\b/,
+  /\bstubResponse\s*\(/i,
+  /\b(?:generate|create|build|get)(?:Mock|Fake|Dummy|Sample)\w*/g,
+  /\b(?:mockData|fakeData|sampleData|dummyData|testData)\b/g,
+  /\bTODO:\s*implement\b/gi,
+  /\bFIXME\b/g,
+  /\bplaceholder\b/gi,
+  /\blorem ipsum\b/gi,
+];
+
+const SECRET_PATTERNS: Array<{ name: string; pattern: RegExp }> = [
+  { name: "AWS access key", pattern: /\bAKIA[0-9A-Z]{16}\b/g },
+  { name: "GitHub token", pattern: /\bgh[pousr]_[A-Za-z0-9_]{20,}\b/g },
+  { name: "Stripe live key", pattern: /\bsk_live_[A-Za-z0-9]{10,}\b/g },
+  { name: "Stripe test key", pattern: /\bsk_test_[A-Za-z0-9]{10,}\b/g },
+  { name: "Private key block", pattern: /-----BEGIN [A-Z ]+PRIVATE KEY-----/g },
+  {
+    name: "Generic API key assignment",
+    pattern: /api[_-]?key\s*[:=]\s*['"][A-Za-z0-9_-]{32,}['"]/gi,
+  },
+];
+
+const HARDCODED_ENV_PATTERNS: Array<{ name: string; pattern: RegExp }> = [
+  { name: "localhost with port", pattern: /(?:['"`])localhost:\d{2,5}(?:['"`])/g },
+  {
+    name: "hardcoded private IP",
+    pattern:
+      /(?:['"`])(?:10\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.(?:1[6-9]|2\d|3[01])\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3})(?::\d+)?(?:['"`])/g,
+  },
+];
+
+const NODE_BUILTINS = new Set([
+  "assert",
+  "async_hooks",
+  "buffer",
+  "child_process",
+  "cluster",
+  "console",
+  "constants",
+  "crypto",
+  "dgram",
+  "dns",
+  "events",
+  "fs",
+  "http",
+  "http2",
+  "https",
+  "module",
+  "net",
+  "os",
+  "path",
+  "process",
+  "stream",
+  "url",
+  "util",
+  "zlib",
+]);
+
+function result(
+  partial: Omit<SubmissionCheckResult, "autofix_eligible"> & {
+    autofix_eligible?: boolean;
+  },
+): SubmissionCheckResult {
+  return { autofix_eligible: false, ...partial };
+}
+
+export function detectMockPlaceholder(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const hits = scanAddedContent(ctx.files, (line, filename) => {
+    if (isTestPath(filename)) return false;
+    if (/\.(md|txt)$/i.test(filename)) return false;
+    return MOCK_PATTERNS.some((re) => {
+      re.lastIndex = 0;
+      return re.test(line);
+    });
+  });
+  if (hits.length === 0) return null;
+  return result({
+    code: "mock_placeholder",
+    severity: "blocking",
+    title: "Mock placeholder in production path",
+    detail: `Found mock/TODO placeholder patterns in ${hits.join(", ")}.`,
+    files: hits,
+    suggested_action: "Remove mock placeholders and implement real behavior.",
+  });
+}
+
+export function detectSecrets(ctx: SubmissionCheckContext): SubmissionCheckResult | null {
+  const hits = scanAddedContent(ctx.files, (line) =>
+    SECRET_PATTERNS.some((entry) => {
+      entry.pattern.lastIndex = 0;
+      return entry.pattern.test(line);
+    }),
+  );
+  if (hits.length === 0) return null;
+  return result({
+    code: "secrets",
+    severity: "blocking",
+    title: "Potential secret in diff",
+    detail: `Added lines match secret patterns in ${hits.join(", ")}.`,
+    files: hits,
+    suggested_action: "Remove secrets; use environment variables or a secret manager.",
+  });
+}
+
+export function detectDestructiveSql(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const sqlFiles = ctx.files.filter((f) => extensionOf(f.filename) === ".sql");
+  const hits = scanAddedContent(sqlFiles, (line) =>
+    /\b(DROP\s+TABLE|TRUNCATE|DELETE\s+FROM(?![^\n]*\bWHERE\b))/i.test(line),
+  );
+  if (hits.length === 0) return null;
+  return result({
+    code: "destructive_sql",
+    severity: "blocking",
+    title: "Destructive SQL in migration",
+    detail: `Added SQL contains destructive statements in ${hits.join(", ")}.`,
+    files: hits,
+    suggested_action:
+      "Use additive migrations; avoid DROP/TRUNCATE without human approval.",
+  });
+}
+
+export function detectArtifactIntegrity(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const referenced = new Set<string>();
+  const pathRefPattern =
+    /(?:^|\s|['"`])([\w@./-]+\.(?:ts|tsx|js|jsx|md|sql|yml|yaml|json))(?:['"`]|\s|:)/g;
+
+  for (const file of ctx.files) {
+    for (const line of addedLines(file.patch)) {
+      if (!/(?:import|from|require|see|fix|update)\s/i.test(line)) continue;
+      for (const match of line.matchAll(pathRefPattern)) {
+        const candidate = match[1]?.replace(/^\.\//, "");
+        if (!candidate || candidate.includes("*")) continue;
+        if (!ctx.prPaths.has(candidate) && !candidate.startsWith("node:")) {
+          referenced.add(candidate);
+        }
+      }
+    }
+  }
+
+  if (referenced.size === 0) return null;
+  const missing = [...referenced].slice(0, 8);
+  return result({
+    code: "artifact_integrity",
+    severity: "blocking",
+    title: "Referenced files missing from PR",
+    detail: `Added lines reference paths not in this PR: ${missing.join(", ")}${referenced.size > 8 ? "…" : ""}.`,
+    files: missing,
+    suggested_action: "Include referenced files or fix hallucinated paths.",
+  });
+}
+
+function isNamingAllowlisted(filename: string, line: string): boolean {
+  const trimmed = line.trim();
+  if (/^import\s|^from\s|require\(/.test(trimmed)) return true;
+  if (/\.sql$/i.test(filename)) return true;
+  if (/(?:^|\/)migrations\//.test(filename)) return true;
+  if (/(?:^|\/)memory\//.test(filename)) return true;
+  if (/RESEARCH\.md$|BRAND\.md$|CHANGELOG\.md$/.test(filename)) return true;
+  if (/^\[.*\]\(.*\)/.test(trimmed)) return true;
+  return false;
+}
+
+export function detectContextFreshness(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  if (ctx.staleTerms.length === 0 && !ctx.komatikInstance) return null;
+
+  const hits: string[] = [];
+  for (const file of ctx.files) {
+    for (const line of addedLines(file.patch)) {
+      if (isNamingAllowlisted(file.filename, line)) continue;
+
+      const terms = ctx.staleTerms.length > 0 ? ctx.staleTerms : [];
+      for (const term of terms) {
+        if (line.toLowerCase().includes(term.toLowerCase())) hits.push(file.filename);
+      }
+
+      if (ctx.komatikInstance) {
+        for (const entry of OLD_NAME_PATTERNS) {
+          entry.pattern.lastIndex = 0;
+          if (entry.pattern.test(line)) hits.push(file.filename);
+        }
+      }
+    }
+  }
+
+  const unique = [...new Set(hits)];
+  if (unique.length === 0) return null;
+  return result({
+    code: "context_freshness",
+    severity: "warn",
+    title: "Stale naming or deprecated terms",
+    detail: `Added lines reference deprecated terms in ${unique.join(", ")}.`,
+    files: unique,
+    suggested_action: "Update naming to current product vocabulary (see BRAND.md).",
+    autofix_eligible: true,
+  });
+}
+
+export function detectPathFormat(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  if (!ctx.komatikInstance) return null;
+  const hits = ctx.files
+    .map((f) => normalizePath(f.filename))
+    .filter(
+      (name) =>
+        /^komatik-agents\/agents\//.test(name) ||
+        /\/agents\/agents\//.test(name) ||
+        (!/^agents\/[a-z][a-z0-9-]*\/suggestions\//.test(name) &&
+          /\/suggestions\//.test(name) &&
+          !name.startsWith("agents/")),
+    );
+  if (hits.length === 0) return null;
+  return result({
+    code: "path_format",
+    severity: "warn",
+    title: "Suspicious agent suggestion path",
+    detail: `Paths should match agents/<id>/suggestions/<project>/… — found: ${hits.join(", ")}.`,
+    files: hits,
+    suggested_action: "Use canonical agent suggestion paths without repo prefix.",
+  });
+}
+
+export function detectHardcodedEnv(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const hits = scanAddedContent(ctx.files, (line, filename) => {
+    if (/\.(md|txt)$/i.test(filename)) return false;
+    if (/^\s*\/\/|^\s*\*|^\s*#/.test(line)) return false;
+    return HARDCODED_ENV_PATTERNS.some((entry) => {
+      entry.pattern.lastIndex = 0;
+      return entry.pattern.test(line);
+    });
+  });
+  if (hits.length === 0) return null;
+  return result({
+    code: "hardcoded_env",
+    severity: "blocking",
+    title: "Hardcoded environment value",
+    detail: `Added lines contain hardcoded localhost/IP patterns in ${hits.join(", ")}.`,
+    files: hits,
+    suggested_action:
+      "Use environment variables or configuration instead of hardcoded hosts.",
+  });
+}
+
+export function detectLargeFile(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const hits = ctx.files
+    .filter((file) => {
+      const lines =
+        typeof file.content === "string"
+          ? file.content.split("\n").length
+          : lineCountFromPatch(file.patch);
+      return lines > ctx.maxFileLines;
+    })
+    .map((f) => f.filename);
+  if (hits.length === 0) return null;
+  return result({
+    code: "large_file",
+    severity: "warn",
+    title: "Large file in PR",
+    detail: `Files exceed ${ctx.maxFileLines} lines: ${hits.join(", ")}.`,
+    files: hits,
+    suggested_action: "Split large changes into smaller PRs.",
+  });
+}
+
+function extractRelativeImports(content: string): string[] {
+  const imports: string[] = [];
+  const patterns = [
+    /\bimport\s+(?:type\s+)?(?:[^'"]+\s+from\s+)?['"](\.\.?[^'"]+)['"]/g,
+    /\brequire\(\s*['"](\.\.?[^'"]+)['"]\s*\)/g,
+  ];
+  for (const pattern of patterns) {
+    for (const match of content.matchAll(pattern)) {
+      if (match[1]) imports.push(match[1]);
+    }
+  }
+  return imports;
+}
+
+function resolveRelativeImport(
+  fromFile: string,
+  specifier: string,
+  prPaths: Set<string>,
+): boolean {
+  const clean = specifier.split("?")[0].split("#")[0];
+  const baseDir = normalizePath(fromFile).split("/").slice(0, -1);
+  const segments = clean.replace(/^\.\//, "").split("/");
+  for (const segment of segments) {
+    if (segment === "..") baseDir.pop();
+    else if (segment !== ".") baseDir.push(segment);
+  }
+  const resolved = baseDir.join("/");
+  const candidates = [
+    resolved,
+    `${resolved}.ts`,
+    `${resolved}.tsx`,
+    `${resolved}.js`,
+    `${resolved}.jsx`,
+    `${resolved}/index.ts`,
+    `${resolved}/index.js`,
+  ];
+  return candidates.some((c) => prPaths.has(c));
+}
+
+export function detectImportResolution(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const codeExts = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"]);
+  const hits: string[] = [];
+
+  for (const file of ctx.files) {
+    if (!codeExts.has(extensionOf(file.filename))) continue;
+    const content = fileContent(file);
+    for (const specifier of extractRelativeImports(content)) {
+      if (!resolveRelativeImport(file.filename, specifier, ctx.prPaths)) {
+        hits.push(file.filename);
+        break;
+      }
+    }
+  }
+
+  if (hits.length === 0) return null;
+  return result({
+    code: "import_resolution",
+    severity: "blocking",
+    title: "Unresolved relative import",
+    detail: `Relative imports could not be resolved within this PR: ${[...new Set(hits)].join(", ")}.`,
+    files: [...new Set(hits)],
+    suggested_action: "Add missing files to the PR or fix import paths.",
+  });
+}
+
+export function detectRlsNewTables(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const sqlFiles = ctx.files.filter((f) => extensionOf(f.filename) === ".sql");
+  const corpus = sqlFiles.map((f) => fileContent(f)).join("\n");
+  const hits: string[] = [];
+  const createTable =
+    /\bCREATE\s+(?!TEMP(?:ORARY)?\s+)TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?((?:"?[A-Za-z_][\w$]*"?\.)?"?[A-Za-z_][\w$]*"?)/gi;
+
+  for (const file of sqlFiles) {
+    const content = fileContent(file);
+    for (const match of content.matchAll(createTable)) {
+      const table = match[1]?.replace(/"/g, "") ?? "";
+      const pattern = new RegExp(
+        `ALTER\\s+TABLE\\s+(?:ONLY\\s+)?["']?${table.split(".").pop()}["']?\\s+ENABLE\\s+ROW\\s+LEVEL\\s+SECURITY`,
+        "i",
+      );
+      if (!pattern.test(corpus)) hits.push(file.filename);
+    }
+  }
+
+  if (hits.length === 0) return null;
+  return result({
+    code: "rls_new_tables",
+    severity: "blocking",
+    title: "New table missing RLS",
+    detail: `CREATE TABLE without ENABLE ROW LEVEL SECURITY in ${[...new Set(hits)].join(", ")}.`,
+    files: [...new Set(hits)],
+    suggested_action:
+      "Add ALTER TABLE ... ENABLE ROW LEVEL SECURITY for every new table.",
+  });
+}
+
+function isRouteAllowlisted(path: string, allowlist: string[]): boolean {
+  return allowlist.some((entry) => path.includes(entry.replace(/^\//, "")));
+}
+
+export function detectAuthRouteAuth(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const routePattern =
+    /(?:^|\/)(?:app\/api\/.+\/route|pages\/api\/.+)\.(?:ts|tsx|js|jsx)$/;
+  const authPattern =
+    /\b(getUser|getSession|getServerSession|auth|requireAuth|withAuth)\s*\(/;
+  const hits: string[] = [];
+
+  for (const file of ctx.files) {
+    const normalized = normalizePath(file.filename);
+    if (!routePattern.test(normalized)) continue;
+    if (isRouteAllowlisted(normalized, ctx.authRouteAllowlist)) continue;
+    if (!authPattern.test(fileContent(file))) hits.push(normalized);
+  }
+
+  if (hits.length === 0) return null;
+  return result({
+    code: "auth_route_auth",
+    severity: "blocking",
+    title: "API route missing auth check",
+    detail: `Routes appear to lack session/user verification: ${hits.join(", ")}.`,
+    files: hits,
+    suggested_action: "Verify authenticated user before handling the request.",
+  });
+}
+
+function packageNameFromSpecifier(specifier: string): string {
+  if (specifier.startsWith("@")) return specifier.split("/").slice(0, 2).join("/");
+  return specifier.split("/")[0];
+}
+
+function isNodeBuiltin(specifier: string): boolean {
+  const bare = specifier.startsWith("node:") ? specifier.slice(5) : specifier;
+  return NODE_BUILTINS.has(bare.split("/")[0]);
+}
+
+export function detectExternalPackageDeps(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  if (ctx.declaredPackages.size === 0) return null;
+  const codeExts = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"]);
+  const hits: string[] = [];
+
+  for (const file of ctx.files) {
+    if (!codeExts.has(extensionOf(file.filename))) continue;
+    const importPattern = /\b(?:import|from|require)\s*(?:\([^)]*|\(?)?['"]([^'"]+)['"]/g;
+    for (const match of fileContent(file).matchAll(importPattern)) {
+      const specifier = match[1];
+      if (!specifier || specifier.startsWith(".") || specifier.startsWith("@/")) continue;
+      if (isNodeBuiltin(specifier)) continue;
+      const pkg = packageNameFromSpecifier(specifier);
+      if (!ctx.declaredPackages.has(pkg)) hits.push(`${file.filename} → ${pkg}`);
+    }
+  }
+
+  if (hits.length === 0) return null;
+  return result({
+    code: "external_package_deps",
+    severity: "warn",
+    title: "Undeclared package import",
+    detail: hits.slice(0, 6).join("; "),
+    files: [...new Set(hits.map((h) => h.split(" → ")[0]))],
+    suggested_action: "Add the package to package.json or remove the import.",
+  });
+}
+
+export function detectSqlSyntaxBasic(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const hits: string[] = [];
+  for (const file of ctx.files.filter((f) => extensionOf(f.filename) === ".sql")) {
+    const content = fileContent(file);
+    const stripped = content.replace(/--[^\n]*/g, "").replace(/\/\*[\s\S]*?\*\//g, "");
+    const beginCount = (stripped.match(/\bBEGIN\b/gi) || []).length;
+    const endCount = (stripped.match(/\bEND\b\s*;/gi) || []).length;
+    if (beginCount > 0 && endCount === 0) hits.push(file.filename);
+    else if (endCount > beginCount) hits.push(file.filename);
+  }
+  if (hits.length === 0) return null;
+  return result({
+    code: "sql_syntax_basic",
+    severity: "blocking",
+    title: "SQL block balance issue",
+    detail: `Possible unmatched BEGIN/END in ${hits.join(", ")}.`,
+    files: hits,
+    suggested_action: "Fix PL/pgSQL block structure before merging.",
+  });
+}
+
+type SwcParseSync = (code: string, options: Record<string, unknown>) => unknown;
+
+let cachedSwcParse: SwcParseSync | null | undefined;
+
+function getSwcParse(): SwcParseSync | null {
+  if (cachedSwcParse !== undefined) return cachedSwcParse;
+  try {
+    // Optional — install @swc/core locally for full parse; Action uses bracket fallback.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const swc = require("@swc/core") as { parseSync: SwcParseSync };
+    cachedSwcParse = swc.parseSync;
+  } catch {
+    cachedSwcParse = null;
+  }
+  return cachedSwcParse;
+}
+
+function basicBracketBalance(content: string): string | null {
+  let braces = 0;
+  let parens = 0;
+  let brackets = 0;
+  for (const ch of content) {
+    if (ch === "{") braces += 1;
+    if (ch === "}") braces -= 1;
+    if (ch === "(") parens += 1;
+    if (ch === ")") parens -= 1;
+    if (ch === "[") brackets += 1;
+    if (ch === "]") brackets -= 1;
+    if (braces < 0 || parens < 0 || brackets < 0) return "Unbalanced brackets/parens";
+  }
+  if (braces !== 0 || parens !== 0 || brackets !== 0) {
+    return "Unclosed brackets/parens in diff hunk";
+  }
+  return null;
+}
+
+function parserOptionsFor(file: SubmissionFileInfo): Record<string, unknown> {
+  const ext = extensionOf(file.filename);
+  const isTs = ext === ".ts" || ext === ".tsx";
+  return {
+    syntax: isTs ? "typescript" : "ecmascript",
+    tsx: ext === ".tsx",
+    jsx: ext === ".jsx",
+    decorators: true,
+    dynamicImport: true,
+  };
+}
+
+export function detectSyntaxValidity(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const errors: Array<{ file: string; message: string }> = [];
+  const codeExts = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"]);
+  const swcParse = getSwcParse();
+
+  for (const file of ctx.files) {
+    const ext = extensionOf(file.filename);
+    const content = fileContent(file);
+    if (!content.trim()) continue;
+
+    try {
+      if (codeExts.has(ext)) {
+        if (swcParse) {
+          swcParse(content, parserOptionsFor(file));
+        } else {
+          const balance = basicBracketBalance(content);
+          if (balance) throw new Error(balance);
+        }
+      } else if (ext === ".json") {
+        JSON.parse(content);
+      }
+    } catch (error) {
+      errors.push({
+        file: file.filename,
+        message: error instanceof Error ? error.message.split("\n")[0] : String(error),
+      });
+    }
+  }
+
+  if (errors.length === 0) return null;
+  return result({
+    code: "syntax_validity",
+    severity: "blocking",
+    title: "Syntax error in changed file",
+    detail: errors.map((e) => `${e.file}: ${e.message}`).join("; "),
+    files: errors.map((e) => e.file),
+    suggested_action: "Fix parse errors before resubmitting.",
+  });
+}
+
+export function detectSoulIntegrity(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  if (!ctx.komatikInstance) return null;
+  const hits = ctx.files
+    .map((f) => normalizePath(f.filename))
+    .filter((name) => /^agents\/[a-z][a-z0-9-]*\/SOUL\.md$/.test(name));
+  if (hits.length === 0) return null;
+  return result({
+    code: "soul_integrity",
+    severity: "blocking",
+    title: "Agent SOUL.md modified",
+    detail: `SOUL changes require human review: ${hits.join(", ")}.`,
+    files: hits,
+    suggested_action: "Revert SOUL.md changes or request explicit human approval.",
+  });
+}
+
+export function runAllDetectors(ctx: SubmissionCheckContext): SubmissionCheckResult[] {
+  const checks = [
+    detectMockPlaceholder(ctx),
+    detectSecrets(ctx),
+    detectDestructiveSql(ctx),
+    detectSyntaxValidity(ctx),
+    detectImportResolution(ctx),
+    detectRlsNewTables(ctx),
+    detectAuthRouteAuth(ctx),
+    detectHardcodedEnv(ctx),
+    detectExternalPackageDeps(ctx),
+    detectSqlSyntaxBasic(ctx),
+    detectLargeFile(ctx),
+    detectArtifactIntegrity(ctx),
+    detectContextFreshness(ctx),
+    detectSoulIntegrity(ctx),
+    detectPathFormat(ctx),
+  ];
+  return checks.filter((check): check is SubmissionCheckResult => check !== null);
+}

--- a/mcp/src/submission-checks/helpers.ts
+++ b/mcp/src/submission-checks/helpers.ts
@@ -1,0 +1,83 @@
+// Shared helpers for Gate 1 submission checks (pure, no I/O).
+
+import type { SubmissionFileInfo } from "./types.js";
+
+export function normalizePath(filePath: string): string {
+  return filePath.replace(/\\/g, "/").replace(/^\.\//, "");
+}
+
+export function extensionOf(filename: string): string {
+  const base = normalizePath(filename);
+  const idx = base.lastIndexOf(".");
+  return idx >= 0 ? base.slice(idx).toLowerCase() : "";
+}
+
+export function addedLines(patch: string | undefined): string[] {
+  if (!patch) return [];
+  return patch
+    .split("\n")
+    .filter((line) => line.startsWith("+") && !line.startsWith("+++"))
+    .map((line) => line.slice(1));
+}
+
+/** Approximate post-change file body from a unified diff hunk (context + additions). */
+export function effectiveContentFromPatch(patch: string | undefined): string {
+  if (!patch) return "";
+  return patch
+    .split("\n")
+    .filter(
+      (line) =>
+        !line.startsWith("@@") && !line.startsWith("---") && !line.startsWith("+++"),
+    )
+    .filter((line) => !line.startsWith("-"))
+    .map((line) => (line.startsWith("+") || line.startsWith(" ") ? line.slice(1) : line))
+    .join("\n");
+}
+
+export function fileContent(file: SubmissionFileInfo): string {
+  if (typeof file.content === "string") return file.content;
+  return effectiveContentFromPatch(file.patch);
+}
+
+export function lineCountFromPatch(patch: string | undefined): number {
+  const content = effectiveContentFromPatch(patch);
+  if (!content) return 0;
+  return content.split("\n").length;
+}
+
+export function scanAddedContent(
+  files: SubmissionFileInfo[],
+  predicate: (line: string, filename: string) => boolean,
+): string[] {
+  const hits: string[] = [];
+  for (const file of files) {
+    for (const line of addedLines(file.patch)) {
+      if (predicate(line, file.filename)) hits.push(file.filename);
+    }
+  }
+  return [...new Set(hits)];
+}
+
+export function scanFileContent(
+  files: SubmissionFileInfo[],
+  predicate: (line: string, filename: string, lineNo: number) => boolean,
+): Array<{ file: string; line: number }> {
+  const hits: Array<{ file: string; line: number }> = [];
+  for (const file of files) {
+    const lines = fileContent(file).split("\n");
+    lines.forEach((line, index) => {
+      if (predicate(line, file.filename, index + 1)) {
+        hits.push({ file: file.filename, line: index + 1 });
+      }
+    });
+  }
+  return hits;
+}
+
+export function prPathSet(files: SubmissionFileInfo[]): Set<string> {
+  return new Set(files.map((f) => normalizePath(f.filename)));
+}
+
+export function isTestPath(filename: string): boolean {
+  return /\/__tests__\/|\/test\/|\/fixtures\/|\.test\.|\.spec\./.test(filename);
+}

--- a/mcp/src/submission-checks/types.ts
+++ b/mcp/src/submission-checks/types.ts
@@ -1,0 +1,18 @@
+export interface SubmissionFileInfo {
+  filename: string;
+  patch?: string;
+  status?: string;
+  /** Full file content when fetched by the gate (optional). */
+  content?: string;
+  additions?: number;
+}
+
+export interface SubmissionCheckContext {
+  files: SubmissionFileInfo[];
+  prPaths: Set<string>;
+  komatikInstance: boolean;
+  staleTerms: string[];
+  authRouteAllowlist: string[];
+  maxFileLines: number;
+  declaredPackages: Set<string>;
+}

--- a/mcp/src/submission-engine.ts
+++ b/mcp/src/submission-engine.ts
@@ -1,220 +1,60 @@
 // Gate 1 — agent submission quality (Phase B1).
 // Pure module: no @actions/*, octokit, or Node I/O.
 
-import type { RepoConfig, SubmissionCheckResult } from "./types.js";
+import { runAllDetectors } from "./submission-checks/detectors.js";
+import type { SubmissionCheckContext } from "./submission-checks/types.js";
+import { prPathSet } from "./submission-checks/helpers.js";
 import { SubmissionCheckCode } from "./types.js";
+import type { RepoConfig, SubmissionCheckResult } from "./types.js";
 
+export type { SubmissionFileInfo } from "./submission-checks/types.js";
 export type { SubmissionCheckCode, SubmissionCheckResult } from "./types.js";
 
 /** All Gate 1 check codes — keep in sync with A8 fixture manifest. */
 export const SUBMISSION_CHECK_CODES = SubmissionCheckCode.options;
 
-export interface SubmissionFileInfo {
-  filename: string;
-  patch?: string;
-  status?: string;
-}
-
-export interface SubmissionEngineOptions {
-  files: SubmissionFileInfo[];
-  repoConfig?: RepoConfig | null;
-  /** When true, enable Komatik-specific checks (SOUL paths, etc.). */
-  komatikInstance?: boolean;
-  mode?: "warn" | "block";
-}
-
-const MOCK_PLACEHOLDER_PATTERNS = [
-  /\bTODO\s*\(\s*mock\s*\)/i,
-  /\bFIXME\s*\(\s*mock\s*\)/i,
-  /\bMOCK_[A-Z0-9_]+\b/,
-  /\bfakeImplementation\b/,
-  /\bstubResponse\s*\(/i,
-];
-
-const SECRET_PATTERNS = [
-  /\bsk_live_[A-Za-z0-9]{10,}\b/,
-  /\bsk_test_[A-Za-z0-9]{10,}\b/,
-  /\bghp_[A-Za-z0-9]{20,}\b/,
-  /\bAKIA[0-9A-Z]{16}\b/,
-];
-
-const DESTRUCTIVE_SQL_PATTERNS = [
-  /\bDROP\s+TABLE\b/i,
-  /\bTRUNCATE\s+TABLE\b/i,
-  /\bDROP\s+COLUMN\b/i,
-];
-
 const DEFAULT_STALE_TERMS = ["deployguard", "DeployGuard"];
 
-function addedLines(patch: string | undefined): string[] {
-  if (!patch) return [];
-  return patch
-    .split("\n")
-    .filter((line) => line.startsWith("+") && !line.startsWith("+++"))
-    .map((line) => line.slice(1));
+const DEFAULT_AUTH_ROUTE_ALLOWLIST = [
+  "/api/auth/",
+  "/api/webhooks/",
+  "/api/health/",
+  "/api/metrics/",
+];
+
+export interface SubmissionEngineOptions {
+  files: import("./submission-checks/types.js").SubmissionFileInfo[];
+  repoConfig?: RepoConfig | null;
+  komatikInstance?: boolean;
+  mode?: "warn" | "block";
+  /** Declared npm package names from root package.json (optional). */
+  declaredPackages?: string[];
 }
 
-function scanAddedContent(
-  files: SubmissionFileInfo[],
-  predicate: (line: string, filename: string) => boolean,
-): string[] {
-  const hits: string[] = [];
-  for (const file of files) {
-    for (const line of addedLines(file.patch)) {
-      if (predicate(line, file.filename)) hits.push(file.filename);
-    }
-  }
-  return [...new Set(hits)];
-}
+function buildContext(options: SubmissionEngineOptions): SubmissionCheckContext {
+  const { files, repoConfig, komatikInstance = false } = options;
+  const staleTerms =
+    repoConfig?.submission?.stale_terms ?? (komatikInstance ? DEFAULT_STALE_TERMS : []);
 
-function detectMockPlaceholder(
-  files: SubmissionFileInfo[],
-): SubmissionCheckResult | null {
-  const hits = scanAddedContent(files, (line) =>
-    MOCK_PLACEHOLDER_PATTERNS.some((re) => re.test(line)),
-  );
-  if (hits.length === 0) return null;
+  const declared = new Set(options.declaredPackages ?? []);
+
   return {
-    code: "mock_placeholder",
-    severity: "blocking",
-    title: "Mock placeholder in production path",
-    detail: `Found mock/TODO placeholder patterns in ${hits.join(", ")}. Replace stubs before review.`,
-    files: hits,
-    suggested_action: "Remove mock placeholders and implement real behavior.",
-    autofix_eligible: false,
-  };
-}
-
-function detectSecrets(files: SubmissionFileInfo[]): SubmissionCheckResult | null {
-  const hits = scanAddedContent(files, (line) =>
-    SECRET_PATTERNS.some((re) => re.test(line)),
-  );
-  if (hits.length === 0) return null;
-  return {
-    code: "secrets",
-    severity: "blocking",
-    title: "Potential secret in diff",
-    detail: `Added lines match secret patterns in ${hits.join(", ")}. Rotate any exposed credential.`,
-    files: hits,
-    suggested_action:
-      "Remove secrets from source; use environment variables or a secret manager.",
-    autofix_eligible: false,
-  };
-}
-
-function detectDestructiveSql(files: SubmissionFileInfo[]): SubmissionCheckResult | null {
-  const sqlFiles = files.filter((f) => /\.sql$/i.test(f.filename));
-  const hits = scanAddedContent(sqlFiles, (line) =>
-    DESTRUCTIVE_SQL_PATTERNS.some((re) => re.test(line)),
-  );
-  if (hits.length === 0) return null;
-  return {
-    code: "destructive_sql",
-    severity: "blocking",
-    title: "Destructive SQL in migration",
-    detail: `Added SQL contains destructive statements in ${hits.join(", ")}.`,
-    files: hits,
-    suggested_action:
-      "Use additive migrations; avoid DROP/TRUNCATE without explicit human approval.",
-    autofix_eligible: false,
-  };
-}
-
-function detectContextFreshness(
-  files: SubmissionFileInfo[],
-  staleTerms: string[],
-): SubmissionCheckResult | null {
-  if (staleTerms.length === 0) return null;
-  const hits = scanAddedContent(files, (line) =>
-    staleTerms.some((term) => line.toLowerCase().includes(term.toLowerCase())),
-  );
-  if (hits.length === 0) return null;
-  return {
-    code: "context_freshness",
-    severity: "warn",
-    title: "Stale naming or deprecated terms",
-    detail: `Added lines reference deprecated terms (${staleTerms.join(", ")}) in ${hits.join(", ")}.`,
-    files: hits,
-    suggested_action:
-      "Update naming to match current product vocabulary (see BRAND.md / repo docs).",
-    autofix_eligible: true,
-  };
-}
-
-function detectPathFormat(files: SubmissionFileInfo[]): SubmissionCheckResult | null {
-  const hits = files
-    .map((f) => f.filename)
-    .filter(
-      (name) => /^komatik-agents\/agents\//.test(name) || /\/agents\/agents\//.test(name),
-    );
-  if (hits.length === 0) return null;
-  return {
-    code: "path_format",
-    severity: "warn",
-    title: "Suspicious agent path prefix",
-    detail: `Files use repo-name prefix in internal paths: ${hits.join(", ")}.`,
-    files: hits,
-    suggested_action:
-      "Use agents/<agent-id>/... not <repo>/agents/... for agent workspace paths.",
-    autofix_eligible: false,
-  };
-}
-
-function detectArtifactIntegrity(
-  files: SubmissionFileInfo[],
-): SubmissionCheckResult | null {
-  const prPaths = new Set(files.map((f) => f.filename.replace(/\\/g, "/")));
-  const referenced = new Set<string>();
-
-  const pathRefPattern =
-    /(?:^|\s|['"`])([\w@./-]+\.(?:ts|tsx|js|jsx|md|sql|yml|yaml|json))(?:['"`]|\s|:)/g;
-
-  for (const file of files) {
-    for (const line of addedLines(file.patch)) {
-      if (!/(?:import|from|require|see|fix|update)\s/i.test(line)) continue;
-      for (const match of line.matchAll(pathRefPattern)) {
-        const candidate = match[1]?.replace(/^\.\//, "");
-        if (!candidate || candidate.includes("*")) continue;
-        if (!prPaths.has(candidate) && !candidate.startsWith("node:")) {
-          referenced.add(candidate);
-        }
-      }
-    }
-  }
-
-  if (referenced.size === 0) return null;
-  const missing = [...referenced].slice(0, 8);
-  return {
-    code: "artifact_integrity",
-    severity: "blocking",
-    title: "Referenced files missing from PR",
-    detail: `Added lines reference paths not in this PR: ${missing.join(", ")}${referenced.size > 8 ? "…" : ""}.`,
-    files: missing,
-    suggested_action:
-      "Include the referenced files in this PR or fix hallucinated paths.",
-    autofix_eligible: false,
+    files,
+    prPaths: prPathSet(files),
+    komatikInstance,
+    staleTerms,
+    authRouteAllowlist:
+      repoConfig?.submission?.auth_route_allowlist ?? DEFAULT_AUTH_ROUTE_ALLOWLIST,
+    maxFileLines: repoConfig?.submission?.max_file_lines ?? 1000,
+    declaredPackages: declared,
   };
 }
 
 export function runSubmissionGate(
   options: SubmissionEngineOptions,
 ): SubmissionCheckResult[] {
-  const { files, repoConfig, komatikInstance = false } = options;
-  if (files.length === 0) return [];
-
-  const staleTerms =
-    repoConfig?.submission?.stale_terms ?? (komatikInstance ? DEFAULT_STALE_TERMS : []);
-
-  const checks: Array<SubmissionCheckResult | null> = [
-    detectMockPlaceholder(files),
-    detectSecrets(files),
-    detectDestructiveSql(files),
-    detectArtifactIntegrity(files),
-    detectContextFreshness(files, staleTerms),
-    komatikInstance ? detectPathFormat(files) : null,
-  ];
-
-  return checks.filter((check): check is SubmissionCheckResult => check !== null);
+  if (options.files.length === 0) return [];
+  return runAllDetectors(buildContext(options));
 }
 
 export function submissionGateShouldBlock(

--- a/mcp/src/submission-remediation.ts
+++ b/mcp/src/submission-remediation.ts
@@ -22,6 +22,10 @@ export function deriveSubmissionFixes(
       files: check.files ?? [],
       suggested_action: check.suggested_action,
       autofix_eligible: check.autofix_eligible ?? false,
+      autofix_class:
+        check.autofix_eligible && check.code === "context_freshness"
+          ? "doc-update"
+          : undefined,
     }),
   );
 }

--- a/mcp/src/trust-score.ts
+++ b/mcp/src/trust-score.ts
@@ -1,0 +1,147 @@
+// Phase B3 — dynamic agent trust scoring (pure module).
+
+export type TrustProfileName = "fast-track" | "standard" | "probation";
+
+export interface AgentTrustMetrics {
+  evaluations: number;
+  releaseReadyCount: number;
+  revertCount: number;
+  humanReviewRequiredCount: number;
+  policyViolationCount: number;
+  sensitivePathViolationCount: number;
+  /** Sum of loop rounds for PRs that reached release_ready. */
+  remediationRoundsToReady: number[];
+}
+
+export interface AgentTrustResult {
+  score: number;
+  profile: TrustProfileName;
+  factors: {
+    release_ready_rate: number;
+    revert_rate: number;
+    human_review_required_rate: number;
+    remediation_efficiency: number;
+    policy_violation_rate: number;
+    sensitive_path_violation_rate: number;
+  };
+  thresholdDelta: number;
+  autofixEnabled: boolean;
+}
+
+const WEIGHTS = {
+  release_ready_rate: 0.3,
+  revert_resistance: 0.2,
+  human_free_rate: 0.2,
+  remediation_efficiency: 0.15,
+  policy_violation_penalty: 0.075,
+  sensitive_path_penalty: 0.075,
+};
+
+function rate(numerator: number, denominator: number): number {
+  if (denominator <= 0) return 0;
+  return numerator / denominator;
+}
+
+function remediationEfficiency(rounds: number[]): number {
+  if (rounds.length === 0) return 0.5;
+  const avg = rounds.reduce((a, b) => a + b, 0) / rounds.length;
+  return Math.max(0, Math.min(1, 1 - (avg - 1) / 4));
+}
+
+export function computeAgentTrustScore(metrics: AgentTrustMetrics): AgentTrustResult {
+  const n = Math.max(metrics.evaluations, 0);
+  const releaseReadyRate = rate(metrics.releaseReadyCount, n);
+  const revertRate = rate(metrics.revertCount, n);
+  const humanReviewRate = rate(metrics.humanReviewRequiredCount, n);
+  const policyViolationRate = rate(metrics.policyViolationCount, n);
+  const sensitiveRate = rate(metrics.sensitivePathViolationCount, n);
+  const remEff = remediationEfficiency(metrics.remediationRoundsToReady);
+
+  const factors = {
+    release_ready_rate: releaseReadyRate,
+    revert_rate: revertRate,
+    human_review_required_rate: humanReviewRate,
+    remediation_efficiency: remEff,
+    policy_violation_rate: policyViolationRate,
+    sensitive_path_violation_rate: sensitiveRate,
+  };
+
+  const score = Math.max(
+    0,
+    Math.min(
+      1,
+      WEIGHTS.release_ready_rate * releaseReadyRate +
+        WEIGHTS.revert_resistance * (1 - revertRate) +
+        WEIGHTS.human_free_rate * (1 - humanReviewRate) +
+        WEIGHTS.remediation_efficiency * remEff -
+        WEIGHTS.policy_violation_penalty * policyViolationRate -
+        WEIGHTS.sensitive_path_penalty * sensitiveRate,
+    ),
+  );
+
+  let profile: TrustProfileName = "standard";
+  if (score >= 0.85) profile = "fast-track";
+  else if (score < 0.6) profile = "probation";
+
+  const thresholdDelta =
+    profile === "fast-track" ? 10 : profile === "probation" ? -10 : 0;
+
+  return {
+    score: Math.round(score * 1000) / 1000,
+    profile,
+    factors,
+    thresholdDelta,
+    autofixEnabled: profile !== "probation",
+  };
+}
+
+export function strictnessFromTrust(
+  trust: AgentTrustResult | null,
+  riskScore: number,
+): {
+  strictness: "baseline" | "elevated" | "strict";
+  reason: string;
+  score?: number;
+  profile?: TrustProfileName;
+  factors?: AgentTrustResult["factors"];
+} {
+  if (!trust) {
+    return riskScore >= 75
+      ? {
+          strictness: "strict",
+          reason: "Automated provenance with high composite risk score",
+        }
+      : {
+          strictness: "elevated",
+          reason: "Automated provenance with elevated review requirements",
+        };
+  }
+
+  if (trust.profile === "probation") {
+    return {
+      strictness: "strict",
+      reason: `Agent trust score ${trust.score} — probation (human review required)`,
+      score: trust.score,
+      profile: trust.profile,
+      factors: trust.factors,
+    };
+  }
+
+  if (trust.profile === "fast-track" && riskScore < 60) {
+    return {
+      strictness: "baseline",
+      reason: `Agent trust score ${trust.score} — fast-track profile`,
+      score: trust.score,
+      profile: trust.profile,
+      factors: trust.factors,
+    };
+  }
+
+  return {
+    strictness: riskScore >= 75 ? "strict" : "elevated",
+    reason: `Agent trust score ${trust.score} (${trust.profile})`,
+    score: trust.score,
+    profile: trust.profile,
+    factors: trust.factors,
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trailhead",
-  "version": "3.0.2",
+  "version": "4.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "trailhead",
-      "version": "3.0.2",
+      "version": "4.4.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trailhead",
-  "version": "4.3.3",
+  "version": "4.4.0",
   "private": true,
   "description": "Release readiness gate for GitHub PRs — waits for CI, scores code risk, checks production health, and blocks merges that are not release-ready.",
   "license": "MIT",

--- a/presets/trailhead-strict-agents.yml
+++ b/presets/trailhead-strict-agents.yml
@@ -34,6 +34,10 @@ remediation:
   enabled: true
   max_loop_rounds: 5
 
+submission:
+  enabled: true
+  mode: block
+
 override:
   enabled: true
   max_per_week: 5

--- a/scripts/copy-shared-src.mjs
+++ b/scripts/copy-shared-src.mjs
@@ -36,6 +36,8 @@ const sharedFiles = [
   "loop-bookkeeping.ts",
   "submission-remediation.ts",
   "submission-engine.ts",
+  "fixer-core.ts",
+  "trust-score.ts",
   "remediation-lanes.ts",
   "trailhead-events.ts",
 ];
@@ -70,6 +72,20 @@ fs.mkdirSync(targetDir, { recursive: true });
 
 for (const file of filesToCopy) {
   fs.copyFileSync(path.join(root, "src", file), path.join(targetDir, file));
+}
+
+if (targetName === "app" || targetName === "mcp") {
+  const submissionChecksSrc = path.join(root, "src", "submission-checks");
+  const submissionChecksDest = path.join(targetDir, "submission-checks");
+  fs.mkdirSync(submissionChecksDest, { recursive: true });
+  for (const file of fs.readdirSync(submissionChecksSrc)) {
+    if (file.endsWith(".ts")) {
+      fs.copyFileSync(
+        path.join(submissionChecksSrc, file),
+        path.join(submissionChecksDest, file),
+      );
+    }
+  }
 }
 
 if (targetName === "app" || targetName === "mcp") {

--- a/src/__tests__/fixer-core.test.ts
+++ b/src/__tests__/fixer-core.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { buildAutofixPlan, isRedLanePath, selectAutofixCommit } from "../fixer-core.js";
+import type { RemediationFix } from "../types.js";
+
+describe("fixer-core", () => {
+  it("blocks autofix on migration paths", () => {
+    expect(isRedLanePath("supabase/migrations/20260101_x.sql")).toBe(true);
+    expect(isRedLanePath("src/utils/format.ts")).toBe(false);
+  });
+
+  it("selects first allowlisted autofix", () => {
+    const fixes: RemediationFix[] = [
+      {
+        code: "submission.context_freshness",
+        severity: "warn",
+        title: "Stale name",
+        detail: "DeployGuard",
+        files: ["README.md"],
+        autofix_eligible: true,
+        autofix_class: "doc-update",
+      },
+      {
+        code: "risk.test_coverage",
+        severity: "warn",
+        title: "Missing tests",
+        detail: "Add tests",
+        files: ["supabase/migrations/x.sql"],
+        autofix_eligible: true,
+        autofix_class: "test-scaffold",
+      },
+    ];
+    const plan = buildAutofixPlan(fixes);
+    expect(plan.blocked).toHaveLength(1);
+    const selected = selectAutofixCommit(plan);
+    expect(selected?.autofix_class).toBe("doc-update");
+  });
+});

--- a/src/__tests__/fixtures/agent-failures/manifest.json
+++ b/src/__tests__/fixtures/agent-failures/manifest.json
@@ -17,7 +17,16 @@
     "context_freshness",
     "destructive_sql",
     "secrets",
-    "path_format"
+    "path_format",
+    "syntax_validity",
+    "import_resolution",
+    "rls_new_tables",
+    "auth_route_auth",
+    "hardcoded_env",
+    "external_package_deps",
+    "sql_syntax_basic",
+    "large_file",
+    "soul_integrity"
   ],
   "coveredRiskFactors": [
     "test_coverage",

--- a/src/__tests__/submission-engine.test.ts
+++ b/src/__tests__/submission-engine.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { runSubmissionGate, submissionGateShouldBlock } from "../submission-engine.js";
+import { runSubmissionGate } from "../submission-engine.js";
 
-describe("submission-engine", () => {
+describe("submission-engine B1 checks", () => {
   it("blocks on mock placeholder patterns", () => {
     const checks = runSubmissionGate({
       files: [
@@ -12,22 +12,6 @@ describe("submission-engine", () => {
       ],
     });
     expect(checks.some((c) => c.code === "mock_placeholder")).toBe(true);
-    expect(submissionGateShouldBlock(checks)).toBe(true);
-  });
-
-  it("warns on stale naming terms when configured", () => {
-    const checks = runSubmissionGate({
-      files: [
-        {
-          filename: "README.md",
-          patch: "@@\n+Uses DeployGuard for gating.\n",
-        },
-      ],
-      komatikInstance: true,
-    });
-    const stale = checks.find((c) => c.code === "context_freshness");
-    expect(stale?.severity).toBe("warn");
-    expect(submissionGateShouldBlock(checks)).toBe(false);
   });
 
   it("blocks on destructive SQL", () => {
@@ -42,15 +26,48 @@ describe("submission-engine", () => {
     expect(checks.some((c) => c.code === "destructive_sql")).toBe(true);
   });
 
-  it("blocks when added lines reference missing files", () => {
+  it("blocks on missing RLS for new table", () => {
     const checks = runSubmissionGate({
       files: [
         {
-          filename: "src/index.ts",
-          patch: "@@\n+import { trust } from './trust.ts';\n",
+          filename: "supabase/migrations/001.sql",
+          patch: "@@\n+CREATE TABLE public.widgets (id uuid primary key);\n",
         },
       ],
     });
-    expect(checks.some((c) => c.code === "artifact_integrity")).toBe(true);
+    expect(checks.some((c) => c.code === "rls_new_tables")).toBe(true);
+  });
+
+  it("blocks on syntax errors in JSON", () => {
+    const checks = runSubmissionGate({
+      files: [
+        {
+          filename: "config.json",
+          patch: "@@\n+{ broken json\n",
+        },
+      ],
+    });
+    expect(checks.some((c) => c.code === "syntax_validity")).toBe(true);
+  });
+
+  it("blocks on API route without auth", () => {
+    const checks = runSubmissionGate({
+      files: [
+        {
+          filename: "app/api/users/route.ts",
+          patch:
+            "@@\n+export async function GET() { return Response.json({ ok: true }); }\n",
+        },
+      ],
+    });
+    expect(checks.some((c) => c.code === "auth_route_auth")).toBe(true);
+  });
+
+  it("blocks SOUL edits on Komatik instance", () => {
+    const checks = runSubmissionGate({
+      komatikInstance: true,
+      files: [{ filename: "agents/frontend-dev/SOUL.md", patch: "@@\n+updated\n" }],
+    });
+    expect(checks.some((c) => c.code === "soul_integrity")).toBe(true);
   });
 });

--- a/src/__tests__/trust-score.test.ts
+++ b/src/__tests__/trust-score.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { computeAgentTrustScore, strictnessFromTrust } from "../trust-score.js";
+
+describe("trust-score", () => {
+  it("assigns fast-track for high release-ready rate", () => {
+    const trust = computeAgentTrustScore({
+      evaluations: 20,
+      releaseReadyCount: 20,
+      revertCount: 0,
+      humanReviewRequiredCount: 0,
+      policyViolationCount: 0,
+      sensitivePathViolationCount: 0,
+      remediationRoundsToReady: [1, 1, 1, 1],
+    });
+    expect(trust.profile).toBe("fast-track");
+    expect(trust.score).toBeGreaterThanOrEqual(0.85);
+    expect(trust.thresholdDelta).toBe(10);
+  });
+
+  it("assigns probation for poor outcomes", () => {
+    const trust = computeAgentTrustScore({
+      evaluations: 10,
+      releaseReadyCount: 2,
+      revertCount: 4,
+      humanReviewRequiredCount: 8,
+      policyViolationCount: 3,
+      sensitivePathViolationCount: 2,
+      remediationRoundsToReady: [5, 4, 5],
+    });
+    expect(trust.profile).toBe("probation");
+    expect(trust.autofixEnabled).toBe(false);
+  });
+
+  it("maps probation to strict trust profile", () => {
+    const trust = computeAgentTrustScore({
+      evaluations: 10,
+      releaseReadyCount: 1,
+      revertCount: 5,
+      humanReviewRequiredCount: 9,
+      policyViolationCount: 4,
+      sensitivePathViolationCount: 3,
+      remediationRoundsToReady: [],
+    });
+    const profile = strictnessFromTrust(trust, 30);
+    expect(profile.strictness).toBe("strict");
+    expect(profile.profile).toBe("probation");
+  });
+});

--- a/src/fixer-core.ts
+++ b/src/fixer-core.ts
@@ -35,17 +35,39 @@ export interface AutofixPlan {
   blocked: Array<{ fix: RemediationFix; reason: string }>;
 }
 
+function escapeRegexChar(ch: string): string {
+  return /[\\^$+?.()|{}[\]]/.test(ch) ? `\\${ch}` : ch;
+}
+
+function globToRegex(glob: string): RegExp {
+  let src = "^";
+  for (let i = 0; i < glob.length; i++) {
+    const c = glob[i]!;
+    if (c === "*") {
+      if (glob[i + 1] === "*") {
+        src += ".*";
+        i++;
+      } else {
+        src += "[^/]*";
+      }
+    } else if (c === ".") {
+      src += "\\.";
+    } else {
+      src += escapeRegexChar(c);
+    }
+  }
+  src += "$";
+  return new RegExp(src);
+}
+
 function matchesGlob(path: string, glob: string): boolean {
   const normalized = path.replace(/\\/g, "/");
   if (glob.endsWith("/**")) {
-    const prefix = glob.slice(0, -3);
-    return normalized.includes(prefix.replace(/\*\*/g, ""));
+    const prefix = glob.slice(0, -3).replace(/\*\*/g, "");
+    return normalized.includes(prefix);
   }
   if (glob.includes("*")) {
-    const re = new RegExp(
-      `^${glob.replace(/\*\*/g, ".*").replace(/\*/g, "[^/]*").replace(/\./g, "\\.")}$`,
-    );
-    return re.test(normalized);
+    return globToRegex(glob).test(normalized);
   }
   return normalized.includes(glob);
 }

--- a/src/fixer-core.ts
+++ b/src/fixer-core.ts
@@ -42,7 +42,7 @@ function escapeRegexChar(ch: string): string {
 function globToRegex(glob: string): RegExp {
   let src = "^";
   for (let i = 0; i < glob.length; i++) {
-    const c = glob[i]!;
+    const c = glob.charAt(i);
     if (c === "*") {
       if (glob[i + 1] === "*") {
         src += ".*";

--- a/src/fixer-core.ts
+++ b/src/fixer-core.ts
@@ -1,0 +1,100 @@
+// Phase B2 — autofix allowlist (pure module; execution lives in app/fixer.ts).
+
+import type { RemediationAutofixClass, RemediationFix } from "./types.js";
+
+export const RED_LANE_GLOBS = [
+  "**/migrations/**",
+  "**/*.sql",
+  "**/rls/**",
+  "src/auth/**",
+  "app/**/auth/**",
+  ".github/workflows/**",
+  "agents/*/SOUL.md",
+  "src/risk-engine.ts",
+  "**/secrets/**",
+  "**/payments/**",
+];
+
+const ALLOWED_AUTOFIX_CLASSES = new Set<RemediationAutofixClass>([
+  "format",
+  "lint",
+  "import-fix",
+  "test-scaffold",
+  "doc-update",
+  "dependency-bump",
+]);
+
+export interface AutofixPlanItem {
+  fix: RemediationFix;
+  files: string[];
+  autofix_class: RemediationAutofixClass;
+}
+
+export interface AutofixPlan {
+  items: AutofixPlanItem[];
+  blocked: Array<{ fix: RemediationFix; reason: string }>;
+}
+
+function matchesGlob(path: string, glob: string): boolean {
+  const normalized = path.replace(/\\/g, "/");
+  if (glob.endsWith("/**")) {
+    const prefix = glob.slice(0, -3);
+    return normalized.includes(prefix.replace(/\*\*/g, ""));
+  }
+  if (glob.includes("*")) {
+    const re = new RegExp(
+      `^${glob.replace(/\*\*/g, ".*").replace(/\*/g, "[^/]*").replace(/\./g, "\\.")}$`,
+    );
+    return re.test(normalized);
+  }
+  return normalized.includes(glob);
+}
+
+export function isRedLanePath(filePath: string): boolean {
+  const normalized = filePath.replace(/\\/g, "/");
+  return RED_LANE_GLOBS.some((glob) => matchesGlob(normalized, glob));
+}
+
+export function isAutofixClassAllowed(autofixClass: RemediationAutofixClass): boolean {
+  return ALLOWED_AUTOFIX_CLASSES.has(autofixClass);
+}
+
+export function buildAutofixPlan(fixes: RemediationFix[]): AutofixPlan {
+  const items: AutofixPlanItem[] = [];
+  const blocked: AutofixPlan["blocked"] = [];
+
+  for (const fix of fixes) {
+    if (!fix.autofix_eligible || !fix.autofix_class) continue;
+
+    if (!isAutofixClassAllowed(fix.autofix_class)) {
+      blocked.push({
+        fix,
+        reason: `Autofix class not allowlisted: ${fix.autofix_class}`,
+      });
+      continue;
+    }
+
+    const touchFiles = fix.files.length > 0 ? fix.files : ["."];
+    const redLane = touchFiles.filter(isRedLanePath);
+    if (redLane.length > 0) {
+      blocked.push({
+        fix,
+        reason: `Red-lane paths forbid autofix: ${redLane.join(", ")}`,
+      });
+      continue;
+    }
+
+    items.push({
+      fix,
+      files: touchFiles,
+      autofix_class: fix.autofix_class,
+    });
+  }
+
+  return { items, blocked };
+}
+
+/** Max one fix commit per gate round (Phase B2). */
+export function selectAutofixCommit(plan: AutofixPlan): AutofixPlanItem | null {
+  return plan.items[0] ?? null;
+}

--- a/src/gate.ts
+++ b/src/gate.ts
@@ -67,6 +67,11 @@ import {
 } from "./override.js";
 import { runSubmissionGate, submissionGateShouldBlock } from "./submission-engine.js";
 import type { SubmissionCheckResult } from "./types.js";
+import {
+  computeAgentTrustScore,
+  strictnessFromTrust,
+  type AgentTrustMetrics,
+} from "./trust-score.js";
 
 export {
   isSensitiveFile,
@@ -82,6 +87,45 @@ export function sensitivityWeight(
   repoConfig?: RepoConfig | null,
 ): number {
   return sensitivityWeightShared(filename, repoConfig ?? null);
+}
+
+function parseDeclaredPackages(raw: string | undefined): string[] | undefined {
+  if (!raw?.trim()) return undefined;
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (Array.isArray(parsed)) {
+      return parsed.filter((entry): entry is string => typeof entry === "string");
+    }
+  } catch {
+    return raw
+      .split(",")
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+  }
+  return undefined;
+}
+
+function parseAgentTrustMetrics(raw: string | undefined): AgentTrustMetrics | null {
+  if (!raw?.trim()) return null;
+  try {
+    const parsed = JSON.parse(raw) as Partial<AgentTrustMetrics>;
+    if (typeof parsed.evaluations !== "number") return null;
+    return {
+      evaluations: parsed.evaluations,
+      releaseReadyCount: parsed.releaseReadyCount ?? 0,
+      revertCount: parsed.revertCount ?? 0,
+      humanReviewRequiredCount: parsed.humanReviewRequiredCount ?? 0,
+      policyViolationCount: parsed.policyViolationCount ?? 0,
+      sensitivePathViolationCount: parsed.sensitivePathViolationCount ?? 0,
+      remediationRoundsToReady: Array.isArray(parsed.remediationRoundsToReady)
+        ? parsed.remediationRoundsToReady.filter(
+            (n): n is number => typeof n === "number",
+          )
+        : [],
+    };
+  } catch {
+    return null;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -1724,10 +1768,15 @@ export async function evaluateGate(
     config.submissionGate === true || repoConfig?.submission?.enabled === true;
   if (submissionEnabled && files.length > 0) {
     submissionChecks = runSubmissionGate({
-      files,
+      files: files.map((f) => ({
+        filename: f.filename,
+        patch: f.patch,
+        additions: f.additions,
+      })),
       repoConfig,
       komatikInstance: process.env.KOMATIK_INSTANCE === "true",
       mode: submissionMode,
+      declaredPackages: parseDeclaredPackages(process.env.TRAILHEAD_DECLARED_PACKAGES),
     });
     if (submissionChecks.length > 0) {
       policyFindings.push(`Submission gate: ${submissionChecks.length} finding(s).`);
@@ -1860,15 +1909,17 @@ export async function evaluateGate(
   }
   const trustProfile =
     provenance?.type && provenance.type !== "human"
-      ? riskScore >= 75
-        ? {
-            strictness: "strict" as const,
-            reason: "Automated provenance with high composite risk score",
+      ? (() => {
+          const metrics = parseAgentTrustMetrics(process.env.TRAILHEAD_AGENT_TRUST_JSON);
+          const trust = metrics ? computeAgentTrustScore(metrics) : null;
+          if (trust && trust.thresholdDelta !== 0) {
+            adjustedRiskThreshold = Math.max(
+              0,
+              Math.min(100, adjustedRiskThreshold + trust.thresholdDelta),
+            );
           }
-        : {
-            strictness: "elevated" as const,
-            reason: "Automated provenance with elevated review requirements",
-          }
+          return strictnessFromTrust(trust, riskScore);
+        })()
       : {
           strictness: "baseline" as const,
           reason: "Human provenance or unknown automation signals",

--- a/src/submission-checks/detectors.ts
+++ b/src/submission-checks/detectors.ts
@@ -1,0 +1,632 @@
+// Gate 1 detectors — ported from komatik-agents agent-gate-checks (patch/content based).
+
+import type { SubmissionCheckResult } from "../types.js";
+import type { SubmissionCheckContext, SubmissionFileInfo } from "./types.js";
+import {
+  addedLines,
+  extensionOf,
+  fileContent,
+  isTestPath,
+  lineCountFromPatch,
+  normalizePath,
+  scanAddedContent,
+} from "./helpers.js";
+
+export const OLD_NAME_PATTERNS: Array<{
+  oldName: string;
+  newName: string;
+  pattern: RegExp;
+}> = [
+  { oldName: "DeployGuard", newName: "Trailhead", pattern: /\bDeployGuard\b/g },
+  { oldName: "Daydream Studio", newName: "Sundog", pattern: /\bDaydream Studio\b/g },
+  {
+    oldName: "Storyboard Studio",
+    newName: "Kindling",
+    pattern: /\bStoryboard Studio\b/g,
+  },
+  { oldName: "Cognitive Debt", newName: "Drift", pattern: /\bCognitive Debt\b/g },
+  { oldName: "cognitive-debt", newName: "Drift", pattern: /\bcognitive-debt\b/g },
+];
+
+const MOCK_PATTERNS = [
+  /\bTODO\s*\(\s*mock\s*\)/i,
+  /\bFIXME\s*\(\s*mock\s*\)/i,
+  /\bMOCK_[A-Z0-9_]+\b/,
+  /\bfakeImplementation\b/,
+  /\bstubResponse\s*\(/i,
+  /\b(?:generate|create|build|get)(?:Mock|Fake|Dummy|Sample)\w*/g,
+  /\b(?:mockData|fakeData|sampleData|dummyData|testData)\b/g,
+  /\bTODO:\s*implement\b/gi,
+  /\bFIXME\b/g,
+  /\bplaceholder\b/gi,
+  /\blorem ipsum\b/gi,
+];
+
+const SECRET_PATTERNS: Array<{ name: string; pattern: RegExp }> = [
+  { name: "AWS access key", pattern: /\bAKIA[0-9A-Z]{16}\b/g },
+  { name: "GitHub token", pattern: /\bgh[pousr]_[A-Za-z0-9_]{20,}\b/g },
+  { name: "Stripe live key", pattern: /\bsk_live_[A-Za-z0-9]{10,}\b/g },
+  { name: "Stripe test key", pattern: /\bsk_test_[A-Za-z0-9]{10,}\b/g },
+  { name: "Private key block", pattern: /-----BEGIN [A-Z ]+PRIVATE KEY-----/g },
+  {
+    name: "Generic API key assignment",
+    pattern: /api[_-]?key\s*[:=]\s*['"][A-Za-z0-9_-]{32,}['"]/gi,
+  },
+];
+
+const HARDCODED_ENV_PATTERNS: Array<{ name: string; pattern: RegExp }> = [
+  { name: "localhost with port", pattern: /(?:['"`])localhost:\d{2,5}(?:['"`])/g },
+  {
+    name: "hardcoded private IP",
+    pattern:
+      /(?:['"`])(?:10\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.(?:1[6-9]|2\d|3[01])\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3})(?::\d+)?(?:['"`])/g,
+  },
+];
+
+const NODE_BUILTINS = new Set([
+  "assert",
+  "async_hooks",
+  "buffer",
+  "child_process",
+  "cluster",
+  "console",
+  "constants",
+  "crypto",
+  "dgram",
+  "dns",
+  "events",
+  "fs",
+  "http",
+  "http2",
+  "https",
+  "module",
+  "net",
+  "os",
+  "path",
+  "process",
+  "stream",
+  "url",
+  "util",
+  "zlib",
+]);
+
+function result(
+  partial: Omit<SubmissionCheckResult, "autofix_eligible"> & {
+    autofix_eligible?: boolean;
+  },
+): SubmissionCheckResult {
+  return { autofix_eligible: false, ...partial };
+}
+
+export function detectMockPlaceholder(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const hits = scanAddedContent(ctx.files, (line, filename) => {
+    if (isTestPath(filename)) return false;
+    if (/\.(md|txt)$/i.test(filename)) return false;
+    return MOCK_PATTERNS.some((re) => {
+      re.lastIndex = 0;
+      return re.test(line);
+    });
+  });
+  if (hits.length === 0) return null;
+  return result({
+    code: "mock_placeholder",
+    severity: "blocking",
+    title: "Mock placeholder in production path",
+    detail: `Found mock/TODO placeholder patterns in ${hits.join(", ")}.`,
+    files: hits,
+    suggested_action: "Remove mock placeholders and implement real behavior.",
+  });
+}
+
+export function detectSecrets(ctx: SubmissionCheckContext): SubmissionCheckResult | null {
+  const hits = scanAddedContent(ctx.files, (line) =>
+    SECRET_PATTERNS.some((entry) => {
+      entry.pattern.lastIndex = 0;
+      return entry.pattern.test(line);
+    }),
+  );
+  if (hits.length === 0) return null;
+  return result({
+    code: "secrets",
+    severity: "blocking",
+    title: "Potential secret in diff",
+    detail: `Added lines match secret patterns in ${hits.join(", ")}.`,
+    files: hits,
+    suggested_action: "Remove secrets; use environment variables or a secret manager.",
+  });
+}
+
+export function detectDestructiveSql(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const sqlFiles = ctx.files.filter((f) => extensionOf(f.filename) === ".sql");
+  const hits = scanAddedContent(sqlFiles, (line) =>
+    /\b(DROP\s+TABLE|TRUNCATE|DELETE\s+FROM(?![^\n]*\bWHERE\b))/i.test(line),
+  );
+  if (hits.length === 0) return null;
+  return result({
+    code: "destructive_sql",
+    severity: "blocking",
+    title: "Destructive SQL in migration",
+    detail: `Added SQL contains destructive statements in ${hits.join(", ")}.`,
+    files: hits,
+    suggested_action:
+      "Use additive migrations; avoid DROP/TRUNCATE without human approval.",
+  });
+}
+
+export function detectArtifactIntegrity(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const referenced = new Set<string>();
+  const pathRefPattern =
+    /(?:^|\s|['"`])([\w@./-]+\.(?:ts|tsx|js|jsx|md|sql|yml|yaml|json))(?:['"`]|\s|:)/g;
+
+  for (const file of ctx.files) {
+    for (const line of addedLines(file.patch)) {
+      if (!/(?:import|from|require|see|fix|update)\s/i.test(line)) continue;
+      for (const match of line.matchAll(pathRefPattern)) {
+        const candidate = match[1]?.replace(/^\.\//, "");
+        if (!candidate || candidate.includes("*")) continue;
+        if (!ctx.prPaths.has(candidate) && !candidate.startsWith("node:")) {
+          referenced.add(candidate);
+        }
+      }
+    }
+  }
+
+  if (referenced.size === 0) return null;
+  const missing = [...referenced].slice(0, 8);
+  return result({
+    code: "artifact_integrity",
+    severity: "blocking",
+    title: "Referenced files missing from PR",
+    detail: `Added lines reference paths not in this PR: ${missing.join(", ")}${referenced.size > 8 ? "…" : ""}.`,
+    files: missing,
+    suggested_action: "Include referenced files or fix hallucinated paths.",
+  });
+}
+
+function isNamingAllowlisted(filename: string, line: string): boolean {
+  const trimmed = line.trim();
+  if (/^import\s|^from\s|require\(/.test(trimmed)) return true;
+  if (/\.sql$/i.test(filename)) return true;
+  if (/(?:^|\/)migrations\//.test(filename)) return true;
+  if (/(?:^|\/)memory\//.test(filename)) return true;
+  if (/RESEARCH\.md$|BRAND\.md$|CHANGELOG\.md$/.test(filename)) return true;
+  if (/^\[.*\]\(.*\)/.test(trimmed)) return true;
+  return false;
+}
+
+export function detectContextFreshness(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  if (ctx.staleTerms.length === 0 && !ctx.komatikInstance) return null;
+
+  const hits: string[] = [];
+  for (const file of ctx.files) {
+    for (const line of addedLines(file.patch)) {
+      if (isNamingAllowlisted(file.filename, line)) continue;
+
+      const terms = ctx.staleTerms.length > 0 ? ctx.staleTerms : [];
+      for (const term of terms) {
+        if (line.toLowerCase().includes(term.toLowerCase())) hits.push(file.filename);
+      }
+
+      if (ctx.komatikInstance) {
+        for (const entry of OLD_NAME_PATTERNS) {
+          entry.pattern.lastIndex = 0;
+          if (entry.pattern.test(line)) hits.push(file.filename);
+        }
+      }
+    }
+  }
+
+  const unique = [...new Set(hits)];
+  if (unique.length === 0) return null;
+  return result({
+    code: "context_freshness",
+    severity: "warn",
+    title: "Stale naming or deprecated terms",
+    detail: `Added lines reference deprecated terms in ${unique.join(", ")}.`,
+    files: unique,
+    suggested_action: "Update naming to current product vocabulary (see BRAND.md).",
+    autofix_eligible: true,
+  });
+}
+
+export function detectPathFormat(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  if (!ctx.komatikInstance) return null;
+  const hits = ctx.files
+    .map((f) => normalizePath(f.filename))
+    .filter(
+      (name) =>
+        /^komatik-agents\/agents\//.test(name) ||
+        /\/agents\/agents\//.test(name) ||
+        (!/^agents\/[a-z][a-z0-9-]*\/suggestions\//.test(name) &&
+          /\/suggestions\//.test(name) &&
+          !name.startsWith("agents/")),
+    );
+  if (hits.length === 0) return null;
+  return result({
+    code: "path_format",
+    severity: "warn",
+    title: "Suspicious agent suggestion path",
+    detail: `Paths should match agents/<id>/suggestions/<project>/… — found: ${hits.join(", ")}.`,
+    files: hits,
+    suggested_action: "Use canonical agent suggestion paths without repo prefix.",
+  });
+}
+
+export function detectHardcodedEnv(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const hits = scanAddedContent(ctx.files, (line, filename) => {
+    if (/\.(md|txt)$/i.test(filename)) return false;
+    if (/^\s*\/\/|^\s*\*|^\s*#/.test(line)) return false;
+    return HARDCODED_ENV_PATTERNS.some((entry) => {
+      entry.pattern.lastIndex = 0;
+      return entry.pattern.test(line);
+    });
+  });
+  if (hits.length === 0) return null;
+  return result({
+    code: "hardcoded_env",
+    severity: "blocking",
+    title: "Hardcoded environment value",
+    detail: `Added lines contain hardcoded localhost/IP patterns in ${hits.join(", ")}.`,
+    files: hits,
+    suggested_action:
+      "Use environment variables or configuration instead of hardcoded hosts.",
+  });
+}
+
+export function detectLargeFile(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const hits = ctx.files
+    .filter((file) => {
+      const lines =
+        typeof file.content === "string"
+          ? file.content.split("\n").length
+          : lineCountFromPatch(file.patch);
+      return lines > ctx.maxFileLines;
+    })
+    .map((f) => f.filename);
+  if (hits.length === 0) return null;
+  return result({
+    code: "large_file",
+    severity: "warn",
+    title: "Large file in PR",
+    detail: `Files exceed ${ctx.maxFileLines} lines: ${hits.join(", ")}.`,
+    files: hits,
+    suggested_action: "Split large changes into smaller PRs.",
+  });
+}
+
+function extractRelativeImports(content: string): string[] {
+  const imports: string[] = [];
+  const patterns = [
+    /\bimport\s+(?:type\s+)?(?:[^'"]+\s+from\s+)?['"](\.\.?[^'"]+)['"]/g,
+    /\brequire\(\s*['"](\.\.?[^'"]+)['"]\s*\)/g,
+  ];
+  for (const pattern of patterns) {
+    for (const match of content.matchAll(pattern)) {
+      if (match[1]) imports.push(match[1]);
+    }
+  }
+  return imports;
+}
+
+function resolveRelativeImport(
+  fromFile: string,
+  specifier: string,
+  prPaths: Set<string>,
+): boolean {
+  const clean = specifier.split("?")[0].split("#")[0];
+  const baseDir = normalizePath(fromFile).split("/").slice(0, -1);
+  const segments = clean.replace(/^\.\//, "").split("/");
+  for (const segment of segments) {
+    if (segment === "..") baseDir.pop();
+    else if (segment !== ".") baseDir.push(segment);
+  }
+  const resolved = baseDir.join("/");
+  const candidates = [
+    resolved,
+    `${resolved}.ts`,
+    `${resolved}.tsx`,
+    `${resolved}.js`,
+    `${resolved}.jsx`,
+    `${resolved}/index.ts`,
+    `${resolved}/index.js`,
+  ];
+  return candidates.some((c) => prPaths.has(c));
+}
+
+export function detectImportResolution(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const codeExts = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"]);
+  const hits: string[] = [];
+
+  for (const file of ctx.files) {
+    if (!codeExts.has(extensionOf(file.filename))) continue;
+    const content = fileContent(file);
+    for (const specifier of extractRelativeImports(content)) {
+      if (!resolveRelativeImport(file.filename, specifier, ctx.prPaths)) {
+        hits.push(file.filename);
+        break;
+      }
+    }
+  }
+
+  if (hits.length === 0) return null;
+  return result({
+    code: "import_resolution",
+    severity: "blocking",
+    title: "Unresolved relative import",
+    detail: `Relative imports could not be resolved within this PR: ${[...new Set(hits)].join(", ")}.`,
+    files: [...new Set(hits)],
+    suggested_action: "Add missing files to the PR or fix import paths.",
+  });
+}
+
+export function detectRlsNewTables(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const sqlFiles = ctx.files.filter((f) => extensionOf(f.filename) === ".sql");
+  const corpus = sqlFiles.map((f) => fileContent(f)).join("\n");
+  const hits: string[] = [];
+  const createTable =
+    /\bCREATE\s+(?!TEMP(?:ORARY)?\s+)TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?((?:"?[A-Za-z_][\w$]*"?\.)?"?[A-Za-z_][\w$]*"?)/gi;
+
+  for (const file of sqlFiles) {
+    const content = fileContent(file);
+    for (const match of content.matchAll(createTable)) {
+      const table = match[1]?.replace(/"/g, "") ?? "";
+      const pattern = new RegExp(
+        `ALTER\\s+TABLE\\s+(?:ONLY\\s+)?["']?${table.split(".").pop()}["']?\\s+ENABLE\\s+ROW\\s+LEVEL\\s+SECURITY`,
+        "i",
+      );
+      if (!pattern.test(corpus)) hits.push(file.filename);
+    }
+  }
+
+  if (hits.length === 0) return null;
+  return result({
+    code: "rls_new_tables",
+    severity: "blocking",
+    title: "New table missing RLS",
+    detail: `CREATE TABLE without ENABLE ROW LEVEL SECURITY in ${[...new Set(hits)].join(", ")}.`,
+    files: [...new Set(hits)],
+    suggested_action:
+      "Add ALTER TABLE ... ENABLE ROW LEVEL SECURITY for every new table.",
+  });
+}
+
+function isRouteAllowlisted(path: string, allowlist: string[]): boolean {
+  return allowlist.some((entry) => path.includes(entry.replace(/^\//, "")));
+}
+
+export function detectAuthRouteAuth(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const routePattern =
+    /(?:^|\/)(?:app\/api\/.+\/route|pages\/api\/.+)\.(?:ts|tsx|js|jsx)$/;
+  const authPattern =
+    /\b(getUser|getSession|getServerSession|auth|requireAuth|withAuth)\s*\(/;
+  const hits: string[] = [];
+
+  for (const file of ctx.files) {
+    const normalized = normalizePath(file.filename);
+    if (!routePattern.test(normalized)) continue;
+    if (isRouteAllowlisted(normalized, ctx.authRouteAllowlist)) continue;
+    if (!authPattern.test(fileContent(file))) hits.push(normalized);
+  }
+
+  if (hits.length === 0) return null;
+  return result({
+    code: "auth_route_auth",
+    severity: "blocking",
+    title: "API route missing auth check",
+    detail: `Routes appear to lack session/user verification: ${hits.join(", ")}.`,
+    files: hits,
+    suggested_action: "Verify authenticated user before handling the request.",
+  });
+}
+
+function packageNameFromSpecifier(specifier: string): string {
+  if (specifier.startsWith("@")) return specifier.split("/").slice(0, 2).join("/");
+  return specifier.split("/")[0];
+}
+
+function isNodeBuiltin(specifier: string): boolean {
+  const bare = specifier.startsWith("node:") ? specifier.slice(5) : specifier;
+  return NODE_BUILTINS.has(bare.split("/")[0]);
+}
+
+export function detectExternalPackageDeps(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  if (ctx.declaredPackages.size === 0) return null;
+  const codeExts = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"]);
+  const hits: string[] = [];
+
+  for (const file of ctx.files) {
+    if (!codeExts.has(extensionOf(file.filename))) continue;
+    const importPattern = /\b(?:import|from|require)\s*(?:\([^)]*|\(?)?['"]([^'"]+)['"]/g;
+    for (const match of fileContent(file).matchAll(importPattern)) {
+      const specifier = match[1];
+      if (!specifier || specifier.startsWith(".") || specifier.startsWith("@/")) continue;
+      if (isNodeBuiltin(specifier)) continue;
+      const pkg = packageNameFromSpecifier(specifier);
+      if (!ctx.declaredPackages.has(pkg)) hits.push(`${file.filename} → ${pkg}`);
+    }
+  }
+
+  if (hits.length === 0) return null;
+  return result({
+    code: "external_package_deps",
+    severity: "warn",
+    title: "Undeclared package import",
+    detail: hits.slice(0, 6).join("; "),
+    files: [...new Set(hits.map((h) => h.split(" → ")[0]))],
+    suggested_action: "Add the package to package.json or remove the import.",
+  });
+}
+
+export function detectSqlSyntaxBasic(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const hits: string[] = [];
+  for (const file of ctx.files.filter((f) => extensionOf(f.filename) === ".sql")) {
+    const content = fileContent(file);
+    const stripped = content.replace(/--[^\n]*/g, "").replace(/\/\*[\s\S]*?\*\//g, "");
+    const beginCount = (stripped.match(/\bBEGIN\b/gi) || []).length;
+    const endCount = (stripped.match(/\bEND\b\s*;/gi) || []).length;
+    if (beginCount > 0 && endCount === 0) hits.push(file.filename);
+    else if (endCount > beginCount) hits.push(file.filename);
+  }
+  if (hits.length === 0) return null;
+  return result({
+    code: "sql_syntax_basic",
+    severity: "blocking",
+    title: "SQL block balance issue",
+    detail: `Possible unmatched BEGIN/END in ${hits.join(", ")}.`,
+    files: hits,
+    suggested_action: "Fix PL/pgSQL block structure before merging.",
+  });
+}
+
+type SwcParseSync = (code: string, options: Record<string, unknown>) => unknown;
+
+let cachedSwcParse: SwcParseSync | null | undefined;
+
+function getSwcParse(): SwcParseSync | null {
+  if (cachedSwcParse !== undefined) return cachedSwcParse;
+  try {
+    // Optional — install @swc/core locally for full parse; Action uses bracket fallback.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const swc = require("@swc/core") as { parseSync: SwcParseSync };
+    cachedSwcParse = swc.parseSync;
+  } catch {
+    cachedSwcParse = null;
+  }
+  return cachedSwcParse;
+}
+
+function basicBracketBalance(content: string): string | null {
+  let braces = 0;
+  let parens = 0;
+  let brackets = 0;
+  for (const ch of content) {
+    if (ch === "{") braces += 1;
+    if (ch === "}") braces -= 1;
+    if (ch === "(") parens += 1;
+    if (ch === ")") parens -= 1;
+    if (ch === "[") brackets += 1;
+    if (ch === "]") brackets -= 1;
+    if (braces < 0 || parens < 0 || brackets < 0) return "Unbalanced brackets/parens";
+  }
+  if (braces !== 0 || parens !== 0 || brackets !== 0) {
+    return "Unclosed brackets/parens in diff hunk";
+  }
+  return null;
+}
+
+function parserOptionsFor(file: SubmissionFileInfo): Record<string, unknown> {
+  const ext = extensionOf(file.filename);
+  const isTs = ext === ".ts" || ext === ".tsx";
+  return {
+    syntax: isTs ? "typescript" : "ecmascript",
+    tsx: ext === ".tsx",
+    jsx: ext === ".jsx",
+    decorators: true,
+    dynamicImport: true,
+  };
+}
+
+export function detectSyntaxValidity(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const errors: Array<{ file: string; message: string }> = [];
+  const codeExts = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"]);
+  const swcParse = getSwcParse();
+
+  for (const file of ctx.files) {
+    const ext = extensionOf(file.filename);
+    const content = fileContent(file);
+    if (!content.trim()) continue;
+
+    try {
+      if (codeExts.has(ext)) {
+        if (swcParse) {
+          swcParse(content, parserOptionsFor(file));
+        } else {
+          const balance = basicBracketBalance(content);
+          if (balance) throw new Error(balance);
+        }
+      } else if (ext === ".json") {
+        JSON.parse(content);
+      }
+    } catch (error) {
+      errors.push({
+        file: file.filename,
+        message: error instanceof Error ? error.message.split("\n")[0] : String(error),
+      });
+    }
+  }
+
+  if (errors.length === 0) return null;
+  return result({
+    code: "syntax_validity",
+    severity: "blocking",
+    title: "Syntax error in changed file",
+    detail: errors.map((e) => `${e.file}: ${e.message}`).join("; "),
+    files: errors.map((e) => e.file),
+    suggested_action: "Fix parse errors before resubmitting.",
+  });
+}
+
+export function detectSoulIntegrity(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  if (!ctx.komatikInstance) return null;
+  const hits = ctx.files
+    .map((f) => normalizePath(f.filename))
+    .filter((name) => /^agents\/[a-z][a-z0-9-]*\/SOUL\.md$/.test(name));
+  if (hits.length === 0) return null;
+  return result({
+    code: "soul_integrity",
+    severity: "blocking",
+    title: "Agent SOUL.md modified",
+    detail: `SOUL changes require human review: ${hits.join(", ")}.`,
+    files: hits,
+    suggested_action: "Revert SOUL.md changes or request explicit human approval.",
+  });
+}
+
+export function runAllDetectors(ctx: SubmissionCheckContext): SubmissionCheckResult[] {
+  const checks = [
+    detectMockPlaceholder(ctx),
+    detectSecrets(ctx),
+    detectDestructiveSql(ctx),
+    detectSyntaxValidity(ctx),
+    detectImportResolution(ctx),
+    detectRlsNewTables(ctx),
+    detectAuthRouteAuth(ctx),
+    detectHardcodedEnv(ctx),
+    detectExternalPackageDeps(ctx),
+    detectSqlSyntaxBasic(ctx),
+    detectLargeFile(ctx),
+    detectArtifactIntegrity(ctx),
+    detectContextFreshness(ctx),
+    detectSoulIntegrity(ctx),
+    detectPathFormat(ctx),
+  ];
+  return checks.filter((check): check is SubmissionCheckResult => check !== null);
+}

--- a/src/submission-checks/helpers.ts
+++ b/src/submission-checks/helpers.ts
@@ -1,0 +1,83 @@
+// Shared helpers for Gate 1 submission checks (pure, no I/O).
+
+import type { SubmissionFileInfo } from "./types.js";
+
+export function normalizePath(filePath: string): string {
+  return filePath.replace(/\\/g, "/").replace(/^\.\//, "");
+}
+
+export function extensionOf(filename: string): string {
+  const base = normalizePath(filename);
+  const idx = base.lastIndexOf(".");
+  return idx >= 0 ? base.slice(idx).toLowerCase() : "";
+}
+
+export function addedLines(patch: string | undefined): string[] {
+  if (!patch) return [];
+  return patch
+    .split("\n")
+    .filter((line) => line.startsWith("+") && !line.startsWith("+++"))
+    .map((line) => line.slice(1));
+}
+
+/** Approximate post-change file body from a unified diff hunk (context + additions). */
+export function effectiveContentFromPatch(patch: string | undefined): string {
+  if (!patch) return "";
+  return patch
+    .split("\n")
+    .filter(
+      (line) =>
+        !line.startsWith("@@") && !line.startsWith("---") && !line.startsWith("+++"),
+    )
+    .filter((line) => !line.startsWith("-"))
+    .map((line) => (line.startsWith("+") || line.startsWith(" ") ? line.slice(1) : line))
+    .join("\n");
+}
+
+export function fileContent(file: SubmissionFileInfo): string {
+  if (typeof file.content === "string") return file.content;
+  return effectiveContentFromPatch(file.patch);
+}
+
+export function lineCountFromPatch(patch: string | undefined): number {
+  const content = effectiveContentFromPatch(patch);
+  if (!content) return 0;
+  return content.split("\n").length;
+}
+
+export function scanAddedContent(
+  files: SubmissionFileInfo[],
+  predicate: (line: string, filename: string) => boolean,
+): string[] {
+  const hits: string[] = [];
+  for (const file of files) {
+    for (const line of addedLines(file.patch)) {
+      if (predicate(line, file.filename)) hits.push(file.filename);
+    }
+  }
+  return [...new Set(hits)];
+}
+
+export function scanFileContent(
+  files: SubmissionFileInfo[],
+  predicate: (line: string, filename: string, lineNo: number) => boolean,
+): Array<{ file: string; line: number }> {
+  const hits: Array<{ file: string; line: number }> = [];
+  for (const file of files) {
+    const lines = fileContent(file).split("\n");
+    lines.forEach((line, index) => {
+      if (predicate(line, file.filename, index + 1)) {
+        hits.push({ file: file.filename, line: index + 1 });
+      }
+    });
+  }
+  return hits;
+}
+
+export function prPathSet(files: SubmissionFileInfo[]): Set<string> {
+  return new Set(files.map((f) => normalizePath(f.filename)));
+}
+
+export function isTestPath(filename: string): boolean {
+  return /\/__tests__\/|\/test\/|\/fixtures\/|\.test\.|\.spec\./.test(filename);
+}

--- a/src/submission-checks/types.ts
+++ b/src/submission-checks/types.ts
@@ -1,0 +1,18 @@
+export interface SubmissionFileInfo {
+  filename: string;
+  patch?: string;
+  status?: string;
+  /** Full file content when fetched by the gate (optional). */
+  content?: string;
+  additions?: number;
+}
+
+export interface SubmissionCheckContext {
+  files: SubmissionFileInfo[];
+  prPaths: Set<string>;
+  komatikInstance: boolean;
+  staleTerms: string[];
+  authRouteAllowlist: string[];
+  maxFileLines: number;
+  declaredPackages: Set<string>;
+}

--- a/src/submission-engine.ts
+++ b/src/submission-engine.ts
@@ -1,220 +1,60 @@
 // Gate 1 — agent submission quality (Phase B1).
 // Pure module: no @actions/*, octokit, or Node I/O.
 
-import type { RepoConfig, SubmissionCheckResult } from "./types.js";
+import { runAllDetectors } from "./submission-checks/detectors.js";
+import type { SubmissionCheckContext } from "./submission-checks/types.js";
+import { prPathSet } from "./submission-checks/helpers.js";
 import { SubmissionCheckCode } from "./types.js";
+import type { RepoConfig, SubmissionCheckResult } from "./types.js";
 
+export type { SubmissionFileInfo } from "./submission-checks/types.js";
 export type { SubmissionCheckCode, SubmissionCheckResult } from "./types.js";
 
 /** All Gate 1 check codes — keep in sync with A8 fixture manifest. */
 export const SUBMISSION_CHECK_CODES = SubmissionCheckCode.options;
 
-export interface SubmissionFileInfo {
-  filename: string;
-  patch?: string;
-  status?: string;
-}
-
-export interface SubmissionEngineOptions {
-  files: SubmissionFileInfo[];
-  repoConfig?: RepoConfig | null;
-  /** When true, enable Komatik-specific checks (SOUL paths, etc.). */
-  komatikInstance?: boolean;
-  mode?: "warn" | "block";
-}
-
-const MOCK_PLACEHOLDER_PATTERNS = [
-  /\bTODO\s*\(\s*mock\s*\)/i,
-  /\bFIXME\s*\(\s*mock\s*\)/i,
-  /\bMOCK_[A-Z0-9_]+\b/,
-  /\bfakeImplementation\b/,
-  /\bstubResponse\s*\(/i,
-];
-
-const SECRET_PATTERNS = [
-  /\bsk_live_[A-Za-z0-9]{10,}\b/,
-  /\bsk_test_[A-Za-z0-9]{10,}\b/,
-  /\bghp_[A-Za-z0-9]{20,}\b/,
-  /\bAKIA[0-9A-Z]{16}\b/,
-];
-
-const DESTRUCTIVE_SQL_PATTERNS = [
-  /\bDROP\s+TABLE\b/i,
-  /\bTRUNCATE\s+TABLE\b/i,
-  /\bDROP\s+COLUMN\b/i,
-];
-
 const DEFAULT_STALE_TERMS = ["deployguard", "DeployGuard"];
 
-function addedLines(patch: string | undefined): string[] {
-  if (!patch) return [];
-  return patch
-    .split("\n")
-    .filter((line) => line.startsWith("+") && !line.startsWith("+++"))
-    .map((line) => line.slice(1));
+const DEFAULT_AUTH_ROUTE_ALLOWLIST = [
+  "/api/auth/",
+  "/api/webhooks/",
+  "/api/health/",
+  "/api/metrics/",
+];
+
+export interface SubmissionEngineOptions {
+  files: import("./submission-checks/types.js").SubmissionFileInfo[];
+  repoConfig?: RepoConfig | null;
+  komatikInstance?: boolean;
+  mode?: "warn" | "block";
+  /** Declared npm package names from root package.json (optional). */
+  declaredPackages?: string[];
 }
 
-function scanAddedContent(
-  files: SubmissionFileInfo[],
-  predicate: (line: string, filename: string) => boolean,
-): string[] {
-  const hits: string[] = [];
-  for (const file of files) {
-    for (const line of addedLines(file.patch)) {
-      if (predicate(line, file.filename)) hits.push(file.filename);
-    }
-  }
-  return [...new Set(hits)];
-}
+function buildContext(options: SubmissionEngineOptions): SubmissionCheckContext {
+  const { files, repoConfig, komatikInstance = false } = options;
+  const staleTerms =
+    repoConfig?.submission?.stale_terms ?? (komatikInstance ? DEFAULT_STALE_TERMS : []);
 
-function detectMockPlaceholder(
-  files: SubmissionFileInfo[],
-): SubmissionCheckResult | null {
-  const hits = scanAddedContent(files, (line) =>
-    MOCK_PLACEHOLDER_PATTERNS.some((re) => re.test(line)),
-  );
-  if (hits.length === 0) return null;
+  const declared = new Set(options.declaredPackages ?? []);
+
   return {
-    code: "mock_placeholder",
-    severity: "blocking",
-    title: "Mock placeholder in production path",
-    detail: `Found mock/TODO placeholder patterns in ${hits.join(", ")}. Replace stubs before review.`,
-    files: hits,
-    suggested_action: "Remove mock placeholders and implement real behavior.",
-    autofix_eligible: false,
-  };
-}
-
-function detectSecrets(files: SubmissionFileInfo[]): SubmissionCheckResult | null {
-  const hits = scanAddedContent(files, (line) =>
-    SECRET_PATTERNS.some((re) => re.test(line)),
-  );
-  if (hits.length === 0) return null;
-  return {
-    code: "secrets",
-    severity: "blocking",
-    title: "Potential secret in diff",
-    detail: `Added lines match secret patterns in ${hits.join(", ")}. Rotate any exposed credential.`,
-    files: hits,
-    suggested_action:
-      "Remove secrets from source; use environment variables or a secret manager.",
-    autofix_eligible: false,
-  };
-}
-
-function detectDestructiveSql(files: SubmissionFileInfo[]): SubmissionCheckResult | null {
-  const sqlFiles = files.filter((f) => /\.sql$/i.test(f.filename));
-  const hits = scanAddedContent(sqlFiles, (line) =>
-    DESTRUCTIVE_SQL_PATTERNS.some((re) => re.test(line)),
-  );
-  if (hits.length === 0) return null;
-  return {
-    code: "destructive_sql",
-    severity: "blocking",
-    title: "Destructive SQL in migration",
-    detail: `Added SQL contains destructive statements in ${hits.join(", ")}.`,
-    files: hits,
-    suggested_action:
-      "Use additive migrations; avoid DROP/TRUNCATE without explicit human approval.",
-    autofix_eligible: false,
-  };
-}
-
-function detectContextFreshness(
-  files: SubmissionFileInfo[],
-  staleTerms: string[],
-): SubmissionCheckResult | null {
-  if (staleTerms.length === 0) return null;
-  const hits = scanAddedContent(files, (line) =>
-    staleTerms.some((term) => line.toLowerCase().includes(term.toLowerCase())),
-  );
-  if (hits.length === 0) return null;
-  return {
-    code: "context_freshness",
-    severity: "warn",
-    title: "Stale naming or deprecated terms",
-    detail: `Added lines reference deprecated terms (${staleTerms.join(", ")}) in ${hits.join(", ")}.`,
-    files: hits,
-    suggested_action:
-      "Update naming to match current product vocabulary (see BRAND.md / repo docs).",
-    autofix_eligible: true,
-  };
-}
-
-function detectPathFormat(files: SubmissionFileInfo[]): SubmissionCheckResult | null {
-  const hits = files
-    .map((f) => f.filename)
-    .filter(
-      (name) => /^komatik-agents\/agents\//.test(name) || /\/agents\/agents\//.test(name),
-    );
-  if (hits.length === 0) return null;
-  return {
-    code: "path_format",
-    severity: "warn",
-    title: "Suspicious agent path prefix",
-    detail: `Files use repo-name prefix in internal paths: ${hits.join(", ")}.`,
-    files: hits,
-    suggested_action:
-      "Use agents/<agent-id>/... not <repo>/agents/... for agent workspace paths.",
-    autofix_eligible: false,
-  };
-}
-
-function detectArtifactIntegrity(
-  files: SubmissionFileInfo[],
-): SubmissionCheckResult | null {
-  const prPaths = new Set(files.map((f) => f.filename.replace(/\\/g, "/")));
-  const referenced = new Set<string>();
-
-  const pathRefPattern =
-    /(?:^|\s|['"`])([\w@./-]+\.(?:ts|tsx|js|jsx|md|sql|yml|yaml|json))(?:['"`]|\s|:)/g;
-
-  for (const file of files) {
-    for (const line of addedLines(file.patch)) {
-      if (!/(?:import|from|require|see|fix|update)\s/i.test(line)) continue;
-      for (const match of line.matchAll(pathRefPattern)) {
-        const candidate = match[1]?.replace(/^\.\//, "");
-        if (!candidate || candidate.includes("*")) continue;
-        if (!prPaths.has(candidate) && !candidate.startsWith("node:")) {
-          referenced.add(candidate);
-        }
-      }
-    }
-  }
-
-  if (referenced.size === 0) return null;
-  const missing = [...referenced].slice(0, 8);
-  return {
-    code: "artifact_integrity",
-    severity: "blocking",
-    title: "Referenced files missing from PR",
-    detail: `Added lines reference paths not in this PR: ${missing.join(", ")}${referenced.size > 8 ? "…" : ""}.`,
-    files: missing,
-    suggested_action:
-      "Include the referenced files in this PR or fix hallucinated paths.",
-    autofix_eligible: false,
+    files,
+    prPaths: prPathSet(files),
+    komatikInstance,
+    staleTerms,
+    authRouteAllowlist:
+      repoConfig?.submission?.auth_route_allowlist ?? DEFAULT_AUTH_ROUTE_ALLOWLIST,
+    maxFileLines: repoConfig?.submission?.max_file_lines ?? 1000,
+    declaredPackages: declared,
   };
 }
 
 export function runSubmissionGate(
   options: SubmissionEngineOptions,
 ): SubmissionCheckResult[] {
-  const { files, repoConfig, komatikInstance = false } = options;
-  if (files.length === 0) return [];
-
-  const staleTerms =
-    repoConfig?.submission?.stale_terms ?? (komatikInstance ? DEFAULT_STALE_TERMS : []);
-
-  const checks: Array<SubmissionCheckResult | null> = [
-    detectMockPlaceholder(files),
-    detectSecrets(files),
-    detectDestructiveSql(files),
-    detectArtifactIntegrity(files),
-    detectContextFreshness(files, staleTerms),
-    komatikInstance ? detectPathFormat(files) : null,
-  ];
-
-  return checks.filter((check): check is SubmissionCheckResult => check !== null);
+  if (options.files.length === 0) return [];
+  return runAllDetectors(buildContext(options));
 }
 
 export function submissionGateShouldBlock(

--- a/src/submission-remediation.ts
+++ b/src/submission-remediation.ts
@@ -22,6 +22,10 @@ export function deriveSubmissionFixes(
       files: check.files ?? [],
       suggested_action: check.suggested_action,
       autofix_eligible: check.autofix_eligible ?? false,
+      autofix_class:
+        check.autofix_eligible && check.code === "context_freshness"
+          ? "doc-update"
+          : undefined,
     }),
   );
 }

--- a/src/trust-score.ts
+++ b/src/trust-score.ts
@@ -1,0 +1,147 @@
+// Phase B3 — dynamic agent trust scoring (pure module).
+
+export type TrustProfileName = "fast-track" | "standard" | "probation";
+
+export interface AgentTrustMetrics {
+  evaluations: number;
+  releaseReadyCount: number;
+  revertCount: number;
+  humanReviewRequiredCount: number;
+  policyViolationCount: number;
+  sensitivePathViolationCount: number;
+  /** Sum of loop rounds for PRs that reached release_ready. */
+  remediationRoundsToReady: number[];
+}
+
+export interface AgentTrustResult {
+  score: number;
+  profile: TrustProfileName;
+  factors: {
+    release_ready_rate: number;
+    revert_rate: number;
+    human_review_required_rate: number;
+    remediation_efficiency: number;
+    policy_violation_rate: number;
+    sensitive_path_violation_rate: number;
+  };
+  thresholdDelta: number;
+  autofixEnabled: boolean;
+}
+
+const WEIGHTS = {
+  release_ready_rate: 0.3,
+  revert_resistance: 0.2,
+  human_free_rate: 0.2,
+  remediation_efficiency: 0.15,
+  policy_violation_penalty: 0.075,
+  sensitive_path_penalty: 0.075,
+};
+
+function rate(numerator: number, denominator: number): number {
+  if (denominator <= 0) return 0;
+  return numerator / denominator;
+}
+
+function remediationEfficiency(rounds: number[]): number {
+  if (rounds.length === 0) return 0.5;
+  const avg = rounds.reduce((a, b) => a + b, 0) / rounds.length;
+  return Math.max(0, Math.min(1, 1 - (avg - 1) / 4));
+}
+
+export function computeAgentTrustScore(metrics: AgentTrustMetrics): AgentTrustResult {
+  const n = Math.max(metrics.evaluations, 0);
+  const releaseReadyRate = rate(metrics.releaseReadyCount, n);
+  const revertRate = rate(metrics.revertCount, n);
+  const humanReviewRate = rate(metrics.humanReviewRequiredCount, n);
+  const policyViolationRate = rate(metrics.policyViolationCount, n);
+  const sensitiveRate = rate(metrics.sensitivePathViolationCount, n);
+  const remEff = remediationEfficiency(metrics.remediationRoundsToReady);
+
+  const factors = {
+    release_ready_rate: releaseReadyRate,
+    revert_rate: revertRate,
+    human_review_required_rate: humanReviewRate,
+    remediation_efficiency: remEff,
+    policy_violation_rate: policyViolationRate,
+    sensitive_path_violation_rate: sensitiveRate,
+  };
+
+  const score = Math.max(
+    0,
+    Math.min(
+      1,
+      WEIGHTS.release_ready_rate * releaseReadyRate +
+        WEIGHTS.revert_resistance * (1 - revertRate) +
+        WEIGHTS.human_free_rate * (1 - humanReviewRate) +
+        WEIGHTS.remediation_efficiency * remEff -
+        WEIGHTS.policy_violation_penalty * policyViolationRate -
+        WEIGHTS.sensitive_path_penalty * sensitiveRate,
+    ),
+  );
+
+  let profile: TrustProfileName = "standard";
+  if (score >= 0.85) profile = "fast-track";
+  else if (score < 0.6) profile = "probation";
+
+  const thresholdDelta =
+    profile === "fast-track" ? 10 : profile === "probation" ? -10 : 0;
+
+  return {
+    score: Math.round(score * 1000) / 1000,
+    profile,
+    factors,
+    thresholdDelta,
+    autofixEnabled: profile !== "probation",
+  };
+}
+
+export function strictnessFromTrust(
+  trust: AgentTrustResult | null,
+  riskScore: number,
+): {
+  strictness: "baseline" | "elevated" | "strict";
+  reason: string;
+  score?: number;
+  profile?: TrustProfileName;
+  factors?: AgentTrustResult["factors"];
+} {
+  if (!trust) {
+    return riskScore >= 75
+      ? {
+          strictness: "strict",
+          reason: "Automated provenance with high composite risk score",
+        }
+      : {
+          strictness: "elevated",
+          reason: "Automated provenance with elevated review requirements",
+        };
+  }
+
+  if (trust.profile === "probation") {
+    return {
+      strictness: "strict",
+      reason: `Agent trust score ${trust.score} — probation (human review required)`,
+      score: trust.score,
+      profile: trust.profile,
+      factors: trust.factors,
+    };
+  }
+
+  if (trust.profile === "fast-track" && riskScore < 60) {
+    return {
+      strictness: "baseline",
+      reason: `Agent trust score ${trust.score} — fast-track profile`,
+      score: trust.score,
+      profile: trust.profile,
+      factors: trust.factors,
+    };
+  }
+
+  return {
+    strictness: riskScore >= 75 ? "strict" : "elevated",
+    reason: `Agent trust score ${trust.score} (${trust.profile})`,
+    score: trust.score,
+    profile: trust.profile,
+    factors: trust.factors,
+  };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -102,6 +102,15 @@ export const SubmissionCheckCode = z.enum([
   "destructive_sql",
   "secrets",
   "path_format",
+  "syntax_validity",
+  "import_resolution",
+  "rls_new_tables",
+  "auth_route_auth",
+  "hardcoded_env",
+  "external_package_deps",
+  "sql_syntax_basic",
+  "large_file",
+  "soul_integrity",
 ]);
 export type SubmissionCheckCode = z.infer<typeof SubmissionCheckCode>;
 
@@ -228,6 +237,9 @@ export const GateEvaluation = z.object({
     .object({
       strictness: z.enum(["baseline", "elevated", "strict"]),
       reason: z.string(),
+      score: z.number().min(0).max(1).optional(),
+      profile: z.enum(["fast-track", "standard", "probation"]).optional(),
+      factors: z.record(z.number()).optional(),
     })
     .optional(),
   policyOverride: PolicyOverrideAudit.optional(),
@@ -403,6 +415,8 @@ export const SubmissionConfig = z.object({
   enabled: z.boolean().default(false),
   mode: z.enum(["warn", "block"]).default("block"),
   stale_terms: z.array(z.string()).optional(),
+  auth_route_allowlist: z.array(z.string()).optional(),
+  max_file_lines: z.number().int().positive().optional(),
 });
 export type SubmissionConfig = z.infer<typeof SubmissionConfig>;
 


### PR DESCRIPTION
## Summary

- **B1** — Port 15 Gate 1 submission checks from `komatik-agents` into `src/submission-engine.ts` + `src/submission-checks/` (secrets, destructive SQL, RLS, auth routes, syntax with optional `@swc/core` or bracket fallback, imports, mock placeholders, etc.). Enabled via `submission-gate: "true"` or `.trailhead.yml` `submission.enabled`. Komatik-only checks (`soul_integrity`, stale terms) require `KOMATIK_INSTANCE=true`.
- **B2** — `fixer-core.ts` red-lane globs + allowlisted autofix classes; `app/src/fixer.ts` plans one fix per round (dry-run only — git write deferred to App handler follow-up).
- **B3** — `trust-score.ts` fast-track / standard / probation profiles; gate reads `TRAILHEAD_AGENT_TRUST_JSON` and extends `trust_profile` with score, profile, factors (hosted nightly compute deferred).
- **B4 prep** — `presets/trailhead-strict-agents.yml` enables submission; `examples/agent-submission-fixture/` for external repos. Komatik `komatik-agents` CI enforce flip is a separate PR after FP <10%.

## Test plan

- [x] `npm test` — 661 tests pass
- [x] `npm run lint` — ESLint + tsc clean
- [x] `npm run build` — ncc bundle without native SWC binary
- [ ] Dogfood on `komatik-agents` with `submission-gate: true` (warn mode first)
- [ ] Tag `v4.4.0` on `main` after dev → staging → main promotion

## Follow-ups (post-merge)

- Wire App fixer to GitHub contents API (`[trailhead-fixer]` commits)
- Nightly trust compute + store lookup (replace env JSON)
- Port 14 Phase-0 komatik-agents stubs when promoted from weight=0
- Flip `komatik-agents` `.trailhead/agents.yaml` to `mode: enforce`


Made with [Cursor](https://cursor.com)