### PR TITLE
feat(phase-b): Phase 0 submission checks + MCP parity tools

### DIFF
--- a/app/src/submission-checks/detectors.ts
+++ b/app/src/submission-checks/detectors.ts
@@ -11,6 +11,7 @@ import {
   normalizePath,
   scanAddedContent,
 } from "./helpers.js";
+import { runPhase0Detectors } from "./phase0-detectors.js";
 
 export const OLD_NAME_PATTERNS: Array<{
   oldName: string;
@@ -611,7 +612,7 @@ export function detectSoulIntegrity(
 }
 
 export function runAllDetectors(ctx: SubmissionCheckContext): SubmissionCheckResult[] {
-  const checks = [
+  const gate1 = [
     detectMockPlaceholder(ctx),
     detectSecrets(ctx),
     detectDestructiveSql(ctx),
@@ -627,6 +628,7 @@ export function runAllDetectors(ctx: SubmissionCheckContext): SubmissionCheckRes
     detectContextFreshness(ctx),
     detectSoulIntegrity(ctx),
     detectPathFormat(ctx),
-  ];
-  return checks.filter((check): check is SubmissionCheckResult => check !== null);
+  ].filter((check): check is SubmissionCheckResult => check !== null);
+
+  return [...gate1, ...runPhase0Detectors(ctx)];
 }

--- a/app/src/submission-checks/phase0-detectors.ts
+++ b/app/src/submission-checks/phase0-detectors.ts
@@ -1,0 +1,405 @@
+// Phase 0 agent suggestion checks (weight=0 / advisory in Trailhead).
+// Ported from komatik-agents agent-gate-checks Phase 0 stubs with real heuristics.
+
+import type { SubmissionCheckResult } from "../types.js";
+import type { SubmissionCheckContext, SubmissionFileInfo } from "./types.js";
+import { fileContent, normalizePath } from "./helpers.js";
+
+const SEVERITY = "advisory" as const;
+const OUTPUT_SIZE_MIN_CHARS = 400;
+const NARRATIVE_MATCH_THRESHOLD = 3;
+
+const PREAMBLE_OPENERS =
+  /^(let me|here is the|here's the|i('| wi)ll|after reviewing|to start|based on my analysis)/i;
+const SESSION_NARRATIVE =
+  /\bI (queried|reviewed|checked|will (build|create|fix|implement|add|update))/gi;
+const PARTIAL_COMPLETION = /\b\d+\s*(?:\/|of)\s*\d+\b/i;
+const INCOMPLETE_MARKER = /\b(INCOMPLETE|PARTIAL)\b/i;
+const FABRICATED_ID = /\b(session|run|task|message)[-_]?[a-f0-9]{6,}\b/gi;
+const FILE_REF =
+  /(?:^|[\s('"`])((?:src|scripts|supabase|app|agents)\/[a-z0-9_/.-]+\.(?:ts|tsx|js|mjs|sql|py|md))/gi;
+const ACTION_SUFFIX = /(?:→\s*@[\w-]+|— No actions surfaced)\s*$/i;
+const UNVERIFIED_MARKER = /\[UNVERIFIED\]|verify after|needs verification/i;
+const OWNER_DUE = /Owner:\s*@[\w-]+[\s\S]{0,120}Due:\s*\d{4}-\d{2}-\d{2}/i;
+const FIX_CLAIM = /\b(fix applied|now working|is live|deployed successfully)\b/i;
+const MULTI_PHASE = /\bphase\s+[ab12]\b/i;
+const DEP_MATRIX = /\b(depends on:|dependency matrix|blocks:|x blocks y)\b/i;
+const RUNBOOK_HINT = /runbook|deploy(?:ment)? guide/i;
+const SECRETS_PREREQ =
+  /\b(secrets list|prerequisites:|required env|environment variables)\b/i;
+const PROPOSAL_ONLY = /\bPROPOSAL_ONLY\b/i;
+const SCHEMA_LINK = /https?:\/\/[^\s)]+\/(schema|openapi|api-docs)/i;
+
+function advisory(
+  partial: Omit<SubmissionCheckResult, "severity" | "autofix_eligible">,
+): SubmissionCheckResult {
+  return { severity: SEVERITY, autofix_eligible: false, ...partial };
+}
+
+export function suggestionMarkdownFiles(
+  ctx: SubmissionCheckContext,
+): SubmissionFileInfo[] {
+  return ctx.files.filter((file) => {
+    const path = normalizePath(file.filename);
+    if (!/\.md$/i.test(path)) return false;
+    return /agents\/[^/]+\/suggestions\//.test(path) || /\/suggestions\//.test(path);
+  });
+}
+
+function agentFromPath(filePath: string): string | null {
+  const match = normalizePath(filePath).match(/^agents\/([^/]+)\//);
+  return match?.[1] ?? null;
+}
+
+function paragraphs(text: string): string[] {
+  return text
+    .split(/\n\s*\n/)
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0 && !/^#+\s/.test(p));
+}
+
+function extractFileRefs(text: string): string[] {
+  const refs = new Set<string>();
+  const re = new RegExp(FILE_REF.source, FILE_REF.flags);
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) {
+    if (m[1]) refs.add(normalizePath(m[1]));
+  }
+  const backtick = /`((?:src|scripts|supabase|app|agents)\/[a-z0-9_/.-]+\.[a-z]+)`/gi;
+  while ((m = backtick.exec(text)) !== null) {
+    refs.add(normalizePath(m[1]));
+  }
+  return [...refs];
+}
+
+function hasToBeCreatedMarker(text: string, ref: string): boolean {
+  const idx = text.indexOf(ref);
+  if (idx < 0) return false;
+  const window = text.slice(Math.max(0, idx - 80), idx + ref.length + 80);
+  return /to-be-created|to be created|TBD path/i.test(window);
+}
+
+export function detectOutputSizeMin(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const files = suggestionMarkdownFiles(ctx);
+  const short = files.filter((f) => fileContent(f).trim().length < OUTPUT_SIZE_MIN_CHARS);
+  if (short.length === 0) return null;
+  return advisory({
+    code: "output_size_min",
+    title: "Agent output below minimum size",
+    detail: `Suggestion markdown under ${OUTPUT_SIZE_MIN_CHARS} chars (possible model bail-out): ${short.map((f) => f.filename).join(", ")}.`,
+    files: short.map((f) => f.filename),
+    suggested_action: "Expand the proposal with concrete actions and file-level detail.",
+  });
+}
+
+export function detectActionExtractionPresent(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const files = suggestionMarkdownFiles(ctx).filter(
+    (f) => agentFromPath(f.filename) === "coordinator",
+  );
+  const missing: string[] = [];
+  for (const file of files) {
+    const paras = paragraphs(fileContent(file));
+    const bad = paras.filter((p) => !ACTION_SUFFIX.test(p));
+    if (bad.length > 0) missing.push(file.filename);
+  }
+  if (missing.length === 0) return null;
+  return advisory({
+    code: "action_extraction_present",
+    title: "Coordinator paragraph missing action extraction",
+    detail: `Paragraphs should end with "→ @owner" or "— No actions surfaced": ${missing.join(", ")}.`,
+    files: missing,
+    suggested_action: "Add explicit owner routing or a no-actions line per paragraph.",
+  });
+}
+
+export function detectDeltaSectionPresent(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const files = suggestionMarkdownFiles(ctx).filter((f) => {
+    const agent = agentFromPath(f.filename);
+    const path = normalizePath(f.filename);
+    return agent === "knowledge-scout" || /DAILY-INTEL\.md$/i.test(path);
+  });
+  const missing: string[] = [];
+  for (const file of files) {
+    const text = fileContent(file);
+    if (!/## Δ Since Last Sweep/i.test(text) && !/No deltas — quiet sweep/i.test(text)) {
+      missing.push(file.filename);
+    }
+  }
+  if (missing.length === 0) return null;
+  return advisory({
+    code: "delta_section_present",
+    title: "Missing delta section (knowledge-scout)",
+    detail: `Require "## Δ Since Last Sweep" or "No deltas — quiet sweep": ${missing.join(", ")}.`,
+    files: missing,
+    suggested_action: "Add a delta header or explicit quiet-sweep line.",
+  });
+}
+
+export function detectPreambleAbsent(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const hits: string[] = [];
+  for (const file of suggestionMarkdownFiles(ctx)) {
+    const paras = paragraphs(fileContent(file)).slice(0, 2);
+    if (paras.some((p) => PREAMBLE_OPENERS.test(p.split("\n")[0]?.trim() ?? ""))) {
+      hits.push(file.filename);
+    }
+  }
+  if (hits.length === 0) return null;
+  return advisory({
+    code: "preamble_absent",
+    title: "Conversational preamble detected",
+    detail: `Opening paragraphs use session-style preambles: ${hits.join(", ")}.`,
+    files: hits,
+    suggested_action: "Start with structured content, not meta narration.",
+  });
+}
+
+export function detectGraduationSignalsSectionPresent(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const files = suggestionMarkdownFiles(ctx).filter(
+    (f) => agentFromPath(f.filename) === "rd-satellite",
+  );
+  const missing = files
+    .filter((f) => !/## Graduation Signals/i.test(fileContent(f)))
+    .map((f) => f.filename);
+  if (missing.length === 0) return null;
+  return advisory({
+    code: "graduation_signals_section_present",
+    title: "Missing Graduation Signals section",
+    detail: `rd-satellite output requires "## Graduation Signals": ${missing.join(", ")}.`,
+    files: missing,
+    suggested_action: "Add a Graduation Signals section with promotion criteria.",
+  });
+}
+
+export function detectFabricatedIdCheck(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const hits: string[] = [];
+  const ids: string[] = [];
+  for (const file of suggestionMarkdownFiles(ctx)) {
+    const text = fileContent(file);
+    const re = new RegExp(FABRICATED_ID.source, FABRICATED_ID.flags);
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(text)) !== null) {
+      ids.push(m[0]);
+      hits.push(file.filename);
+    }
+  }
+  if (ids.length === 0) return null;
+  return advisory({
+    code: "fabricated_id_check",
+    title: "Suspicious session/run identifiers",
+    detail: `Verify identifiers against agent_runs/tasks/messages: ${[...new Set(ids)].slice(0, 8).join(", ")}.`,
+    files: [...new Set(hits)],
+    suggested_action: "Replace fabricated IDs with verified references or remove them.",
+  });
+}
+
+export function detectSessionNarrativeDetection(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const hits: string[] = [];
+  let total = 0;
+  for (const file of suggestionMarkdownFiles(ctx)) {
+    const text = fileContent(file);
+    const re = new RegExp(SESSION_NARRATIVE.source, SESSION_NARRATIVE.flags);
+    const matches = text.match(re);
+    if (matches && matches.length > 0) {
+      total += matches.length;
+      hits.push(file.filename);
+    }
+  }
+  if (total < NARRATIVE_MATCH_THRESHOLD) return null;
+  return advisory({
+    code: "session_narrative_detection",
+    title: "Session narrative instead of file content",
+    detail: `${total} first-person session phrases across ${hits.join(", ")}.`,
+    files: hits,
+    suggested_action: "Replace narration with concrete diffs, paths, and commands.",
+  });
+}
+
+export function detectIncompletenessSelfFlag(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const hits: string[] = [];
+  for (const file of suggestionMarkdownFiles(ctx)) {
+    const text = fileContent(file);
+    if (PARTIAL_COMPLETION.test(text) && !INCOMPLETE_MARKER.test(text)) {
+      hits.push(file.filename);
+    }
+  }
+  if (hits.length === 0) return null;
+  return advisory({
+    code: "incompleteness_self_flag",
+    title: "Partial completion without INCOMPLETE marker",
+    detail: `Fractional completion hints require INCOMPLETE/PARTIAL flag: ${hits.join(", ")}.`,
+    files: hits,
+    suggested_action: 'Add an explicit "INCOMPLETE" or "PARTIAL" marker for scoped work.',
+  });
+}
+
+export function detectReferencedFilesExist(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const missing: string[] = [];
+  for (const file of suggestionMarkdownFiles(ctx)) {
+    const text = fileContent(file);
+    for (const ref of extractFileRefs(text)) {
+      const inPr =
+        ctx.prPaths.has(ref) || [...ctx.prPaths].some((p) => p.endsWith(`/${ref}`));
+      if (!inPr && !hasToBeCreatedMarker(text, ref)) {
+        missing.push(`${file.filename}: ${ref}`);
+      }
+    }
+  }
+  if (missing.length === 0) return null;
+  return advisory({
+    code: "referenced_files_exist",
+    title: "Referenced path not in PR",
+    detail: missing.slice(0, 12).join("; "),
+    files: missing.map((m) => m.split(": ")[0] ?? m),
+    suggested_action: 'Include the file in the PR or mark adjacent "to-be-created".',
+  });
+}
+
+export function detectPrerequisiteSecretsCheck(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const hits: string[] = [];
+  for (const file of suggestionMarkdownFiles(ctx)) {
+    const path = normalizePath(file.filename);
+    const text = fileContent(file);
+    const titleLine = text.split("\n").find((l) => /^#\s/.test(l)) ?? "";
+    if (!RUNBOOK_HINT.test(`${path} ${titleLine}`)) continue;
+    const head = text.split("\n").slice(0, 30).join("\n");
+    if (!SECRETS_PREREQ.test(head)) hits.push(file.filename);
+  }
+  if (hits.length === 0) return null;
+  return advisory({
+    code: "prerequisite_secrets_check",
+    title: "Runbook missing secrets prerequisite step",
+    detail: `First 30 lines should include secrets/env prerequisites: ${hits.join(", ")}.`,
+    files: hits,
+    suggested_action: "Open runbooks with Prerequisites or `secrets list` verification.",
+  });
+}
+
+export function detectDependencyDagValidation(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const hits: string[] = [];
+  for (const file of suggestionMarkdownFiles(ctx)) {
+    const text = fileContent(file);
+    const phases = (text.match(/\bphase\s+[ab12]\b/gi) ?? []).length;
+    if (phases >= 2 && !DEP_MATRIX.test(text)) {
+      hits.push(file.filename);
+    }
+  }
+  if (hits.length === 0) return null;
+  return advisory({
+    code: "dependency_dag_validation",
+    title: "Multi-phase plan missing dependency matrix",
+    detail: `Multi-phase proposals need Depends on / blocks lines: ${hits.join(", ")}.`,
+    files: hits,
+    suggested_action: "Add explicit phase dependencies (X blocks Y).",
+  });
+}
+
+export function detectUncommittedFixCheck(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const hits: string[] = [];
+  for (const file of suggestionMarkdownFiles(ctx)) {
+    if (FIX_CLAIM.test(fileContent(file))) hits.push(file.filename);
+  }
+  if (hits.length === 0) return null;
+  return advisory({
+    code: "uncommitted_fix_check",
+    title: "Fix claim requires commit verification",
+    detail: `Claims like "fix applied" / "now working" need matching git history: ${hits.join(", ")}.`,
+    files: hits,
+    suggested_action:
+      "Reference the commit SHA or flag changes as on-disk pending commit.",
+  });
+}
+
+export function detectVerificationOwnerAssigned(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const hits: string[] = [];
+  for (const file of suggestionMarkdownFiles(ctx)) {
+    const lines = fileContent(file).split("\n");
+    for (let i = 0; i < lines.length; i++) {
+      if (!UNVERIFIED_MARKER.test(lines[i] ?? "")) continue;
+      const window = lines.slice(i, i + 6).join("\n");
+      if (!OWNER_DUE.test(window)) {
+        hits.push(file.filename);
+        break;
+      }
+    }
+  }
+  if (hits.length === 0) return null;
+  return advisory({
+    code: "verification_owner_assigned",
+    title: "UNVERIFIED item missing owner and due date",
+    detail: `Add Owner: @user and Due: YYYY-MM-DD near unverified items: ${[...new Set(hits)].join(", ")}.`,
+    files: [...new Set(hits)],
+    suggested_action: "Assign verification owner and due date for each UNVERIFIED line.",
+  });
+}
+
+export function detectExternalInterfaceValidation(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const hits: string[] = [];
+  for (const file of suggestionMarkdownFiles(ctx)) {
+    const path = normalizePath(file.filename);
+    const crossRepo = /suggestions\/(?!komatik-agents)[^/]+\//.test(path);
+    if (!crossRepo) continue;
+    const text = fileContent(file);
+    if (!PROPOSAL_ONLY.test(text) && !SCHEMA_LINK.test(text)) {
+      hits.push(file.filename);
+    }
+  }
+  if (hits.length === 0) return null;
+  return advisory({
+    code: "external_interface_validation",
+    title: "Cross-repo proposal lacks schema verification",
+    detail: `Cross-repo suggestions need PROPOSAL_ONLY or verified schema link: ${hits.join(", ")}.`,
+    files: hits,
+    suggested_action: "Link verified target schema or mark PROPOSAL_ONLY.",
+  });
+}
+
+export function runPhase0Detectors(ctx: SubmissionCheckContext): SubmissionCheckResult[] {
+  if (suggestionMarkdownFiles(ctx).length === 0) return [];
+  const checks = [
+    detectOutputSizeMin,
+    detectActionExtractionPresent,
+    detectDeltaSectionPresent,
+    detectPreambleAbsent,
+    detectGraduationSignalsSectionPresent,
+    detectFabricatedIdCheck,
+    detectSessionNarrativeDetection,
+    detectIncompletenessSelfFlag,
+    detectReferencedFilesExist,
+    detectPrerequisiteSecretsCheck,
+    detectDependencyDagValidation,
+    detectUncommittedFixCheck,
+    detectVerificationOwnerAssigned,
+    detectExternalInterfaceValidation,
+  ];
+  return checks
+    .map((fn) => fn(ctx))
+    .filter((check): check is SubmissionCheckResult => check !== null);
+}

--- a/app/src/submission-checks/phase0-detectors.ts
+++ b/app/src/submission-checks/phase0-detectors.ts
@@ -22,7 +22,7 @@ const ACTION_SUFFIX = /(?:→\s*@[\w-]+|— No actions surfaced)\s*$/i;
 const UNVERIFIED_MARKER = /\[UNVERIFIED\]|verify after|needs verification/i;
 const OWNER_DUE = /Owner:\s*@[\w-]+[\s\S]{0,120}Due:\s*\d{4}-\d{2}-\d{2}/i;
 const FIX_CLAIM = /\b(fix applied|now working|is live|deployed successfully)\b/i;
-const MULTI_PHASE = /\bphase\s+[ab12]\b/i;
+const MULTI_PHASE = /\bphase\s+[ab12]\b/gi;
 const DEP_MATRIX = /\b(depends on:|dependency matrix|blocks:|x blocks y)\b/i;
 const RUNBOOK_HINT = /runbook|deploy(?:ment)? guide/i;
 const SECRETS_PREREQ =
@@ -300,7 +300,7 @@ export function detectDependencyDagValidation(
   const hits: string[] = [];
   for (const file of suggestionMarkdownFiles(ctx)) {
     const text = fileContent(file);
-    const phases = (text.match(/\bphase\s+[ab12]\b/gi) ?? []).length;
+    const phases = (text.match(MULTI_PHASE) ?? []).length;
     if (phases >= 2 && !DEP_MATRIX.test(text)) {
       hits.push(file.filename);
     }

--- a/app/src/submission-engine.ts
+++ b/app/src/submission-engine.ts
@@ -10,7 +10,7 @@ import type { RepoConfig, SubmissionCheckResult } from "./types.js";
 export type { SubmissionFileInfo } from "./submission-checks/types.js";
 export type { SubmissionCheckCode, SubmissionCheckResult } from "./types.js";
 
-/** All Gate 1 check codes — keep in sync with A8 fixture manifest. */
+/** Gate 1 + Phase 0 submission check codes — keep in sync with A8 fixture manifest. */
 export const SUBMISSION_CHECK_CODES = SubmissionCheckCode.options;
 
 const DEFAULT_STALE_TERMS = ["deployguard", "DeployGuard"];

--- a/dist/index.js
+++ b/dist/index.js
@@ -40656,6 +40656,21 @@ const SubmissionCheckCode = enumType([
     "sql_syntax_basic",
     "large_file",
     "soul_integrity",
+    // Phase 0 — agent suggestion quality (advisory / weight=0 in komatik-agents)
+    "output_size_min",
+    "action_extraction_present",
+    "delta_section_present",
+    "preamble_absent",
+    "graduation_signals_section_present",
+    "fabricated_id_check",
+    "session_narrative_detection",
+    "incompleteness_self_flag",
+    "referenced_files_exist",
+    "prerequisite_secrets_check",
+    "dependency_dag_validation",
+    "uncommitted_fix_check",
+    "verification_owner_assigned",
+    "external_interface_validation",
 ]);
 const SubmissionCheckResult = objectType({
     code: SubmissionCheckCode,
@@ -42559,8 +42574,372 @@ function isTestPath(filename) {
     return /\/__tests__\/|\/test\/|\/fixtures\/|\.test\.|\.spec\./.test(filename);
 }
 
+;// CONCATENATED MODULE: ./src/submission-checks/phase0-detectors.ts
+// Phase 0 agent suggestion checks (weight=0 / advisory in Trailhead).
+// Ported from komatik-agents agent-gate-checks Phase 0 stubs with real heuristics.
+
+const SEVERITY = "advisory";
+const OUTPUT_SIZE_MIN_CHARS = 400;
+const NARRATIVE_MATCH_THRESHOLD = 3;
+const PREAMBLE_OPENERS = /^(let me|here is the|here's the|i('| wi)ll|after reviewing|to start|based on my analysis)/i;
+const SESSION_NARRATIVE = /\bI (queried|reviewed|checked|will (build|create|fix|implement|add|update))/gi;
+const PARTIAL_COMPLETION = /\b\d+\s*(?:\/|of)\s*\d+\b/i;
+const INCOMPLETE_MARKER = /\b(INCOMPLETE|PARTIAL)\b/i;
+const FABRICATED_ID = /\b(session|run|task|message)[-_]?[a-f0-9]{6,}\b/gi;
+const FILE_REF = /(?:^|[\s('"`])((?:src|scripts|supabase|app|agents)\/[a-z0-9_/.-]+\.(?:ts|tsx|js|mjs|sql|py|md))/gi;
+const ACTION_SUFFIX = /(?:→\s*@[\w-]+|— No actions surfaced)\s*$/i;
+const UNVERIFIED_MARKER = /\[UNVERIFIED\]|verify after|needs verification/i;
+const OWNER_DUE = /Owner:\s*@[\w-]+[\s\S]{0,120}Due:\s*\d{4}-\d{2}-\d{2}/i;
+const FIX_CLAIM = /\b(fix applied|now working|is live|deployed successfully)\b/i;
+const MULTI_PHASE = /\bphase\s+[ab12]\b/gi;
+const DEP_MATRIX = /\b(depends on:|dependency matrix|blocks:|x blocks y)\b/i;
+const RUNBOOK_HINT = /runbook|deploy(?:ment)? guide/i;
+const SECRETS_PREREQ = /\b(secrets list|prerequisites:|required env|environment variables)\b/i;
+const PROPOSAL_ONLY = /\bPROPOSAL_ONLY\b/i;
+const SCHEMA_LINK = /https?:\/\/[^\s)]+\/(schema|openapi|api-docs)/i;
+function advisory(partial) {
+    return { severity: SEVERITY, autofix_eligible: false, ...partial };
+}
+function suggestionMarkdownFiles(ctx) {
+    return ctx.files.filter((file) => {
+        const path = normalizePath(file.filename);
+        if (!/\.md$/i.test(path))
+            return false;
+        return /agents\/[^/]+\/suggestions\//.test(path) || /\/suggestions\//.test(path);
+    });
+}
+function agentFromPath(filePath) {
+    const match = normalizePath(filePath).match(/^agents\/([^/]+)\//);
+    return match?.[1] ?? null;
+}
+function paragraphs(text) {
+    return text
+        .split(/\n\s*\n/)
+        .map((p) => p.trim())
+        .filter((p) => p.length > 0 && !/^#+\s/.test(p));
+}
+function extractFileRefs(text) {
+    const refs = new Set();
+    const re = new RegExp(FILE_REF.source, FILE_REF.flags);
+    let m;
+    while ((m = re.exec(text)) !== null) {
+        if (m[1])
+            refs.add(normalizePath(m[1]));
+    }
+    const backtick = /`((?:src|scripts|supabase|app|agents)\/[a-z0-9_/.-]+\.[a-z]+)`/gi;
+    while ((m = backtick.exec(text)) !== null) {
+        refs.add(normalizePath(m[1]));
+    }
+    return [...refs];
+}
+function hasToBeCreatedMarker(text, ref) {
+    const idx = text.indexOf(ref);
+    if (idx < 0)
+        return false;
+    const window = text.slice(Math.max(0, idx - 80), idx + ref.length + 80);
+    return /to-be-created|to be created|TBD path/i.test(window);
+}
+function detectOutputSizeMin(ctx) {
+    const files = suggestionMarkdownFiles(ctx);
+    const short = files.filter((f) => fileContent(f).trim().length < OUTPUT_SIZE_MIN_CHARS);
+    if (short.length === 0)
+        return null;
+    return advisory({
+        code: "output_size_min",
+        title: "Agent output below minimum size",
+        detail: `Suggestion markdown under ${OUTPUT_SIZE_MIN_CHARS} chars (possible model bail-out): ${short.map((f) => f.filename).join(", ")}.`,
+        files: short.map((f) => f.filename),
+        suggested_action: "Expand the proposal with concrete actions and file-level detail.",
+    });
+}
+function detectActionExtractionPresent(ctx) {
+    const files = suggestionMarkdownFiles(ctx).filter((f) => agentFromPath(f.filename) === "coordinator");
+    const missing = [];
+    for (const file of files) {
+        const paras = paragraphs(fileContent(file));
+        const bad = paras.filter((p) => !ACTION_SUFFIX.test(p));
+        if (bad.length > 0)
+            missing.push(file.filename);
+    }
+    if (missing.length === 0)
+        return null;
+    return advisory({
+        code: "action_extraction_present",
+        title: "Coordinator paragraph missing action extraction",
+        detail: `Paragraphs should end with "→ @owner" or "— No actions surfaced": ${missing.join(", ")}.`,
+        files: missing,
+        suggested_action: "Add explicit owner routing or a no-actions line per paragraph.",
+    });
+}
+function detectDeltaSectionPresent(ctx) {
+    const files = suggestionMarkdownFiles(ctx).filter((f) => {
+        const agent = agentFromPath(f.filename);
+        const path = normalizePath(f.filename);
+        return agent === "knowledge-scout" || /DAILY-INTEL\.md$/i.test(path);
+    });
+    const missing = [];
+    for (const file of files) {
+        const text = fileContent(file);
+        if (!/## Δ Since Last Sweep/i.test(text) && !/No deltas — quiet sweep/i.test(text)) {
+            missing.push(file.filename);
+        }
+    }
+    if (missing.length === 0)
+        return null;
+    return advisory({
+        code: "delta_section_present",
+        title: "Missing delta section (knowledge-scout)",
+        detail: `Require "## Δ Since Last Sweep" or "No deltas — quiet sweep": ${missing.join(", ")}.`,
+        files: missing,
+        suggested_action: "Add a delta header or explicit quiet-sweep line.",
+    });
+}
+function detectPreambleAbsent(ctx) {
+    const hits = [];
+    for (const file of suggestionMarkdownFiles(ctx)) {
+        const paras = paragraphs(fileContent(file)).slice(0, 2);
+        if (paras.some((p) => PREAMBLE_OPENERS.test(p.split("\n")[0]?.trim() ?? ""))) {
+            hits.push(file.filename);
+        }
+    }
+    if (hits.length === 0)
+        return null;
+    return advisory({
+        code: "preamble_absent",
+        title: "Conversational preamble detected",
+        detail: `Opening paragraphs use session-style preambles: ${hits.join(", ")}.`,
+        files: hits,
+        suggested_action: "Start with structured content, not meta narration.",
+    });
+}
+function detectGraduationSignalsSectionPresent(ctx) {
+    const files = suggestionMarkdownFiles(ctx).filter((f) => agentFromPath(f.filename) === "rd-satellite");
+    const missing = files
+        .filter((f) => !/## Graduation Signals/i.test(fileContent(f)))
+        .map((f) => f.filename);
+    if (missing.length === 0)
+        return null;
+    return advisory({
+        code: "graduation_signals_section_present",
+        title: "Missing Graduation Signals section",
+        detail: `rd-satellite output requires "## Graduation Signals": ${missing.join(", ")}.`,
+        files: missing,
+        suggested_action: "Add a Graduation Signals section with promotion criteria.",
+    });
+}
+function detectFabricatedIdCheck(ctx) {
+    const hits = [];
+    const ids = [];
+    for (const file of suggestionMarkdownFiles(ctx)) {
+        const text = fileContent(file);
+        const re = new RegExp(FABRICATED_ID.source, FABRICATED_ID.flags);
+        let m;
+        while ((m = re.exec(text)) !== null) {
+            ids.push(m[0]);
+            hits.push(file.filename);
+        }
+    }
+    if (ids.length === 0)
+        return null;
+    return advisory({
+        code: "fabricated_id_check",
+        title: "Suspicious session/run identifiers",
+        detail: `Verify identifiers against agent_runs/tasks/messages: ${[...new Set(ids)].slice(0, 8).join(", ")}.`,
+        files: [...new Set(hits)],
+        suggested_action: "Replace fabricated IDs with verified references or remove them.",
+    });
+}
+function detectSessionNarrativeDetection(ctx) {
+    const hits = [];
+    let total = 0;
+    for (const file of suggestionMarkdownFiles(ctx)) {
+        const text = fileContent(file);
+        const re = new RegExp(SESSION_NARRATIVE.source, SESSION_NARRATIVE.flags);
+        const matches = text.match(re);
+        if (matches && matches.length > 0) {
+            total += matches.length;
+            hits.push(file.filename);
+        }
+    }
+    if (total < NARRATIVE_MATCH_THRESHOLD)
+        return null;
+    return advisory({
+        code: "session_narrative_detection",
+        title: "Session narrative instead of file content",
+        detail: `${total} first-person session phrases across ${hits.join(", ")}.`,
+        files: hits,
+        suggested_action: "Replace narration with concrete diffs, paths, and commands.",
+    });
+}
+function detectIncompletenessSelfFlag(ctx) {
+    const hits = [];
+    for (const file of suggestionMarkdownFiles(ctx)) {
+        const text = fileContent(file);
+        if (PARTIAL_COMPLETION.test(text) && !INCOMPLETE_MARKER.test(text)) {
+            hits.push(file.filename);
+        }
+    }
+    if (hits.length === 0)
+        return null;
+    return advisory({
+        code: "incompleteness_self_flag",
+        title: "Partial completion without INCOMPLETE marker",
+        detail: `Fractional completion hints require INCOMPLETE/PARTIAL flag: ${hits.join(", ")}.`,
+        files: hits,
+        suggested_action: 'Add an explicit "INCOMPLETE" or "PARTIAL" marker for scoped work.',
+    });
+}
+function detectReferencedFilesExist(ctx) {
+    const missing = [];
+    for (const file of suggestionMarkdownFiles(ctx)) {
+        const text = fileContent(file);
+        for (const ref of extractFileRefs(text)) {
+            const inPr = ctx.prPaths.has(ref) || [...ctx.prPaths].some((p) => p.endsWith(`/${ref}`));
+            if (!inPr && !hasToBeCreatedMarker(text, ref)) {
+                missing.push(`${file.filename}: ${ref}`);
+            }
+        }
+    }
+    if (missing.length === 0)
+        return null;
+    return advisory({
+        code: "referenced_files_exist",
+        title: "Referenced path not in PR",
+        detail: missing.slice(0, 12).join("; "),
+        files: missing.map((m) => m.split(": ")[0] ?? m),
+        suggested_action: 'Include the file in the PR or mark adjacent "to-be-created".',
+    });
+}
+function detectPrerequisiteSecretsCheck(ctx) {
+    const hits = [];
+    for (const file of suggestionMarkdownFiles(ctx)) {
+        const path = normalizePath(file.filename);
+        const text = fileContent(file);
+        const titleLine = text.split("\n").find((l) => /^#\s/.test(l)) ?? "";
+        if (!RUNBOOK_HINT.test(`${path} ${titleLine}`))
+            continue;
+        const head = text.split("\n").slice(0, 30).join("\n");
+        if (!SECRETS_PREREQ.test(head))
+            hits.push(file.filename);
+    }
+    if (hits.length === 0)
+        return null;
+    return advisory({
+        code: "prerequisite_secrets_check",
+        title: "Runbook missing secrets prerequisite step",
+        detail: `First 30 lines should include secrets/env prerequisites: ${hits.join(", ")}.`,
+        files: hits,
+        suggested_action: "Open runbooks with Prerequisites or `secrets list` verification.",
+    });
+}
+function detectDependencyDagValidation(ctx) {
+    const hits = [];
+    for (const file of suggestionMarkdownFiles(ctx)) {
+        const text = fileContent(file);
+        const phases = (text.match(MULTI_PHASE) ?? []).length;
+        if (phases >= 2 && !DEP_MATRIX.test(text)) {
+            hits.push(file.filename);
+        }
+    }
+    if (hits.length === 0)
+        return null;
+    return advisory({
+        code: "dependency_dag_validation",
+        title: "Multi-phase plan missing dependency matrix",
+        detail: `Multi-phase proposals need Depends on / blocks lines: ${hits.join(", ")}.`,
+        files: hits,
+        suggested_action: "Add explicit phase dependencies (X blocks Y).",
+    });
+}
+function detectUncommittedFixCheck(ctx) {
+    const hits = [];
+    for (const file of suggestionMarkdownFiles(ctx)) {
+        if (FIX_CLAIM.test(fileContent(file)))
+            hits.push(file.filename);
+    }
+    if (hits.length === 0)
+        return null;
+    return advisory({
+        code: "uncommitted_fix_check",
+        title: "Fix claim requires commit verification",
+        detail: `Claims like "fix applied" / "now working" need matching git history: ${hits.join(", ")}.`,
+        files: hits,
+        suggested_action: "Reference the commit SHA or flag changes as on-disk pending commit.",
+    });
+}
+function detectVerificationOwnerAssigned(ctx) {
+    const hits = [];
+    for (const file of suggestionMarkdownFiles(ctx)) {
+        const lines = fileContent(file).split("\n");
+        for (let i = 0; i < lines.length; i++) {
+            if (!UNVERIFIED_MARKER.test(lines[i] ?? ""))
+                continue;
+            const window = lines.slice(i, i + 6).join("\n");
+            if (!OWNER_DUE.test(window)) {
+                hits.push(file.filename);
+                break;
+            }
+        }
+    }
+    if (hits.length === 0)
+        return null;
+    return advisory({
+        code: "verification_owner_assigned",
+        title: "UNVERIFIED item missing owner and due date",
+        detail: `Add Owner: @user and Due: YYYY-MM-DD near unverified items: ${[...new Set(hits)].join(", ")}.`,
+        files: [...new Set(hits)],
+        suggested_action: "Assign verification owner and due date for each UNVERIFIED line.",
+    });
+}
+function detectExternalInterfaceValidation(ctx) {
+    const hits = [];
+    for (const file of suggestionMarkdownFiles(ctx)) {
+        const path = normalizePath(file.filename);
+        const crossRepo = /suggestions\/(?!komatik-agents)[^/]+\//.test(path);
+        if (!crossRepo)
+            continue;
+        const text = fileContent(file);
+        if (!PROPOSAL_ONLY.test(text) && !SCHEMA_LINK.test(text)) {
+            hits.push(file.filename);
+        }
+    }
+    if (hits.length === 0)
+        return null;
+    return advisory({
+        code: "external_interface_validation",
+        title: "Cross-repo proposal lacks schema verification",
+        detail: `Cross-repo suggestions need PROPOSAL_ONLY or verified schema link: ${hits.join(", ")}.`,
+        files: hits,
+        suggested_action: "Link verified target schema or mark PROPOSAL_ONLY.",
+    });
+}
+function runPhase0Detectors(ctx) {
+    if (suggestionMarkdownFiles(ctx).length === 0)
+        return [];
+    const checks = [
+        detectOutputSizeMin,
+        detectActionExtractionPresent,
+        detectDeltaSectionPresent,
+        detectPreambleAbsent,
+        detectGraduationSignalsSectionPresent,
+        detectFabricatedIdCheck,
+        detectSessionNarrativeDetection,
+        detectIncompletenessSelfFlag,
+        detectReferencedFilesExist,
+        detectPrerequisiteSecretsCheck,
+        detectDependencyDagValidation,
+        detectUncommittedFixCheck,
+        detectVerificationOwnerAssigned,
+        detectExternalInterfaceValidation,
+    ];
+    return checks
+        .map((fn) => fn(ctx))
+        .filter((check) => check !== null);
+}
+
 ;// CONCATENATED MODULE: ./src/submission-checks/detectors.ts
 // Gate 1 detectors — ported from komatik-agents agent-gate-checks (patch/content based).
+
 
 const OLD_NAME_PATTERNS = [
     { oldName: "DeployGuard", newName: "Trailhead", pattern: /\bDeployGuard\b/g },
@@ -43115,7 +43494,7 @@ function detectSoulIntegrity(ctx) {
     });
 }
 function runAllDetectors(ctx) {
-    const checks = [
+    const gate1 = [
         detectMockPlaceholder(ctx),
         detectSecrets(ctx),
         detectDestructiveSql(ctx),
@@ -43131,8 +43510,8 @@ function runAllDetectors(ctx) {
         detectContextFreshness(ctx),
         detectSoulIntegrity(ctx),
         detectPathFormat(ctx),
-    ];
-    return checks.filter((check) => check !== null);
+    ].filter((check) => check !== null);
+    return [...gate1, ...runPhase0Detectors(ctx)];
 }
 
 ;// CONCATENATED MODULE: ./src/submission-engine.ts
@@ -43141,7 +43520,7 @@ function runAllDetectors(ctx) {
 
 
 
-/** All Gate 1 check codes — keep in sync with A8 fixture manifest. */
+/** Gate 1 + Phase 0 submission check codes — keep in sync with A8 fixture manifest. */
 const SUBMISSION_CHECK_CODES = SubmissionCheckCode.options;
 const DEFAULT_STALE_TERMS = ["deployguard", "DeployGuard"];
 const DEFAULT_AUTH_ROUTE_ALLOWLIST = [

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,33 +1,38 @@
 # Trailhead MCP Server
 
-A [Model Context Protocol](https://modelcontextprotocol.io) server that exposes Trailhead's deployment gate capabilities as 22 tools for AI agents.
+A [Model Context Protocol](https://modelcontextprotocol.io) server that exposes Trailhead's deployment gate capabilities as 26 tools for AI agents.
 
 ## Tools
 
-| Tool                      | Description                                               | Requires                                                   |
-| ------------------------- | --------------------------------------------------------- | ---------------------------------------------------------- |
-| `check-http-health`       | Check health of HTTP endpoints or provider adapters       | —                                                          |
-| `check-vercel-health`     | Check latest Vercel production deployment status          | `VERCEL_TOKEN`, `VERCEL_PROJECT_ID`                        |
-| `check-supabase-health`   | Check Supabase REST health                                | `SUPABASE_URL`, `SUPABASE_ANON_KEY`                        |
-| `compute-risk-score`      | Compute weighted risk score from changed files            | —                                                          |
-| `detect-provenance`       | Classify PR provenance from author/branch/commit signals  | —                                                          |
-| `check-ci-integrity`      | Detect CI bypass/test-deletion/coverage-downgrade signals | —                                                          |
-| `check-supply-chain`      | Detect dependency-introduction/major-bump/vuln signals    | —                                                          |
-| `evaluate-deployment`     | Full evaluation (health checks + risk scoring)            | —                                                          |
-| `get-dora-metrics`        | Compute DORA metrics for a GitHub repo                    | `GITHUB_TOKEN`                                             |
-| `compare-risk-history`    | Compare risk across recently merged PRs                   | `GITHUB_TOKEN`                                             |
-| `explain-risk-factors`    | Explain risk-factor contributions in natural language     | —                                                          |
-| `evaluate-policy`         | Full policy evaluation for a PR/commit                    | `GITHUB_TOKEN`                                             |
-| `get-pr-release-status`   | Composite release readiness (CI + risk) for a PR          | `GITHUB_TOKEN`                                             |
-| `get-security-alerts`     | Fetch open code-scanning alerts by severity               | `GITHUB_TOKEN`                                             |
-| `get-deployment-status`   | Get deployment status for an environment                  | `GITHUB_TOKEN`                                             |
-| `suggest-deploy-timing`   | Suggest whether conditions are safe for deploy            | `GITHUB_TOKEN`                                             |
-| `query-overrides`         | Query governed override records                           | `TRAILHEAD_OVERRIDES_JSON` or `TRAILHEAD_OVERRIDES_INLINE` |
-| `get-escalation-status`   | Evaluate escalation SLA status                            | —                                                          |
-| `record-finding-feedback` | Persist detector feedback for tuning                      | Cloud API or `TRAILHEAD_FEEDBACK_STORE` (optional)         |
-| `get-detector-noise`      | Aggregate false-positive/true-positive rates              | Cloud API or `TRAILHEAD_FEEDBACK_STORE` (optional)         |
-| `recommend-policy-tuning` | Generate tuning recommendations from detector noise       | Cloud API or `TRAILHEAD_FEEDBACK_STORE` (optional)         |
-| `recommend-rollback`      | Recommend rollback action from canary + provenance        | —                                                          |
+| Tool                      | Description                                                 | Requires                                                   |
+| ------------------------- | ----------------------------------------------------------- | ---------------------------------------------------------- |
+| `check-http-health`       | Check health of HTTP endpoints or provider adapters         | —                                                          |
+| `check-vercel-health`     | Check latest Vercel production deployment status            | `VERCEL_TOKEN`, `VERCEL_PROJECT_ID`                        |
+| `check-supabase-health`   | Check Supabase REST health                                  | `SUPABASE_URL`, `SUPABASE_ANON_KEY`                        |
+| `compute-risk-score`      | Compute weighted risk score from changed files              | —                                                          |
+| `detect-provenance`       | Classify PR provenance from author/branch/commit signals    | —                                                          |
+| `check-ci-integrity`      | Detect CI bypass/test-deletion/coverage-downgrade signals   | —                                                          |
+| `check-supply-chain`      | Detect dependency-introduction/major-bump/vuln signals      | —                                                          |
+| `evaluate-deployment`     | Full evaluation (health checks + risk scoring)              | —                                                          |
+| `get-dora-metrics`        | Compute DORA metrics for a GitHub repo                      | `GITHUB_TOKEN`                                             |
+| `compare-risk-history`    | Compare risk across recently merged PRs                     | `GITHUB_TOKEN`                                             |
+| `explain-risk-factors`    | Explain risk-factor contributions in natural language       | —                                                          |
+| `evaluate-policy`         | Full policy evaluation for a PR/commit                      | `GITHUB_TOKEN`                                             |
+| `get-pr-release-status`   | Composite release readiness (CI + risk) for a PR            | `GITHUB_TOKEN`                                             |
+| `get-security-alerts`     | Fetch open code-scanning alerts by severity                 | `GITHUB_TOKEN`                                             |
+| `get-deployment-status`   | Get deployment status for an environment                    | `GITHUB_TOKEN`                                             |
+| `suggest-deploy-timing`   | Suggest whether conditions are safe for deploy              | `GITHUB_TOKEN`                                             |
+| `query-overrides`         | Query governed override records                             | `TRAILHEAD_OVERRIDES_JSON` or `TRAILHEAD_OVERRIDES_INLINE` |
+| `get-escalation-status`   | Evaluate escalation SLA status                              | —                                                          |
+| `record-finding-feedback` | Persist detector feedback for tuning                        | Cloud API or `TRAILHEAD_FEEDBACK_STORE` (optional)         |
+| `get-detector-noise`      | Aggregate false-positive/true-positive rates                | Cloud API or `TRAILHEAD_FEEDBACK_STORE` (optional)         |
+| `recommend-policy-tuning` | Generate tuning recommendations from detector noise         | Cloud API or `TRAILHEAD_FEEDBACK_STORE` (optional)         |
+| `get-remediation`         | Read remediation block from evaluation JSON or Cloud        | Cloud API or inline `evaluation_json` (optional)           |
+| `subscribe-events`        | Poll Trailhead semantic webhook events until match          | `TRAILHEAD_EVENTS_JSON` or webhook feed (optional)         |
+| `validate-submission`     | Run Gate 1 + Phase 0 submission checks on file diffs        | —                                                          |
+| `apply-autofix`           | Plan allowlisted autofixes from remediation fixes (dry-run) | —                                                          |
+| `get-trust-score`         | Compute agent trust score/profile from evaluation metrics   | —                                                          |
+| `recommend-rollback`      | Recommend rollback action from canary + provenance          | —                                                          |
 
 ## Quick Start
 
@@ -95,7 +100,8 @@ When `TRAILHEAD_CLOUD_API_URL` and `TRAILHEAD_API_KEY` are set, feedback tools P
 
 Tools that don't require environment variables (for example, `compute-risk-score`,
 `evaluate-deployment`, `detect-provenance`, `check-ci-integrity`, `check-supply-chain`,
-`get-escalation-status`, `recommend-rollback`) work with zero configuration.
+`get-escalation-status`, `recommend-rollback`, `validate-submission`, `apply-autofix`,
+`get-trust-score`) work with zero configuration.
 
 ## Shared Risk Engine
 

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -41,6 +41,10 @@ import {
   TRAILHEAD_EVENT_TYPES,
   type TrailheadEventType,
 } from "./trailhead-events.js";
+import { runSubmissionGate, submissionGateShouldBlock } from "./submission-engine.js";
+import { deriveSubmissionFixes } from "./submission-remediation.js";
+import { buildAutofixPlan, selectAutofixCommit } from "./fixer-core.js";
+import { computeAgentTrustScore } from "./trust-score.js";
 
 registerAllAdapters();
 
@@ -1956,6 +1960,167 @@ server.tool(
 );
 
 server.tool(
+  "validate-submission",
+  "Run Gate 1 submission checks (including Phase 0 suggestion heuristics) on PR file patches or full suggestion content.",
+  {
+    files: z
+      .array(
+        z.object({
+          filename: z.string(),
+          patch: z.string().optional(),
+          content: z.string().optional(),
+        }),
+      )
+      .min(1)
+      .describe("Changed files with unified diff patches and/or full content"),
+    komatik_instance: z
+      .boolean()
+      .optional()
+      .describe("Enable Komatik-only checks (SOUL, stale naming, etc.)"),
+    mode: z
+      .enum(["warn", "block"])
+      .default("block")
+      .describe("Whether blocking severities should fail the gate"),
+    declared_packages: z
+      .array(z.string())
+      .optional()
+      .describe("Root package.json dependency names for import resolution"),
+  },
+  async ({ files, komatik_instance, mode, declared_packages }): Promise<ToolReturn> => {
+    const checks = runSubmissionGate({
+      files,
+      komatikInstance: komatik_instance ?? false,
+      mode,
+      declaredPackages: declared_packages,
+    });
+    const fixes = deriveSubmissionFixes(checks);
+    const blocking = submissionGateShouldBlock(checks, mode);
+    const phase0Count = checks.filter((c) =>
+      [
+        "output_size_min",
+        "action_extraction_present",
+        "delta_section_present",
+        "preamble_absent",
+        "graduation_signals_section_present",
+        "fabricated_id_check",
+        "session_narrative_detection",
+        "incompleteness_self_flag",
+        "referenced_files_exist",
+        "prerequisite_secrets_check",
+        "dependency_dag_validation",
+        "uncommitted_fix_check",
+        "verification_owner_assigned",
+        "external_interface_validation",
+      ].includes(c.code),
+    ).length;
+
+    return jsonResult({
+      checks,
+      fixes,
+      blocking,
+      summary: {
+        total: checks.length,
+        blocking: checks.filter((c) => c.severity === "blocking").length,
+        warn: checks.filter((c) => c.severity === "warn").length,
+        advisory: checks.filter((c) => c.severity === "advisory").length,
+        phase0: phase0Count,
+      },
+    });
+  },
+);
+
+server.tool(
+  "apply-autofix",
+  "Plan allowlisted autofixes from remediation fixes (dry-run by default; no git writes from MCP).",
+  {
+    fixes: z
+      .array(
+        z.object({
+          code: z.string(),
+          severity: z.enum(["blocking", "warn", "advisory"]),
+          title: z.string(),
+          detail: z.string(),
+          files: z.array(z.string()).default([]),
+          suggested_action: z.string().optional(),
+          suggested_command: z.string().optional(),
+          autofix_eligible: z.boolean().default(false),
+          autofix_class: z
+            .enum([
+              "format",
+              "lint",
+              "import-fix",
+              "type-narrow",
+              "test-scaffold",
+              "doc-update",
+              "dependency-bump",
+            ])
+            .optional(),
+        }),
+      )
+      .min(1)
+      .describe("Remediation fixes (e.g. from validate-submission or get-remediation)"),
+    dry_run: z
+      .boolean()
+      .default(true)
+      .describe("When true (default), return plan only without executing commands"),
+  },
+  async ({ fixes, dry_run }): Promise<ToolReturn> => {
+    const plan = buildAutofixPlan(fixes);
+    const selected = selectAutofixCommit(plan);
+    return jsonResult({
+      dryRun: dry_run,
+      executed: false,
+      plan,
+      selectedCommit: selected,
+      note: dry_run
+        ? "MCP returns plans only; run autofix via GitHub App fixer or local CI."
+        : "Git execution is not available from MCP — use the returned plan in your runner.",
+    });
+  },
+);
+
+server.tool(
+  "get-trust-score",
+  "Compute dynamic agent trust score and profile from evaluation metrics (Phase B3).",
+  {
+    evaluations: z.number().int().min(0).describe("Total gate evaluations in window"),
+    release_ready_count: z
+      .number()
+      .int()
+      .min(0)
+      .describe("Evaluations ending release_ready"),
+    revert_count: z.number().int().min(0).default(0),
+    human_review_required_count: z.number().int().min(0).default(0),
+    policy_violation_count: z.number().int().min(0).default(0),
+    sensitive_path_violation_count: z.number().int().min(0).default(0),
+    remediation_rounds_to_ready: z
+      .array(z.number().int().min(0))
+      .default([])
+      .describe("Loop rounds for PRs that reached release_ready"),
+  },
+  async ({
+    evaluations,
+    release_ready_count,
+    revert_count,
+    human_review_required_count,
+    policy_violation_count,
+    sensitive_path_violation_count,
+    remediation_rounds_to_ready,
+  }): Promise<ToolReturn> => {
+    const trust = computeAgentTrustScore({
+      evaluations,
+      releaseReadyCount: release_ready_count,
+      revertCount: revert_count,
+      humanReviewRequiredCount: human_review_required_count,
+      policyViolationCount: policy_violation_count,
+      sensitivePathViolationCount: sensitive_path_violation_count,
+      remediationRoundsToReady: remediation_rounds_to_ready,
+    });
+    return jsonResult({ trust });
+  },
+);
+
+server.tool(
   "recommend-rollback",
   "Recommend rollback action based on canary failure and PR provenance.",
   {
@@ -2101,6 +2266,9 @@ server.resource(
               "recommend-policy-tuning",
               "get-remediation",
               "subscribe-events",
+              "validate-submission",
+              "apply-autofix",
+              "get-trust-score",
               "recommend-rollback",
             ],
             resources: ["trailhead://health", "trailhead://server-card"],

--- a/mcp/src/submission-checks/detectors.ts
+++ b/mcp/src/submission-checks/detectors.ts
@@ -11,6 +11,7 @@ import {
   normalizePath,
   scanAddedContent,
 } from "./helpers.js";
+import { runPhase0Detectors } from "./phase0-detectors.js";
 
 export const OLD_NAME_PATTERNS: Array<{
   oldName: string;
@@ -611,7 +612,7 @@ export function detectSoulIntegrity(
 }
 
 export function runAllDetectors(ctx: SubmissionCheckContext): SubmissionCheckResult[] {
-  const checks = [
+  const gate1 = [
     detectMockPlaceholder(ctx),
     detectSecrets(ctx),
     detectDestructiveSql(ctx),
@@ -627,6 +628,7 @@ export function runAllDetectors(ctx: SubmissionCheckContext): SubmissionCheckRes
     detectContextFreshness(ctx),
     detectSoulIntegrity(ctx),
     detectPathFormat(ctx),
-  ];
-  return checks.filter((check): check is SubmissionCheckResult => check !== null);
+  ].filter((check): check is SubmissionCheckResult => check !== null);
+
+  return [...gate1, ...runPhase0Detectors(ctx)];
 }

--- a/mcp/src/submission-checks/phase0-detectors.ts
+++ b/mcp/src/submission-checks/phase0-detectors.ts
@@ -1,0 +1,405 @@
+// Phase 0 agent suggestion checks (weight=0 / advisory in Trailhead).
+// Ported from komatik-agents agent-gate-checks Phase 0 stubs with real heuristics.
+
+import type { SubmissionCheckResult } from "../types.js";
+import type { SubmissionCheckContext, SubmissionFileInfo } from "./types.js";
+import { fileContent, normalizePath } from "./helpers.js";
+
+const SEVERITY = "advisory" as const;
+const OUTPUT_SIZE_MIN_CHARS = 400;
+const NARRATIVE_MATCH_THRESHOLD = 3;
+
+const PREAMBLE_OPENERS =
+  /^(let me|here is the|here's the|i('| wi)ll|after reviewing|to start|based on my analysis)/i;
+const SESSION_NARRATIVE =
+  /\bI (queried|reviewed|checked|will (build|create|fix|implement|add|update))/gi;
+const PARTIAL_COMPLETION = /\b\d+\s*(?:\/|of)\s*\d+\b/i;
+const INCOMPLETE_MARKER = /\b(INCOMPLETE|PARTIAL)\b/i;
+const FABRICATED_ID = /\b(session|run|task|message)[-_]?[a-f0-9]{6,}\b/gi;
+const FILE_REF =
+  /(?:^|[\s('"`])((?:src|scripts|supabase|app|agents)\/[a-z0-9_/.-]+\.(?:ts|tsx|js|mjs|sql|py|md))/gi;
+const ACTION_SUFFIX = /(?:→\s*@[\w-]+|— No actions surfaced)\s*$/i;
+const UNVERIFIED_MARKER = /\[UNVERIFIED\]|verify after|needs verification/i;
+const OWNER_DUE = /Owner:\s*@[\w-]+[\s\S]{0,120}Due:\s*\d{4}-\d{2}-\d{2}/i;
+const FIX_CLAIM = /\b(fix applied|now working|is live|deployed successfully)\b/i;
+const MULTI_PHASE = /\bphase\s+[ab12]\b/i;
+const DEP_MATRIX = /\b(depends on:|dependency matrix|blocks:|x blocks y)\b/i;
+const RUNBOOK_HINT = /runbook|deploy(?:ment)? guide/i;
+const SECRETS_PREREQ =
+  /\b(secrets list|prerequisites:|required env|environment variables)\b/i;
+const PROPOSAL_ONLY = /\bPROPOSAL_ONLY\b/i;
+const SCHEMA_LINK = /https?:\/\/[^\s)]+\/(schema|openapi|api-docs)/i;
+
+function advisory(
+  partial: Omit<SubmissionCheckResult, "severity" | "autofix_eligible">,
+): SubmissionCheckResult {
+  return { severity: SEVERITY, autofix_eligible: false, ...partial };
+}
+
+export function suggestionMarkdownFiles(
+  ctx: SubmissionCheckContext,
+): SubmissionFileInfo[] {
+  return ctx.files.filter((file) => {
+    const path = normalizePath(file.filename);
+    if (!/\.md$/i.test(path)) return false;
+    return /agents\/[^/]+\/suggestions\//.test(path) || /\/suggestions\//.test(path);
+  });
+}
+
+function agentFromPath(filePath: string): string | null {
+  const match = normalizePath(filePath).match(/^agents\/([^/]+)\//);
+  return match?.[1] ?? null;
+}
+
+function paragraphs(text: string): string[] {
+  return text
+    .split(/\n\s*\n/)
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0 && !/^#+\s/.test(p));
+}
+
+function extractFileRefs(text: string): string[] {
+  const refs = new Set<string>();
+  const re = new RegExp(FILE_REF.source, FILE_REF.flags);
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) {
+    if (m[1]) refs.add(normalizePath(m[1]));
+  }
+  const backtick = /`((?:src|scripts|supabase|app|agents)\/[a-z0-9_/.-]+\.[a-z]+)`/gi;
+  while ((m = backtick.exec(text)) !== null) {
+    refs.add(normalizePath(m[1]));
+  }
+  return [...refs];
+}
+
+function hasToBeCreatedMarker(text: string, ref: string): boolean {
+  const idx = text.indexOf(ref);
+  if (idx < 0) return false;
+  const window = text.slice(Math.max(0, idx - 80), idx + ref.length + 80);
+  return /to-be-created|to be created|TBD path/i.test(window);
+}
+
+export function detectOutputSizeMin(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const files = suggestionMarkdownFiles(ctx);
+  const short = files.filter((f) => fileContent(f).trim().length < OUTPUT_SIZE_MIN_CHARS);
+  if (short.length === 0) return null;
+  return advisory({
+    code: "output_size_min",
+    title: "Agent output below minimum size",
+    detail: `Suggestion markdown under ${OUTPUT_SIZE_MIN_CHARS} chars (possible model bail-out): ${short.map((f) => f.filename).join(", ")}.`,
+    files: short.map((f) => f.filename),
+    suggested_action: "Expand the proposal with concrete actions and file-level detail.",
+  });
+}
+
+export function detectActionExtractionPresent(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const files = suggestionMarkdownFiles(ctx).filter(
+    (f) => agentFromPath(f.filename) === "coordinator",
+  );
+  const missing: string[] = [];
+  for (const file of files) {
+    const paras = paragraphs(fileContent(file));
+    const bad = paras.filter((p) => !ACTION_SUFFIX.test(p));
+    if (bad.length > 0) missing.push(file.filename);
+  }
+  if (missing.length === 0) return null;
+  return advisory({
+    code: "action_extraction_present",
+    title: "Coordinator paragraph missing action extraction",
+    detail: `Paragraphs should end with "→ @owner" or "— No actions surfaced": ${missing.join(", ")}.`,
+    files: missing,
+    suggested_action: "Add explicit owner routing or a no-actions line per paragraph.",
+  });
+}
+
+export function detectDeltaSectionPresent(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const files = suggestionMarkdownFiles(ctx).filter((f) => {
+    const agent = agentFromPath(f.filename);
+    const path = normalizePath(f.filename);
+    return agent === "knowledge-scout" || /DAILY-INTEL\.md$/i.test(path);
+  });
+  const missing: string[] = [];
+  for (const file of files) {
+    const text = fileContent(file);
+    if (!/## Δ Since Last Sweep/i.test(text) && !/No deltas — quiet sweep/i.test(text)) {
+      missing.push(file.filename);
+    }
+  }
+  if (missing.length === 0) return null;
+  return advisory({
+    code: "delta_section_present",
+    title: "Missing delta section (knowledge-scout)",
+    detail: `Require "## Δ Since Last Sweep" or "No deltas — quiet sweep": ${missing.join(", ")}.`,
+    files: missing,
+    suggested_action: "Add a delta header or explicit quiet-sweep line.",
+  });
+}
+
+export function detectPreambleAbsent(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const hits: string[] = [];
+  for (const file of suggestionMarkdownFiles(ctx)) {
+    const paras = paragraphs(fileContent(file)).slice(0, 2);
+    if (paras.some((p) => PREAMBLE_OPENERS.test(p.split("\n")[0]?.trim() ?? ""))) {
+      hits.push(file.filename);
+    }
+  }
+  if (hits.length === 0) return null;
+  return advisory({
+    code: "preamble_absent",
+    title: "Conversational preamble detected",
+    detail: `Opening paragraphs use session-style preambles: ${hits.join(", ")}.`,
+    files: hits,
+    suggested_action: "Start with structured content, not meta narration.",
+  });
+}
+
+export function detectGraduationSignalsSectionPresent(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const files = suggestionMarkdownFiles(ctx).filter(
+    (f) => agentFromPath(f.filename) === "rd-satellite",
+  );
+  const missing = files
+    .filter((f) => !/## Graduation Signals/i.test(fileContent(f)))
+    .map((f) => f.filename);
+  if (missing.length === 0) return null;
+  return advisory({
+    code: "graduation_signals_section_present",
+    title: "Missing Graduation Signals section",
+    detail: `rd-satellite output requires "## Graduation Signals": ${missing.join(", ")}.`,
+    files: missing,
+    suggested_action: "Add a Graduation Signals section with promotion criteria.",
+  });
+}
+
+export function detectFabricatedIdCheck(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const hits: string[] = [];
+  const ids: string[] = [];
+  for (const file of suggestionMarkdownFiles(ctx)) {
+    const text = fileContent(file);
+    const re = new RegExp(FABRICATED_ID.source, FABRICATED_ID.flags);
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(text)) !== null) {
+      ids.push(m[0]);
+      hits.push(file.filename);
+    }
+  }
+  if (ids.length === 0) return null;
+  return advisory({
+    code: "fabricated_id_check",
+    title: "Suspicious session/run identifiers",
+    detail: `Verify identifiers against agent_runs/tasks/messages: ${[...new Set(ids)].slice(0, 8).join(", ")}.`,
+    files: [...new Set(hits)],
+    suggested_action: "Replace fabricated IDs with verified references or remove them.",
+  });
+}
+
+export function detectSessionNarrativeDetection(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const hits: string[] = [];
+  let total = 0;
+  for (const file of suggestionMarkdownFiles(ctx)) {
+    const text = fileContent(file);
+    const re = new RegExp(SESSION_NARRATIVE.source, SESSION_NARRATIVE.flags);
+    const matches = text.match(re);
+    if (matches && matches.length > 0) {
+      total += matches.length;
+      hits.push(file.filename);
+    }
+  }
+  if (total < NARRATIVE_MATCH_THRESHOLD) return null;
+  return advisory({
+    code: "session_narrative_detection",
+    title: "Session narrative instead of file content",
+    detail: `${total} first-person session phrases across ${hits.join(", ")}.`,
+    files: hits,
+    suggested_action: "Replace narration with concrete diffs, paths, and commands.",
+  });
+}
+
+export function detectIncompletenessSelfFlag(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const hits: string[] = [];
+  for (const file of suggestionMarkdownFiles(ctx)) {
+    const text = fileContent(file);
+    if (PARTIAL_COMPLETION.test(text) && !INCOMPLETE_MARKER.test(text)) {
+      hits.push(file.filename);
+    }
+  }
+  if (hits.length === 0) return null;
+  return advisory({
+    code: "incompleteness_self_flag",
+    title: "Partial completion without INCOMPLETE marker",
+    detail: `Fractional completion hints require INCOMPLETE/PARTIAL flag: ${hits.join(", ")}.`,
+    files: hits,
+    suggested_action: 'Add an explicit "INCOMPLETE" or "PARTIAL" marker for scoped work.',
+  });
+}
+
+export function detectReferencedFilesExist(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const missing: string[] = [];
+  for (const file of suggestionMarkdownFiles(ctx)) {
+    const text = fileContent(file);
+    for (const ref of extractFileRefs(text)) {
+      const inPr =
+        ctx.prPaths.has(ref) || [...ctx.prPaths].some((p) => p.endsWith(`/${ref}`));
+      if (!inPr && !hasToBeCreatedMarker(text, ref)) {
+        missing.push(`${file.filename}: ${ref}`);
+      }
+    }
+  }
+  if (missing.length === 0) return null;
+  return advisory({
+    code: "referenced_files_exist",
+    title: "Referenced path not in PR",
+    detail: missing.slice(0, 12).join("; "),
+    files: missing.map((m) => m.split(": ")[0] ?? m),
+    suggested_action: 'Include the file in the PR or mark adjacent "to-be-created".',
+  });
+}
+
+export function detectPrerequisiteSecretsCheck(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const hits: string[] = [];
+  for (const file of suggestionMarkdownFiles(ctx)) {
+    const path = normalizePath(file.filename);
+    const text = fileContent(file);
+    const titleLine = text.split("\n").find((l) => /^#\s/.test(l)) ?? "";
+    if (!RUNBOOK_HINT.test(`${path} ${titleLine}`)) continue;
+    const head = text.split("\n").slice(0, 30).join("\n");
+    if (!SECRETS_PREREQ.test(head)) hits.push(file.filename);
+  }
+  if (hits.length === 0) return null;
+  return advisory({
+    code: "prerequisite_secrets_check",
+    title: "Runbook missing secrets prerequisite step",
+    detail: `First 30 lines should include secrets/env prerequisites: ${hits.join(", ")}.`,
+    files: hits,
+    suggested_action: "Open runbooks with Prerequisites or `secrets list` verification.",
+  });
+}
+
+export function detectDependencyDagValidation(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const hits: string[] = [];
+  for (const file of suggestionMarkdownFiles(ctx)) {
+    const text = fileContent(file);
+    const phases = (text.match(/\bphase\s+[ab12]\b/gi) ?? []).length;
+    if (phases >= 2 && !DEP_MATRIX.test(text)) {
+      hits.push(file.filename);
+    }
+  }
+  if (hits.length === 0) return null;
+  return advisory({
+    code: "dependency_dag_validation",
+    title: "Multi-phase plan missing dependency matrix",
+    detail: `Multi-phase proposals need Depends on / blocks lines: ${hits.join(", ")}.`,
+    files: hits,
+    suggested_action: "Add explicit phase dependencies (X blocks Y).",
+  });
+}
+
+export function detectUncommittedFixCheck(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const hits: string[] = [];
+  for (const file of suggestionMarkdownFiles(ctx)) {
+    if (FIX_CLAIM.test(fileContent(file))) hits.push(file.filename);
+  }
+  if (hits.length === 0) return null;
+  return advisory({
+    code: "uncommitted_fix_check",
+    title: "Fix claim requires commit verification",
+    detail: `Claims like "fix applied" / "now working" need matching git history: ${hits.join(", ")}.`,
+    files: hits,
+    suggested_action:
+      "Reference the commit SHA or flag changes as on-disk pending commit.",
+  });
+}
+
+export function detectVerificationOwnerAssigned(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const hits: string[] = [];
+  for (const file of suggestionMarkdownFiles(ctx)) {
+    const lines = fileContent(file).split("\n");
+    for (let i = 0; i < lines.length; i++) {
+      if (!UNVERIFIED_MARKER.test(lines[i] ?? "")) continue;
+      const window = lines.slice(i, i + 6).join("\n");
+      if (!OWNER_DUE.test(window)) {
+        hits.push(file.filename);
+        break;
+      }
+    }
+  }
+  if (hits.length === 0) return null;
+  return advisory({
+    code: "verification_owner_assigned",
+    title: "UNVERIFIED item missing owner and due date",
+    detail: `Add Owner: @user and Due: YYYY-MM-DD near unverified items: ${[...new Set(hits)].join(", ")}.`,
+    files: [...new Set(hits)],
+    suggested_action: "Assign verification owner and due date for each UNVERIFIED line.",
+  });
+}
+
+export function detectExternalInterfaceValidation(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const hits: string[] = [];
+  for (const file of suggestionMarkdownFiles(ctx)) {
+    const path = normalizePath(file.filename);
+    const crossRepo = /suggestions\/(?!komatik-agents)[^/]+\//.test(path);
+    if (!crossRepo) continue;
+    const text = fileContent(file);
+    if (!PROPOSAL_ONLY.test(text) && !SCHEMA_LINK.test(text)) {
+      hits.push(file.filename);
+    }
+  }
+  if (hits.length === 0) return null;
+  return advisory({
+    code: "external_interface_validation",
+    title: "Cross-repo proposal lacks schema verification",
+    detail: `Cross-repo suggestions need PROPOSAL_ONLY or verified schema link: ${hits.join(", ")}.`,
+    files: hits,
+    suggested_action: "Link verified target schema or mark PROPOSAL_ONLY.",
+  });
+}
+
+export function runPhase0Detectors(ctx: SubmissionCheckContext): SubmissionCheckResult[] {
+  if (suggestionMarkdownFiles(ctx).length === 0) return [];
+  const checks = [
+    detectOutputSizeMin,
+    detectActionExtractionPresent,
+    detectDeltaSectionPresent,
+    detectPreambleAbsent,
+    detectGraduationSignalsSectionPresent,
+    detectFabricatedIdCheck,
+    detectSessionNarrativeDetection,
+    detectIncompletenessSelfFlag,
+    detectReferencedFilesExist,
+    detectPrerequisiteSecretsCheck,
+    detectDependencyDagValidation,
+    detectUncommittedFixCheck,
+    detectVerificationOwnerAssigned,
+    detectExternalInterfaceValidation,
+  ];
+  return checks
+    .map((fn) => fn(ctx))
+    .filter((check): check is SubmissionCheckResult => check !== null);
+}

--- a/mcp/src/submission-checks/phase0-detectors.ts
+++ b/mcp/src/submission-checks/phase0-detectors.ts
@@ -22,7 +22,7 @@ const ACTION_SUFFIX = /(?:→\s*@[\w-]+|— No actions surfaced)\s*$/i;
 const UNVERIFIED_MARKER = /\[UNVERIFIED\]|verify after|needs verification/i;
 const OWNER_DUE = /Owner:\s*@[\w-]+[\s\S]{0,120}Due:\s*\d{4}-\d{2}-\d{2}/i;
 const FIX_CLAIM = /\b(fix applied|now working|is live|deployed successfully)\b/i;
-const MULTI_PHASE = /\bphase\s+[ab12]\b/i;
+const MULTI_PHASE = /\bphase\s+[ab12]\b/gi;
 const DEP_MATRIX = /\b(depends on:|dependency matrix|blocks:|x blocks y)\b/i;
 const RUNBOOK_HINT = /runbook|deploy(?:ment)? guide/i;
 const SECRETS_PREREQ =
@@ -300,7 +300,7 @@ export function detectDependencyDagValidation(
   const hits: string[] = [];
   for (const file of suggestionMarkdownFiles(ctx)) {
     const text = fileContent(file);
-    const phases = (text.match(/\bphase\s+[ab12]\b/gi) ?? []).length;
+    const phases = (text.match(MULTI_PHASE) ?? []).length;
     if (phases >= 2 && !DEP_MATRIX.test(text)) {
       hits.push(file.filename);
     }

--- a/mcp/src/submission-engine.ts
+++ b/mcp/src/submission-engine.ts
@@ -10,7 +10,7 @@ import type { RepoConfig, SubmissionCheckResult } from "./types.js";
 export type { SubmissionFileInfo } from "./submission-checks/types.js";
 export type { SubmissionCheckCode, SubmissionCheckResult } from "./types.js";
 
-/** All Gate 1 check codes — keep in sync with A8 fixture manifest. */
+/** Gate 1 + Phase 0 submission check codes — keep in sync with A8 fixture manifest. */
 export const SUBMISSION_CHECK_CODES = SubmissionCheckCode.options;
 
 const DEFAULT_STALE_TERMS = ["deployguard", "DeployGuard"];

--- a/src/__tests__/fixtures/agent-failures/manifest.json
+++ b/src/__tests__/fixtures/agent-failures/manifest.json
@@ -26,7 +26,21 @@
     "external_package_deps",
     "sql_syntax_basic",
     "large_file",
-    "soul_integrity"
+    "soul_integrity",
+    "output_size_min",
+    "action_extraction_present",
+    "delta_section_present",
+    "preamble_absent",
+    "graduation_signals_section_present",
+    "fabricated_id_check",
+    "session_narrative_detection",
+    "incompleteness_self_flag",
+    "referenced_files_exist",
+    "prerequisite_secrets_check",
+    "dependency_dag_validation",
+    "uncommitted_fix_check",
+    "verification_owner_assigned",
+    "external_interface_validation"
   ],
   "coveredRiskFactors": [
     "test_coverage",

--- a/src/__tests__/phase0-detectors.test.ts
+++ b/src/__tests__/phase0-detectors.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import { runSubmissionGate } from "../submission-engine.js";
+import {
+  detectActionExtractionPresent,
+  detectOutputSizeMin,
+  detectPreambleAbsent,
+} from "../submission-checks/phase0-detectors.js";
+import type { SubmissionCheckContext } from "../submission-checks/types.js";
+import { prPathSet } from "../submission-checks/helpers.js";
+
+function ctx(
+  files: Array<{ filename: string; content?: string; patch?: string }>,
+): SubmissionCheckContext {
+  const normalized = files.map((f) => ({
+    filename: f.filename,
+    content: f.content,
+    patch: f.patch,
+  }));
+  return {
+    files: normalized,
+    prPaths: prPathSet(normalized),
+    komatikInstance: true,
+    staleTerms: [],
+    authRouteAllowlist: [],
+    maxFileLines: 1000,
+    declaredPackages: new Set(),
+  };
+}
+
+describe("phase0 submission detectors", () => {
+  it("flags short coordinator suggestion output", () => {
+    const check = detectOutputSizeMin(
+      ctx([
+        {
+          filename: "agents/coordinator/suggestions/2026-05-28.md",
+          content: "Brief note only.",
+        },
+      ]),
+    );
+    expect(check?.code).toBe("output_size_min");
+    expect(check?.severity).toBe("advisory");
+  });
+
+  it("flags coordinator paragraphs without action extraction", () => {
+    const check = detectActionExtractionPresent(
+      ctx([
+        {
+          filename: "agents/coordinator/suggestions/brief.md",
+          content:
+            "## Summary\n\nPipeline health is stable.\n\n## Follow-ups\n\nReview open PRs tomorrow.",
+        },
+      ]),
+    );
+    expect(check?.code).toBe("action_extraction_present");
+  });
+
+  it("passes coordinator when paragraphs end with owner routing", () => {
+    const check = detectActionExtractionPresent(
+      ctx([
+        {
+          filename: "agents/coordinator/suggestions/brief.md",
+          content:
+            "Pipeline stable. → @pipeline-ops\n\nNo blockers. — No actions surfaced",
+        },
+      ]),
+    );
+    expect(check).toBeNull();
+  });
+
+  it("flags conversational preambles", () => {
+    const check = detectPreambleAbsent(
+      ctx([
+        {
+          filename: "agents/frontend-dev/suggestions/ui.md",
+          content:
+            "Let me analyze the navigation regression.\n\n## Fix\n\nUpdate the header.",
+        },
+      ]),
+    );
+    expect(check?.code).toBe("preamble_absent");
+  });
+
+  it("integrates phase0 checks via runSubmissionGate for suggestion paths", () => {
+    const checks = runSubmissionGate({
+      komatikInstance: true,
+      files: [
+        {
+          filename: "agents/knowledge-scout/suggestions/DAILY-INTEL.md",
+          content: "Let me summarize today.\n\nNo delta header here.",
+        },
+      ],
+    });
+    expect(checks.some((c) => c.code === "preamble_absent")).toBe(true);
+    expect(checks.some((c) => c.code === "delta_section_present")).toBe(true);
+    expect(
+      checks.every((c) => c.severity !== "blocking" || !c.code.startsWith("output")),
+    ).toBe(true);
+  });
+
+  it("skips phase0 on non-suggestion markdown", () => {
+    const checks = runSubmissionGate({
+      files: [{ filename: "README.md", content: "Let me explain this project." }],
+    });
+    expect(checks.some((c) => c.code === "preamble_absent")).toBe(false);
+  });
+});

--- a/src/submission-checks/detectors.ts
+++ b/src/submission-checks/detectors.ts
@@ -11,6 +11,7 @@ import {
   normalizePath,
   scanAddedContent,
 } from "./helpers.js";
+import { runPhase0Detectors } from "./phase0-detectors.js";
 
 export const OLD_NAME_PATTERNS: Array<{
   oldName: string;
@@ -611,7 +612,7 @@ export function detectSoulIntegrity(
 }
 
 export function runAllDetectors(ctx: SubmissionCheckContext): SubmissionCheckResult[] {
-  const checks = [
+  const gate1 = [
     detectMockPlaceholder(ctx),
     detectSecrets(ctx),
     detectDestructiveSql(ctx),
@@ -627,6 +628,7 @@ export function runAllDetectors(ctx: SubmissionCheckContext): SubmissionCheckRes
     detectContextFreshness(ctx),
     detectSoulIntegrity(ctx),
     detectPathFormat(ctx),
-  ];
-  return checks.filter((check): check is SubmissionCheckResult => check !== null);
+  ].filter((check): check is SubmissionCheckResult => check !== null);
+
+  return [...gate1, ...runPhase0Detectors(ctx)];
 }

--- a/src/submission-checks/phase0-detectors.ts
+++ b/src/submission-checks/phase0-detectors.ts
@@ -1,0 +1,405 @@
+// Phase 0 agent suggestion checks (weight=0 / advisory in Trailhead).
+// Ported from komatik-agents agent-gate-checks Phase 0 stubs with real heuristics.
+
+import type { SubmissionCheckResult } from "../types.js";
+import type { SubmissionCheckContext, SubmissionFileInfo } from "./types.js";
+import { fileContent, normalizePath } from "./helpers.js";
+
+const SEVERITY = "advisory" as const;
+const OUTPUT_SIZE_MIN_CHARS = 400;
+const NARRATIVE_MATCH_THRESHOLD = 3;
+
+const PREAMBLE_OPENERS =
+  /^(let me|here is the|here's the|i('| wi)ll|after reviewing|to start|based on my analysis)/i;
+const SESSION_NARRATIVE =
+  /\bI (queried|reviewed|checked|will (build|create|fix|implement|add|update))/gi;
+const PARTIAL_COMPLETION = /\b\d+\s*(?:\/|of)\s*\d+\b/i;
+const INCOMPLETE_MARKER = /\b(INCOMPLETE|PARTIAL)\b/i;
+const FABRICATED_ID = /\b(session|run|task|message)[-_]?[a-f0-9]{6,}\b/gi;
+const FILE_REF =
+  /(?:^|[\s('"`])((?:src|scripts|supabase|app|agents)\/[a-z0-9_/.-]+\.(?:ts|tsx|js|mjs|sql|py|md))/gi;
+const ACTION_SUFFIX = /(?:→\s*@[\w-]+|— No actions surfaced)\s*$/i;
+const UNVERIFIED_MARKER = /\[UNVERIFIED\]|verify after|needs verification/i;
+const OWNER_DUE = /Owner:\s*@[\w-]+[\s\S]{0,120}Due:\s*\d{4}-\d{2}-\d{2}/i;
+const FIX_CLAIM = /\b(fix applied|now working|is live|deployed successfully)\b/i;
+const MULTI_PHASE = /\bphase\s+[ab12]\b/i;
+const DEP_MATRIX = /\b(depends on:|dependency matrix|blocks:|x blocks y)\b/i;
+const RUNBOOK_HINT = /runbook|deploy(?:ment)? guide/i;
+const SECRETS_PREREQ =
+  /\b(secrets list|prerequisites:|required env|environment variables)\b/i;
+const PROPOSAL_ONLY = /\bPROPOSAL_ONLY\b/i;
+const SCHEMA_LINK = /https?:\/\/[^\s)]+\/(schema|openapi|api-docs)/i;
+
+function advisory(
+  partial: Omit<SubmissionCheckResult, "severity" | "autofix_eligible">,
+): SubmissionCheckResult {
+  return { severity: SEVERITY, autofix_eligible: false, ...partial };
+}
+
+export function suggestionMarkdownFiles(
+  ctx: SubmissionCheckContext,
+): SubmissionFileInfo[] {
+  return ctx.files.filter((file) => {
+    const path = normalizePath(file.filename);
+    if (!/\.md$/i.test(path)) return false;
+    return /agents\/[^/]+\/suggestions\//.test(path) || /\/suggestions\//.test(path);
+  });
+}
+
+function agentFromPath(filePath: string): string | null {
+  const match = normalizePath(filePath).match(/^agents\/([^/]+)\//);
+  return match?.[1] ?? null;
+}
+
+function paragraphs(text: string): string[] {
+  return text
+    .split(/\n\s*\n/)
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0 && !/^#+\s/.test(p));
+}
+
+function extractFileRefs(text: string): string[] {
+  const refs = new Set<string>();
+  const re = new RegExp(FILE_REF.source, FILE_REF.flags);
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) {
+    if (m[1]) refs.add(normalizePath(m[1]));
+  }
+  const backtick = /`((?:src|scripts|supabase|app|agents)\/[a-z0-9_/.-]+\.[a-z]+)`/gi;
+  while ((m = backtick.exec(text)) !== null) {
+    refs.add(normalizePath(m[1]));
+  }
+  return [...refs];
+}
+
+function hasToBeCreatedMarker(text: string, ref: string): boolean {
+  const idx = text.indexOf(ref);
+  if (idx < 0) return false;
+  const window = text.slice(Math.max(0, idx - 80), idx + ref.length + 80);
+  return /to-be-created|to be created|TBD path/i.test(window);
+}
+
+export function detectOutputSizeMin(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const files = suggestionMarkdownFiles(ctx);
+  const short = files.filter((f) => fileContent(f).trim().length < OUTPUT_SIZE_MIN_CHARS);
+  if (short.length === 0) return null;
+  return advisory({
+    code: "output_size_min",
+    title: "Agent output below minimum size",
+    detail: `Suggestion markdown under ${OUTPUT_SIZE_MIN_CHARS} chars (possible model bail-out): ${short.map((f) => f.filename).join(", ")}.`,
+    files: short.map((f) => f.filename),
+    suggested_action: "Expand the proposal with concrete actions and file-level detail.",
+  });
+}
+
+export function detectActionExtractionPresent(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const files = suggestionMarkdownFiles(ctx).filter(
+    (f) => agentFromPath(f.filename) === "coordinator",
+  );
+  const missing: string[] = [];
+  for (const file of files) {
+    const paras = paragraphs(fileContent(file));
+    const bad = paras.filter((p) => !ACTION_SUFFIX.test(p));
+    if (bad.length > 0) missing.push(file.filename);
+  }
+  if (missing.length === 0) return null;
+  return advisory({
+    code: "action_extraction_present",
+    title: "Coordinator paragraph missing action extraction",
+    detail: `Paragraphs should end with "→ @owner" or "— No actions surfaced": ${missing.join(", ")}.`,
+    files: missing,
+    suggested_action: "Add explicit owner routing or a no-actions line per paragraph.",
+  });
+}
+
+export function detectDeltaSectionPresent(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const files = suggestionMarkdownFiles(ctx).filter((f) => {
+    const agent = agentFromPath(f.filename);
+    const path = normalizePath(f.filename);
+    return agent === "knowledge-scout" || /DAILY-INTEL\.md$/i.test(path);
+  });
+  const missing: string[] = [];
+  for (const file of files) {
+    const text = fileContent(file);
+    if (!/## Δ Since Last Sweep/i.test(text) && !/No deltas — quiet sweep/i.test(text)) {
+      missing.push(file.filename);
+    }
+  }
+  if (missing.length === 0) return null;
+  return advisory({
+    code: "delta_section_present",
+    title: "Missing delta section (knowledge-scout)",
+    detail: `Require "## Δ Since Last Sweep" or "No deltas — quiet sweep": ${missing.join(", ")}.`,
+    files: missing,
+    suggested_action: "Add a delta header or explicit quiet-sweep line.",
+  });
+}
+
+export function detectPreambleAbsent(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const hits: string[] = [];
+  for (const file of suggestionMarkdownFiles(ctx)) {
+    const paras = paragraphs(fileContent(file)).slice(0, 2);
+    if (paras.some((p) => PREAMBLE_OPENERS.test(p.split("\n")[0]?.trim() ?? ""))) {
+      hits.push(file.filename);
+    }
+  }
+  if (hits.length === 0) return null;
+  return advisory({
+    code: "preamble_absent",
+    title: "Conversational preamble detected",
+    detail: `Opening paragraphs use session-style preambles: ${hits.join(", ")}.`,
+    files: hits,
+    suggested_action: "Start with structured content, not meta narration.",
+  });
+}
+
+export function detectGraduationSignalsSectionPresent(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const files = suggestionMarkdownFiles(ctx).filter(
+    (f) => agentFromPath(f.filename) === "rd-satellite",
+  );
+  const missing = files
+    .filter((f) => !/## Graduation Signals/i.test(fileContent(f)))
+    .map((f) => f.filename);
+  if (missing.length === 0) return null;
+  return advisory({
+    code: "graduation_signals_section_present",
+    title: "Missing Graduation Signals section",
+    detail: `rd-satellite output requires "## Graduation Signals": ${missing.join(", ")}.`,
+    files: missing,
+    suggested_action: "Add a Graduation Signals section with promotion criteria.",
+  });
+}
+
+export function detectFabricatedIdCheck(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const hits: string[] = [];
+  const ids: string[] = [];
+  for (const file of suggestionMarkdownFiles(ctx)) {
+    const text = fileContent(file);
+    const re = new RegExp(FABRICATED_ID.source, FABRICATED_ID.flags);
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(text)) !== null) {
+      ids.push(m[0]);
+      hits.push(file.filename);
+    }
+  }
+  if (ids.length === 0) return null;
+  return advisory({
+    code: "fabricated_id_check",
+    title: "Suspicious session/run identifiers",
+    detail: `Verify identifiers against agent_runs/tasks/messages: ${[...new Set(ids)].slice(0, 8).join(", ")}.`,
+    files: [...new Set(hits)],
+    suggested_action: "Replace fabricated IDs with verified references or remove them.",
+  });
+}
+
+export function detectSessionNarrativeDetection(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const hits: string[] = [];
+  let total = 0;
+  for (const file of suggestionMarkdownFiles(ctx)) {
+    const text = fileContent(file);
+    const re = new RegExp(SESSION_NARRATIVE.source, SESSION_NARRATIVE.flags);
+    const matches = text.match(re);
+    if (matches && matches.length > 0) {
+      total += matches.length;
+      hits.push(file.filename);
+    }
+  }
+  if (total < NARRATIVE_MATCH_THRESHOLD) return null;
+  return advisory({
+    code: "session_narrative_detection",
+    title: "Session narrative instead of file content",
+    detail: `${total} first-person session phrases across ${hits.join(", ")}.`,
+    files: hits,
+    suggested_action: "Replace narration with concrete diffs, paths, and commands.",
+  });
+}
+
+export function detectIncompletenessSelfFlag(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const hits: string[] = [];
+  for (const file of suggestionMarkdownFiles(ctx)) {
+    const text = fileContent(file);
+    if (PARTIAL_COMPLETION.test(text) && !INCOMPLETE_MARKER.test(text)) {
+      hits.push(file.filename);
+    }
+  }
+  if (hits.length === 0) return null;
+  return advisory({
+    code: "incompleteness_self_flag",
+    title: "Partial completion without INCOMPLETE marker",
+    detail: `Fractional completion hints require INCOMPLETE/PARTIAL flag: ${hits.join(", ")}.`,
+    files: hits,
+    suggested_action: 'Add an explicit "INCOMPLETE" or "PARTIAL" marker for scoped work.',
+  });
+}
+
+export function detectReferencedFilesExist(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const missing: string[] = [];
+  for (const file of suggestionMarkdownFiles(ctx)) {
+    const text = fileContent(file);
+    for (const ref of extractFileRefs(text)) {
+      const inPr =
+        ctx.prPaths.has(ref) || [...ctx.prPaths].some((p) => p.endsWith(`/${ref}`));
+      if (!inPr && !hasToBeCreatedMarker(text, ref)) {
+        missing.push(`${file.filename}: ${ref}`);
+      }
+    }
+  }
+  if (missing.length === 0) return null;
+  return advisory({
+    code: "referenced_files_exist",
+    title: "Referenced path not in PR",
+    detail: missing.slice(0, 12).join("; "),
+    files: missing.map((m) => m.split(": ")[0] ?? m),
+    suggested_action: 'Include the file in the PR or mark adjacent "to-be-created".',
+  });
+}
+
+export function detectPrerequisiteSecretsCheck(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const hits: string[] = [];
+  for (const file of suggestionMarkdownFiles(ctx)) {
+    const path = normalizePath(file.filename);
+    const text = fileContent(file);
+    const titleLine = text.split("\n").find((l) => /^#\s/.test(l)) ?? "";
+    if (!RUNBOOK_HINT.test(`${path} ${titleLine}`)) continue;
+    const head = text.split("\n").slice(0, 30).join("\n");
+    if (!SECRETS_PREREQ.test(head)) hits.push(file.filename);
+  }
+  if (hits.length === 0) return null;
+  return advisory({
+    code: "prerequisite_secrets_check",
+    title: "Runbook missing secrets prerequisite step",
+    detail: `First 30 lines should include secrets/env prerequisites: ${hits.join(", ")}.`,
+    files: hits,
+    suggested_action: "Open runbooks with Prerequisites or `secrets list` verification.",
+  });
+}
+
+export function detectDependencyDagValidation(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const hits: string[] = [];
+  for (const file of suggestionMarkdownFiles(ctx)) {
+    const text = fileContent(file);
+    const phases = (text.match(/\bphase\s+[ab12]\b/gi) ?? []).length;
+    if (phases >= 2 && !DEP_MATRIX.test(text)) {
+      hits.push(file.filename);
+    }
+  }
+  if (hits.length === 0) return null;
+  return advisory({
+    code: "dependency_dag_validation",
+    title: "Multi-phase plan missing dependency matrix",
+    detail: `Multi-phase proposals need Depends on / blocks lines: ${hits.join(", ")}.`,
+    files: hits,
+    suggested_action: "Add explicit phase dependencies (X blocks Y).",
+  });
+}
+
+export function detectUncommittedFixCheck(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const hits: string[] = [];
+  for (const file of suggestionMarkdownFiles(ctx)) {
+    if (FIX_CLAIM.test(fileContent(file))) hits.push(file.filename);
+  }
+  if (hits.length === 0) return null;
+  return advisory({
+    code: "uncommitted_fix_check",
+    title: "Fix claim requires commit verification",
+    detail: `Claims like "fix applied" / "now working" need matching git history: ${hits.join(", ")}.`,
+    files: hits,
+    suggested_action:
+      "Reference the commit SHA or flag changes as on-disk pending commit.",
+  });
+}
+
+export function detectVerificationOwnerAssigned(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const hits: string[] = [];
+  for (const file of suggestionMarkdownFiles(ctx)) {
+    const lines = fileContent(file).split("\n");
+    for (let i = 0; i < lines.length; i++) {
+      if (!UNVERIFIED_MARKER.test(lines[i] ?? "")) continue;
+      const window = lines.slice(i, i + 6).join("\n");
+      if (!OWNER_DUE.test(window)) {
+        hits.push(file.filename);
+        break;
+      }
+    }
+  }
+  if (hits.length === 0) return null;
+  return advisory({
+    code: "verification_owner_assigned",
+    title: "UNVERIFIED item missing owner and due date",
+    detail: `Add Owner: @user and Due: YYYY-MM-DD near unverified items: ${[...new Set(hits)].join(", ")}.`,
+    files: [...new Set(hits)],
+    suggested_action: "Assign verification owner and due date for each UNVERIFIED line.",
+  });
+}
+
+export function detectExternalInterfaceValidation(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const hits: string[] = [];
+  for (const file of suggestionMarkdownFiles(ctx)) {
+    const path = normalizePath(file.filename);
+    const crossRepo = /suggestions\/(?!komatik-agents)[^/]+\//.test(path);
+    if (!crossRepo) continue;
+    const text = fileContent(file);
+    if (!PROPOSAL_ONLY.test(text) && !SCHEMA_LINK.test(text)) {
+      hits.push(file.filename);
+    }
+  }
+  if (hits.length === 0) return null;
+  return advisory({
+    code: "external_interface_validation",
+    title: "Cross-repo proposal lacks schema verification",
+    detail: `Cross-repo suggestions need PROPOSAL_ONLY or verified schema link: ${hits.join(", ")}.`,
+    files: hits,
+    suggested_action: "Link verified target schema or mark PROPOSAL_ONLY.",
+  });
+}
+
+export function runPhase0Detectors(ctx: SubmissionCheckContext): SubmissionCheckResult[] {
+  if (suggestionMarkdownFiles(ctx).length === 0) return [];
+  const checks = [
+    detectOutputSizeMin,
+    detectActionExtractionPresent,
+    detectDeltaSectionPresent,
+    detectPreambleAbsent,
+    detectGraduationSignalsSectionPresent,
+    detectFabricatedIdCheck,
+    detectSessionNarrativeDetection,
+    detectIncompletenessSelfFlag,
+    detectReferencedFilesExist,
+    detectPrerequisiteSecretsCheck,
+    detectDependencyDagValidation,
+    detectUncommittedFixCheck,
+    detectVerificationOwnerAssigned,
+    detectExternalInterfaceValidation,
+  ];
+  return checks
+    .map((fn) => fn(ctx))
+    .filter((check): check is SubmissionCheckResult => check !== null);
+}

--- a/src/submission-checks/phase0-detectors.ts
+++ b/src/submission-checks/phase0-detectors.ts
@@ -22,7 +22,7 @@ const ACTION_SUFFIX = /(?:→\s*@[\w-]+|— No actions surfaced)\s*$/i;
 const UNVERIFIED_MARKER = /\[UNVERIFIED\]|verify after|needs verification/i;
 const OWNER_DUE = /Owner:\s*@[\w-]+[\s\S]{0,120}Due:\s*\d{4}-\d{2}-\d{2}/i;
 const FIX_CLAIM = /\b(fix applied|now working|is live|deployed successfully)\b/i;
-const MULTI_PHASE = /\bphase\s+[ab12]\b/i;
+const MULTI_PHASE = /\bphase\s+[ab12]\b/gi;
 const DEP_MATRIX = /\b(depends on:|dependency matrix|blocks:|x blocks y)\b/i;
 const RUNBOOK_HINT = /runbook|deploy(?:ment)? guide/i;
 const SECRETS_PREREQ =
@@ -300,7 +300,7 @@ export function detectDependencyDagValidation(
   const hits: string[] = [];
   for (const file of suggestionMarkdownFiles(ctx)) {
     const text = fileContent(file);
-    const phases = (text.match(/\bphase\s+[ab12]\b/gi) ?? []).length;
+    const phases = (text.match(MULTI_PHASE) ?? []).length;
     if (phases >= 2 && !DEP_MATRIX.test(text)) {
       hits.push(file.filename);
     }

--- a/src/submission-engine.ts
+++ b/src/submission-engine.ts
@@ -10,7 +10,7 @@ import type { RepoConfig, SubmissionCheckResult } from "./types.js";
 export type { SubmissionFileInfo } from "./submission-checks/types.js";
 export type { SubmissionCheckCode, SubmissionCheckResult } from "./types.js";
 
-/** All Gate 1 check codes — keep in sync with A8 fixture manifest. */
+/** Gate 1 + Phase 0 submission check codes — keep in sync with A8 fixture manifest. */
 export const SUBMISSION_CHECK_CODES = SubmissionCheckCode.options;
 
 const DEFAULT_STALE_TERMS = ["deployguard", "DeployGuard"];

--- a/src/types.ts
+++ b/src/types.ts
@@ -111,6 +111,21 @@ export const SubmissionCheckCode = z.enum([
   "sql_syntax_basic",
   "large_file",
   "soul_integrity",
+  // Phase 0 — agent suggestion quality (advisory / weight=0 in komatik-agents)
+  "output_size_min",
+  "action_extraction_present",
+  "delta_section_present",
+  "preamble_absent",
+  "graduation_signals_section_present",
+  "fabricated_id_check",
+  "session_narrative_detection",
+  "incompleteness_self_flag",
+  "referenced_files_exist",
+  "prerequisite_secrets_check",
+  "dependency_dag_validation",
+  "uncommitted_fix_check",
+  "verification_owner_assigned",
+  "external_interface_validation",
 ]);
 export type SubmissionCheckCode = z.infer<typeof SubmissionCheckCode>;
 


### PR DESCRIPTION
## Summary
- Port 14 komatik-agents Phase 0 suggestion checks into the shared submission engine as **advisory** (measurement-only) heuristics on `agents/*/suggestions/**/*.md`
- Extend `SubmissionCheckCode` to 29 codes and sync A8 fixture manifest
- Add MCP Phase B parity tools: `validate-submission`, `apply-autofix`, `get-trust-score` (26 tools total)
- Prebuild copies updated for `app/` and `mcp/` submission-checks

## Test plan
- [x] `npm test` — 672 tests pass (includes `phase0-detectors.test.ts`)
- [x] `node scripts/copy-shared-src.mjs mcp && cd mcp && npx tsc --noEmit`
- [ ] CI green on PR
- [ ] Spot-check `validate-submission` via MCP on a komatik-agents suggestion markdown fixture


Made with [Cursor](https://cursor.com)