### PR TITLE
fix(submission-checks): phase-1 divergence + artifact_integrity precision

### DIFF
--- a/src/submission-checks/detectors.ts
+++ b/src/submission-checks/detectors.ts
@@ -32,6 +32,10 @@ export const OLD_NAME_PATTERNS: Array<{
   },
   { oldName: "Cognitive Debt", newName: "Drift", pattern: /\bCognitive Debt\b/g },
   { oldName: "cognitive-debt", newName: "Drift", pattern: /\bcognitive-debt\b/g },
+  { oldName: "Undercurrent", newName: "Slipstream", pattern: /\bUndercurrent\b/g },
+  { oldName: "Yggdrasil", newName: "Cairn", pattern: /\bYggdrasil\b/g },
+  { oldName: "Bored", newName: "Lodge", pattern: /\bBored\b/g },
+  { oldName: "Forge", newName: "Pack", pattern: /\bForge\b/g },
 ];
 
 const SLUG_ONLY_PATTERNS = [
@@ -171,20 +175,42 @@ export function detectDestructiveSql(
   });
 }
 
+// Only code files can carry hard file references; prose (.md/.mdx/.txt) merely
+// *mentions* paths and was the dominant artifact_integrity false-positive source.
+const ARTIFACT_CODE_EXTS = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"]);
+// Repo-ubiquitous manifests are referenced everywhere and are never the kind of
+// "hallucinated/missing artifact" this check is meant to catch.
+const ARTIFACT_BARE_IGNORE = new Set([
+  "package.json",
+  "package-lock.json",
+  "tsconfig.json",
+  "readme.md",
+]);
+
 export function detectArtifactIntegrity(
   ctx: SubmissionCheckContext,
 ): SubmissionCheckResult | null {
   const referenced = new Set<string>();
-  const pathRefPattern =
-    /(?:^|\s|['"`])([\w@./-]+\.(?:ts|tsx|js|jsx|md|sql|yml|yaml|json))(?:['"`]|\s|:)/g;
+  // Only treat a path *literal* inside an import/require/export-from statement
+  // as a hard reference — natural-language "see X" / "fix Y" / "update Z" in
+  // prose is not a code dependency (the old prose trigger over-flagged docs).
+  const importRefPattern =
+    /(?:\bimport\b|\bfrom\b|\brequire\s*\(|\bexport\b[^'"`]*\bfrom\b)\s*['"`]([\w@./-]+\.(?:ts|tsx|js|jsx|sql|yml|yaml|json))['"`]/g;
 
   for (const file of ctx.files) {
+    // Prose/doc files only mention paths; never flag them as missing code refs.
+    if (!ARTIFACT_CODE_EXTS.has(extensionOf(file.filename))) continue;
+
     for (const line of addedLines(file.patch)) {
-      if (!/(?:import|from|require|see|fix|update)\s/i.test(line)) continue;
-      for (const match of line.matchAll(pathRefPattern)) {
+      importRefPattern.lastIndex = 0;
+      for (const match of line.matchAll(importRefPattern)) {
         const candidate = match[1]?.replace(/^\.\//, "");
         if (!candidate || candidate.includes("*")) continue;
-        if (!ctx.prPaths.has(candidate) && !candidate.startsWith("node:")) {
+        if (candidate.startsWith("node:")) continue;
+        // Skip bare, repo-ubiquitous manifest names (package.json, etc.).
+        const base = candidate.split("/").pop()?.toLowerCase() ?? "";
+        if (!candidate.includes("/") && ARTIFACT_BARE_IGNORE.has(base)) continue;
+        if (!ctx.prPaths.has(candidate)) {
           referenced.add(candidate);
         }
       }


### PR DESCRIPTION
## Phase 1 — drive legacy↔trailhead gate divergence to 0 + fix the red-lane false-positives

Part of the autonomous-contribution-pipeline cutover (komatik-agents will delegate its Gate-1 content checks to the trailhead CLI). This makes trailhead an exact superset of the legacy JS gate on the shared checks, and removes the dominant `artifact_integrity` false-positive so the eventual red lane reflects real defects.

Canonical edit is **`src/submission-checks/detectors.ts` only**; the `app/`, `mcp/`, `cli/` copies regenerate from `src/` via `copy-shared-src.mjs` at build.

### 1. `OLD_NAME_PATTERNS` — add 4 missing product renames
trailhead had 5, the komatik legacy gate has 9. Added: `Undercurrent→Slipstream`, `Yggdrasil→Cairn`, `Bored→Lodge`, `Forge→Pack`. These only fire under `komatikInstance`, so trailhead-as-a-product for other users is unaffected.

### 2. `detectArtifactIntegrity` — precision
Old logic flagged any added line matching `import|from|require|see|fix|update` + a path-like token in **any** file, so prose in `.md` notes mentioning `package.json` or another report filename produced **blocking** false-positives. Now scoped to:
- code files only (`.ts/.tsx/.js/.jsx/.mjs/.cjs`; prose excluded)
- path literals inside `import/from/require/export-from` only (the prose `see X` trigger dropped)
- bare ubiquitous manifests (`package.json`/`tsconfig.json`/`README.md`/`package-lock.json`) ignored

Real code missing-refs are still caught; `import_resolution` continues to cover extensionless imports.

### Verification (CLI rebuilt from this branch, 69 live komatik bundles)
| metric | before | after |
|---|---|---|
| shadow-compare divergent decisions | 2 | **1** (the 1 is an `/_stale/` bundle trailhead correctly skips → non-archived divergence = 0) |
| artifact_integrity **blocking** | 34 | **6** (every survivor is a real missing `.ts/.tsx/.js` import) |
| full would-block | 38 | 24 |
| RED-lane blockers agreement (secrets/destructive_sql/hardcoded_env/large_file) | 100% | 100% |

Survivor examples (genuine missing imports, correctly flagged): `../_shared/supabase.ts`, `@modelcontextprotocol/sdk/server/mcp.js`, `../augmenter.js`.

Fixtures: real missing `.ts` import → flagged ✅ · `.md` prose mention → not flagged ✅ · bare `package.json` import → not flagged ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)