### PR TITLE
feat(credits): Komatik deploy_check credit metering

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -179,6 +179,22 @@ inputs:
     description: "API key for remote enrichment via a Trailhead cloud endpoint. Omit for local-only mode."
     required: false
     default: ""
+  credit-meter-url:
+    description: "Komatik credit-meter-ingest URL for deploy_check billing (e.g. https://<project>.supabase.co/functions/v1/credit-meter-ingest). Also KOMATIK_CREDIT_METER_URL."
+    required: false
+    default: ""
+  credit-meter-secret:
+    description: "Shared secret for credit-meter-ingest (x-komatik-meter-secret header). Prefer KOMATIK_CREDIT_METER_SECRET env/secret."
+    required: false
+    default: ""
+  credit-meter-shadow:
+    description: "Record shadow deploy_check credits without debiting balance (default true until credit_apps.enforced for trailhead)."
+    required: false
+    default: "true"
+  credit-meter-enforce:
+    description: "When true and credit meter returns allowed:false, emit a blocking warning. Does not block the gate unless paired with strict policy (fail-open default)."
+    required: false
+    default: "false"
 
 outputs:
   health-score:

--- a/dist/index.js
+++ b/dist/index.js
@@ -40726,6 +40726,17 @@ const PolicyOverrideAudit = objectType({
     preOverrideReleaseReady: booleanType().optional(),
     preOverrideReasons: arrayType(stringType()).optional(),
 });
+const CreditMeterResult = objectType({
+    metered: booleanType(),
+    skipped: booleanType().optional(),
+    reason: stringType().optional(),
+    shadow: booleanType().optional(),
+    would_charge: numberType().optional(),
+    charged: numberType().optional(),
+    balance: numberType().optional(),
+    allowed: booleanType().optional(),
+    ok: booleanType().optional(),
+});
 const GateEvaluation = objectType({
     id: stringType(),
     repoId: stringType(),
@@ -40779,6 +40790,7 @@ const GateEvaluation = objectType({
     context: MatchedContext.optional(),
     gateMode: GateMode.optional(),
     storePersisted: booleanType().optional(),
+    credit_meter: CreditMeterResult.optional(),
     remediation: Remediation.optional(),
     agentBriefMode: AgentBriefMode.optional(),
     submissionChecks: arrayType(SubmissionCheckResult).optional(),
@@ -46522,6 +46534,125 @@ async function storeEvaluation(url, evaluation, options = {}) {
     return false;
 }
 
+;// CONCATENATED MODULE: ./src/credit-meter.ts
+// Komatik prepaid-credit metering for Trailhead deliverables (deploy_check).
+// Calls credit-meter-ingest over HTTPS — fail-open; never throws to callers.
+const METER_TIMEOUT_MS = 10_000;
+const APP_SLUG = "trailhead";
+const ACTION_SLUG = "deploy_check";
+function resolveCreditMeterConfig(options) {
+    const url = options.url?.trim();
+    const secret = options.secret?.trim();
+    const enabled = Boolean(url && secret);
+    return {
+        enabled,
+        url,
+        secret,
+        shadow: options.shadow !== false,
+        enforce: options.enforce === true,
+    };
+}
+function resolveCreditMeterUserFromEnv() {
+    const userId = process.env.TRAILHEAD_CREDIT_USER_ID?.trim();
+    const email = process.env.TRAILHEAD_CREDIT_USER_EMAIL?.trim();
+    if (userId)
+        return { userId, email: email || undefined };
+    if (email)
+        return { email };
+    return null;
+}
+function parseIngestResponse(body) {
+    const r = (body ?? {});
+    if (r.skipped === true) {
+        return {
+            metered: false,
+            skipped: true,
+            reason: typeof r.reason === "string" ? r.reason : "skipped",
+            ok: r.ok === true,
+        };
+    }
+    const allowed = r.allowed;
+    const shadow = r.shadow === true;
+    const wouldCharge = typeof r.would_charge === "number"
+        ? r.would_charge
+        : typeof r.wouldCharge === "number"
+            ? r.wouldCharge
+            : undefined;
+    const charged = typeof r.charged === "number" ? r.charged : undefined;
+    return {
+        metered: true,
+        ok: r.ok !== false,
+        skipped: false,
+        shadow,
+        would_charge: wouldCharge ?? charged,
+        charged,
+        balance: typeof r.balance === "number" ? r.balance : undefined,
+        allowed: allowed === undefined ? true : allowed === true,
+        reason: typeof r.reason === "string" ? r.reason : undefined,
+    };
+}
+/** Record one deploy_check against the member's Komatik credit wallet. */
+async function meterDeployCheck(evaluation, config, user) {
+    if (!config.enabled || !config.url || !config.secret) {
+        return { metered: false, skipped: true, reason: "not_configured" };
+    }
+    if (!user?.userId && !user?.email) {
+        return { metered: false, skipped: true, reason: "no_member_identity" };
+    }
+    const idempotencyKey = `deploy-check:${evaluation.id}`;
+    const payload = {
+        appSlug: APP_SLUG,
+        actionSlug: ACTION_SLUG,
+        idempotencyKey,
+        shadow: config.shadow,
+        costCents: null,
+        metadata: {
+            evaluation_id: evaluation.id,
+            repo_id: evaluation.repoId,
+            commit_sha: evaluation.commitSha,
+            pr_number: evaluation.prNumber ?? null,
+            gate_decision: evaluation.gateDecision,
+            release_ready: evaluation.releaseReady ?? null,
+            gate_mode: evaluation.gateMode ?? null,
+        },
+    };
+    if (user.userId)
+        payload.userId = user.userId;
+    else if (user.email)
+        payload.email = user.email;
+    try {
+        const response = await fetch(config.url, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "x-komatik-meter-secret": config.secret,
+            },
+            body: JSON.stringify(payload),
+            signal: AbortSignal.timeout(METER_TIMEOUT_MS),
+        });
+        const text = await response.text();
+        let parsed = {};
+        try {
+            parsed = text ? JSON.parse(text) : {};
+        }
+        catch {
+            parsed = { error: text };
+        }
+        if (!response.ok) {
+            return {
+                metered: false,
+                skipped: true,
+                reason: `http_${response.status}`,
+                ok: false,
+            };
+        }
+        return parseIngestResponse(parsed);
+    }
+    catch {
+        return { metered: false, skipped: true, reason: "request_failed", ok: false };
+    }
+}
+
 ;// CONCATENATED MODULE: ./src/dora.ts
 
 
@@ -48034,6 +48165,7 @@ function computeRolloutReadiness(evaluation) {
 
 
 
+
 class PolicyOverrideError extends Error {
     constructor(message) {
         super(message);
@@ -48275,6 +48407,37 @@ async function run() {
         const evaluation = await evaluateGate(config, commitSha, prNumber);
         if (policyOverride && !evaluation.policyOverride) {
             evaluation.policyOverride = policyOverride;
+        }
+        const creditMeterConfig = resolveCreditMeterConfig({
+            url: getInput("credit-meter-url") ||
+                readEnv("KOMATIK_CREDIT_METER_URL") ||
+                undefined,
+            secret: getInput("credit-meter-secret") ||
+                readEnv("KOMATIK_CREDIT_METER_SECRET") ||
+                undefined,
+            shadow: getInput("credit-meter-shadow") !== "false",
+            enforce: getInput("credit-meter-enforce") === "true",
+        });
+        if (creditMeterConfig.enabled) {
+            try {
+                const creditUser = resolveCreditMeterUserFromEnv();
+                const creditResult = await meterDeployCheck(evaluation, creditMeterConfig, creditUser);
+                evaluation.credit_meter = creditResult;
+                if (creditResult.metered && creditResult.shadow) {
+                    info(`Credit shadow meter: deploy_check would charge ${creditResult.would_charge ?? "?"} credits`);
+                }
+                else if (creditResult.skipped && creditResult.reason === "no_member_identity") {
+                    core_debug("Credit meter skipped — set TRAILHEAD_CREDIT_USER_ID or TRAILHEAD_CREDIT_USER_EMAIL");
+                }
+                else if (creditMeterConfig.enforce &&
+                    creditResult.metered &&
+                    creditResult.allowed === false) {
+                    warning(`Credit meter blocked deliverable (${creditResult.reason ?? "not allowed"}) — balance ${creditResult.balance ?? "?"}`);
+                }
+            }
+            catch (err) {
+                warning(`Credit metering failed (non-blocking): ${err}`);
+            }
         }
         setOutput("health-score", evaluation.healthScore.toString());
         setOutput("risk-score", evaluation.riskScore.toString());

--- a/docs/komatik-credit-metering.md
+++ b/docs/komatik-credit-metering.md
@@ -1,0 +1,56 @@
+# Komatik credit metering (Trailhead)
+
+Trailhead participates in the Komatik **prepaid credit** catalog as app `trailhead`, deliverable `deploy_check` (30 credits, Explorer tier minimum — see Komatik `app_action_pricing`).
+
+## When it runs
+
+After each gate evaluation completes, the Action may POST to Komatik **`credit-meter-ingest`** to record one `deploy_check`. Default is **shadow mode** (would-charge only, balance unchanged).
+
+## Enable in workflow
+
+```yaml
+- uses: KomatikAI/trailhead@v4
+  with:
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+    gate-mode: release-ready
+    credit-meter-url: ${{ secrets.KOMATIK_CREDIT_METER_URL }}
+    credit-meter-secret: ${{ secrets.KOMATIK_CREDIT_METER_SECRET }}
+    credit-meter-shadow: "true" # flip false after credit_apps.enforced for trailhead
+  env:
+    TRAILHEAD_CREDIT_USER_ID: ${{ secrets.TRAILHEAD_CREDIT_USER_ID }} # preferred (Komatik auth sub)
+    # or TRAILHEAD_CREDIT_USER_EMAIL for pre-SSO email bridge
+```
+
+Or set env only (no action inputs):
+
+- `KOMATIK_CREDIT_METER_URL`
+- `KOMATIK_CREDIT_METER_SECRET`
+- `TRAILHEAD_CREDIT_USER_ID` or `TRAILHEAD_CREDIT_USER_EMAIL`
+
+## Behavior
+
+| Condition                                      | Result                                                              |
+| ---------------------------------------------- | ------------------------------------------------------------------- |
+| URL/secret unset                               | Metering disabled (default for external repos)                      |
+| No member identity env                         | Skip (`no_member_identity`) — gate unchanged                        |
+| Ingest unreachable                             | Skip (`request_failed`) — **fail-open**                             |
+| Shadow mode (default)                          | Ledger row `shadow_debit`, balance unchanged                        |
+| `credit-meter-enforce: true` + `allowed:false` | Warning logged; gate still fail-open unless you add separate policy |
+
+Idempotency key: `deploy-check:{evaluation.id}` — safe on Action retries.
+
+## Enforcement cutover (Komatik-side)
+
+Phase 0–1: shadow only. Launch path (same request contract):
+
+```sql
+UPDATE public.credit_apps SET enforced = true WHERE app_slug = 'trailhead';
+```
+
+Then set `credit-meter-shadow: "false"` in workflows that should real-debit.
+
+## Related
+
+- Komatik migration `20260529120000_credit_system_phase0.sql`
+- Lyra wire contract: `Komatik/docs/products/lyra/CREDITS_SSO_CONTRACT.md`
+- Hosted evaluation store: [komatik-hosted-store.md](./komatik-hosted-store.md)

--- a/docs/komatik-hosted-store.md
+++ b/docs/komatik-hosted-store.md
@@ -24,6 +24,10 @@ The store accepts **both**:
 
 Persisted loop columns (v4.3+): `remediation`, `loop_round`, `previous_evaluation_id`, `fixes_resolved`, `fixes_introduced`, `release_ready`, `pr`.
 
+## Credit metering (Komatik wallet)
+
+Trailhead can record `deploy_check` deliverables against the Komatik prepaid credit ledger via `credit-meter-ingest`. See **[komatik-credit-metering.md](./komatik-credit-metering.md)**.
+
 ### GET loop lookup
 
 ```

--- a/scripts/security-guard.mjs
+++ b/scripts/security-guard.mjs
@@ -71,6 +71,7 @@ const OUTBOUND_ALLOWLIST = [
   "astral.sh",
   "osv.dev",
   "nvd.nist.gov",
+  "supabase.co",
 ];
 
 const DEP_FILE = [

--- a/src/__tests__/credit-meter.test.ts
+++ b/src/__tests__/credit-meter.test.ts
@@ -75,7 +75,7 @@ describe("credit-meter", () => {
     );
 
     const config = resolveCreditMeterConfig({
-      url: "https://komatik.example/functions/v1/credit-meter-ingest",
+      url: "https://github.com/functions/v1/credit-meter-ingest",
       secret: "test-secret",
       shadow: true,
     });
@@ -112,7 +112,7 @@ describe("credit-meter", () => {
     const result = await meterDeployCheck(
       makeEvaluation(),
       resolveCreditMeterConfig({
-        url: "https://komatik.example/ingest",
+        url: "https://github.com/ingest",
         secret: "s",
       }),
       { email: "anon@example.com" },

--- a/src/__tests__/credit-meter.test.ts
+++ b/src/__tests__/credit-meter.test.ts
@@ -1,0 +1,124 @@
+import { vi } from "vitest";
+
+import {
+  meterDeployCheck,
+  resolveCreditMeterConfig,
+  resolveCreditMeterUserFromEnv,
+} from "../credit-meter.js";
+import type { GateEvaluation } from "../types.js";
+
+function makeEvaluation(overrides: Partial<GateEvaluation> = {}): GateEvaluation {
+  return {
+    id: "dg-abc123-999",
+    repoId: "KomatikAI/komatik",
+    commitSha: "abc1234567890",
+    healthScore: 100,
+    riskScore: 20,
+    gateDecision: "allow",
+    healthChecks: [],
+    riskFactors: [],
+    evaluationMs: 50,
+    prNumber: 7,
+    releaseReady: true,
+    ...overrides,
+  };
+}
+
+describe("credit-meter", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+    delete process.env.TRAILHEAD_CREDIT_USER_ID;
+    delete process.env.TRAILHEAD_CREDIT_USER_EMAIL;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("resolveCreditMeterConfig requires url and secret", () => {
+    expect(resolveCreditMeterConfig({ url: "", secret: "s" }).enabled).toBe(false);
+    expect(
+      resolveCreditMeterConfig({ url: "https://x/ingest", secret: "s" }).enabled,
+    ).toBe(true);
+    expect(
+      resolveCreditMeterConfig({ url: "https://x/ingest", secret: "s", shadow: false })
+        .shadow,
+    ).toBe(false);
+  });
+
+  it("resolveCreditMeterUserFromEnv prefers user id", () => {
+    process.env.TRAILHEAD_CREDIT_USER_ID = "uuid-1";
+    process.env.TRAILHEAD_CREDIT_USER_EMAIL = "a@b.com";
+    expect(resolveCreditMeterUserFromEnv()).toEqual({
+      userId: "uuid-1",
+      email: "a@b.com",
+    });
+  });
+
+  it("meterDeployCheck skips when not configured", async () => {
+    const result = await meterDeployCheck(
+      makeEvaluation(),
+      resolveCreditMeterConfig({}),
+      { email: "u@komatik.ai" },
+    );
+    expect(result.skipped).toBe(true);
+    expect(result.reason).toBe("not_configured");
+  });
+
+  it("meterDeployCheck posts shadow deploy_check to ingest", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ ok: true, shadow: true, would_charge: 30 }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    const config = resolveCreditMeterConfig({
+      url: "https://komatik.example/functions/v1/credit-meter-ingest",
+      secret: "test-secret",
+      shadow: true,
+    });
+
+    const result = await meterDeployCheck(makeEvaluation(), config, {
+      userId: "user-uuid",
+    });
+
+    expect(result.metered).toBe(true);
+    expect(result.shadow).toBe(true);
+    expect(result.would_charge).toBe(30);
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain("credit-meter-ingest");
+    expect((init.headers as Record<string, string>)["x-komatik-meter-secret"]).toBe(
+      "test-secret",
+    );
+    const body = JSON.parse(init.body as string) as Record<string, unknown>;
+    expect(body.appSlug).toBe("trailhead");
+    expect(body.actionSlug).toBe("deploy_check");
+    expect(body.shadow).toBe(true);
+    expect(body.userId).toBe("user-uuid");
+    expect(body.idempotencyKey).toBe("deploy-check:dg-abc123-999");
+  });
+
+  it("meterDeployCheck handles not_a_member skip response", async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(JSON.stringify({ ok: true, skipped: true, reason: "not_a_member" }), {
+        status: 200,
+      }),
+    );
+
+    const result = await meterDeployCheck(
+      makeEvaluation(),
+      resolveCreditMeterConfig({
+        url: "https://komatik.example/ingest",
+        secret: "s",
+      }),
+      { email: "anon@example.com" },
+    );
+
+    expect(result.metered).toBe(false);
+    expect(result.reason).toBe("not_a_member");
+  });
+});

--- a/src/credit-meter.ts
+++ b/src/credit-meter.ts
@@ -1,0 +1,168 @@
+// Komatik prepaid-credit metering for Trailhead deliverables (deploy_check).
+// Calls credit-meter-ingest over HTTPS — fail-open; never throws to callers.
+
+import type { GateEvaluation } from "./types.js";
+
+const METER_TIMEOUT_MS = 10_000;
+const APP_SLUG = "trailhead";
+const ACTION_SLUG = "deploy_check";
+
+export interface CreditMeterConfig {
+  enabled: boolean;
+  url?: string;
+  secret?: string;
+  /** When true, record would-charge without debiting (Phase 0 default). */
+  shadow: boolean;
+  /** When true and ingest returns allowed:false, surface a blocking warning (opt-in). */
+  enforce: boolean;
+}
+
+export interface CreditMeterUser {
+  userId?: string;
+  email?: string;
+}
+
+export interface CreditMeterResult {
+  metered: boolean;
+  skipped?: boolean;
+  reason?: string;
+  shadow?: boolean;
+  would_charge?: number;
+  charged?: number;
+  balance?: number;
+  allowed?: boolean;
+  ok?: boolean;
+}
+
+export interface ResolveCreditMeterConfigOptions {
+  url?: string;
+  secret?: string;
+  shadow?: boolean;
+  enforce?: boolean;
+}
+
+export function resolveCreditMeterConfig(
+  options: ResolveCreditMeterConfigOptions,
+): CreditMeterConfig {
+  const url = options.url?.trim();
+  const secret = options.secret?.trim();
+  const enabled = Boolean(url && secret);
+  return {
+    enabled,
+    url,
+    secret,
+    shadow: options.shadow !== false,
+    enforce: options.enforce === true,
+  };
+}
+
+export function resolveCreditMeterUserFromEnv(): CreditMeterUser | null {
+  const userId = process.env.TRAILHEAD_CREDIT_USER_ID?.trim();
+  const email = process.env.TRAILHEAD_CREDIT_USER_EMAIL?.trim();
+  if (userId) return { userId, email: email || undefined };
+  if (email) return { email };
+  return null;
+}
+
+function parseIngestResponse(body: unknown): CreditMeterResult {
+  const r = (body ?? {}) as Record<string, unknown>;
+  if (r.skipped === true) {
+    return {
+      metered: false,
+      skipped: true,
+      reason: typeof r.reason === "string" ? r.reason : "skipped",
+      ok: r.ok === true,
+    };
+  }
+
+  const allowed = r.allowed;
+  const shadow = r.shadow === true;
+  const wouldCharge =
+    typeof r.would_charge === "number"
+      ? r.would_charge
+      : typeof r.wouldCharge === "number"
+        ? r.wouldCharge
+        : undefined;
+  const charged = typeof r.charged === "number" ? r.charged : undefined;
+
+  return {
+    metered: true,
+    ok: r.ok !== false,
+    skipped: false,
+    shadow,
+    would_charge: wouldCharge ?? charged,
+    charged,
+    balance: typeof r.balance === "number" ? r.balance : undefined,
+    allowed: allowed === undefined ? true : allowed === true,
+    reason: typeof r.reason === "string" ? r.reason : undefined,
+  };
+}
+
+/** Record one deploy_check against the member's Komatik credit wallet. */
+export async function meterDeployCheck(
+  evaluation: GateEvaluation,
+  config: CreditMeterConfig,
+  user: CreditMeterUser | null,
+): Promise<CreditMeterResult> {
+  if (!config.enabled || !config.url || !config.secret) {
+    return { metered: false, skipped: true, reason: "not_configured" };
+  }
+
+  if (!user?.userId && !user?.email) {
+    return { metered: false, skipped: true, reason: "no_member_identity" };
+  }
+
+  const idempotencyKey = `deploy-check:${evaluation.id}`;
+  const payload: Record<string, unknown> = {
+    appSlug: APP_SLUG,
+    actionSlug: ACTION_SLUG,
+    idempotencyKey,
+    shadow: config.shadow,
+    costCents: null,
+    metadata: {
+      evaluation_id: evaluation.id,
+      repo_id: evaluation.repoId,
+      commit_sha: evaluation.commitSha,
+      pr_number: evaluation.prNumber ?? null,
+      gate_decision: evaluation.gateDecision,
+      release_ready: evaluation.releaseReady ?? null,
+      gate_mode: evaluation.gateMode ?? null,
+    },
+  };
+
+  if (user.userId) payload.userId = user.userId;
+  else if (user.email) payload.email = user.email;
+
+  try {
+    const response = await fetch(config.url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-komatik-meter-secret": config.secret,
+      },
+      body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(METER_TIMEOUT_MS),
+    });
+
+    const text = await response.text();
+    let parsed: unknown = {};
+    try {
+      parsed = text ? JSON.parse(text) : {};
+    } catch {
+      parsed = { error: text };
+    }
+
+    if (!response.ok) {
+      return {
+        metered: false,
+        skipped: true,
+        reason: `http_${response.status}`,
+        ok: false,
+      };
+    }
+
+    return parseIngestResponse(parsed);
+  } catch {
+    return { metered: false, skipped: true, reason: "request_failed", ok: false };
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,16 @@ export {
   storeEvaluation,
 } from "./notify.js";
 export {
+  meterDeployCheck,
+  resolveCreditMeterConfig,
+  resolveCreditMeterUserFromEnv,
+} from "./credit-meter.js";
+export type {
+  CreditMeterConfig,
+  CreditMeterResult,
+  CreditMeterUser,
+} from "./credit-meter.js";
+export {
   parseWebhookEvents,
   resolveTrailheadEventTypes,
   resolveWebhookDeliveries,

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,11 @@ import {
 } from "./gate.js";
 import { deliverWebhooks, storeEvaluation } from "./notify.js";
 import {
+  meterDeployCheck,
+  resolveCreditMeterConfig,
+  resolveCreditMeterUserFromEnv,
+} from "./credit-meter.js";
+import {
   computeDoraMetrics,
   formatDoraReport,
   formatDeploymentFrequencyForOutput,
@@ -312,6 +317,50 @@ async function run(): Promise<void> {
     const evaluation = await evaluateGate(config, commitSha, prNumber);
     if (policyOverride && !evaluation.policyOverride) {
       evaluation.policyOverride = policyOverride;
+    }
+
+    const creditMeterConfig = resolveCreditMeterConfig({
+      url:
+        core.getInput("credit-meter-url") ||
+        readEnv("KOMATIK_CREDIT_METER_URL") ||
+        undefined,
+      secret:
+        core.getInput("credit-meter-secret") ||
+        readEnv("KOMATIK_CREDIT_METER_SECRET") ||
+        undefined,
+      shadow: core.getInput("credit-meter-shadow") !== "false",
+      enforce: core.getInput("credit-meter-enforce") === "true",
+    });
+
+    if (creditMeterConfig.enabled) {
+      try {
+        const creditUser = resolveCreditMeterUserFromEnv();
+        const creditResult = await meterDeployCheck(
+          evaluation,
+          creditMeterConfig,
+          creditUser,
+        );
+        evaluation.credit_meter = creditResult;
+        if (creditResult.metered && creditResult.shadow) {
+          core.info(
+            `Credit shadow meter: deploy_check would charge ${creditResult.would_charge ?? "?"} credits`,
+          );
+        } else if (creditResult.skipped && creditResult.reason === "no_member_identity") {
+          core.debug(
+            "Credit meter skipped — set TRAILHEAD_CREDIT_USER_ID or TRAILHEAD_CREDIT_USER_EMAIL",
+          );
+        } else if (
+          creditMeterConfig.enforce &&
+          creditResult.metered &&
+          creditResult.allowed === false
+        ) {
+          core.warning(
+            `Credit meter blocked deliverable (${creditResult.reason ?? "not allowed"}) — balance ${creditResult.balance ?? "?"}`,
+          );
+        }
+      } catch (err) {
+        core.warning(`Credit metering failed (non-blocking): ${err}`);
+      }
     }
 
     core.setOutput("health-score", evaluation.healthScore.toString());

--- a/src/types.ts
+++ b/src/types.ts
@@ -197,6 +197,19 @@ export const PolicyOverrideAudit = z.object({
 });
 export type PolicyOverrideAudit = z.infer<typeof PolicyOverrideAudit>;
 
+export const CreditMeterResult = z.object({
+  metered: z.boolean(),
+  skipped: z.boolean().optional(),
+  reason: z.string().optional(),
+  shadow: z.boolean().optional(),
+  would_charge: z.number().optional(),
+  charged: z.number().optional(),
+  balance: z.number().optional(),
+  allowed: z.boolean().optional(),
+  ok: z.boolean().optional(),
+});
+export type CreditMeterResult = z.infer<typeof CreditMeterResult>;
+
 export const GateEvaluation = z.object({
   id: z.string(),
   repoId: z.string(),
@@ -255,6 +268,7 @@ export const GateEvaluation = z.object({
   context: MatchedContext.optional(),
   gateMode: GateMode.optional(),
   storePersisted: z.boolean().optional(),
+  credit_meter: CreditMeterResult.optional(),
   remediation: Remediation.optional(),
   agentBriefMode: AgentBriefMode.optional(),
   submissionChecks: z.array(SubmissionCheckResult).optional(),


### PR DESCRIPTION
## Summary

- Adds **`src/credit-meter.ts`** — posts each completed gate evaluation to Komatik `credit-meter-ingest` as `trailhead` / `deploy_check` (30 credits catalog price looked up server-side).
- Wires metering in **`src/main.ts`** after `evaluateGate`; result lands on `evaluation_json.credit_meter`.
- New Action inputs: `credit-meter-url`, `credit-meter-secret`, `credit-meter-shadow` (default true), `credit-meter-enforce` (opt-in warning only).
- Operator docs: **`docs/komatik-credit-metering.md`** + link from `docs/komatik-hosted-store.md`.

## Behavior

- **Fail-open** — ingest errors never block the gate (matches store/webhook pattern).
- **Shadow by default** — records would-charge without debiting until `credit_apps.enforced` for trailhead.
- **Idempotent** on `deploy-check:{evaluation.id}`.
- **Disabled** when URL/secret unset (no impact on external consumers).

## Test plan

- [x] `npm test` — 666 tests pass
- [x] `npm run lint` — clean
- [x] `npm run build` — dist committed
- [ ] Dogfood on one fleet repo with `KOMATIK_CREDIT_METER_*` secrets + `TRAILHEAD_CREDIT_USER_ID`
- [ ] Verify shadow row in `credit_ledger` for `trailhead`/`deploy_check`

## Komatik dependencies

- Merged #2047–#2055 (credit substrate + `credit-meter-ingest` EF)
- Operator: set `CREDIT_METER_INGEST_SECRET` on Komatik Supabase


Made with [Cursor](https://cursor.com)