### PR TITLE
fix(submission): Phase-0 precision — referenced_files_exist + session_narrative

### DIFF
--- a/app/src/submission-checks/phase0-detectors.ts
+++ b/app/src/submission-checks/phase0-detectors.ts
@@ -213,16 +213,19 @@ export function detectSessionNarrativeDetection(
     const text = fileContent(file);
     const re = new RegExp(SESSION_NARRATIVE.source, SESSION_NARRATIVE.flags);
     const matches = text.match(re);
-    if (matches && matches.length > 0) {
+    // Per-file threshold: flag a single document dense with first-person
+    // session narration, not a cumulative count that a large multi-file
+    // submission would trip just by volume.
+    if (matches && matches.length >= NARRATIVE_MATCH_THRESHOLD) {
       total += matches.length;
       hits.push(file.filename);
     }
   }
-  if (total < NARRATIVE_MATCH_THRESHOLD) return null;
+  if (hits.length === 0) return null;
   return advisory({
     code: "session_narrative_detection",
     title: "Session narrative instead of file content",
-    detail: `${total} first-person session phrases across ${hits.join(", ")}.`,
+    detail: `${total} first-person session phrases in ${hits.join(", ")}.`,
     files: hits,
     suggested_action: "Replace narration with concrete diffs, paths, and commands.",
   });
@@ -251,13 +254,21 @@ export function detectIncompletenessSelfFlag(
 export function detectReferencedFilesExist(
   ctx: SubmissionCheckContext,
 ): SubmissionCheckResult | null {
+  // Needs a repo file listing to tell a fabricated path from a reference to an
+  // existing, unchanged file. Without it, stay dormant — flagging every path
+  // that merely isn't part of this PR is almost all false positives.
+  if (!ctx.repoPaths) return null;
+  const repoPaths = ctx.repoPaths;
   const missing: string[] = [];
   for (const file of suggestionMarkdownFiles(ctx)) {
     const text = fileContent(file);
     for (const ref of extractFileRefs(text)) {
-      const inPr =
-        ctx.prPaths.has(ref) || [...ctx.prPaths].some((p) => p.endsWith(`/${ref}`));
-      if (!inPr && !hasToBeCreatedMarker(text, ref)) {
+      const known =
+        ctx.prPaths.has(ref) ||
+        repoPaths.has(ref) ||
+        [...ctx.prPaths].some((p) => p.endsWith(`/${ref}`)) ||
+        [...repoPaths].some((p) => p.endsWith(`/${ref}`));
+      if (!known && !hasToBeCreatedMarker(text, ref)) {
         missing.push(`${file.filename}: ${ref}`);
       }
     }
@@ -265,7 +276,7 @@ export function detectReferencedFilesExist(
   if (missing.length === 0) return null;
   return advisory({
     code: "referenced_files_exist",
-    title: "Referenced path not in PR",
+    title: "Referenced path missing from PR and repo",
     detail: missing.slice(0, 12).join("; "),
     files: missing.map((m) => m.split(": ")[0] ?? m),
     suggested_action: 'Include the file in the PR or mark adjacent "to-be-created".',

--- a/app/src/submission-checks/types.ts
+++ b/app/src/submission-checks/types.ts
@@ -15,4 +15,11 @@ export interface SubmissionCheckContext {
   authRouteAllowlist: string[];
   maxFileLines: number;
   declaredPackages: Set<string>;
+  /**
+   * Full set of paths that exist in the target repo (e.g. `git ls-files`),
+   * used to tell a fabricated reference from a reference to an existing,
+   * unchanged file. When absent, existence-dependent checks stay dormant
+   * rather than flag every path that simply isn't part of this PR.
+   */
+  repoPaths?: Set<string>;
 }

--- a/app/src/submission-engine.ts
+++ b/app/src/submission-engine.ts
@@ -29,6 +29,8 @@ export interface SubmissionEngineOptions {
   mode?: "warn" | "block";
   /** Declared npm package names from root package.json (optional). */
   declaredPackages?: string[];
+  /** Paths that exist in the target repo (e.g. `git ls-files`), optional. */
+  repoPaths?: string[];
 }
 
 function buildContext(options: SubmissionEngineOptions): SubmissionCheckContext {
@@ -47,6 +49,7 @@ function buildContext(options: SubmissionEngineOptions): SubmissionCheckContext 
       repoConfig?.submission?.auth_route_allowlist ?? DEFAULT_AUTH_ROUTE_ALLOWLIST,
     maxFileLines: repoConfig?.submission?.max_file_lines ?? 1000,
     declaredPackages: declared,
+    repoPaths: options.repoPaths ? new Set(options.repoPaths) : undefined,
   };
 }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -42756,17 +42756,20 @@ function detectSessionNarrativeDetection(ctx) {
         const text = fileContent(file);
         const re = new RegExp(SESSION_NARRATIVE.source, SESSION_NARRATIVE.flags);
         const matches = text.match(re);
-        if (matches && matches.length > 0) {
+        // Per-file threshold: flag a single document dense with first-person
+        // session narration, not a cumulative count that a large multi-file
+        // submission would trip just by volume.
+        if (matches && matches.length >= NARRATIVE_MATCH_THRESHOLD) {
             total += matches.length;
             hits.push(file.filename);
         }
     }
-    if (total < NARRATIVE_MATCH_THRESHOLD)
+    if (hits.length === 0)
         return null;
     return advisory({
         code: "session_narrative_detection",
         title: "Session narrative instead of file content",
-        detail: `${total} first-person session phrases across ${hits.join(", ")}.`,
+        detail: `${total} first-person session phrases in ${hits.join(", ")}.`,
         files: hits,
         suggested_action: "Replace narration with concrete diffs, paths, and commands.",
     });
@@ -42790,12 +42793,21 @@ function detectIncompletenessSelfFlag(ctx) {
     });
 }
 function detectReferencedFilesExist(ctx) {
+    // Needs a repo file listing to tell a fabricated path from a reference to an
+    // existing, unchanged file. Without it, stay dormant — flagging every path
+    // that merely isn't part of this PR is almost all false positives.
+    if (!ctx.repoPaths)
+        return null;
+    const repoPaths = ctx.repoPaths;
     const missing = [];
     for (const file of suggestionMarkdownFiles(ctx)) {
         const text = fileContent(file);
         for (const ref of extractFileRefs(text)) {
-            const inPr = ctx.prPaths.has(ref) || [...ctx.prPaths].some((p) => p.endsWith(`/${ref}`));
-            if (!inPr && !hasToBeCreatedMarker(text, ref)) {
+            const known = ctx.prPaths.has(ref) ||
+                repoPaths.has(ref) ||
+                [...ctx.prPaths].some((p) => p.endsWith(`/${ref}`)) ||
+                [...repoPaths].some((p) => p.endsWith(`/${ref}`));
+            if (!known && !hasToBeCreatedMarker(text, ref)) {
                 missing.push(`${file.filename}: ${ref}`);
             }
         }
@@ -42804,7 +42816,7 @@ function detectReferencedFilesExist(ctx) {
         return null;
     return advisory({
         code: "referenced_files_exist",
-        title: "Referenced path not in PR",
+        title: "Referenced path missing from PR and repo",
         detail: missing.slice(0, 12).join("; "),
         files: missing.map((m) => m.split(": ")[0] ?? m),
         suggested_action: 'Include the file in the PR or mark adjacent "to-be-created".',
@@ -43541,6 +43553,7 @@ function buildContext(options) {
         authRouteAllowlist: repoConfig?.submission?.auth_route_allowlist ?? DEFAULT_AUTH_ROUTE_ALLOWLIST,
         maxFileLines: repoConfig?.submission?.max_file_lines ?? 1000,
         declaredPackages: declared,
+        repoPaths: options.repoPaths ? new Set(options.repoPaths) : undefined,
     };
 }
 function runSubmissionGate(options) {

--- a/mcp/src/submission-checks/phase0-detectors.ts
+++ b/mcp/src/submission-checks/phase0-detectors.ts
@@ -213,16 +213,19 @@ export function detectSessionNarrativeDetection(
     const text = fileContent(file);
     const re = new RegExp(SESSION_NARRATIVE.source, SESSION_NARRATIVE.flags);
     const matches = text.match(re);
-    if (matches && matches.length > 0) {
+    // Per-file threshold: flag a single document dense with first-person
+    // session narration, not a cumulative count that a large multi-file
+    // submission would trip just by volume.
+    if (matches && matches.length >= NARRATIVE_MATCH_THRESHOLD) {
       total += matches.length;
       hits.push(file.filename);
     }
   }
-  if (total < NARRATIVE_MATCH_THRESHOLD) return null;
+  if (hits.length === 0) return null;
   return advisory({
     code: "session_narrative_detection",
     title: "Session narrative instead of file content",
-    detail: `${total} first-person session phrases across ${hits.join(", ")}.`,
+    detail: `${total} first-person session phrases in ${hits.join(", ")}.`,
     files: hits,
     suggested_action: "Replace narration with concrete diffs, paths, and commands.",
   });
@@ -251,13 +254,21 @@ export function detectIncompletenessSelfFlag(
 export function detectReferencedFilesExist(
   ctx: SubmissionCheckContext,
 ): SubmissionCheckResult | null {
+  // Needs a repo file listing to tell a fabricated path from a reference to an
+  // existing, unchanged file. Without it, stay dormant — flagging every path
+  // that merely isn't part of this PR is almost all false positives.
+  if (!ctx.repoPaths) return null;
+  const repoPaths = ctx.repoPaths;
   const missing: string[] = [];
   for (const file of suggestionMarkdownFiles(ctx)) {
     const text = fileContent(file);
     for (const ref of extractFileRefs(text)) {
-      const inPr =
-        ctx.prPaths.has(ref) || [...ctx.prPaths].some((p) => p.endsWith(`/${ref}`));
-      if (!inPr && !hasToBeCreatedMarker(text, ref)) {
+      const known =
+        ctx.prPaths.has(ref) ||
+        repoPaths.has(ref) ||
+        [...ctx.prPaths].some((p) => p.endsWith(`/${ref}`)) ||
+        [...repoPaths].some((p) => p.endsWith(`/${ref}`));
+      if (!known && !hasToBeCreatedMarker(text, ref)) {
         missing.push(`${file.filename}: ${ref}`);
       }
     }
@@ -265,7 +276,7 @@ export function detectReferencedFilesExist(
   if (missing.length === 0) return null;
   return advisory({
     code: "referenced_files_exist",
-    title: "Referenced path not in PR",
+    title: "Referenced path missing from PR and repo",
     detail: missing.slice(0, 12).join("; "),
     files: missing.map((m) => m.split(": ")[0] ?? m),
     suggested_action: 'Include the file in the PR or mark adjacent "to-be-created".',

--- a/mcp/src/submission-checks/types.ts
+++ b/mcp/src/submission-checks/types.ts
@@ -15,4 +15,11 @@ export interface SubmissionCheckContext {
   authRouteAllowlist: string[];
   maxFileLines: number;
   declaredPackages: Set<string>;
+  /**
+   * Full set of paths that exist in the target repo (e.g. `git ls-files`),
+   * used to tell a fabricated reference from a reference to an existing,
+   * unchanged file. When absent, existence-dependent checks stay dormant
+   * rather than flag every path that simply isn't part of this PR.
+   */
+  repoPaths?: Set<string>;
 }

--- a/mcp/src/submission-engine.ts
+++ b/mcp/src/submission-engine.ts
@@ -29,6 +29,8 @@ export interface SubmissionEngineOptions {
   mode?: "warn" | "block";
   /** Declared npm package names from root package.json (optional). */
   declaredPackages?: string[];
+  /** Paths that exist in the target repo (e.g. `git ls-files`), optional. */
+  repoPaths?: string[];
 }
 
 function buildContext(options: SubmissionEngineOptions): SubmissionCheckContext {
@@ -47,6 +49,7 @@ function buildContext(options: SubmissionEngineOptions): SubmissionCheckContext 
       repoConfig?.submission?.auth_route_allowlist ?? DEFAULT_AUTH_ROUTE_ALLOWLIST,
     maxFileLines: repoConfig?.submission?.max_file_lines ?? 1000,
     declaredPackages: declared,
+    repoPaths: options.repoPaths ? new Set(options.repoPaths) : undefined,
   };
 }
 

--- a/src/__tests__/phase0-detectors.test.ts
+++ b/src/__tests__/phase0-detectors.test.ts
@@ -4,12 +4,15 @@ import {
   detectActionExtractionPresent,
   detectOutputSizeMin,
   detectPreambleAbsent,
+  detectReferencedFilesExist,
+  detectSessionNarrativeDetection,
 } from "../submission-checks/phase0-detectors.js";
 import type { SubmissionCheckContext } from "../submission-checks/types.js";
 import { prPathSet } from "../submission-checks/helpers.js";
 
 function ctx(
   files: Array<{ filename: string; content?: string; patch?: string }>,
+  repoPaths?: string[],
 ): SubmissionCheckContext {
   const normalized = files.map((f) => ({
     filename: f.filename,
@@ -24,6 +27,7 @@ function ctx(
     authRouteAllowlist: [],
     maxFileLines: 1000,
     declaredPackages: new Set(),
+    repoPaths: repoPaths ? new Set(repoPaths) : undefined,
   };
 }
 
@@ -102,5 +106,60 @@ describe("phase0 submission detectors", () => {
       files: [{ filename: "README.md", content: "Let me explain this project." }],
     });
     expect(checks.some((c) => c.code === "preamble_absent")).toBe(false);
+  });
+
+  describe("referenced_files_exist precision", () => {
+    const fileReferencing = (path: string) => [
+      {
+        filename: "agents/coordinator/suggestions/plan.md",
+        content: `Update the loader in \`${path}\` before the next run.`,
+      },
+    ];
+
+    it("stays dormant without a repo file listing (no false accusation)", () => {
+      const check = detectReferencedFilesExist(ctx(fileReferencing("src/loader.ts")));
+      expect(check).toBeNull();
+    });
+
+    it("passes when the referenced file exists in the repo but not the PR", () => {
+      const check = detectReferencedFilesExist(
+        ctx(fileReferencing("src/loader.ts"), ["src/loader.ts", "src/other.ts"]),
+      );
+      expect(check).toBeNull();
+    });
+
+    it("flags a referenced path absent from both PR and repo", () => {
+      const check = detectReferencedFilesExist(
+        ctx(fileReferencing("src/loader.ts"), ["src/other.ts"]),
+      );
+      expect(check?.code).toBe("referenced_files_exist");
+      expect(check?.severity).toBe("advisory");
+    });
+  });
+
+  describe("session_narrative_detection threshold is per-file", () => {
+    it("flags a single document dense with session narration", () => {
+      const check = detectSessionNarrativeDetection(
+        ctx([
+          {
+            filename: "agents/rd-satellite/suggestions/log.md",
+            content:
+              "I queried the table. I reviewed the diffs. I will implement the fix.",
+          },
+        ]),
+      );
+      expect(check?.code).toBe("session_narrative_detection");
+    });
+
+    it("does not flag narration spread thin across many files", () => {
+      const check = detectSessionNarrativeDetection(
+        ctx([
+          { filename: "agents/a/suggestions/x.md", content: "I queried the table." },
+          { filename: "agents/b/suggestions/y.md", content: "I reviewed the diffs." },
+          { filename: "agents/c/suggestions/z.md", content: "I checked the logs." },
+        ]),
+      );
+      expect(check).toBeNull();
+    });
   });
 });

--- a/src/submission-checks/phase0-detectors.ts
+++ b/src/submission-checks/phase0-detectors.ts
@@ -213,16 +213,19 @@ export function detectSessionNarrativeDetection(
     const text = fileContent(file);
     const re = new RegExp(SESSION_NARRATIVE.source, SESSION_NARRATIVE.flags);
     const matches = text.match(re);
-    if (matches && matches.length > 0) {
+    // Per-file threshold: flag a single document dense with first-person
+    // session narration, not a cumulative count that a large multi-file
+    // submission would trip just by volume.
+    if (matches && matches.length >= NARRATIVE_MATCH_THRESHOLD) {
       total += matches.length;
       hits.push(file.filename);
     }
   }
-  if (total < NARRATIVE_MATCH_THRESHOLD) return null;
+  if (hits.length === 0) return null;
   return advisory({
     code: "session_narrative_detection",
     title: "Session narrative instead of file content",
-    detail: `${total} first-person session phrases across ${hits.join(", ")}.`,
+    detail: `${total} first-person session phrases in ${hits.join(", ")}.`,
     files: hits,
     suggested_action: "Replace narration with concrete diffs, paths, and commands.",
   });
@@ -251,13 +254,21 @@ export function detectIncompletenessSelfFlag(
 export function detectReferencedFilesExist(
   ctx: SubmissionCheckContext,
 ): SubmissionCheckResult | null {
+  // Needs a repo file listing to tell a fabricated path from a reference to an
+  // existing, unchanged file. Without it, stay dormant — flagging every path
+  // that merely isn't part of this PR is almost all false positives.
+  if (!ctx.repoPaths) return null;
+  const repoPaths = ctx.repoPaths;
   const missing: string[] = [];
   for (const file of suggestionMarkdownFiles(ctx)) {
     const text = fileContent(file);
     for (const ref of extractFileRefs(text)) {
-      const inPr =
-        ctx.prPaths.has(ref) || [...ctx.prPaths].some((p) => p.endsWith(`/${ref}`));
-      if (!inPr && !hasToBeCreatedMarker(text, ref)) {
+      const known =
+        ctx.prPaths.has(ref) ||
+        repoPaths.has(ref) ||
+        [...ctx.prPaths].some((p) => p.endsWith(`/${ref}`)) ||
+        [...repoPaths].some((p) => p.endsWith(`/${ref}`));
+      if (!known && !hasToBeCreatedMarker(text, ref)) {
         missing.push(`${file.filename}: ${ref}`);
       }
     }
@@ -265,7 +276,7 @@ export function detectReferencedFilesExist(
   if (missing.length === 0) return null;
   return advisory({
     code: "referenced_files_exist",
-    title: "Referenced path not in PR",
+    title: "Referenced path missing from PR and repo",
     detail: missing.slice(0, 12).join("; "),
     files: missing.map((m) => m.split(": ")[0] ?? m),
     suggested_action: 'Include the file in the PR or mark adjacent "to-be-created".',

--- a/src/submission-checks/types.ts
+++ b/src/submission-checks/types.ts
@@ -15,4 +15,11 @@ export interface SubmissionCheckContext {
   authRouteAllowlist: string[];
   maxFileLines: number;
   declaredPackages: Set<string>;
+  /**
+   * Full set of paths that exist in the target repo (e.g. `git ls-files`),
+   * used to tell a fabricated reference from a reference to an existing,
+   * unchanged file. When absent, existence-dependent checks stay dormant
+   * rather than flag every path that simply isn't part of this PR.
+   */
+  repoPaths?: Set<string>;
 }

--- a/src/submission-engine.ts
+++ b/src/submission-engine.ts
@@ -29,6 +29,8 @@ export interface SubmissionEngineOptions {
   mode?: "warn" | "block";
   /** Declared npm package names from root package.json (optional). */
   declaredPackages?: string[];
+  /** Paths that exist in the target repo (e.g. `git ls-files`), optional. */
+  repoPaths?: string[];
 }
 
 function buildContext(options: SubmissionEngineOptions): SubmissionCheckContext {
@@ -47,6 +49,7 @@ function buildContext(options: SubmissionEngineOptions): SubmissionCheckContext 
       repoConfig?.submission?.auth_route_allowlist ?? DEFAULT_AUTH_ROUTE_ALLOWLIST,
     maxFileLines: repoConfig?.submission?.max_file_lines ?? 1000,
     declaredPackages: declared,
+    repoPaths: options.repoPaths ? new Set(options.repoPaths) : undefined,
   };
 }
 


### PR DESCRIPTION
## What
Two correctness fixes on the advisory Phase-0 submission detectors (the ones added in #246), made now while they're still **weight=0** — before any earns weight in the trust pipeline.

- **`referenced_files_exist`** — was flagging *any* referenced path not in the PR's changed files, so every mention of an existing-but-unchanged repo file was a false positive (the worst precision bug from the #246 review). Now takes an optional `repoPaths` (e.g. `git ls-files`) via `SubmissionCheckContext` / `SubmissionEngineOptions`; a reference counts as known if it's in the PR **or** the repo. Without a repo listing the check stays **dormant** rather than false-accuse.
- **`session_narrative_detection`** — threshold was *cumulative across all files*, so a large legitimate multi-file submission tripped it by volume. Now **per-file** (one document dense with first-person narration).

## Verification
- `npm test` → **677 pass** (672 + 5 new covering both fixes: dormant-without-repoPaths, passes-when-in-repo, flags-when-truly-missing; per-file narration flagged, thin-spread not flagged)
- `npm run typecheck` clean; `dist` rebuilt; `app/` + `mcp/` copies regenerated
- Advisory-only — **no change to any gate block/warn decision**

Part of the submission-systems unification (trailhead = source of truth). Context: memory `project_autonomous_contribution_pipeline`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)