### PR TITLE
feat(trust): agent-trust loop end-user-ready (epic #252)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,13 @@ jobs:
 
       - name: Typecheck cli/
         run: |
-          cd cli && npm ci && npm run prebuild && npx tsc --noEmit
+          cd cli && npm ci && npm run typecheck
+
+      - name: Build CLI bundle
+        run: npm run build:cli
+
+      - name: Verify CLI bundle (offline doctor)
+        run: node cli/dist/index.js doctor --offline --path .
 
       - name: Typecheck app/
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,12 +57,16 @@ jobs:
         with:
           node-version: 24
           registry-url: "https://registry.npmjs.org"
+          cache: npm
 
-      - name: Build CLI
-        working-directory: cli
-        run: |
-          npm ci
-          npm run build
+      - name: Install root deps (ncc + @swc/core for bundle)
+        run: npm ci
+
+      - name: Build CLI bundle
+        run: npm run build:cli
+
+      - name: Verify CLI bundle
+        run: node cli/dist/index.js doctor --offline --path .
 
       - name: Publish to npm
         working-directory: cli

--- a/action.yml
+++ b/action.yml
@@ -209,6 +209,8 @@ outputs:
     description: "URL to the full evaluation report (only set when using a remote API)."
   evaluation-json:
     description: "Full gate evaluation as JSON for downstream workflow steps."
+  verdict-json:
+    description: "Versioned trailhead.verdict.v1 payload (stable collector contract)."
   rollout-readiness-json:
     description: "Rollout readiness summary (go/review/hold) derived from the evaluation."
   dora-deployment-frequency:

--- a/app/src/agent-trust-feedback.ts
+++ b/app/src/agent-trust-feedback.ts
@@ -1,0 +1,175 @@
+// Post-merge outcome feedback contract (epic #252 / issue #257).
+
+import { z } from "zod";
+import type { TrustFeedbackCounts } from "./agent-trust-metrics.js";
+
+export const AGENT_TRUST_FEEDBACK_SCHEMA = "trailhead.feedback.v1" as const;
+
+export const TrustFeedbackOutcome = z.enum([
+  "ci_pass",
+  "ci_fail",
+  "revert",
+  "rollback",
+  "rounds_to_green",
+  "human_review",
+]);
+export type TrustFeedbackOutcome = z.infer<typeof TrustFeedbackOutcome>;
+
+export const TrustFeedbackEventSchema = z.object({
+  schema: z.literal(AGENT_TRUST_FEEDBACK_SCHEMA).optional(),
+  submission_id: z.string().optional(),
+  pr_number: z.number().int().positive().optional(),
+  evaluation_id: z.string().optional(),
+  agent_id: z.string().optional(),
+  head_ref: z.string().optional(),
+  project_slug: z.string().optional(),
+  outcome: TrustFeedbackOutcome,
+  remediation_rounds: z.number().int().min(0).optional(),
+  observed_at: z.string(),
+  metadata: z.record(z.unknown()).optional(),
+});
+export type TrustFeedbackEvent = z.infer<typeof TrustFeedbackEventSchema>;
+
+export const TrustFeedbackBatchSchema = z.object({
+  schema: z.literal(AGENT_TRUST_FEEDBACK_SCHEMA),
+  collected_at: z.string(),
+  events: z.array(TrustFeedbackEventSchema),
+  unattributed: z
+    .object({
+      ci_failures: z.number().int().min(0).optional(),
+      reverts: z.number().int().min(0).optional(),
+      human_review: z.number().int().min(0).optional(),
+    })
+    .optional(),
+});
+export type TrustFeedbackBatch = z.infer<typeof TrustFeedbackBatchSchema>;
+
+export interface TrustFeedbackRollup {
+  feedback: TrustFeedbackCounts;
+  remediationRoundsToReady: number[];
+  attributed: number;
+  unattributed: number;
+}
+
+const AGENT_HEAD_REF = /^agent\/([a-z][a-z0-9-]*)\//;
+
+export function resolveAgentIdFromFeedbackEvent(
+  event: TrustFeedbackEvent,
+): string | null {
+  if (event.agent_id?.trim()) return event.agent_id.trim();
+
+  const headRef = event.head_ref?.trim();
+  if (headRef) {
+    const match = headRef.match(AGENT_HEAD_REF);
+    if (match) return match[1];
+  }
+
+  const metaRef =
+    typeof event.metadata?.head_ref === "string"
+      ? event.metadata.head_ref
+      : typeof event.metadata?.ref === "string"
+        ? event.metadata.ref.replace(/^refs\/heads\//, "")
+        : null;
+  if (metaRef) {
+    const match = metaRef.match(AGENT_HEAD_REF);
+    if (match) return match[1];
+  }
+
+  return null;
+}
+
+export function parseTrustFeedbackEvent(raw: unknown): TrustFeedbackEvent | null {
+  const parsed = TrustFeedbackEventSchema.safeParse(raw);
+  return parsed.success ? parsed.data : null;
+}
+
+export function parseTrustFeedbackBatch(
+  raw: string | unknown,
+): TrustFeedbackBatch | null {
+  try {
+    const value = typeof raw === "string" ? JSON.parse(raw) : raw;
+    const parsed = TrustFeedbackBatchSchema.safeParse(value);
+    return parsed.success ? parsed.data : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Map feedback events for a single agent into AgentTrustMetrics partial fields. */
+export function rollupFeedbackForAgent(
+  events: TrustFeedbackEvent[],
+  agentId: string,
+): TrustFeedbackRollup {
+  const feedback: TrustFeedbackCounts = {
+    ciFailures: 0,
+    reverts: 0,
+    humanReview: 0,
+  };
+  const remediationRoundsToReady: number[] = [];
+  let attributed = 0;
+  let unattributed = 0;
+
+  for (const event of events) {
+    const resolved = resolveAgentIdFromFeedbackEvent(event);
+    if (resolved !== agentId) {
+      if (resolved === null && !event.agent_id) unattributed += 1;
+      continue;
+    }
+    attributed += 1;
+
+    switch (event.outcome) {
+      case "ci_fail":
+        feedback.ciFailures = (feedback.ciFailures ?? 0) + 1;
+        break;
+      case "revert":
+      case "rollback":
+        feedback.reverts = (feedback.reverts ?? 0) + 1;
+        break;
+      case "human_review":
+        feedback.humanReview = (feedback.humanReview ?? 0) + 1;
+        break;
+      case "rounds_to_green":
+        if (typeof event.remediation_rounds === "number") {
+          remediationRoundsToReady.push(event.remediation_rounds);
+        }
+        break;
+      case "ci_pass":
+        break;
+    }
+  }
+
+  return {
+    feedback,
+    remediationRoundsToReady,
+    attributed,
+    unattributed,
+  };
+}
+
+export function mergeFeedbackIntoMetrics<
+  T extends {
+    revertCount: number;
+    humanReviewRequiredCount: number;
+    policyViolationCount: number;
+    remediationRoundsToReady: number[];
+    feedback?: TrustFeedbackCounts;
+  },
+>(metrics: T, rollup: TrustFeedbackRollup): T {
+  const fb = rollup.feedback;
+  return {
+    ...metrics,
+    revertCount: metrics.revertCount + (fb.reverts ?? 0),
+    humanReviewRequiredCount:
+      metrics.humanReviewRequiredCount + (fb.humanReview ?? 0) + (fb.ciFailures ?? 0),
+    policyViolationCount: metrics.policyViolationCount + (fb.ciFailures ?? 0),
+    remediationRoundsToReady: [
+      ...metrics.remediationRoundsToReady,
+      ...rollup.remediationRoundsToReady,
+    ],
+    feedback: {
+      ciFailures: (metrics.feedback?.ciFailures ?? 0) + (fb.ciFailures ?? 0),
+      reverts: (metrics.feedback?.reverts ?? 0) + (fb.reverts ?? 0),
+      humanReview: (metrics.feedback?.humanReview ?? 0) + (fb.humanReview ?? 0),
+    },
+  };
+}

--- a/app/src/agent-trust-metrics.ts
+++ b/app/src/agent-trust-metrics.ts
@@ -1,0 +1,217 @@
+// Versioned ingestion contract for dynamic agent trust (Phase B3 / epic #252).
+
+import { z } from "zod";
+
+export const AGENT_TRUST_METRICS_SCHEMA = "trailhead.agent_trust_metrics.v1" as const;
+
+export const DEFAULT_TRUST_COLLECTOR_CONFIG = {
+  windowDays: 30,
+  minEvidenceEvaluations: 5,
+  /** Minimum std-dev on gate penalty total_score to treat distribution as informative. */
+  minScoreStdDev: 1,
+  /** Gate penalty total_score at or below this is "clean" (lower = cleaner). */
+  cleanPenaltyThreshold: 1,
+  /** Gate penalty total_score at or above this is "noisy". */
+  noisyPenaltyThreshold: 3,
+} as const;
+
+export type TrustCollectorConfig = typeof DEFAULT_TRUST_COLLECTOR_CONFIG;
+
+export const PenaltyQualitySignalSchema = z.object({
+  mean: z.number().describe("Mean gate penalty total_score (lower = cleaner)"),
+  stdDev: z.number().min(0),
+  cleanRate: z.number().min(0).max(1),
+  sampleCount: z.number().int().min(0),
+});
+export type PenaltyQualitySignal = z.infer<typeof PenaltyQualitySignalSchema>;
+
+export const TrustFeedbackCountsSchema = z.object({
+  ciFailures: z.number().int().min(0).optional(),
+  reverts: z.number().int().min(0).optional(),
+  humanReview: z.number().int().min(0).optional(),
+});
+export type TrustFeedbackCounts = z.infer<typeof TrustFeedbackCountsSchema>;
+
+export const AgentTrustMetricsSchema = z.object({
+  evaluations: z.number().int().min(0),
+  releaseReadyCount: z.number().int().min(0).default(0),
+  revertCount: z.number().int().min(0).default(0),
+  humanReviewRequiredCount: z.number().int().min(0).default(0),
+  policyViolationCount: z.number().int().min(0).default(0),
+  sensitivePathViolationCount: z.number().int().min(0).default(0),
+  remediationRoundsToReady: z.array(z.number().int().min(0)).default([]),
+  penaltyQuality: PenaltyQualitySignalSchema.optional(),
+  feedback: TrustFeedbackCountsSchema.optional(),
+});
+export type AgentTrustMetrics = z.infer<typeof AgentTrustMetricsSchema>;
+
+export const ScoreDistributionSchema = z.object({
+  count: z.number().int().min(0),
+  mean: z.number(),
+  stdDev: z.number().min(0),
+  min: z.number(),
+  max: z.number(),
+  hasVariance: z.boolean(),
+});
+export type ScoreDistribution = z.infer<typeof ScoreDistributionSchema>;
+
+export const AgentTrustColdStartSchema = z.object({
+  emitTrust: z.boolean(),
+  reason: z.string().nullable(),
+});
+export type AgentTrustColdStart = z.infer<typeof AgentTrustColdStartSchema>;
+
+export const AgentTrustEnvelopeSchema = z.object({
+  schema: z.literal(AGENT_TRUST_METRICS_SCHEMA),
+  agent_id: z.string(),
+  collected_at: z.string(),
+  window_days: z.number().int().min(1),
+  trust: AgentTrustMetricsSchema.nullable(),
+  cold_start: AgentTrustColdStartSchema,
+  distribution: ScoreDistributionSchema.nullable().optional(),
+  feedback: TrustFeedbackCountsSchema.optional(),
+});
+export type AgentTrustEnvelope = z.infer<typeof AgentTrustEnvelopeSchema>;
+
+export function computeScoreDistribution(
+  scores: number[],
+  options: { minScoreStdDev?: number } = {},
+): ScoreDistribution | null {
+  const minScoreStdDev =
+    options.minScoreStdDev ?? DEFAULT_TRUST_COLLECTOR_CONFIG.minScoreStdDev;
+  const values = scores.filter((s) => typeof s === "number" && !Number.isNaN(s));
+  if (values.length === 0) return null;
+
+  const count = values.length;
+  const mean = values.reduce((sum, value) => sum + value, 0) / count;
+  const variance =
+    count === 1 ? 0 : values.reduce((sum, value) => sum + (value - mean) ** 2, 0) / count;
+  const stdDev = Math.sqrt(variance);
+
+  return {
+    count,
+    mean: Math.round(mean * 10) / 10,
+    stdDev: Math.round(stdDev * 10) / 10,
+    min: Math.min(...values),
+    max: Math.max(...values),
+    hasVariance: stdDev >= minScoreStdDev,
+  };
+}
+
+export function assessColdStart(params: {
+  evaluations: number;
+  distribution?: ScoreDistribution | null;
+  blockedCount?: number;
+  warnedCount?: number;
+  feedback?: TrustFeedbackCounts | null;
+  config?: Partial<TrustCollectorConfig>;
+}): AgentTrustColdStart {
+  const config = { ...DEFAULT_TRUST_COLLECTOR_CONFIG, ...params.config };
+  const feedback = params.feedback ?? null;
+  const feedbackEvaluations =
+    (feedback?.ciFailures ?? 0) + (feedback?.reverts ?? 0) + (feedback?.humanReview ?? 0);
+  const totalEvidence = params.evaluations + feedbackEvaluations;
+
+  if (totalEvidence < config.minEvidenceEvaluations) {
+    return {
+      emitTrust: false,
+      reason: `insufficient_evaluations (${totalEvidence} < ${config.minEvidenceEvaluations})`,
+    };
+  }
+
+  const hasOutcomeVariance =
+    (params.blockedCount ?? 0) > 0 ||
+    (params.warnedCount ?? 0) > 0 ||
+    (feedback?.reverts ?? 0) > 0 ||
+    (feedback?.ciFailures ?? 0) > 0 ||
+    (feedback?.humanReview ?? 0) > 0 ||
+    params.distribution?.hasVariance === true ||
+    (params.distribution?.stdDev ?? 0) >= config.minScoreStdDev;
+
+  if (!hasOutcomeVariance) {
+    return {
+      emitTrust: false,
+      reason: "flat_signals (no outcome variance and no penalty distribution variance)",
+    };
+  }
+
+  return { emitTrust: true, reason: null };
+}
+
+export function assessColdStartFromMetrics(
+  metrics: AgentTrustMetrics,
+  config?: Partial<TrustCollectorConfig>,
+): AgentTrustColdStart {
+  const mergedConfig = { ...DEFAULT_TRUST_COLLECTOR_CONFIG, ...config };
+  const feedbackEvidence =
+    (metrics.feedback?.ciFailures ?? 0) +
+    (metrics.feedback?.reverts ?? 0) +
+    (metrics.feedback?.humanReview ?? 0);
+  const totalEvidence = metrics.evaluations + feedbackEvidence;
+
+  if (totalEvidence < mergedConfig.minEvidenceEvaluations) {
+    return {
+      emitTrust: false,
+      reason: `insufficient_evaluations (${totalEvidence} < ${mergedConfig.minEvidenceEvaluations})`,
+    };
+  }
+
+  const penaltyVariance =
+    (metrics.penaltyQuality?.stdDev ?? 0) >= mergedConfig.minScoreStdDev;
+  const hasOutcomeVariance =
+    metrics.revertCount > 0 ||
+    metrics.humanReviewRequiredCount > 0 ||
+    metrics.policyViolationCount > 0 ||
+    metrics.sensitivePathViolationCount > 0 ||
+    penaltyVariance ||
+    feedbackEvidence > 0 ||
+    (metrics.releaseReadyCount > 0 && metrics.releaseReadyCount < metrics.evaluations);
+
+  if (!hasOutcomeVariance) {
+    return {
+      emitTrust: false,
+      reason: "flat_signals (no outcome variance and no penalty distribution variance)",
+    };
+  }
+
+  return { emitTrust: true, reason: null };
+}
+
+export function parseAgentTrustMetricsObject(raw: unknown): AgentTrustMetrics | null {
+  const parsed = AgentTrustMetricsSchema.safeParse(raw);
+  return parsed.success ? parsed.data : null;
+}
+
+export function parseAgentTrustMetrics(
+  raw: string | undefined,
+): AgentTrustMetrics | null {
+  if (!raw?.trim()) return null;
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      "schema" in parsed &&
+      (parsed as { schema?: string }).schema === AGENT_TRUST_METRICS_SCHEMA
+    ) {
+      const envelope = AgentTrustEnvelopeSchema.safeParse(parsed);
+      if (!envelope.success || !envelope.data.trust) return null;
+      return envelope.data.trust;
+    }
+    return parseAgentTrustMetricsObject(parsed);
+  } catch {
+    return null;
+  }
+}
+
+export function createEmptyAgentTrustMetrics(): AgentTrustMetrics {
+  return {
+    evaluations: 0,
+    releaseReadyCount: 0,
+    revertCount: 0,
+    humanReviewRequiredCount: 0,
+    policyViolationCount: 0,
+    sensitivePathViolationCount: 0,
+    remediationRoundsToReady: [],
+  };
+}

--- a/app/src/submission-checks/detector-policy.ts
+++ b/app/src/submission-checks/detector-policy.ts
@@ -1,0 +1,103 @@
+// Resolve submission detector policy from `.trailhead.yml` (issue #256).
+
+import type {
+  RemediationSeverity,
+  SubmissionCheckCode,
+  SubmissionConfig,
+  SubmissionDetectorPolicyEntry,
+} from "../types.js";
+import { SubmissionCheckCode as SubmissionCheckCodeEnum } from "../types.js";
+import {
+  compileRenamePattern,
+  compileSlugOnlyPatterns,
+  DEFAULT_ARTIFACT_FILE_GLOBS,
+  DEFAULT_RENAME_PATTERNS,
+  DEFAULT_SLUG_ONLY_PATTERN_SOURCES,
+  type RenamePatternEntry,
+} from "./policy-defaults.js";
+
+export type DetectorPolicyEntry = {
+  enabled?: boolean;
+  severity?: RemediationSeverity;
+  fileGlobs?: string[];
+  pathIgnore?: string[];
+};
+
+export type DetectorPolicyMap = Partial<Record<SubmissionCheckCode, DetectorPolicyEntry>>;
+
+function normalizeSeverity(
+  severity: NonNullable<SubmissionDetectorPolicyEntry["severity"]>,
+): RemediationSeverity {
+  if (severity === "block") return "blocking";
+  return severity as RemediationSeverity;
+}
+
+export function resolveDetectorPolicy(submission?: Partial<SubmissionConfig>): {
+  policy: DetectorPolicyMap;
+  warnings: string[];
+} {
+  const raw = submission?.detectors ?? {};
+  const warnings: string[] = [];
+  const policy: DetectorPolicyMap = {};
+
+  for (const [key, value] of Object.entries(raw)) {
+    const parsed = SubmissionCheckCodeEnum.safeParse(key);
+    if (!parsed.success) {
+      warnings.push(`Unknown submission.detectors key "${key}" will be ignored.`);
+      continue;
+    }
+    if (!value || typeof value !== "object") continue;
+
+    policy[parsed.data] = {
+      enabled: value.enabled,
+      severity: value.severity ? normalizeSeverity(value.severity) : undefined,
+      fileGlobs: value.file_globs,
+      pathIgnore: value.path_ignore,
+    };
+  }
+
+  return { policy, warnings };
+}
+
+export function buildRenamePatterns(
+  submission?: Partial<SubmissionConfig>,
+  options?: { includeKomatikDefaults?: boolean },
+): RenamePatternEntry[] {
+  const custom = (submission?.rename_patterns ?? []).map(({ old, new: newName }) =>
+    compileRenamePattern(old, newName),
+  );
+  const defaults = options?.includeKomatikDefaults ? DEFAULT_RENAME_PATTERNS : [];
+  return [...defaults, ...custom];
+}
+
+export function buildSlugOnlyPatterns(submission?: Partial<SubmissionConfig>): RegExp[] {
+  const sources = [
+    ...DEFAULT_SLUG_ONLY_PATTERN_SOURCES,
+    ...(submission?.slug_only_patterns ?? []),
+  ];
+  return compileSlugOnlyPatterns(sources);
+}
+
+export function artifactFileGlobs(policy: DetectorPolicyMap): string[] {
+  return policy.artifact_integrity?.fileGlobs ?? DEFAULT_ARTIFACT_FILE_GLOBS;
+}
+
+export function applyDetectorPolicy(
+  code: SubmissionCheckCode,
+  check: import("../types.js").SubmissionCheckResult | null,
+  policy: DetectorPolicyMap,
+): import("../types.js").SubmissionCheckResult | null {
+  const entry = policy[code];
+  if (entry?.enabled === false) return null;
+  if (!check) return null;
+  if (entry?.severity) {
+    return { ...check, severity: entry.severity };
+  }
+  return check;
+}
+
+export function getSubmissionConfigWarnings(
+  submission?: Partial<SubmissionConfig>,
+): string[] {
+  return resolveDetectorPolicy(submission).warnings;
+}

--- a/app/src/submission-checks/detectors.ts
+++ b/app/src/submission-checks/detectors.ts
@@ -1,17 +1,22 @@
 // Gate 1 detectors — ported from komatik-agents agent-gate-checks (patch/content based).
 
 import type { SubmissionCheckResult } from "../types.js";
-import type { SubmissionCheckContext, SubmissionFileInfo } from "./types.js";
+import type { SubmissionCheckContext } from "./types.js";
 import {
   addedLines,
   extensionOf,
+  extractAllImports,
   fileContent,
+  isStaleArchivedPath,
   isTestPath,
   lineCountFromPatch,
+  linesForFreshnessScan,
   normalizePath,
   scanAddedContent,
 } from "./helpers.js";
+import type { NamingAllowlistConfig } from "./types.js";
 import { runPhase0Detectors } from "./phase0-detectors.js";
+import { validateFileSyntax } from "./syntax-validity.js";
 
 export const OLD_NAME_PATTERNS: Array<{
   oldName: string;
@@ -27,6 +32,17 @@ export const OLD_NAME_PATTERNS: Array<{
   },
   { oldName: "Cognitive Debt", newName: "Drift", pattern: /\bCognitive Debt\b/g },
   { oldName: "cognitive-debt", newName: "Drift", pattern: /\bcognitive-debt\b/g },
+  { oldName: "Undercurrent", newName: "Slipstream", pattern: /\bUndercurrent\b/g },
+  { oldName: "Yggdrasil", newName: "Cairn", pattern: /\bYggdrasil\b/g },
+  { oldName: "Bored", newName: "Lodge", pattern: /\bBored\b/g },
+  { oldName: "Forge", newName: "Pack", pattern: /\bForge\b/g },
+];
+
+const SLUG_ONLY_PATTERNS = [
+  /\bcognitive-debt\b/,
+  /\bstoryboard-studio\b/,
+  /\bdaydream-studio\b/,
+  /\bshadow-ai-governance\b/,
 ];
 
 const MOCK_PATTERNS = [
@@ -39,6 +55,7 @@ const MOCK_PATTERNS = [
   /\b(?:mockData|fakeData|sampleData|dummyData|testData)\b/g,
   /\bTODO:\s*implement\b/gi,
   /\bFIXME\b/g,
+  /\bIn production,\s*use\b/i,
   /\bplaceholder\b/gi,
   /\blorem ipsum\b/gi,
 ];
@@ -158,20 +175,42 @@ export function detectDestructiveSql(
   });
 }
 
+// Only code files can carry hard file references; prose (.md/.mdx/.txt) merely
+// *mentions* paths and was the dominant artifact_integrity false-positive source.
+const ARTIFACT_CODE_EXTS = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"]);
+// Repo-ubiquitous manifests are referenced everywhere and are never the kind of
+// "hallucinated/missing artifact" this check is meant to catch.
+const ARTIFACT_BARE_IGNORE = new Set([
+  "package.json",
+  "package-lock.json",
+  "tsconfig.json",
+  "readme.md",
+]);
+
 export function detectArtifactIntegrity(
   ctx: SubmissionCheckContext,
 ): SubmissionCheckResult | null {
   const referenced = new Set<string>();
-  const pathRefPattern =
-    /(?:^|\s|['"`])([\w@./-]+\.(?:ts|tsx|js|jsx|md|sql|yml|yaml|json))(?:['"`]|\s|:)/g;
+  // Only treat a path *literal* inside an import/require/export-from statement
+  // as a hard reference — natural-language "see X" / "fix Y" / "update Z" in
+  // prose is not a code dependency (the old prose trigger over-flagged docs).
+  const importRefPattern =
+    /(?:\bimport\b|\bfrom\b|\brequire\s*\(|\bexport\b[^'"`]*\bfrom\b)\s*['"`]([\w@./-]+\.(?:ts|tsx|js|jsx|sql|yml|yaml|json))['"`]/g;
 
   for (const file of ctx.files) {
+    // Prose/doc files only mention paths; never flag them as missing code refs.
+    if (!ARTIFACT_CODE_EXTS.has(extensionOf(file.filename))) continue;
+
     for (const line of addedLines(file.patch)) {
-      if (!/(?:import|from|require|see|fix|update)\s/i.test(line)) continue;
-      for (const match of line.matchAll(pathRefPattern)) {
+      importRefPattern.lastIndex = 0;
+      for (const match of line.matchAll(importRefPattern)) {
         const candidate = match[1]?.replace(/^\.\//, "");
         if (!candidate || candidate.includes("*")) continue;
-        if (!ctx.prPaths.has(candidate) && !candidate.startsWith("node:")) {
+        if (candidate.startsWith("node:")) continue;
+        // Skip bare, repo-ubiquitous manifest names (package.json, etc.).
+        const base = candidate.split("/").pop()?.toLowerCase() ?? "";
+        if (!candidate.includes("/") && ARTIFACT_BARE_IGNORE.has(base)) continue;
+        if (!ctx.prPaths.has(candidate)) {
           referenced.add(candidate);
         }
       }
@@ -190,29 +229,74 @@ export function detectArtifactIntegrity(
   });
 }
 
-function isNamingAllowlisted(filename: string, line: string): boolean {
+function isNamingAllowlisted(
+  filename: string,
+  line: string,
+  allowlist: NamingAllowlistConfig = {},
+): boolean {
   const trimmed = line.trim();
-  if (/^import\s|^from\s|require\(/.test(trimmed)) return true;
-  if (/\.sql$/i.test(filename)) return true;
-  if (/(?:^|\/)migrations\//.test(filename)) return true;
-  if (/(?:^|\/)memory\//.test(filename)) return true;
-  if (/RESEARCH\.md$|BRAND\.md$|CHANGELOG\.md$/.test(filename)) return true;
-  if (/^\[.*\]\(.*\)/.test(trimmed)) return true;
+  const path = normalizePath(filename);
+  const ext = extensionOf(filename);
+  const skipExtensions = allowlist.skip_extensions ?? [".sql"];
+  const skipPathPatterns = allowlist.skip_path_patterns ?? ["migrations/", "schema/"];
+  const skipCommentMarkers = allowlist.skip_comment_markers ?? [
+    "historical:",
+    "migration:",
+    "deprecated:",
+  ];
+
+  if (
+    allowlist.skip_in_imports !== false &&
+    /^import\s|^from\s|require\(/.test(trimmed)
+  ) {
+    return true;
+  }
+  if (skipExtensions.includes(ext)) return true;
+  if (skipPathPatterns.some((pattern) => path.includes(pattern))) return true;
+  if (
+    skipCommentMarkers.some((marker) =>
+      trimmed.toLowerCase().includes(marker.toLowerCase()),
+    )
+  ) {
+    return true;
+  }
+  if (/\/memory\//.test(path)) return true;
+  if (/RESEARCH\.md$|BRAND\.md$|CHANGELOG\.md$/.test(path)) return true;
+  if (/^\[.*\]\(.*\)/.test(trimmed) || /\]\(http/.test(trimmed)) return true;
+
+  if (
+    SLUG_ONLY_PATTERNS.some((p) => p.test(trimmed)) &&
+    !/[A-Z]/.test(
+      trimmed.match(
+        /(?:cognitive-debt|storyboard-studio|daydream-studio|shadow-ai-governance)/,
+      )?.[0] ?? "",
+    )
+  ) {
+    return true;
+  }
+
+  if (/["'`/]/.test(trimmed)) {
+    const inStringOrPath =
+      /["'`/][^"'`]*(?:deployguard|storyboard-studio|daydream-studio|cognitive-debt|shadow-ai-governance|komatik-yggdrasil)[^"'`]*["'`/]/i;
+    if (inStringOrPath.test(trimmed)) return true;
+  }
+
   return false;
 }
 
 export function detectContextFreshness(
   ctx: SubmissionCheckContext,
 ): SubmissionCheckResult | null {
-  if (ctx.staleTerms.length === 0 && !ctx.komatikInstance) return null;
+  if (!ctx.komatikInstance && ctx.staleTerms.length === 0) return null;
 
   const hits: string[] = [];
   for (const file of ctx.files) {
-    for (const line of addedLines(file.patch)) {
-      if (isNamingAllowlisted(file.filename, line)) continue;
+    if (isStaleArchivedPath(file.filename, ctx.pathIgnorePatterns)) continue;
 
-      const terms = ctx.staleTerms.length > 0 ? ctx.staleTerms : [];
-      for (const term of terms) {
+    for (const line of linesForFreshnessScan(file)) {
+      if (isNamingAllowlisted(file.filename, line, ctx.namingAllowlist)) continue;
+
+      for (const term of ctx.staleTerms) {
         if (line.toLowerCase().includes(term.toLowerCase())) hits.push(file.filename);
       }
 
@@ -459,10 +543,12 @@ export function detectExternalPackageDeps(
 
   for (const file of ctx.files) {
     if (!codeExts.has(extensionOf(file.filename))) continue;
-    const importPattern = /\b(?:import|from|require)\s*(?:\([^)]*|\(?)?['"]([^'"]+)['"]/g;
-    for (const match of fileContent(file).matchAll(importPattern)) {
-      const specifier = match[1];
-      if (!specifier || specifier.startsWith(".") || specifier.startsWith("@/")) continue;
+
+    for (const imp of extractAllImports(fileContent(file))) {
+      const specifier = imp.specifier;
+      if (specifier.startsWith(".") || specifier.startsWith("/")) continue;
+      if (specifier.startsWith("@/") || specifier.startsWith("~/")) continue;
+      if (specifier.startsWith("http:") || specifier.startsWith("https:")) continue;
       if (isNodeBuiltin(specifier)) continue;
       const pkg = packageNameFromSpecifier(specifier);
       if (!ctx.declaredPackages.has(pkg)) hits.push(`${file.filename} → ${pkg}`);
@@ -480,116 +566,62 @@ export function detectExternalPackageDeps(
   });
 }
 
+function stripSqlComments(content: string): string {
+  return content.replace(/--[^\n]*/g, "").replace(/\/\*[\s\S]*?\*\//g, "");
+}
+
+function countPlpgsqlBlockBegins(sql: string): number {
+  const re = /\bBEGIN\b(?!\s+(?:TRANSACTION|WORK)\b)/gi;
+  return (sql.match(re) || []).length;
+}
+
+function countPlpgsqlBlockEnds(sql: string): number {
+  const re = /\bEND\s*(?!IF\b|LOOP\b|CASE\b)\s*(?:;|\$\$)/gi;
+  return (sql.match(re) || []).length;
+}
+
 export function detectSqlSyntaxBasic(
   ctx: SubmissionCheckContext,
 ): SubmissionCheckResult | null {
   const hits: string[] = [];
   for (const file of ctx.files.filter((f) => extensionOf(f.filename) === ".sql")) {
-    const content = fileContent(file);
-    const stripped = content.replace(/--[^\n]*/g, "").replace(/\/\*[\s\S]*?\*\//g, "");
-    const beginCount = (stripped.match(/\bBEGIN\b/gi) || []).length;
-    const endCount = (stripped.match(/\bEND\b\s*;/gi) || []).length;
-    if (beginCount > 0 && endCount === 0) hits.push(file.filename);
-    else if (endCount > beginCount) hits.push(file.filename);
+    const stripped = stripSqlComments(fileContent(file));
+    const beginCount = countPlpgsqlBlockBegins(stripped);
+    const endCount = countPlpgsqlBlockEnds(stripped);
+    if (beginCount > 0 && beginCount > endCount) hits.push(file.filename);
   }
   if (hits.length === 0) return null;
   return result({
     code: "sql_syntax_basic",
-    severity: "blocking",
+    severity: "warn",
     title: "SQL block balance issue",
-    detail: `Possible unmatched BEGIN/END in ${hits.join(", ")}.`,
+    detail: `Possible unclosed BEGIN block in ${hits.join(", ")}.`,
     files: hits,
-    suggested_action: "Fix PL/pgSQL block structure before merging.",
+    suggested_action: "Verify PL/pgSQL block structure before merging.",
   });
-}
-
-type SwcParseSync = (code: string, options: Record<string, unknown>) => unknown;
-
-let cachedSwcParse: SwcParseSync | null | undefined;
-
-function getSwcParse(): SwcParseSync | null {
-  if (cachedSwcParse !== undefined) return cachedSwcParse;
-  try {
-    // Optional — install @swc/core locally for full parse; Action uses bracket fallback.
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const swc = require("@swc/core") as { parseSync: SwcParseSync };
-    cachedSwcParse = swc.parseSync;
-  } catch {
-    cachedSwcParse = null;
-  }
-  return cachedSwcParse;
-}
-
-function basicBracketBalance(content: string): string | null {
-  let braces = 0;
-  let parens = 0;
-  let brackets = 0;
-  for (const ch of content) {
-    if (ch === "{") braces += 1;
-    if (ch === "}") braces -= 1;
-    if (ch === "(") parens += 1;
-    if (ch === ")") parens -= 1;
-    if (ch === "[") brackets += 1;
-    if (ch === "]") brackets -= 1;
-    if (braces < 0 || parens < 0 || brackets < 0) return "Unbalanced brackets/parens";
-  }
-  if (braces !== 0 || parens !== 0 || brackets !== 0) {
-    return "Unclosed brackets/parens in diff hunk";
-  }
-  return null;
-}
-
-function parserOptionsFor(file: SubmissionFileInfo): Record<string, unknown> {
-  const ext = extensionOf(file.filename);
-  const isTs = ext === ".ts" || ext === ".tsx";
-  return {
-    syntax: isTs ? "typescript" : "ecmascript",
-    tsx: ext === ".tsx",
-    jsx: ext === ".jsx",
-    decorators: true,
-    dynamicImport: true,
-  };
 }
 
 export function detectSyntaxValidity(
   ctx: SubmissionCheckContext,
 ): SubmissionCheckResult | null {
-  const errors: Array<{ file: string; message: string }> = [];
-  const codeExts = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"]);
-  const swcParse = getSwcParse();
+  const errors: string[] = [];
 
   for (const file of ctx.files) {
-    const ext = extensionOf(file.filename);
-    const content = fileContent(file);
-    if (!content.trim()) continue;
+    // Real parsers need the whole file — skip patch-only inputs (PR diff fragments).
+    if (typeof file.content !== "string") continue;
 
-    try {
-      if (codeExts.has(ext)) {
-        if (swcParse) {
-          swcParse(content, parserOptionsFor(file));
-        } else {
-          const balance = basicBracketBalance(content);
-          if (balance) throw new Error(balance);
-        }
-      } else if (ext === ".json") {
-        JSON.parse(content);
-      }
-    } catch (error) {
-      errors.push({
-        file: file.filename,
-        message: error instanceof Error ? error.message.split("\n")[0] : String(error),
-      });
-    }
+    const message = validateFileSyntax(file.filename, file.content);
+    if (message) errors.push(`${file.filename}: ${message}`);
   }
 
   if (errors.length === 0) return null;
   return result({
     code: "syntax_validity",
     severity: "blocking",
-    title: "Syntax error in changed file",
-    detail: errors.map((e) => `${e.file}: ${e.message}`).join("; "),
-    files: errors.map((e) => e.file),
-    suggested_action: "Fix parse errors before resubmitting.",
+    title: "Syntax error in submitted file",
+    detail: errors.slice(0, 12).join("; "),
+    files: errors.map((e) => e.split(": ")[0] ?? e),
+    suggested_action: "Fix the parse error before submitting.",
   });
 }
 

--- a/app/src/submission-checks/detectors.ts
+++ b/app/src/submission-checks/detectors.ts
@@ -1,6 +1,6 @@
 // Gate 1 detectors — ported from komatik-agents agent-gate-checks (patch/content based).
 
-import type { SubmissionCheckResult } from "../types.js";
+import type { SubmissionCheckResult, SubmissionCheckCode } from "../types.js";
 import type { SubmissionCheckContext } from "./types.js";
 import {
   addedLines,
@@ -17,33 +17,9 @@ import {
 import type { NamingAllowlistConfig } from "./types.js";
 import { runPhase0Detectors } from "./phase0-detectors.js";
 import { validateFileSyntax } from "./syntax-validity.js";
-
-export const OLD_NAME_PATTERNS: Array<{
-  oldName: string;
-  newName: string;
-  pattern: RegExp;
-}> = [
-  { oldName: "DeployGuard", newName: "Trailhead", pattern: /\bDeployGuard\b/g },
-  { oldName: "Daydream Studio", newName: "Sundog", pattern: /\bDaydream Studio\b/g },
-  {
-    oldName: "Storyboard Studio",
-    newName: "Kindling",
-    pattern: /\bStoryboard Studio\b/g,
-  },
-  { oldName: "Cognitive Debt", newName: "Drift", pattern: /\bCognitive Debt\b/g },
-  { oldName: "cognitive-debt", newName: "Drift", pattern: /\bcognitive-debt\b/g },
-  { oldName: "Undercurrent", newName: "Slipstream", pattern: /\bUndercurrent\b/g },
-  { oldName: "Yggdrasil", newName: "Cairn", pattern: /\bYggdrasil\b/g },
-  { oldName: "Bored", newName: "Lodge", pattern: /\bBored\b/g },
-  { oldName: "Forge", newName: "Pack", pattern: /\bForge\b/g },
-];
-
-const SLUG_ONLY_PATTERNS = [
-  /\bcognitive-debt\b/,
-  /\bstoryboard-studio\b/,
-  /\bdaydream-studio\b/,
-  /\bshadow-ai-governance\b/,
-];
+import { matchesGlobs } from "../risk-engine.js";
+import { applyDetectorPolicy, artifactFileGlobs } from "./detector-policy.js";
+export { DEFAULT_RENAME_PATTERNS, OLD_NAME_PATTERNS } from "./policy-defaults.js";
 
 const MOCK_PATTERNS = [
   /\bTODO\s*\(\s*mock\s*\)/i,
@@ -177,9 +153,6 @@ export function detectDestructiveSql(
 
 // Only code files can carry hard file references; prose (.md/.mdx/.txt) merely
 // *mentions* paths and was the dominant artifact_integrity false-positive source.
-const ARTIFACT_CODE_EXTS = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"]);
-// Repo-ubiquitous manifests are referenced everywhere and are never the kind of
-// "hallucinated/missing artifact" this check is meant to catch.
 const ARTIFACT_BARE_IGNORE = new Set([
   "package.json",
   "package-lock.json",
@@ -191,6 +164,8 @@ export function detectArtifactIntegrity(
   ctx: SubmissionCheckContext,
 ): SubmissionCheckResult | null {
   const referenced = new Set<string>();
+  const fileGlobs = artifactFileGlobs(ctx.detectorPolicy);
+  const pathIgnore = ctx.detectorPolicy.artifact_integrity?.pathIgnore ?? [];
   // Only treat a path *literal* inside an import/require/export-from statement
   // as a hard reference — natural-language "see X" / "fix Y" / "update Z" in
   // prose is not a code dependency (the old prose trigger over-flagged docs).
@@ -198,8 +173,8 @@ export function detectArtifactIntegrity(
     /(?:\bimport\b|\bfrom\b|\brequire\s*\(|\bexport\b[^'"`]*\bfrom\b)\s*['"`]([\w@./-]+\.(?:ts|tsx|js|jsx|sql|yml|yaml|json))['"`]/g;
 
   for (const file of ctx.files) {
-    // Prose/doc files only mention paths; never flag them as missing code refs.
-    if (!ARTIFACT_CODE_EXTS.has(extensionOf(file.filename))) continue;
+    if (!matchesGlobs(file.filename, fileGlobs)) continue;
+    if (pathIgnore.length > 0 && matchesGlobs(file.filename, pathIgnore)) continue;
 
     for (const line of addedLines(file.patch)) {
       importRefPattern.lastIndex = 0;
@@ -233,6 +208,7 @@ function isNamingAllowlisted(
   filename: string,
   line: string,
   allowlist: NamingAllowlistConfig = {},
+  slugOnlyPatterns: RegExp[] = [],
 ): boolean {
   const trimmed = line.trim();
   const path = normalizePath(filename);
@@ -265,7 +241,7 @@ function isNamingAllowlisted(
   if (/^\[.*\]\(.*\)/.test(trimmed) || /\]\(http/.test(trimmed)) return true;
 
   if (
-    SLUG_ONLY_PATTERNS.some((p) => p.test(trimmed)) &&
+    slugOnlyPatterns.some((p) => p.test(trimmed)) &&
     !/[A-Z]/.test(
       trimmed.match(
         /(?:cognitive-debt|storyboard-studio|daydream-studio|shadow-ai-governance)/,
@@ -287,24 +263,33 @@ function isNamingAllowlisted(
 export function detectContextFreshness(
   ctx: SubmissionCheckContext,
 ): SubmissionCheckResult | null {
-  if (!ctx.komatikInstance && ctx.staleTerms.length === 0) return null;
+  if (ctx.staleTerms.length === 0 && ctx.renamePatterns.length === 0) {
+    return null;
+  }
 
   const hits: string[] = [];
   for (const file of ctx.files) {
     if (isStaleArchivedPath(file.filename, ctx.pathIgnorePatterns)) continue;
 
     for (const line of linesForFreshnessScan(file)) {
-      if (isNamingAllowlisted(file.filename, line, ctx.namingAllowlist)) continue;
+      if (
+        isNamingAllowlisted(
+          file.filename,
+          line,
+          ctx.namingAllowlist,
+          ctx.slugOnlyPatterns,
+        )
+      ) {
+        continue;
+      }
 
       for (const term of ctx.staleTerms) {
         if (line.toLowerCase().includes(term.toLowerCase())) hits.push(file.filename);
       }
 
-      if (ctx.komatikInstance) {
-        for (const entry of OLD_NAME_PATTERNS) {
-          entry.pattern.lastIndex = 0;
-          if (entry.pattern.test(line)) hits.push(file.filename);
-        }
+      for (const entry of ctx.renamePatterns) {
+        entry.pattern.lastIndex = 0;
+        if (entry.pattern.test(line)) hits.push(file.filename);
       }
     }
   }
@@ -644,23 +629,33 @@ export function detectSoulIntegrity(
 }
 
 export function runAllDetectors(ctx: SubmissionCheckContext): SubmissionCheckResult[] {
+  const policy = ctx.detectorPolicy;
+  const finalize = (
+    code: SubmissionCheckCode,
+    check: SubmissionCheckResult | null,
+  ): SubmissionCheckResult | null => applyDetectorPolicy(code, check, policy);
+
   const gate1 = [
-    detectMockPlaceholder(ctx),
-    detectSecrets(ctx),
-    detectDestructiveSql(ctx),
-    detectSyntaxValidity(ctx),
-    detectImportResolution(ctx),
-    detectRlsNewTables(ctx),
-    detectAuthRouteAuth(ctx),
-    detectHardcodedEnv(ctx),
-    detectExternalPackageDeps(ctx),
-    detectSqlSyntaxBasic(ctx),
-    detectLargeFile(ctx),
-    detectArtifactIntegrity(ctx),
-    detectContextFreshness(ctx),
-    detectSoulIntegrity(ctx),
-    detectPathFormat(ctx),
+    finalize("mock_placeholder", detectMockPlaceholder(ctx)),
+    finalize("secrets", detectSecrets(ctx)),
+    finalize("destructive_sql", detectDestructiveSql(ctx)),
+    finalize("syntax_validity", detectSyntaxValidity(ctx)),
+    finalize("import_resolution", detectImportResolution(ctx)),
+    finalize("rls_new_tables", detectRlsNewTables(ctx)),
+    finalize("auth_route_auth", detectAuthRouteAuth(ctx)),
+    finalize("hardcoded_env", detectHardcodedEnv(ctx)),
+    finalize("external_package_deps", detectExternalPackageDeps(ctx)),
+    finalize("sql_syntax_basic", detectSqlSyntaxBasic(ctx)),
+    finalize("large_file", detectLargeFile(ctx)),
+    finalize("artifact_integrity", detectArtifactIntegrity(ctx)),
+    finalize("context_freshness", detectContextFreshness(ctx)),
+    finalize("soul_integrity", detectSoulIntegrity(ctx)),
+    finalize("path_format", detectPathFormat(ctx)),
   ].filter((check): check is SubmissionCheckResult => check !== null);
 
-  return [...gate1, ...runPhase0Detectors(ctx)];
+  const phase0 = runPhase0Detectors(ctx)
+    .map((check) => finalize(check.code, check))
+    .filter((check): check is SubmissionCheckResult => check !== null);
+
+  return [...gate1, ...phase0];
 }

--- a/app/src/submission-checks/helpers.ts
+++ b/app/src/submission-checks/helpers.ts
@@ -81,3 +81,70 @@ export function prPathSet(files: SubmissionFileInfo[]): Set<string> {
 export function isTestPath(filename: string): boolean {
   return /\/__tests__\/|\/test\/|\/fixtures\/|\.test\.|\.spec\./.test(filename);
 }
+
+/** Default archived/stale path segments skipped by context_freshness. */
+export const DEFAULT_STALE_PATH_IGNORE = ["/_stale/", "/_archive/", "/.archive/"];
+
+export function isStaleArchivedPath(
+  filename: string,
+  extraPatterns: string[] = [],
+): boolean {
+  const path = normalizePath(filename);
+  return [...DEFAULT_STALE_PATH_IGNORE, ...extraPatterns].some((segment) =>
+    path.includes(segment),
+  );
+}
+
+export function packageJsonPathForFile(
+  filename: string,
+  prPaths: Set<string>,
+): string | null {
+  const parts = normalizePath(filename).split("/");
+  for (let i = parts.length - 1; i >= 0; i--) {
+    const candidate = [...parts.slice(0, i), "package.json"].filter(Boolean).join("/");
+    if (prPaths.has(candidate)) return candidate;
+  }
+  return prPaths.has("package.json") ? "package.json" : null;
+}
+
+const VALID_PACKAGE_SPECIFIER = /^(@[\w.-]+\/[\w.-]+|[\w@][\w.-]*)(?:\/[\w./-]*)?$/;
+
+export function isValidPackageSpecifier(specifier: string): boolean {
+  if (!specifier || specifier.startsWith(".") || specifier.startsWith("@/")) return false;
+  if (/^https?:|^node:/.test(specifier)) return false;
+  if (/[:()\\]/.test(specifier)) return false;
+  return VALID_PACKAGE_SPECIFIER.test(specifier);
+}
+
+/** Extract module specifiers from full file content (legacy agent-gate parity). */
+export function extractAllImports(
+  content: string,
+): Array<{ specifier: string; line: number }> {
+  const results: Array<{ specifier: string; line: number }> = [];
+  const patterns = [
+    /\bimport\s+(?:type\s+)?(?:[^'"]+\s+from\s+)?['"]([^'"]+)['"]/g,
+    /\bexport\s+(?:type\s+)?(?:[^'"]+\s+from\s+)['"]([^'"]+)['"]/g,
+    /\brequire\(\s*['"]([^'"]+)['"]\s*\)/g,
+    /\bimport\(\s*['"]([^'"]+)['"]\s*\)/g,
+  ];
+
+  for (const pattern of patterns) {
+    pattern.lastIndex = 0;
+    for (const match of content.matchAll(pattern)) {
+      const specifier = match[1];
+      if (!specifier) continue;
+      const line = content.slice(0, match.index ?? 0).split("\n").length;
+      results.push({ specifier, line });
+    }
+  }
+  return results;
+}
+
+export function linesForFreshnessScan(file: {
+  filename: string;
+  patch?: string;
+  content?: string;
+}): string[] {
+  if (typeof file.content === "string") return file.content.split("\n");
+  return addedLines(file.patch);
+}

--- a/app/src/submission-checks/policy-defaults.ts
+++ b/app/src/submission-checks/policy-defaults.ts
@@ -1,0 +1,54 @@
+// Default submission detector policy data (Komatik fleet rename vocabulary).
+
+export interface RenamePatternEntry {
+  oldName: string;
+  newName: string;
+  pattern: RegExp;
+}
+
+export const DEFAULT_RENAME_PATTERNS: RenamePatternEntry[] = [
+  { oldName: "DeployGuard", newName: "Trailhead", pattern: /\bDeployGuard\b/g },
+  { oldName: "Daydream Studio", newName: "Sundog", pattern: /\bDaydream Studio\b/g },
+  {
+    oldName: "Storyboard Studio",
+    newName: "Kindling",
+    pattern: /\bStoryboard Studio\b/g,
+  },
+  { oldName: "Cognitive Debt", newName: "Drift", pattern: /\bCognitive Debt\b/g },
+  { oldName: "cognitive-debt", newName: "Drift", pattern: /\bcognitive-debt\b/g },
+  { oldName: "Undercurrent", newName: "Slipstream", pattern: /\bUndercurrent\b/g },
+  { oldName: "Yggdrasil", newName: "Cairn", pattern: /\bYggdrasil\b/g },
+  { oldName: "Bored", newName: "Lodge", pattern: /\bBored\b/g },
+  { oldName: "Forge", newName: "Pack", pattern: /\bForge\b/g },
+];
+
+/** @deprecated use DEFAULT_RENAME_PATTERNS */
+export const OLD_NAME_PATTERNS = DEFAULT_RENAME_PATTERNS;
+
+export const DEFAULT_SLUG_ONLY_PATTERN_SOURCES = [
+  "\\bcognitive-debt\\b",
+  "\\bstoryboard-studio\\b",
+  "\\bdaydream-studio\\b",
+  "\\bshadow-ai-governance\\b",
+];
+
+export const DEFAULT_ARTIFACT_FILE_GLOBS = ["**/*.{ts,tsx,js,jsx,mjs,cjs}"];
+
+function escapeRegexLiteral(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function compileRenamePattern(
+  oldName: string,
+  newName: string,
+): RenamePatternEntry {
+  return {
+    oldName,
+    newName,
+    pattern: new RegExp(`\\b${escapeRegexLiteral(oldName)}\\b`, "g"),
+  };
+}
+
+export function compileSlugOnlyPatterns(sources: string[]): RegExp[] {
+  return sources.map((source) => new RegExp(source, "i"));
+}

--- a/app/src/submission-checks/syntax-validity.ts
+++ b/app/src/submission-checks/syntax-validity.ts
@@ -1,0 +1,42 @@
+// Real parse-based syntax validation for Gate 1 (no bracket-count fallback).
+// Parses full file content only — never a partial diff hunk (see submission-gate.md).
+
+import { parseSync, type ParseOptions } from "@swc/core";
+import yaml from "js-yaml";
+import { extensionOf } from "./helpers.js";
+
+const PARSEABLE = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"] as const;
+
+function parserOptionsFor(ext: string): ParseOptions {
+  const isTs = ext === ".ts" || ext === ".tsx";
+  return {
+    syntax: isTs ? "typescript" : "ecmascript",
+    tsx: ext === ".tsx",
+    jsx: ext === ".jsx",
+    decorators: true,
+    dynamicImport: true,
+  };
+}
+
+/** Returns a one-line error message, or null when content parses cleanly. */
+export function validateFileSyntax(filename: string, content: string): string | null {
+  if (!content.trim()) return null;
+
+  const ext = extensionOf(filename);
+  try {
+    if ((PARSEABLE as readonly string[]).includes(ext)) {
+      parseSync(content, parserOptionsFor(ext));
+    } else if (ext === ".json") {
+      JSON.parse(content);
+    } else if (ext === ".yaml" || ext === ".yml") {
+      yaml.load(content);
+    } else if (ext === ".md" && content.startsWith("---")) {
+      const end = content.indexOf("\n---", 3);
+      if (end > 0) yaml.load(content.slice(3, end));
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message.split("\n")[0] : String(error);
+    return message || "Parse error";
+  }
+  return null;
+}

--- a/app/src/submission-checks/types.ts
+++ b/app/src/submission-checks/types.ts
@@ -7,6 +7,9 @@ export interface SubmissionFileInfo {
   additions?: number;
 }
 
+import type { DetectorPolicyMap } from "./detector-policy.js";
+import type { RenamePatternEntry } from "./policy-defaults.js";
+
 export interface NamingAllowlistConfig {
   skip_extensions?: string[];
   skip_path_patterns?: string[];
@@ -25,6 +28,9 @@ export interface SubmissionCheckContext {
   declaredPackages: Set<string>;
   /** Extra path segments to skip for context_freshness (merged with defaults). */
   pathIgnorePatterns: string[];
+  renamePatterns: RenamePatternEntry[];
+  slugOnlyPatterns: RegExp[];
+  detectorPolicy: DetectorPolicyMap;
   /**
    * Full set of paths that exist in the target repo (e.g. `git ls-files`),
    * used to tell a fabricated reference from a reference to an existing,

--- a/app/src/submission-checks/types.ts
+++ b/app/src/submission-checks/types.ts
@@ -7,14 +7,24 @@ export interface SubmissionFileInfo {
   additions?: number;
 }
 
+export interface NamingAllowlistConfig {
+  skip_extensions?: string[];
+  skip_path_patterns?: string[];
+  skip_comment_markers?: string[];
+  skip_in_imports?: boolean;
+}
+
 export interface SubmissionCheckContext {
   files: SubmissionFileInfo[];
   prPaths: Set<string>;
   komatikInstance: boolean;
   staleTerms: string[];
+  namingAllowlist: NamingAllowlistConfig;
   authRouteAllowlist: string[];
   maxFileLines: number;
   declaredPackages: Set<string>;
+  /** Extra path segments to skip for context_freshness (merged with defaults). */
+  pathIgnorePatterns: string[];
   /**
    * Full set of paths that exist in the target repo (e.g. `git ls-files`),
    * used to tell a fabricated reference from a reference to an existing,

--- a/app/src/submission-engine.ts
+++ b/app/src/submission-engine.ts
@@ -4,11 +4,18 @@
 import { runAllDetectors } from "./submission-checks/detectors.js";
 import type { SubmissionCheckContext } from "./submission-checks/types.js";
 import { prPathSet } from "./submission-checks/helpers.js";
+import {
+  buildRenamePatterns,
+  buildSlugOnlyPatterns,
+  getSubmissionConfigWarnings,
+  resolveDetectorPolicy,
+} from "./submission-checks/detector-policy.js";
 import { SubmissionCheckCode } from "./types.js";
 import type { RepoConfig, SubmissionCheckResult } from "./types.js";
 
 export type { SubmissionFileInfo } from "./submission-checks/types.js";
 export type { SubmissionCheckCode, SubmissionCheckResult } from "./types.js";
+export { getSubmissionConfigWarnings };
 
 /** Gate 1 + Phase 0 submission check codes — keep in sync with A8 fixture manifest. */
 export const SUBMISSION_CHECK_CODES = SubmissionCheckCode.options;
@@ -51,6 +58,7 @@ function buildContext(options: SubmissionEngineOptions): SubmissionCheckContext 
   const staleTerms = repoConfig?.submission?.stale_terms ?? [];
 
   const declared = new Set(options.declaredPackages ?? []);
+  const { policy } = resolveDetectorPolicy(repoConfig?.submission);
 
   return {
     files,
@@ -63,6 +71,11 @@ function buildContext(options: SubmissionEngineOptions): SubmissionCheckContext 
     maxFileLines: repoConfig?.submission?.max_file_lines ?? 1000,
     declaredPackages: declared,
     pathIgnorePatterns: repoConfig?.submission?.path_ignore ?? [],
+    renamePatterns: buildRenamePatterns(repoConfig?.submission, {
+      includeKomatikDefaults: komatikInstance,
+    }),
+    slugOnlyPatterns: buildSlugOnlyPatterns(repoConfig?.submission),
+    detectorPolicy: policy,
     repoPaths: options.repoPaths ? new Set(options.repoPaths) : undefined,
   };
 }

--- a/app/src/submission-engine.ts
+++ b/app/src/submission-engine.ts
@@ -13,14 +13,27 @@ export type { SubmissionCheckCode, SubmissionCheckResult } from "./types.js";
 /** Gate 1 + Phase 0 submission check codes — keep in sync with A8 fixture manifest. */
 export const SUBMISSION_CHECK_CODES = SubmissionCheckCode.options;
 
-const DEFAULT_STALE_TERMS = ["deployguard", "DeployGuard"];
-
 const DEFAULT_AUTH_ROUTE_ALLOWLIST = [
   "/api/auth/",
   "/api/webhooks/",
   "/api/health/",
   "/api/metrics/",
 ];
+
+/** Package names declared in a package.json (legacy gate parity). */
+export function declaredPackageNamesFromPackageJson(
+  pkg: Record<string, unknown>,
+): string[] {
+  const sections = [
+    "dependencies",
+    "devDependencies",
+    "peerDependencies",
+    "optionalDependencies",
+  ] as const;
+  return sections.flatMap((key) =>
+    Object.keys((pkg[key] as Record<string, string> | undefined) ?? {}),
+  );
+}
 
 export interface SubmissionEngineOptions {
   files: import("./submission-checks/types.js").SubmissionFileInfo[];
@@ -35,8 +48,7 @@ export interface SubmissionEngineOptions {
 
 function buildContext(options: SubmissionEngineOptions): SubmissionCheckContext {
   const { files, repoConfig, komatikInstance = false } = options;
-  const staleTerms =
-    repoConfig?.submission?.stale_terms ?? (komatikInstance ? DEFAULT_STALE_TERMS : []);
+  const staleTerms = repoConfig?.submission?.stale_terms ?? [];
 
   const declared = new Set(options.declaredPackages ?? []);
 
@@ -45,10 +57,12 @@ function buildContext(options: SubmissionEngineOptions): SubmissionCheckContext 
     prPaths: prPathSet(files),
     komatikInstance,
     staleTerms,
+    namingAllowlist: repoConfig?.submission?.naming_allowlist ?? {},
     authRouteAllowlist:
       repoConfig?.submission?.auth_route_allowlist ?? DEFAULT_AUTH_ROUTE_ALLOWLIST,
     maxFileLines: repoConfig?.submission?.max_file_lines ?? 1000,
     declaredPackages: declared,
+    pathIgnorePatterns: repoConfig?.submission?.path_ignore ?? [],
     repoPaths: options.repoPaths ? new Set(options.repoPaths) : undefined,
   };
 }

--- a/app/src/trust-runtime.ts
+++ b/app/src/trust-runtime.ts
@@ -1,0 +1,24 @@
+// Shadow / enforce runtime for agent trust injection (issue #259).
+
+export interface TrustRuntime {
+  enabled: boolean;
+  /** Log trust profile without applying threshold delta. */
+  shadow: boolean;
+  /** Apply threshold delta and strictness adjustments from trust score. */
+  enforce: boolean;
+  /** Collector-only: inject TRAILHEAD_AGENT_TRUST_JSON (Komatik dogfood). */
+  injectTrustJson: boolean;
+}
+
+export function readTrustRuntime(env: NodeJS.ProcessEnv = process.env): TrustRuntime {
+  const enabled = env.TRAILHEAD_TRUST_ENABLED !== "false";
+  const shadow = enabled && env.TRAILHEAD_TRUST_SHADOW === "true";
+  const enforce = enabled && !shadow;
+
+  return {
+    enabled,
+    shadow,
+    enforce,
+    injectTrustJson: enabled && env.TRAILHEAD_TRUST_ENFORCE === "true",
+  };
+}

--- a/app/src/trust-score.ts
+++ b/app/src/trust-score.ts
@@ -1,17 +1,15 @@
 // Phase B3 — dynamic agent trust scoring (pure module).
 
-export type TrustProfileName = "fast-track" | "standard" | "probation";
+import {
+  assessColdStartFromMetrics,
+  DEFAULT_TRUST_COLLECTOR_CONFIG,
+  type AgentTrustMetrics,
+  type TrustCollectorConfig,
+} from "./agent-trust-metrics.js";
 
-export interface AgentTrustMetrics {
-  evaluations: number;
-  releaseReadyCount: number;
-  revertCount: number;
-  humanReviewRequiredCount: number;
-  policyViolationCount: number;
-  sensitivePathViolationCount: number;
-  /** Sum of loop rounds for PRs that reached release_ready. */
-  remediationRoundsToReady: number[];
-}
+export type { AgentTrustMetrics } from "./agent-trust-metrics.js";
+
+export type TrustProfileName = "fast-track" | "standard" | "probation";
 
 export interface AgentTrustResult {
   score: number;
@@ -23,9 +21,12 @@ export interface AgentTrustResult {
     remediation_efficiency: number;
     policy_violation_rate: number;
     sensitive_path_violation_rate: number;
+    penalty_clean_rate?: number;
+    penalty_mean_quality?: number;
   };
   thresholdDelta: number;
   autofixEnabled: boolean;
+  coldStart?: { reason: string };
 }
 
 const WEIGHTS = {
@@ -35,6 +36,7 @@ const WEIGHTS = {
   remediation_efficiency: 0.15,
   policy_violation_penalty: 0.075,
   sensitive_path_penalty: 0.075,
+  penalty_mean_quality: 0.05,
 };
 
 function rate(numerator: number, denominator: number): number {
@@ -48,36 +50,66 @@ function remediationEfficiency(rounds: number[]): number {
   return Math.max(0, Math.min(1, 1 - (avg - 1) / 4));
 }
 
-export function computeAgentTrustScore(metrics: AgentTrustMetrics): AgentTrustResult {
+function penaltyMeanQuality(
+  penaltyQuality: AgentTrustMetrics["penaltyQuality"],
+  noisyThreshold: number,
+): number | undefined {
+  if (!penaltyQuality || penaltyQuality.sampleCount <= 0) return undefined;
+  return Math.max(0, Math.min(1, 1 - penaltyQuality.mean / noisyThreshold));
+}
+
+export function computeAgentTrustScore(
+  metrics: AgentTrustMetrics,
+  options?: { config?: Partial<TrustCollectorConfig> },
+): AgentTrustResult | null {
+  const config = { ...DEFAULT_TRUST_COLLECTOR_CONFIG, ...options?.config };
+  const coldStart = assessColdStartFromMetrics(metrics, config);
+  if (!coldStart.emitTrust) {
+    return null;
+  }
+
   const n = Math.max(metrics.evaluations, 0);
   const releaseReadyRate = rate(metrics.releaseReadyCount, n);
+  const penaltyCleanRate = metrics.penaltyQuality?.cleanRate;
+  const releaseSignal =
+    penaltyCleanRate !== undefined
+      ? Math.max(releaseReadyRate, penaltyCleanRate)
+      : releaseReadyRate;
+
   const revertRate = rate(metrics.revertCount, n);
   const humanReviewRate = rate(metrics.humanReviewRequiredCount, n);
   const policyViolationRate = rate(metrics.policyViolationCount, n);
   const sensitiveRate = rate(metrics.sensitivePathViolationCount, n);
   const remEff = remediationEfficiency(metrics.remediationRoundsToReady);
+  const meanQuality = penaltyMeanQuality(
+    metrics.penaltyQuality,
+    config.noisyPenaltyThreshold,
+  );
 
   const factors = {
-    release_ready_rate: releaseReadyRate,
+    release_ready_rate: releaseSignal,
     revert_rate: revertRate,
     human_review_required_rate: humanReviewRate,
     remediation_efficiency: remEff,
     policy_violation_rate: policyViolationRate,
     sensitive_path_violation_rate: sensitiveRate,
+    ...(penaltyCleanRate !== undefined ? { penalty_clean_rate: penaltyCleanRate } : {}),
+    ...(meanQuality !== undefined ? { penalty_mean_quality: meanQuality } : {}),
   };
 
-  const score = Math.max(
-    0,
-    Math.min(
-      1,
-      WEIGHTS.release_ready_rate * releaseReadyRate +
-        WEIGHTS.revert_resistance * (1 - revertRate) +
-        WEIGHTS.human_free_rate * (1 - humanReviewRate) +
-        WEIGHTS.remediation_efficiency * remEff -
-        WEIGHTS.policy_violation_penalty * policyViolationRate -
-        WEIGHTS.sensitive_path_penalty * sensitiveRate,
-    ),
-  );
+  let score =
+    WEIGHTS.release_ready_rate * releaseSignal +
+    WEIGHTS.revert_resistance * (1 - revertRate) +
+    WEIGHTS.human_free_rate * (1 - humanReviewRate) +
+    WEIGHTS.remediation_efficiency * remEff -
+    WEIGHTS.policy_violation_penalty * policyViolationRate -
+    WEIGHTS.sensitive_path_penalty * sensitiveRate;
+
+  if (meanQuality !== undefined) {
+    score += WEIGHTS.penalty_mean_quality * meanQuality;
+  }
+
+  score = Math.max(0, Math.min(1, score));
 
   let profile: TrustProfileName = "standard";
   if (score >= 0.85) profile = "fast-track";

--- a/app/src/verdict.ts
+++ b/app/src/verdict.ts
@@ -1,0 +1,260 @@
+// Stable versioned gate verdict contract (epic #252 / issue #260).
+
+import { z } from "zod";
+import type { GateEvaluation, SubmissionCheckResult } from "./types.js";
+import { GateDecision, SubmissionCheckCode } from "./types.js";
+import type { TrustRuntime } from "./trust-runtime.js";
+import { DEFAULT_TRUST_COLLECTOR_CONFIG } from "./agent-trust-metrics.js";
+import type { PenaltyQualitySignal } from "./agent-trust-metrics.js";
+
+export const TRAILHEAD_VERDICT_SCHEMA = "trailhead.verdict.v1" as const;
+
+export const PENALTY_SEMANTICS = "lower_is_cleaner" as const;
+export const RISK_SEMANTICS = "higher_is_worse" as const;
+
+const SEVERITY_PENALTY: Record<SubmissionCheckResult["severity"], number> = {
+  blocking: 3,
+  warn: 2,
+  advisory: 1,
+};
+
+export const VerdictPenaltySchema = z.object({
+  total_score: z.number().min(0),
+  factor_scores: z.record(z.number().min(0)),
+  semantics: z.literal(PENALTY_SEMANTICS),
+});
+export type VerdictPenalty = z.infer<typeof VerdictPenaltySchema>;
+
+export const VerdictRiskSchema = z.object({
+  score: z.number().min(0).max(100),
+  semantics: z.literal(RISK_SEMANTICS),
+  factors: z.record(z.number().min(0).max(100)),
+});
+export type VerdictRisk = z.infer<typeof VerdictRiskSchema>;
+
+export const VerdictTrustProfileSchema = z.object({
+  shadow: z.boolean().optional(),
+  enforce: z.boolean().optional(),
+  score: z.number().min(0).max(1).optional(),
+  profile: z.enum(["fast-track", "standard", "probation"]).optional(),
+  strictness: z.enum(["baseline", "elevated", "strict"]),
+  reason: z.string(),
+  factors: z.record(z.number()).optional(),
+});
+export type VerdictTrustProfile = z.infer<typeof VerdictTrustProfileSchema>;
+
+export const VerdictRemediationSchema = z.object({
+  loop_round: z.number().int().min(0).optional(),
+  max_loop_rounds: z.number().int().min(0).optional(),
+  next_action: z.string().optional(),
+  fix_count: z.number().int().min(0).optional(),
+});
+export type VerdictRemediation = z.infer<typeof VerdictRemediationSchema>;
+
+export const TrailheadVerdictSchema = z.object({
+  schema: z.literal(TRAILHEAD_VERDICT_SCHEMA),
+  evaluation_id: z.string(),
+  repo_id: z.string(),
+  commit_sha: z.string(),
+  pr_number: z.number().int().positive().optional(),
+  head_ref: z.string().optional(),
+  agent_id: z.string().optional(),
+  decision: GateDecision,
+  gate_mode: z.enum(["risk-only", "advisory", "release-ready"]).optional(),
+  release_ready: z.boolean().optional(),
+  penalty: VerdictPenaltySchema,
+  risk: VerdictRiskSchema,
+  trust_profile: VerdictTrustProfileSchema.optional(),
+  submission_checks: z.array(
+    z.object({
+      code: SubmissionCheckCode,
+      severity: z.enum(["blocking", "warn", "advisory"]),
+      title: z.string(),
+      detail: z.string(),
+      files: z.array(z.string()).default([]),
+    }),
+  ),
+  remediation: VerdictRemediationSchema.optional(),
+  reasons: z.array(z.string()),
+  evaluated_at: z.string(),
+  /** Deprecated flat fields — remove after one release (#260). */
+  _legacy: z
+    .object({
+      riskScore: z.number(),
+      healthScore: z.number(),
+      releaseReadyReasons: z.array(z.string()).optional(),
+      policyFindings: z.array(z.string()).optional(),
+    })
+    .optional(),
+});
+export type TrailheadVerdict = z.infer<typeof TrailheadVerdictSchema>;
+
+export function computeSubmissionPenalty(
+  checks: SubmissionCheckResult[] = [],
+): VerdictPenalty {
+  const factor_scores: Record<string, number> = {};
+  for (const check of checks) {
+    const penalty = SEVERITY_PENALTY[check.severity] ?? 0;
+    factor_scores[check.code] = Math.max(factor_scores[check.code] ?? 0, penalty);
+  }
+
+  const values = Object.values(factor_scores);
+  const total_score =
+    values.length === 0
+      ? 0
+      : Math.round((values.reduce((sum, value) => sum + value, 0) / values.length) * 10) /
+        10;
+
+  return {
+    total_score,
+    factor_scores,
+    semantics: PENALTY_SEMANTICS,
+  };
+}
+
+export function collectVerdictReasons(evaluation: GateEvaluation): string[] {
+  const reasons = new Set<string>();
+
+  for (const finding of evaluation.policyFindings ?? []) {
+    reasons.add(finding);
+  }
+  for (const reason of evaluation.releaseReadyReasons ?? []) {
+    reasons.add(reason);
+  }
+  if (evaluation.remediation?.next_action) {
+    reasons.add(`Remediation next action: ${evaluation.remediation.next_action}`);
+  }
+  if (evaluation.trust_profile?.reason) {
+    reasons.add(evaluation.trust_profile.reason);
+  }
+  if (evaluation.gateDecision === "block") {
+    reasons.add("Gate decision is BLOCK");
+  } else if (evaluation.gateDecision === "warn") {
+    reasons.add("Gate decision is WARN");
+  }
+
+  return [...reasons];
+}
+
+export interface BuildGateVerdictOptions {
+  evaluatedAt?: string;
+  trustRuntime?: TrustRuntime;
+  agentId?: string | null;
+}
+
+export function buildGateVerdict(
+  evaluation: GateEvaluation,
+  options: BuildGateVerdictOptions = {},
+): TrailheadVerdict {
+  const checks = evaluation.submissionChecks ?? [];
+  const penalty = computeSubmissionPenalty(checks);
+  const trustRuntime = options.trustRuntime;
+
+  const verdict: TrailheadVerdict = {
+    schema: TRAILHEAD_VERDICT_SCHEMA,
+    evaluation_id: evaluation.id,
+    repo_id: evaluation.repoId,
+    commit_sha: evaluation.commitSha,
+    pr_number: evaluation.prNumber,
+    head_ref: evaluation.pr?.headRef,
+    agent_id: options.agentId ?? undefined,
+    decision: evaluation.gateDecision,
+    gate_mode: evaluation.gateMode,
+    release_ready: evaluation.releaseReady,
+    penalty,
+    risk: {
+      score: evaluation.riskScore,
+      semantics: RISK_SEMANTICS,
+      factors: Object.fromEntries(
+        evaluation.riskFactors.map((factor) => [factor.type, factor.score]),
+      ),
+    },
+    trust_profile: evaluation.trust_profile
+      ? {
+          shadow: trustRuntime?.shadow,
+          enforce: trustRuntime?.enforce,
+          score: evaluation.trust_profile.score,
+          profile: evaluation.trust_profile.profile,
+          strictness: evaluation.trust_profile.strictness,
+          reason: evaluation.trust_profile.reason,
+          factors: evaluation.trust_profile.factors,
+        }
+      : undefined,
+    submission_checks: checks.map((check) => ({
+      code: check.code,
+      severity: check.severity,
+      title: check.title,
+      detail: check.detail,
+      files: check.files ?? [],
+    })),
+    remediation: evaluation.remediation
+      ? {
+          loop_round: evaluation.remediation.loop_round,
+          max_loop_rounds: evaluation.remediation.max_loop_rounds,
+          next_action: evaluation.remediation.next_action,
+          fix_count: evaluation.remediation.fixes?.length,
+        }
+      : undefined,
+    reasons: collectVerdictReasons(evaluation),
+    evaluated_at: options.evaluatedAt ?? new Date().toISOString(),
+    _legacy: {
+      riskScore: evaluation.riskScore,
+      healthScore: evaluation.healthScore,
+      releaseReadyReasons: evaluation.releaseReadyReasons,
+      policyFindings: evaluation.policyFindings,
+    },
+  };
+
+  return TrailheadVerdictSchema.parse(verdict);
+}
+
+export function parseGateVerdict(raw: string | unknown): TrailheadVerdict | null {
+  try {
+    const value = typeof raw === "string" ? JSON.parse(raw) : raw;
+    const parsed = TrailheadVerdictSchema.safeParse(value);
+    return parsed.success ? parsed.data : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Collector helper: map penalty verdicts to trust penaltyQuality stats. */
+export function aggregateVerdictPenaltyQuality(
+  verdicts: TrailheadVerdict[],
+): PenaltyQualitySignal | null {
+  const scores = verdicts.map((verdict) => verdict.penalty.total_score);
+  if (scores.length === 0) return null;
+
+  const count = scores.length;
+  const mean = scores.reduce((sum, value) => sum + value, 0) / count;
+  const variance =
+    count === 1 ? 0 : scores.reduce((sum, value) => sum + (value - mean) ** 2, 0) / count;
+  const stdDev = Math.sqrt(variance);
+  const cleanThreshold = DEFAULT_TRUST_COLLECTOR_CONFIG.cleanPenaltyThreshold;
+  const cleanCount = scores.filter((score) => score <= cleanThreshold).length;
+
+  return {
+    mean: Math.round(mean * 10) / 10,
+    stdDev: Math.round(stdDev * 10) / 10,
+    cleanRate: Math.round((cleanCount / count) * 1000) / 1000,
+    sampleCount: count,
+  };
+}
+
+/** Example collector projection: one verdict → trust correlation fields. */
+export function projectVerdictToTrustCorrelation(verdict: TrailheadVerdict): {
+  evaluation_id: string;
+  agent_id?: string;
+  head_ref?: string;
+  penalty: VerdictPenalty;
+  release_ready_clean: boolean;
+} {
+  return {
+    evaluation_id: verdict.evaluation_id,
+    agent_id: verdict.agent_id,
+    head_ref: verdict.head_ref,
+    penalty: verdict.penalty,
+    release_ready_clean:
+      verdict.penalty.total_score <= DEFAULT_TRUST_COLLECTOR_CONFIG.cleanPenaltyThreshold,
+  };
+}

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,32 +1,39 @@
 # Trailhead CLI
 
-Interactive setup wizard and diagnostics for Trailhead. Generates `.trailhead.yml`, validates policy files, and compares configured CI check names against GitHub.
+Interactive setup wizard and diagnostics for Trailhead. Generates `.trailhead.yml`, validates policy files, compares configured CI check names against GitHub, and runs the submission gate (`validate-submission`).
+
+## Install (no build required)
+
+The published npm package ships a **prebuilt bundle** (`dist/index.js` + vendored `swc.*.node` bindings). You do not need to clone this repo or run `npm run build`.
+
+```bash
+npx @komatikai/trailhead doctor --offline
+npx @komatikai/trailhead init
+```
+
+Pin a version for CI:
+
+```bash
+npm install -D @komatikai/trailhead@4.4.4
+npx trailhead validate-submission --input bundle.json
+```
+
+### Migrating from vendored `cli-dist`
+
+Komatik agents and other repos that vendor `trailhead/cli-dist/` can replace the copy with an npm pin:
+
+```bash
+npm install -D @komatikai/trailhead@<tag>
+# invoke: npx trailhead validate-submission …
+```
+
+Set `TRAILHEAD_CLI=$(npm root)/.bin/trailhead` (or `npx trailhead`) in shadow-compare harnesses instead of a repo-relative `cli/dist/index.js`.
 
 ## Usage
 
-```bash
-npx @komatikai/trailhead init
-npx @komatikai/trailhead doctor
-```
-
 ### `trailhead init`
 
-No installation required. The wizard walks you through:
-
-1. **Gate mode** — release-ready, advisory, or risk-only
-2. **Branch model** — main-only or progressive promotion paths
-3. **Required checks** — CI job names for release-ready contexts
-4. **Sensitivity patterns** — which file paths are high/medium risk
-5. **Thresholds** — risk and warn scores
-6. **Freeze windows** — days and hours when deployments are blocked
-7. **Environments** — per-environment threshold overrides
-8. **Services** — monorepo service boundaries with path patterns
-9. **Security gate** — Code Scanning alerts as a risk factor
-10. **Canary tracking** — deploy outcome webhook type
-11. **DORA metrics** — compute DORA-5 alongside gate evaluations
-12. **Health checks** — URLs to probe before scoring
-13. **OpenTelemetry** — OTLP endpoint for evaluation span export
-14. **Evaluation store** — URL for persisting evaluations to a trend dashboard
+Interactive wizard — no GitHub token required. Creates `.trailhead.yml` and `.github/workflows/trailhead.yml`.
 
 ### `trailhead doctor`
 
@@ -43,8 +50,6 @@ GITHUB_TOKEN=ghp_... trailhead doctor --repo owner/repo
 trailhead doctor --json
 ```
 
-Options:
-
 | Flag                  | Description                            |
 | --------------------- | -------------------------------------- |
 | `--path <dir>`        | Directory to scan (default: cwd)       |
@@ -56,30 +61,26 @@ Options:
 
 Exit code `0` when there are no errors; `1` when config is missing/invalid or structural errors are found. Warnings do not fail the command.
 
-## Output (`init`)
+### `trailhead validate-submission`
 
-The wizard generates two files:
+Runs the canonical Gate 1 engine on a JSON payload of files (used by komatik-agents and MCP). See `cli/src/index.ts` for input shape.
 
-- **`.trailhead.yml`** — per-repo configuration
-- **`.github/workflows/trailhead.yml`** — GitHub Actions workflow with selected features
+## Development (this repo)
 
-## Development
+Source lives in `cli/src/`; shared modules are copied from `src/` at build time. **Do not commit `cli/dist/`** — CI and the release workflow build the bundle.
 
 ```bash
-cd cli
-npm install
-npm run build
-node dist/index.js doctor --offline --path ..
+# From repo root
+npm ci
+npm run build:cli
+node cli/dist/index.js doctor --offline --path .
+
+# Typecheck CLI sources only
+cd cli && npm ci && npm run typecheck
 ```
 
-The CLI copies shared validation modules from `src/` during prebuild. Build output goes to `cli/dist/` (gitignored — build before npm publish).
+Bundle pipeline: `scripts/build-cli-bundle.mjs` → `ncc` + `scripts/copy-swc-bindings.mjs` (same pattern as the GitHub Action).
 
 ## Publishing
 
-```bash
-cd cli
-npm run build
-npm publish
-```
-
-The package is published as `@komatikai/trailhead` on npm.
+On tag push (`v*`), `.github/workflows/release.yml` runs `npm run build:cli` on ubuntu-latest and publishes `@komatikai/trailhead` to npm. The tarball contains only `dist/` — no runtime `@swc/core` install step for consumers.

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,272 +1,23 @@
 {
   "name": "@komatikai/trailhead",
-  "version": "4.4.3",
+  "version": "4.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@komatikai/trailhead",
-      "version": "4.4.3",
+      "version": "4.4.4",
       "license": "MIT",
-      "dependencies": {
-        "@swc/core": "^1.15.40",
-        "js-yaml": "^4.1.1",
-        "zod": "^3.24.0"
-      },
       "bin": {
         "trailhead": "dist/index.js"
       },
       "devDependencies": {
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^25.8.0",
-        "typescript": "^6.0.3"
-      }
-    },
-    "node_modules/@swc/core": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.40.tgz",
-      "integrity": "sha512-2kwzJikRvgtNAG7MwVZY2vEzZjTxKIq5jXOihuSV/8U+Hej8Va22t65aKnJZs3P+NwojZvR8Mf8kyM7O+V8sQg==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@swc/counter": "^0.1.3",
-        "@swc/types": "^0.1.26"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/swc"
-      },
-      "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.15.40",
-        "@swc/core-darwin-x64": "1.15.40",
-        "@swc/core-linux-arm-gnueabihf": "1.15.40",
-        "@swc/core-linux-arm64-gnu": "1.15.40",
-        "@swc/core-linux-arm64-musl": "1.15.40",
-        "@swc/core-linux-ppc64-gnu": "1.15.40",
-        "@swc/core-linux-s390x-gnu": "1.15.40",
-        "@swc/core-linux-x64-gnu": "1.15.40",
-        "@swc/core-linux-x64-musl": "1.15.40",
-        "@swc/core-win32-arm64-msvc": "1.15.40",
-        "@swc/core-win32-ia32-msvc": "1.15.40",
-        "@swc/core-win32-x64-msvc": "1.15.40"
-      },
-      "peerDependencies": {
-        "@swc/helpers": ">=0.5.17"
-      },
-      "peerDependenciesMeta": {
-        "@swc/helpers": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@swc/core-darwin-arm64": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.40.tgz",
-      "integrity": "sha512-PaYyclfmQ++77D8ityYvmmVzHv9aG8ROwt2GfG6/ccloy4Hgf80qtOnzb9VYvPsUT7Ty1uhuDRhv3XYpf62qhQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0 AND MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-darwin-x64": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.40.tgz",
-      "integrity": "sha512-HbbPzvfLBUXjIB1Ezks+//lNUjmLjfyd63XSwprJgrZaXYdm70kohXPJUWdqKZozolFxbPaO+xtBaiUp6BoueA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0 AND MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.40.tgz",
-      "integrity": "sha512-SlRZsCjOCPR2LvFs0Ri/Xrx/5o5TCt8vl4gW6mX1hEZOG0a625RxzRHpHdAQNGykmAN/7IeaFAJG+QnNmxlHcA==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.40.tgz",
-      "integrity": "sha512-Q8byxJt2fh8CR3EUX6snBpy47AoBVm+In/+Z3rjDHMjC38ZvR9/gtUUNCT0tfrn4EdVsO8/QPi59nxrxvqxvBQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0 AND MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.40.tgz",
-      "integrity": "sha512-4z0MgHU+7M0pZDqBN1El7mFXDI1SBwinfcUkAyA4v8QrhOIUOZltySt2aStQLZGrdXVXM4Y4ylfiTC04ED+MoQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0 AND MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-linux-ppc64-gnu": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.40.tgz",
-      "integrity": "sha512-fLI4iUgeSZu0eRWUXwe6YzPFx9gHbFiPkl8Rp3mJfP8OpNR3nTQCGPvHdDh9xniW7mVvgMY4ni7A4VzqI1KrpA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "Apache-2.0 AND MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-linux-s390x-gnu": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.40.tgz",
-      "integrity": "sha512-YqeKMAb7d4nQSGMJQ454IlaCENpzcDqhvBE9+CPfdnYpnUXxd+BSrB6Xk0YjW8UyoEhUj4p6quATCxbsp6J3jg==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "Apache-2.0 AND MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.40.tgz",
-      "integrity": "sha512-7HOuS1iGcme/j/TuL1TfmmLGiMQrjv/GmjyZeydl00FKPtpGXEldwqfI56xgd1YzrzoB2svWjxbGGyQ0TEASxg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0 AND MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.40.tgz",
-      "integrity": "sha512-h4kZYHc7dpc9P9u4brRJaS8Pl7tPVHAeiLSzw7T5RfIJgAoSdaCMKzI/2Uay9gFhaw8uyCDl0L5q37r0EpAfIA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0 AND MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.40.tgz",
-      "integrity": "sha512-+mQgKZXSj6mV38Zh05QaxSjUDmGP/R2JWlXZTDLSPkDzHU6p3GxN9eeSf5dfyDVU86946fmCvSzyl/ucImx8+A==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0 AND MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.40.tgz",
-      "integrity": "sha512-yvwdPLGd25mcj/mNatjNQ0lZujtQD6psH3v9PNmMb+fSzjbNG8KIDxjFWrcV+fsFVLOkyOmdJsFmX7NAFjVyPw==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "Apache-2.0 AND MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.40.tgz",
-      "integrity": "sha512-OXtKsLU1bVtInzzDEAY2sYiF/rl4tvAnLLLpuMp3HzAOQZ5A+i69AKDhA1YLQTaMAqO3vzyYNVAYVRMPtSYD4w==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0 AND MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/counter": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
-      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@swc/types": {
-      "version": "0.1.26",
-      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.26.tgz",
-      "integrity": "sha512-lyMwd7WGgG79RS7EERZV3T8wMdmPq3xwyg+1nmAM64kIhx5yl+juO2PYIHb7vTiPgPCj8LYjsNV2T5wiQHUEaw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@swc/counter": "^0.1.3"
+        "@vercel/ncc": "^0.38.4",
+        "js-yaml": "^4.1.1",
+        "typescript": "^6.0.3",
+        "zod": "^3.24.0"
       }
     },
     "node_modules/@types/js-yaml": {
@@ -286,16 +37,28 @@
         "undici-types": ">=7.24.0 <7.24.7"
       }
     },
+    "node_modules/@vercel/ncc": {
+      "version": "0.38.4",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.38.4.tgz",
+      "integrity": "sha512-8LwjnlP39s08C08J5NstzriPvW1SP8Zfpp1BvC2sI35kPeZnHfxVkCwu4/+Wodgnd60UtT1n8K8zw+Mp7J9JmQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "ncc": "dist/ncc/cli.js"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/js-yaml": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -329,6 +92,7 @@
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/cli/package.json
+++ b/cli/package.json
@@ -2,13 +2,13 @@
   "name": "@komatikai/trailhead",
   "version": "4.4.4",
   "description": "Trailhead CLI — setup wizard and utilities for the Trailhead deployment gate",
-  "type": "module",
   "bin": {
     "trailhead": "dist/index.js"
   },
   "scripts": {
     "prebuild": "node ../scripts/copy-shared-src.mjs cli",
-    "build": "npm run prebuild && tsc",
+    "build": "node ../scripts/build-cli-bundle.mjs",
+    "typecheck": "npm run prebuild && tsc --noEmit",
     "prepublishOnly": "npm run build",
     "start": "node dist/index.js"
   },
@@ -25,14 +25,13 @@
     "dora"
   ],
   "license": "MIT",
-  "dependencies": {
-    "@swc/core": "^1.15.40",
-    "js-yaml": "^4.1.1",
-    "zod": "^3.24.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^25.8.0",
-    "typescript": "^6.0.3"
+    "@vercel/ncc": "^0.38.4",
+    "js-yaml": "^4.1.1",
+    "typescript": "^6.0.3",
+    "zod": "^3.24.0"
   }
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -283,6 +283,7 @@ Trailhead is evolving from a human-supervised merge gate into a **coach → fixe
 - **Phase 0 suggestion heuristics** — 14 advisory checks on `agents/*/suggestions/**/*.md` (v4.4.2)
 - **Autofix allowlist** — `fixer-core` + `app/fixer.ts` (plan only; git write pending)
 - **Trust scoring** — `trust-score.ts`; versioned metrics via `TRAILHEAD_AGENT_TRUST_JSON` ([agent-trust-metrics.md](./agent-trust-metrics.md))
+- **Gate verdict** — stable `trailhead.verdict.v1` on Action `verdict-json` output ([verdict.md](./verdict.md))
 - **MCP tools** — `validate-submission`, `apply-autofix`, `get-trust-score`
 - **Credit metering** — optional Komatik `deploy_check` ingest ([komatik-credit-metering.md](./komatik-credit-metering.md))
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -282,7 +282,7 @@ Trailhead is evolving from a human-supervised merge gate into a **coach → fixe
 - **Gate 1 submission engine** — 15 blocking checks via `submission-gate: true` ([submission-gate.md](./submission-gate.md))
 - **Phase 0 suggestion heuristics** — 14 advisory checks on `agents/*/suggestions/**/*.md` (v4.4.2)
 - **Autofix allowlist** — `fixer-core` + `app/fixer.ts` (plan only; git write pending)
-- **Trust scoring** — `trust-score.ts`; `TRAILHEAD_AGENT_TRUST_JSON` env until hosted lookup
+- **Trust scoring** — `trust-score.ts`; versioned metrics via `TRAILHEAD_AGENT_TRUST_JSON` ([agent-trust-metrics.md](./agent-trust-metrics.md))
 - **MCP tools** — `validate-submission`, `apply-autofix`, `get-trust-score`
 - **Credit metering** — optional Komatik `deploy_check` ingest ([komatik-credit-metering.md](./komatik-credit-metering.md))
 

--- a/docs/agent-trust-feedback.md
+++ b/docs/agent-trust-feedback.md
@@ -1,0 +1,93 @@
+# Post-merge trust feedback (v1)
+
+Correlates **post-merge outcomes** (CI, reverts, remediation rounds) to agent trust metrics. Closes the loop for outcome-based fields in `AgentTrustMetrics` that gate decisions alone cannot populate.
+
+Reference collector: [KomatikAI/agents PR #203](https://github.com/KomatikAI/agents/pull/203) (`scripts/lib/agent-trust-feedback.js`).
+
+Related: [agent-trust-metrics.md](./agent-trust-metrics.md) · Epic [#252](https://github.com/KomatikAI/trailhead/issues/252) · Issue [#257](https://github.com/KomatikAI/trailhead/issues/257)
+
+## Schema
+
+- **Event schema id:** `trailhead.feedback.v1`
+- **Zod export:** `src/agent-trust-feedback.ts`
+- **Example events:** `examples/agent-trust-feedback.v1.json`
+
+### Event fields
+
+| Field                | Required | Notes                                                                                   |
+| -------------------- | -------- | --------------------------------------------------------------------------------------- |
+| `outcome`            | yes      | `ci_pass` \| `ci_fail` \| `revert` \| `rollback` \| `rounds_to_green` \| `human_review` |
+| `observed_at`        | yes      | ISO-8601 timestamp                                                                      |
+| `agent_id`           | no       | Preferred attribution key                                                               |
+| `head_ref`           | no       | Resolved via `agent/<id>/…` when `agent_id` absent                                      |
+| `submission_id`      | no       | Suggestion bundle / submission correlation                                              |
+| `pr_number`          | no       | GitHub PR number                                                                        |
+| `evaluation_id`      | no       | Trailhead evaluation id (`dg-…`)                                                        |
+| `project_slug`       | no       | Used by collectors for ambiguous CI attribution                                         |
+| `remediation_rounds` | no       | Required for `rounds_to_green`                                                          |
+| `metadata`           | no       | Adapter-specific payload (title, ref, workflow run id)                                  |
+
+### Batch envelope
+
+Collectors may emit a batch for storage or debugging:
+
+```json
+{
+  "schema": "trailhead.feedback.v1",
+  "collected_at": "2026-05-29T12:00:00.000Z",
+  "events": ["... TrustFeedbackEvent ..."],
+  "unattributed": { "ci_failures": 3, "reverts": 0 }
+}
+```
+
+## Mapping → `AgentTrustMetrics`
+
+| Feedback outcome      | Metrics fields                                                                  | Semantics                                                       |
+| --------------------- | ------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| `ci_fail`             | `feedback.ciFailures`, +1 `humanReviewRequiredCount`, +1 `policyViolationCount` | Post-merge CI regression attributed to agent                    |
+| `revert` / `rollback` | `feedback.reverts`, +1 `revertCount`                                            | Merged agent work reverted                                      |
+| `human_review`        | `feedback.humanReview`, +1 `humanReviewRequiredCount`                           | Escalation / block requiring human follow-up                    |
+| `rounds_to_green`     | append `remediationRoundsToReady[]`                                             | Loop rounds until release-ready (requires `remediation_rounds`) |
+| `ci_pass`             | (none)                                                                          | Positive signal; optional for future scoring                    |
+
+Use `rollupFeedbackForAgent()` + `mergeFeedbackIntoMetrics()` from `src/agent-trust-feedback.ts` when building collector output.
+
+**When feedback is absent:** collectors should leave `revertCount` / `remediationRoundsToReady` at 0 and rely on gate penalty signals (#254). Cold-start (#253) counts optional `feedback.*` toward minimum evidence.
+
+## Attribution rules
+
+1. **`agent_id` present** → use directly.
+2. **`head_ref` matches `agent/<agent-id>/…`** → resolve agent id from branch pattern.
+3. **`metadata.head_ref` / `metadata.ref`** → same resolution as (2).
+4. **Otherwise** → event is **unattributed**; increment batch `unattributed.*` counters. Do not invent agent blame.
+
+Komatik dogfood adds project_slug + recency heuristics when multiple agents share a project — see agents `agent-trust-feedback.js`. Product schema supports `project_slug`; heuristics remain collector-specific until promoted.
+
+## Ingestion surfaces (adopter options)
+
+| Surface                        | Status                 | Notes                                                                         |
+| ------------------------------ | ---------------------- | ----------------------------------------------------------------------------- |
+| **Reference collector**        | Dogfood in agents #203 | Queries fleet event store                                                     |
+| **Webhook adapter**            | Spec only              | CI workflow `workflow_run` → map conclusion to `ci_pass`/`ci_fail` + head_ref |
+| **GitHub App extension**       | Future                 | Attach feedback on deploy/canary webhooks                                     |
+| **Evaluation store extension** | Future                 | Komatik hosted store post-merge fields                                        |
+
+### Workflow template (sketch)
+
+```yaml
+- name: Report Trailhead feedback
+  if: always() && github.event.pull_request.head.ref != ''
+  run: |
+    curl -sf "$TRAILHEAD_FEEDBACK_WEBHOOK" -d "$(jq -n \
+      --arg ref "${{ github.head_ref }}" \
+      --arg outcome "${{ job.status == 'success' && 'ci_pass' || 'ci_fail' }}" \
+      '{ outcome: $outcome, head_ref: $ref, observed_at: (now|todate) }')"
+```
+
+Set `TRAILHEAD_FEEDBACK_WEBHOOK` to your collector endpoint; collector translates events → `AgentTrustMetrics.feedback` before injecting `TRAILHEAD_AGENT_TRUST_JSON`.
+
+## Honest gaps (dogfood oracle)
+
+- Many CI failure rows lack stable `agent_id` — unattributed counts are expected.
+- `remediationRoundsToReady` requires explicit `rounds_to_green` events with `remediation_rounds`; gate decisions alone do not populate this field.
+- Binary gate `allow` is non-discriminating — use penalty `total_score` for pre-merge quality (#254).

--- a/docs/agent-trust-metrics.md
+++ b/docs/agent-trust-metrics.md
@@ -1,0 +1,88 @@
+# Agent trust metrics (v1)
+
+Trailhead dynamic agent trust consumes a versioned metrics payload via `TRAILHEAD_AGENT_TRUST_JSON` (Action runtime) or the MCP `get-trust-score` tool.
+
+Reference collector: [KomatikAI/agents PR #203](https://github.com/KomatikAI/agents/pull/203) (`scripts/lib/agent-trust-collector.js`).
+
+## Schema
+
+- **Envelope schema id:** `trailhead.agent_trust_metrics.v1`
+- **Zod export:** `src/agent-trust-metrics.ts` (`AgentTrustMetricsSchema`, `AgentTrustEnvelopeSchema`)
+- **Example payload:** `examples/agent-trust-metrics.v1.json`
+
+### Core fields
+
+| Field                         | Type    | Notes                                                                               |
+| ----------------------------- | ------- | ----------------------------------------------------------------------------------- |
+| `evaluations`                 | int ≥ 0 | Gate evaluations in window (+ optional feedback counts in collector)                |
+| `releaseReadyCount`           | int     | Clean submissions; collectors map low **penalty** `total_score`, not binary `allow` |
+| `revertCount`                 | int     | Post-merge reverts attributed to agent                                              |
+| `humanReviewRequiredCount`    | int     | Blocks, warns, CI failures requiring human follow-up                                |
+| `policyViolationCount`        | int     | Policy detector hits + attributed CI failures                                       |
+| `sensitivePathViolationCount` | int     | Secrets / destructive SQL / env detector hits                                       |
+| `remediationRoundsToReady`    | int[]   | Loop rounds for PRs that reached release-ready                                      |
+
+### Optional continuous signals (#254)
+
+| Field                        | Type   | Notes                                                                                   |
+| ---------------------------- | ------ | --------------------------------------------------------------------------------------- |
+| `penaltyQuality.mean`        | number | Mean gate penalty `total_score` (**lower = cleaner**, typically 0–8)                    |
+| `penaltyQuality.stdDev`      | number | Std-dev of penalty scores; ≥ `minScoreStdDev` (default 1) satisfies cold-start variance |
+| `penaltyQuality.cleanRate`   | 0–1    | Share of evaluations with penalty ≤ `cleanPenaltyThreshold` (default 1)                 |
+| `penaltyQuality.sampleCount` | int    | Evaluations used for penalty stats                                                      |
+
+### Optional post-merge feedback (#257 precursor)
+
+| Field                  | Type |
+| ---------------------- | ---- |
+| `feedback.ciFailures`  | int  |
+| `feedback.reverts`     | int  |
+| `feedback.humanReview` | int  |
+
+## Cold start (#253)
+
+`computeAgentTrustScore()` returns **`null`** (not a flat 0.5) when:
+
+1. Total evidence `< minEvidenceEvaluations` (default **5**), or
+2. Signals are flat: all clean, zero violations, no penalty variance, no feedback.
+
+Collectors should omit `TRAILHEAD_AGENT_TRUST_JSON` when cold-start applies. The Action logs `[agent-trust] … trust=null` if metrics are present but scoring refuses to emit trust.
+
+## Shadow / enforce runtime (#259)
+
+| Env var                   | Default | Effect                                                                 |
+| ------------------------- | ------- | ---------------------------------------------------------------------- |
+| `TRAILHEAD_TRUST_ENABLED` | enabled | Kill switch (`false` ignores trust JSON entirely)                      |
+| `TRAILHEAD_TRUST_SHADOW`  | off     | Log trust profile; **do not** apply `thresholdDelta`                   |
+| `TRAILHEAD_TRUST_ENFORCE` | off     | Collector: inject JSON. Gate applies threshold unless shadow is on     |
+
+## Ingestion forms
+
+**Bare metrics** (injected env JSON):
+
+```json
+{ "evaluations": 12, "releaseReadyCount": 10, "...": "..." }
+```
+
+**Versioned envelope** (export / storage; `trust` may be `null` during cold start):
+
+```json
+{
+  "schema": "trailhead.agent_trust_metrics.v1",
+  "agent_id": "pixel",
+  "collected_at": "2026-05-29T00:00:00.000Z",
+  "window_days": 30,
+  "trust": { "...": "..." },
+  "cold_start": { "emitTrust": true, "reason": null }
+}
+```
+
+The Action parser accepts either form; envelope with `trust: null` yields no scoring input.
+
+## Penalty semantics (critical)
+
+Live `agent_gate_decision` events store **`total_score` as a penalty** (lower = cleaner), not 0–100 risk. Binary `decision: allow` was ~100% in the Komatik measurement window — map release-readiness from **low penalty**, not from `allow` alone. See agents `scripts/lib/agent-trust-penalty.js`.
+
+## Related issues
+
+Epic [#252](https://github.com/KomatikAI/trailhead/issues/252): #253 cold-start, #254 penalty distribution, #255 schema, #259 shadow mode.

--- a/docs/agent-trust-metrics.md
+++ b/docs/agent-trust-metrics.md
@@ -50,11 +50,11 @@ Collectors should omit `TRAILHEAD_AGENT_TRUST_JSON` when cold-start applies. The
 
 ## Shadow / enforce runtime (#259)
 
-| Env var                   | Default | Effect                                                                 |
-| ------------------------- | ------- | ---------------------------------------------------------------------- |
-| `TRAILHEAD_TRUST_ENABLED` | enabled | Kill switch (`false` ignores trust JSON entirely)                      |
-| `TRAILHEAD_TRUST_SHADOW`  | off     | Log trust profile; **do not** apply `thresholdDelta`                   |
-| `TRAILHEAD_TRUST_ENFORCE` | off     | Collector: inject JSON. Gate applies threshold unless shadow is on     |
+| Env var                   | Default | Effect                                                             |
+| ------------------------- | ------- | ------------------------------------------------------------------ |
+| `TRAILHEAD_TRUST_ENABLED` | enabled | Kill switch (`false` ignores trust JSON entirely)                  |
+| `TRAILHEAD_TRUST_SHADOW`  | off     | Log trust profile; **do not** apply `thresholdDelta`               |
+| `TRAILHEAD_TRUST_ENFORCE` | off     | Collector: inject JSON. Gate applies threshold unless shadow is on |
 
 ## Ingestion forms
 

--- a/docs/agent-trust-metrics.md
+++ b/docs/agent-trust-metrics.md
@@ -31,13 +31,15 @@ Reference collector: [KomatikAI/agents PR #203](https://github.com/KomatikAI/age
 | `penaltyQuality.cleanRate`   | 0–1    | Share of evaluations with penalty ≤ `cleanPenaltyThreshold` (default 1)                 |
 | `penaltyQuality.sampleCount` | int    | Evaluations used for penalty stats                                                      |
 
-### Optional post-merge feedback (#257 precursor)
+### Optional post-merge feedback (#257)
 
 | Field                  | Type |
 | ---------------------- | ---- |
 | `feedback.ciFailures`  | int  |
 | `feedback.reverts`     | int  |
 | `feedback.humanReview` | int  |
+
+Ingest events via **`trailhead.feedback.v1`** — see [agent-trust-feedback.md](./agent-trust-feedback.md).
 
 ## Cold start (#253)
 

--- a/docs/schemas/verdict.v1.json
+++ b/docs/schemas/verdict.v1.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://trailhead.dev/schemas/verdict.v1.json",
+  "title": "Trailhead Gate Verdict v1",
+  "description": "Stable gate verdict for collectors and event stores.",
+  "type": "object",
+  "required": [
+    "schema",
+    "evaluation_id",
+    "repo_id",
+    "commit_sha",
+    "decision",
+    "penalty",
+    "risk",
+    "submission_checks",
+    "reasons",
+    "evaluated_at"
+  ],
+  "properties": {
+    "schema": { "const": "trailhead.verdict.v1" },
+    "evaluation_id": { "type": "string" },
+    "repo_id": { "type": "string" },
+    "commit_sha": { "type": "string", "minLength": 7 },
+    "pr_number": { "type": "integer", "minimum": 1 },
+    "head_ref": { "type": "string" },
+    "agent_id": { "type": "string" },
+    "decision": { "enum": ["allow", "warn", "block"] },
+    "gate_mode": { "enum": ["risk-only", "advisory", "release-ready"] },
+    "release_ready": { "type": "boolean" },
+    "penalty": {
+      "type": "object",
+      "required": ["total_score", "factor_scores", "semantics"],
+      "properties": {
+        "total_score": { "type": "number", "minimum": 0 },
+        "factor_scores": {
+          "type": "object",
+          "additionalProperties": { "type": "number", "minimum": 0 }
+        },
+        "semantics": { "const": "lower_is_cleaner" }
+      }
+    },
+    "risk": {
+      "type": "object",
+      "required": ["score", "semantics", "factors"],
+      "properties": {
+        "score": { "type": "number", "minimum": 0, "maximum": 100 },
+        "semantics": { "const": "higher_is_worse" },
+        "factors": {
+          "type": "object",
+          "additionalProperties": { "type": "number", "minimum": 0, "maximum": 100 }
+        }
+      }
+    },
+    "evaluated_at": { "type": "string", "format": "date-time" }
+  }
+}

--- a/docs/submission-gate.md
+++ b/docs/submission-gate.md
@@ -100,7 +100,11 @@ Before retiring `komatik-agents/scripts/lib/agent-gate-checks.js`, run the read-
 ```bash
 # Shallow clone komatik-agents dev, then:
 KOMATIK_AGENTS_ROOT=/path/to/agents npm run shadow-compare
+# Default CLI: repo-local bundle (npm run build:cli) or:
+# TRAILHEAD_CLI="$(npm root -g)/@komatikai/trailhead/dist/index.js"  # after npm i -g
 ```
+
+The published **`@komatikai/trailhead`** npm package ships a prebuilt `dist/index.js` with vendored `swc.*.node` bindings — no `@swc/core` install at consumer time. See `cli/README.md`.
 
 Report written to `shadow-compare-out/shadow-compare-report.json` (gitignored). **Cutover criterion:** 0 divergent decisions on shared checks (`secrets`, `destructive_sql`, `syntax_validity`, `mock_placeholder`, `hardcoded_env`, `external_package_deps`, `sql_syntax_basic`, `large_file`, `context_freshness`).
 

--- a/docs/submission-gate.md
+++ b/docs/submission-gate.md
@@ -58,6 +58,41 @@ submission:
     skip_comment_markers: ["historical:", "migration:", "deprecated:"]
 ```
 
+### Detector policy (#256)
+
+Move **policy** into config; detector **logic** stays in the product. No source edits required for rename rules or per-detector scope/severity.
+
+```yaml
+submission:
+  rename_patterns:
+    - old: DeployGuard
+      new: Trailhead
+    - old: AcmeCorp
+      new: BetaInc
+  slug_only_patterns:
+    - "\\blegacy-slug\\b"
+  detectors:
+    artifact_integrity:
+      enabled: true
+      file_globs: ["**/*.{ts,tsx,js,jsx,mjs,cjs}"]
+      path_ignore: ["docs/**"]
+      severity: block # block | warn | advisory (maps block → blocking)
+    context_freshness:
+      enabled: true
+      severity: warn
+    mock_placeholder:
+      enabled: false
+```
+
+- **`rename_patterns`** — extends Komatik defaults when `KOMATIK_INSTANCE=true`; usable standalone on any repo
+- **`detectors.<code>.enabled`** — skip a detector entirely
+- **`detectors.<code>.severity`** — override default severity (`block` → `blocking`)
+- **`detectors.<code>.file_globs`** — limit which files a detector scans (`artifact_integrity` default: code extensions only)
+- **`detectors.<code>.path_ignore`** — skip paths matching globs for that detector
+- Unknown detector keys → Action warning (same pattern as unknown top-level config keys)
+
+MCP `validate-submission` accepts the same `submission` object shape as `.trailhead.yml` and returns `config_warnings` for unknown keys.
+
 ## Shadow comparison (cutover gate)
 
 Before retiring `komatik-agents/scripts/lib/agent-gate-checks.js`, run the read-only divergence report against real suggestion bundles:

--- a/docs/verdict.md
+++ b/docs/verdict.md
@@ -1,0 +1,64 @@
+# Gate verdict contract (v1)
+
+Stable, versioned output for collectors, event stores, and dashboards — replaces ad-hoc `agent_gate_decision.metadata` field guessing.
+
+Related: [agent-trust-metrics.md](./agent-trust-metrics.md) · [agent-trust-feedback.md](./agent-trust-feedback.md) · Epic [#252](https://github.com/KomatikAI/trailhead/issues/252) · Issue [#260](https://github.com/KomatikAI/trailhead/issues/260)
+
+## Schema
+
+- **Schema id:** `trailhead.verdict.v1`
+- **Zod export:** `src/verdict.ts` (`TrailheadVerdictSchema`)
+- **JSON Schema:** `docs/schemas/verdict.v1.json`
+- **Example:** `examples/verdict/gate-allow-clean.v1.json`
+
+## Emission surfaces
+
+| Surface                   | Output                                                      |
+| ------------------------- | ----------------------------------------------------------- |
+| GitHub Action             | `verdict-json` output (+ `evaluation-json` legacy superset) |
+| Semantic webhooks         | `verdict` block on `trailhead.webhook.v1` payloads          |
+| MCP `validate-submission` | `verdict` + legacy `gate_decision`                          |
+| MCP `evaluate-policy`     | `verdict` + legacy `gate_decision`                          |
+
+Build helper: `buildGateVerdict(evaluation, options)` — pure, no I/O.
+
+## Penalty vs risk (do not conflate)
+
+| Block         | Field                          | Semantics                     | Source                                                       |
+| ------------- | ------------------------------ | ----------------------------- | ------------------------------------------------------------ |
+| **`penalty`** | `total_score`, `factor_scores` | **`lower_is_cleaner`**        | Submission gate checks (severity-weighted per detector code) |
+| **`risk`**    | `score`, `factors`             | **`higher_is_worse`** (0–100) | Deploy gate risk engine                                      |
+
+Trust collectors (#255) should use **`penalty`**, not `risk.score`, for pre-merge agent quality — see [agent-trust-metrics.md](./agent-trust-metrics.md).
+
+Default severity → penalty weights: `blocking=3`, `warn=2`, `advisory=1`. `total_score` is the mean of per-code max penalties.
+
+## Trust profile block
+
+When dynamic trust is active, `trust_profile` includes:
+
+- `strictness`, `reason`, optional `score` / `profile` / `factors`
+- `shadow` / `enforce` from `TRAILHEAD_TRUST_*` runtime (see [agent-trust-metrics.md](./agent-trust-metrics.md))
+
+## Collector mapping
+
+```typescript
+import {
+  aggregateVerdictPenaltyQuality,
+  projectVerdictToTrustCorrelation,
+} from "./verdict.js";
+
+const correlation = projectVerdictToTrustCorrelation(verdict);
+// → { evaluation_id, agent_id, penalty, release_ready_clean }
+
+const penaltyQuality = aggregateVerdictPenaltyQuality(verdictHistory);
+// → AgentTrustMetrics.penaltyQuality shape
+```
+
+Pair with post-merge events via `evaluation_id` → [agent-trust-feedback.md](./agent-trust-feedback.md).
+
+## Backward compatibility
+
+`_legacy` carries flat `riskScore`, `healthScore`, and finding arrays for one release. Top-level webhook fields (`riskScore`, `decision`, …) remain; prefer `verdict` for new integrations.
+
+Komatik dogfood migration: point `log-gate-decision.js` / `agent-trust-loader.js` at `verdict.penalty` instead of parsing raw metadata keys.

--- a/examples/agent-trust-feedback.v1.json
+++ b/examples/agent-trust-feedback.v1.json
@@ -1,0 +1,29 @@
+[
+  {
+    "schema": "trailhead.feedback.v1",
+    "submission_id": "sub-2026-05-28-pixel-pack-001",
+    "pr_number": 412,
+    "evaluation_id": "dg-a1b2c3d-1710000000000",
+    "agent_id": "pixel",
+    "head_ref": "agent/pixel/suggestions/pack/ui-tweak",
+    "outcome": "ci_fail",
+    "observed_at": "2026-05-28T14:22:00.000Z",
+    "project_slug": "pack"
+  },
+  {
+    "agent_id": "forge",
+    "head_ref": "agent/forge/fix-api-timeout",
+    "outcome": "revert",
+    "observed_at": "2026-05-29T09:10:00.000Z",
+    "metadata": {
+      "title": "Revert agent/forge/fix-api-timeout"
+    }
+  },
+  {
+    "agent_id": "vault",
+    "outcome": "rounds_to_green",
+    "remediation_rounds": 2,
+    "observed_at": "2026-05-29T11:00:00.000Z",
+    "evaluation_id": "dg-deadbeef-1710001111111"
+  }
+]

--- a/examples/agent-trust-metrics.v1.json
+++ b/examples/agent-trust-metrics.v1.json
@@ -1,0 +1,20 @@
+{
+  "evaluations": 24,
+  "releaseReadyCount": 22,
+  "revertCount": 1,
+  "humanReviewRequiredCount": 3,
+  "policyViolationCount": 2,
+  "sensitivePathViolationCount": 1,
+  "remediationRoundsToReady": [1, 1, 2, 1],
+  "penaltyQuality": {
+    "mean": 0.7,
+    "stdDev": 1.3,
+    "cleanRate": 0.92,
+    "sampleCount": 24
+  },
+  "feedback": {
+    "ciFailures": 1,
+    "reverts": 1,
+    "humanReview": 0
+  }
+}

--- a/examples/verdict/gate-allow-clean.v1.json
+++ b/examples/verdict/gate-allow-clean.v1.json
@@ -1,0 +1,44 @@
+{
+  "schema": "trailhead.verdict.v1",
+  "evaluation_id": "dg-abc1234-1710000000000",
+  "repo_id": "KomatikAI/agents",
+  "commit_sha": "abc1234567890abcdef1234567890abcdef12345678",
+  "pr_number": 203,
+  "head_ref": "agent/pixel/suggestions/pack/ui-tweak",
+  "agent_id": "pixel",
+  "decision": "allow",
+  "gate_mode": "release-ready",
+  "release_ready": true,
+  "penalty": {
+    "total_score": 0,
+    "factor_scores": {},
+    "semantics": "lower_is_cleaner"
+  },
+  "risk": {
+    "score": 28,
+    "semantics": "higher_is_worse",
+    "factors": {
+      "file_count": 20,
+      "code_churn": 35
+    }
+  },
+  "trust_profile": {
+    "shadow": true,
+    "enforce": false,
+    "score": 0.81,
+    "profile": "fast-track",
+    "strictness": "baseline",
+    "reason": "Agent trust score 0.81 — fast-track profile",
+    "factors": {
+      "release_ready_rate": 0.95
+    }
+  },
+  "submission_checks": [],
+  "reasons": ["All submission checks passed"],
+  "evaluated_at": "2026-05-30T12:00:00.000Z",
+  "_legacy": {
+    "riskScore": 28,
+    "healthScore": 100,
+    "releaseReadyReasons": ["CI required checks passed"]
+  }
+}

--- a/mcp/src/agent-trust-feedback.ts
+++ b/mcp/src/agent-trust-feedback.ts
@@ -1,0 +1,175 @@
+// Post-merge outcome feedback contract (epic #252 / issue #257).
+
+import { z } from "zod";
+import type { TrustFeedbackCounts } from "./agent-trust-metrics.js";
+
+export const AGENT_TRUST_FEEDBACK_SCHEMA = "trailhead.feedback.v1" as const;
+
+export const TrustFeedbackOutcome = z.enum([
+  "ci_pass",
+  "ci_fail",
+  "revert",
+  "rollback",
+  "rounds_to_green",
+  "human_review",
+]);
+export type TrustFeedbackOutcome = z.infer<typeof TrustFeedbackOutcome>;
+
+export const TrustFeedbackEventSchema = z.object({
+  schema: z.literal(AGENT_TRUST_FEEDBACK_SCHEMA).optional(),
+  submission_id: z.string().optional(),
+  pr_number: z.number().int().positive().optional(),
+  evaluation_id: z.string().optional(),
+  agent_id: z.string().optional(),
+  head_ref: z.string().optional(),
+  project_slug: z.string().optional(),
+  outcome: TrustFeedbackOutcome,
+  remediation_rounds: z.number().int().min(0).optional(),
+  observed_at: z.string(),
+  metadata: z.record(z.unknown()).optional(),
+});
+export type TrustFeedbackEvent = z.infer<typeof TrustFeedbackEventSchema>;
+
+export const TrustFeedbackBatchSchema = z.object({
+  schema: z.literal(AGENT_TRUST_FEEDBACK_SCHEMA),
+  collected_at: z.string(),
+  events: z.array(TrustFeedbackEventSchema),
+  unattributed: z
+    .object({
+      ci_failures: z.number().int().min(0).optional(),
+      reverts: z.number().int().min(0).optional(),
+      human_review: z.number().int().min(0).optional(),
+    })
+    .optional(),
+});
+export type TrustFeedbackBatch = z.infer<typeof TrustFeedbackBatchSchema>;
+
+export interface TrustFeedbackRollup {
+  feedback: TrustFeedbackCounts;
+  remediationRoundsToReady: number[];
+  attributed: number;
+  unattributed: number;
+}
+
+const AGENT_HEAD_REF = /^agent\/([a-z][a-z0-9-]*)\//;
+
+export function resolveAgentIdFromFeedbackEvent(
+  event: TrustFeedbackEvent,
+): string | null {
+  if (event.agent_id?.trim()) return event.agent_id.trim();
+
+  const headRef = event.head_ref?.trim();
+  if (headRef) {
+    const match = headRef.match(AGENT_HEAD_REF);
+    if (match) return match[1];
+  }
+
+  const metaRef =
+    typeof event.metadata?.head_ref === "string"
+      ? event.metadata.head_ref
+      : typeof event.metadata?.ref === "string"
+        ? event.metadata.ref.replace(/^refs\/heads\//, "")
+        : null;
+  if (metaRef) {
+    const match = metaRef.match(AGENT_HEAD_REF);
+    if (match) return match[1];
+  }
+
+  return null;
+}
+
+export function parseTrustFeedbackEvent(raw: unknown): TrustFeedbackEvent | null {
+  const parsed = TrustFeedbackEventSchema.safeParse(raw);
+  return parsed.success ? parsed.data : null;
+}
+
+export function parseTrustFeedbackBatch(
+  raw: string | unknown,
+): TrustFeedbackBatch | null {
+  try {
+    const value = typeof raw === "string" ? JSON.parse(raw) : raw;
+    const parsed = TrustFeedbackBatchSchema.safeParse(value);
+    return parsed.success ? parsed.data : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Map feedback events for a single agent into AgentTrustMetrics partial fields. */
+export function rollupFeedbackForAgent(
+  events: TrustFeedbackEvent[],
+  agentId: string,
+): TrustFeedbackRollup {
+  const feedback: TrustFeedbackCounts = {
+    ciFailures: 0,
+    reverts: 0,
+    humanReview: 0,
+  };
+  const remediationRoundsToReady: number[] = [];
+  let attributed = 0;
+  let unattributed = 0;
+
+  for (const event of events) {
+    const resolved = resolveAgentIdFromFeedbackEvent(event);
+    if (resolved !== agentId) {
+      if (resolved === null && !event.agent_id) unattributed += 1;
+      continue;
+    }
+    attributed += 1;
+
+    switch (event.outcome) {
+      case "ci_fail":
+        feedback.ciFailures = (feedback.ciFailures ?? 0) + 1;
+        break;
+      case "revert":
+      case "rollback":
+        feedback.reverts = (feedback.reverts ?? 0) + 1;
+        break;
+      case "human_review":
+        feedback.humanReview = (feedback.humanReview ?? 0) + 1;
+        break;
+      case "rounds_to_green":
+        if (typeof event.remediation_rounds === "number") {
+          remediationRoundsToReady.push(event.remediation_rounds);
+        }
+        break;
+      case "ci_pass":
+        break;
+    }
+  }
+
+  return {
+    feedback,
+    remediationRoundsToReady,
+    attributed,
+    unattributed,
+  };
+}
+
+export function mergeFeedbackIntoMetrics<
+  T extends {
+    revertCount: number;
+    humanReviewRequiredCount: number;
+    policyViolationCount: number;
+    remediationRoundsToReady: number[];
+    feedback?: TrustFeedbackCounts;
+  },
+>(metrics: T, rollup: TrustFeedbackRollup): T {
+  const fb = rollup.feedback;
+  return {
+    ...metrics,
+    revertCount: metrics.revertCount + (fb.reverts ?? 0),
+    humanReviewRequiredCount:
+      metrics.humanReviewRequiredCount + (fb.humanReview ?? 0) + (fb.ciFailures ?? 0),
+    policyViolationCount: metrics.policyViolationCount + (fb.ciFailures ?? 0),
+    remediationRoundsToReady: [
+      ...metrics.remediationRoundsToReady,
+      ...rollup.remediationRoundsToReady,
+    ],
+    feedback: {
+      ciFailures: (metrics.feedback?.ciFailures ?? 0) + (fb.ciFailures ?? 0),
+      reverts: (metrics.feedback?.reverts ?? 0) + (fb.reverts ?? 0),
+      humanReview: (metrics.feedback?.humanReview ?? 0) + (fb.humanReview ?? 0),
+    },
+  };
+}

--- a/mcp/src/agent-trust-metrics.ts
+++ b/mcp/src/agent-trust-metrics.ts
@@ -1,0 +1,217 @@
+// Versioned ingestion contract for dynamic agent trust (Phase B3 / epic #252).
+
+import { z } from "zod";
+
+export const AGENT_TRUST_METRICS_SCHEMA = "trailhead.agent_trust_metrics.v1" as const;
+
+export const DEFAULT_TRUST_COLLECTOR_CONFIG = {
+  windowDays: 30,
+  minEvidenceEvaluations: 5,
+  /** Minimum std-dev on gate penalty total_score to treat distribution as informative. */
+  minScoreStdDev: 1,
+  /** Gate penalty total_score at or below this is "clean" (lower = cleaner). */
+  cleanPenaltyThreshold: 1,
+  /** Gate penalty total_score at or above this is "noisy". */
+  noisyPenaltyThreshold: 3,
+} as const;
+
+export type TrustCollectorConfig = typeof DEFAULT_TRUST_COLLECTOR_CONFIG;
+
+export const PenaltyQualitySignalSchema = z.object({
+  mean: z.number().describe("Mean gate penalty total_score (lower = cleaner)"),
+  stdDev: z.number().min(0),
+  cleanRate: z.number().min(0).max(1),
+  sampleCount: z.number().int().min(0),
+});
+export type PenaltyQualitySignal = z.infer<typeof PenaltyQualitySignalSchema>;
+
+export const TrustFeedbackCountsSchema = z.object({
+  ciFailures: z.number().int().min(0).optional(),
+  reverts: z.number().int().min(0).optional(),
+  humanReview: z.number().int().min(0).optional(),
+});
+export type TrustFeedbackCounts = z.infer<typeof TrustFeedbackCountsSchema>;
+
+export const AgentTrustMetricsSchema = z.object({
+  evaluations: z.number().int().min(0),
+  releaseReadyCount: z.number().int().min(0).default(0),
+  revertCount: z.number().int().min(0).default(0),
+  humanReviewRequiredCount: z.number().int().min(0).default(0),
+  policyViolationCount: z.number().int().min(0).default(0),
+  sensitivePathViolationCount: z.number().int().min(0).default(0),
+  remediationRoundsToReady: z.array(z.number().int().min(0)).default([]),
+  penaltyQuality: PenaltyQualitySignalSchema.optional(),
+  feedback: TrustFeedbackCountsSchema.optional(),
+});
+export type AgentTrustMetrics = z.infer<typeof AgentTrustMetricsSchema>;
+
+export const ScoreDistributionSchema = z.object({
+  count: z.number().int().min(0),
+  mean: z.number(),
+  stdDev: z.number().min(0),
+  min: z.number(),
+  max: z.number(),
+  hasVariance: z.boolean(),
+});
+export type ScoreDistribution = z.infer<typeof ScoreDistributionSchema>;
+
+export const AgentTrustColdStartSchema = z.object({
+  emitTrust: z.boolean(),
+  reason: z.string().nullable(),
+});
+export type AgentTrustColdStart = z.infer<typeof AgentTrustColdStartSchema>;
+
+export const AgentTrustEnvelopeSchema = z.object({
+  schema: z.literal(AGENT_TRUST_METRICS_SCHEMA),
+  agent_id: z.string(),
+  collected_at: z.string(),
+  window_days: z.number().int().min(1),
+  trust: AgentTrustMetricsSchema.nullable(),
+  cold_start: AgentTrustColdStartSchema,
+  distribution: ScoreDistributionSchema.nullable().optional(),
+  feedback: TrustFeedbackCountsSchema.optional(),
+});
+export type AgentTrustEnvelope = z.infer<typeof AgentTrustEnvelopeSchema>;
+
+export function computeScoreDistribution(
+  scores: number[],
+  options: { minScoreStdDev?: number } = {},
+): ScoreDistribution | null {
+  const minScoreStdDev =
+    options.minScoreStdDev ?? DEFAULT_TRUST_COLLECTOR_CONFIG.minScoreStdDev;
+  const values = scores.filter((s) => typeof s === "number" && !Number.isNaN(s));
+  if (values.length === 0) return null;
+
+  const count = values.length;
+  const mean = values.reduce((sum, value) => sum + value, 0) / count;
+  const variance =
+    count === 1 ? 0 : values.reduce((sum, value) => sum + (value - mean) ** 2, 0) / count;
+  const stdDev = Math.sqrt(variance);
+
+  return {
+    count,
+    mean: Math.round(mean * 10) / 10,
+    stdDev: Math.round(stdDev * 10) / 10,
+    min: Math.min(...values),
+    max: Math.max(...values),
+    hasVariance: stdDev >= minScoreStdDev,
+  };
+}
+
+export function assessColdStart(params: {
+  evaluations: number;
+  distribution?: ScoreDistribution | null;
+  blockedCount?: number;
+  warnedCount?: number;
+  feedback?: TrustFeedbackCounts | null;
+  config?: Partial<TrustCollectorConfig>;
+}): AgentTrustColdStart {
+  const config = { ...DEFAULT_TRUST_COLLECTOR_CONFIG, ...params.config };
+  const feedback = params.feedback ?? null;
+  const feedbackEvaluations =
+    (feedback?.ciFailures ?? 0) + (feedback?.reverts ?? 0) + (feedback?.humanReview ?? 0);
+  const totalEvidence = params.evaluations + feedbackEvaluations;
+
+  if (totalEvidence < config.minEvidenceEvaluations) {
+    return {
+      emitTrust: false,
+      reason: `insufficient_evaluations (${totalEvidence} < ${config.minEvidenceEvaluations})`,
+    };
+  }
+
+  const hasOutcomeVariance =
+    (params.blockedCount ?? 0) > 0 ||
+    (params.warnedCount ?? 0) > 0 ||
+    (feedback?.reverts ?? 0) > 0 ||
+    (feedback?.ciFailures ?? 0) > 0 ||
+    (feedback?.humanReview ?? 0) > 0 ||
+    params.distribution?.hasVariance === true ||
+    (params.distribution?.stdDev ?? 0) >= config.minScoreStdDev;
+
+  if (!hasOutcomeVariance) {
+    return {
+      emitTrust: false,
+      reason: "flat_signals (no outcome variance and no penalty distribution variance)",
+    };
+  }
+
+  return { emitTrust: true, reason: null };
+}
+
+export function assessColdStartFromMetrics(
+  metrics: AgentTrustMetrics,
+  config?: Partial<TrustCollectorConfig>,
+): AgentTrustColdStart {
+  const mergedConfig = { ...DEFAULT_TRUST_COLLECTOR_CONFIG, ...config };
+  const feedbackEvidence =
+    (metrics.feedback?.ciFailures ?? 0) +
+    (metrics.feedback?.reverts ?? 0) +
+    (metrics.feedback?.humanReview ?? 0);
+  const totalEvidence = metrics.evaluations + feedbackEvidence;
+
+  if (totalEvidence < mergedConfig.minEvidenceEvaluations) {
+    return {
+      emitTrust: false,
+      reason: `insufficient_evaluations (${totalEvidence} < ${mergedConfig.minEvidenceEvaluations})`,
+    };
+  }
+
+  const penaltyVariance =
+    (metrics.penaltyQuality?.stdDev ?? 0) >= mergedConfig.minScoreStdDev;
+  const hasOutcomeVariance =
+    metrics.revertCount > 0 ||
+    metrics.humanReviewRequiredCount > 0 ||
+    metrics.policyViolationCount > 0 ||
+    metrics.sensitivePathViolationCount > 0 ||
+    penaltyVariance ||
+    feedbackEvidence > 0 ||
+    (metrics.releaseReadyCount > 0 && metrics.releaseReadyCount < metrics.evaluations);
+
+  if (!hasOutcomeVariance) {
+    return {
+      emitTrust: false,
+      reason: "flat_signals (no outcome variance and no penalty distribution variance)",
+    };
+  }
+
+  return { emitTrust: true, reason: null };
+}
+
+export function parseAgentTrustMetricsObject(raw: unknown): AgentTrustMetrics | null {
+  const parsed = AgentTrustMetricsSchema.safeParse(raw);
+  return parsed.success ? parsed.data : null;
+}
+
+export function parseAgentTrustMetrics(
+  raw: string | undefined,
+): AgentTrustMetrics | null {
+  if (!raw?.trim()) return null;
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      "schema" in parsed &&
+      (parsed as { schema?: string }).schema === AGENT_TRUST_METRICS_SCHEMA
+    ) {
+      const envelope = AgentTrustEnvelopeSchema.safeParse(parsed);
+      if (!envelope.success || !envelope.data.trust) return null;
+      return envelope.data.trust;
+    }
+    return parseAgentTrustMetricsObject(parsed);
+  } catch {
+    return null;
+  }
+}
+
+export function createEmptyAgentTrustMetrics(): AgentTrustMetrics {
+  return {
+    evaluations: 0,
+    releaseReadyCount: 0,
+    revertCount: 0,
+    humanReviewRequiredCount: 0,
+    policyViolationCount: 0,
+    sensitivePathViolationCount: 0,
+    remediationRoundsToReady: [],
+  };
+}

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -44,6 +44,7 @@ import {
 import { runSubmissionGate, submissionGateShouldBlock } from "./submission-engine.js";
 import { deriveSubmissionFixes } from "./submission-remediation.js";
 import { buildAutofixPlan, selectAutofixCommit } from "./fixer-core.js";
+import { assessColdStartFromMetrics } from "./agent-trust-metrics.js";
 import { computeAgentTrustScore } from "./trust-score.js";
 
 registerAllAdapters();
@@ -2081,7 +2082,7 @@ server.tool(
 
 server.tool(
   "get-trust-score",
-  "Compute dynamic agent trust score and profile from evaluation metrics (Phase B3).",
+  "Compute dynamic agent trust score and profile from evaluation metrics (Phase B3). Returns trust=null on cold start.",
   {
     evaluations: z.number().int().min(0).describe("Total gate evaluations in window"),
     release_ready_count: z
@@ -2097,6 +2098,22 @@ server.tool(
       .array(z.number().int().min(0))
       .default([])
       .describe("Loop rounds for PRs that reached release_ready"),
+    penalty_quality: z
+      .object({
+        mean: z.number(),
+        std_dev: z.number().min(0),
+        clean_rate: z.number().min(0).max(1),
+        sample_count: z.number().int().min(0),
+      })
+      .optional()
+      .describe("Aggregated gate penalty total_score stats (lower mean = cleaner)"),
+    feedback: z
+      .object({
+        ci_failures: z.number().int().min(0).optional(),
+        reverts: z.number().int().min(0).optional(),
+        human_review: z.number().int().min(0).optional(),
+      })
+      .optional(),
   },
   async ({
     evaluations,
@@ -2106,8 +2123,10 @@ server.tool(
     policy_violation_count,
     sensitive_path_violation_count,
     remediation_rounds_to_ready,
+    penalty_quality,
+    feedback,
   }): Promise<ToolReturn> => {
-    const trust = computeAgentTrustScore({
+    const metrics = {
       evaluations,
       releaseReadyCount: release_ready_count,
       revertCount: revert_count,
@@ -2115,8 +2134,33 @@ server.tool(
       policyViolationCount: policy_violation_count,
       sensitivePathViolationCount: sensitive_path_violation_count,
       remediationRoundsToReady: remediation_rounds_to_ready,
+      ...(penalty_quality
+        ? {
+            penaltyQuality: {
+              mean: penalty_quality.mean,
+              stdDev: penalty_quality.std_dev,
+              cleanRate: penalty_quality.clean_rate,
+              sampleCount: penalty_quality.sample_count,
+            },
+          }
+        : {}),
+      ...(feedback
+        ? {
+            feedback: {
+              ciFailures: feedback.ci_failures,
+              reverts: feedback.reverts,
+              humanReview: feedback.human_review,
+            },
+          }
+        : {}),
+    };
+    const trust = computeAgentTrustScore(metrics);
+    const coldStart = assessColdStartFromMetrics(metrics);
+    return jsonResult({
+      trust,
+      cold_start: trust ? null : coldStart,
+      schema: "trailhead.agent_trust_metrics.v1",
     });
-    return jsonResult({ trust });
   },
 );
 

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -51,7 +51,7 @@ import { buildAutofixPlan, selectAutofixCommit } from "./fixer-core.js";
 import { assessColdStartFromMetrics } from "./agent-trust-metrics.js";
 import { computeAgentTrustScore } from "./trust-score.js";
 import { buildGateVerdict } from "./verdict.js";
-import type { GateDecision, GateEvaluation } from "./types.js";
+import type { GateDecision, GateEvaluation, RiskFactor } from "./types.js";
 
 registerAllAdapters();
 
@@ -1277,7 +1277,7 @@ server.tool(
       gateDecision: decision,
       healthChecks: [],
       riskFactors: riskFactors.map((factor) => ({
-        type: factor.type,
+        type: factor.type as RiskFactor["type"],
         score: factor.score,
       })),
       evaluationMs: 0,

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -50,6 +50,8 @@ import { deriveSubmissionFixes } from "./submission-remediation.js";
 import { buildAutofixPlan, selectAutofixCommit } from "./fixer-core.js";
 import { assessColdStartFromMetrics } from "./agent-trust-metrics.js";
 import { computeAgentTrustScore } from "./trust-score.js";
+import { buildGateVerdict } from "./verdict.js";
+import type { GateDecision, GateEvaluation } from "./types.js";
 
 registerAllAdapters();
 
@@ -1265,8 +1267,30 @@ server.tool(
       /* skip */
     }
 
+    const structuredVerdict = buildGateVerdict({
+      id: `mcp-${owner}-${repo}-${Date.now()}`,
+      repoId: `${owner}/${repo}`,
+      commitSha: commitSha ?? "unknown",
+      prNumber,
+      healthScore: 100,
+      riskScore,
+      gateDecision: decision,
+      healthChecks: [],
+      riskFactors: riskFactors.map((factor) => ({
+        type: factor.type,
+        score: factor.score,
+      })),
+      evaluationMs: 0,
+      releaseReady,
+      releaseReadyReasons: reasons,
+      ci: ciSummary ?? undefined,
+      gateMode: "release-ready",
+      policyFindings: reasons.length > 0 ? reasons : undefined,
+    } satisfies GateEvaluation);
+
     return jsonResult({
-      verdict: decision,
+      verdict: structuredVerdict,
+      gate_decision: decision,
       riskScore,
       releaseReady: releaseReady ?? null,
       releaseReadyReasons: releaseReadyReasons ?? [],
@@ -2056,10 +2080,33 @@ server.tool(
       ].includes(c.code),
     ).length;
 
+    const configWarnings = getSubmissionConfigWarnings(submission);
+    const gateDecision: GateDecision = submissionGateShouldBlock(checks, mode)
+      ? "block"
+      : checks.some((check) => check.severity === "warn")
+        ? "warn"
+        : "allow";
+    const verdict = buildGateVerdict({
+      id: `sub-${Date.now()}`,
+      repoId: "mcp/submission",
+      commitSha: "0000000",
+      healthScore: 100,
+      riskScore: 0,
+      gateDecision,
+      healthChecks: [],
+      riskFactors: [],
+      evaluationMs: 0,
+      submissionChecks: checks,
+      gateMode: "advisory",
+      policyFindings: configWarnings.length > 0 ? configWarnings : undefined,
+    } satisfies GateEvaluation);
+
     return jsonResult({
       checks,
       fixes,
-      config_warnings: getSubmissionConfigWarnings(submission),
+      config_warnings: configWarnings,
+      verdict,
+      gate_decision: gateDecision,
       blocking,
       summary: {
         total: checks.length,

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -41,7 +41,11 @@ import {
   TRAILHEAD_EVENT_TYPES,
   type TrailheadEventType,
 } from "./trailhead-events.js";
-import { runSubmissionGate, submissionGateShouldBlock } from "./submission-engine.js";
+import {
+  runSubmissionGate,
+  getSubmissionConfigWarnings,
+  submissionGateShouldBlock,
+} from "./submission-engine.js";
 import { deriveSubmissionFixes } from "./submission-remediation.js";
 import { buildAutofixPlan, selectAutofixCommit } from "./fixer-core.js";
 import { assessColdStartFromMetrics } from "./agent-trust-metrics.js";
@@ -1986,13 +1990,50 @@ server.tool(
       .array(z.string())
       .optional()
       .describe("Root package.json dependency names for import resolution"),
+    submission: z
+      .object({
+        stale_terms: z.array(z.string()).optional(),
+        rename_patterns: z
+          .array(z.object({ old: z.string(), new: z.string() }))
+          .optional(),
+        slug_only_patterns: z.array(z.string()).optional(),
+        path_ignore: z.array(z.string()).optional(),
+        naming_allowlist: z
+          .object({
+            skip_extensions: z.array(z.string()).optional(),
+            skip_path_patterns: z.array(z.string()).optional(),
+            skip_comment_markers: z.array(z.string()).optional(),
+            skip_in_imports: z.boolean().optional(),
+          })
+          .optional(),
+        detectors: z
+          .record(
+            z.object({
+              enabled: z.boolean().optional(),
+              severity: z.enum(["block", "warn", "advisory", "blocking"]).optional(),
+              file_globs: z.array(z.string()).optional(),
+              path_ignore: z.array(z.string()).optional(),
+            }),
+          )
+          .optional(),
+      })
+      .optional()
+      .describe("submission block from .trailhead.yml (detector policy + rename rules)"),
   },
-  async ({ files, komatik_instance, mode, declared_packages }): Promise<ToolReturn> => {
+  async ({
+    files,
+    komatik_instance,
+    mode,
+    declared_packages,
+    submission,
+  }): Promise<ToolReturn> => {
+    const repoConfig = submission ? { submission } : undefined;
     const checks = runSubmissionGate({
       files,
       komatikInstance: komatik_instance ?? false,
       mode,
       declaredPackages: declared_packages,
+      repoConfig: repoConfig as import("./types.js").RepoConfig | undefined,
     });
     const fixes = deriveSubmissionFixes(checks);
     const blocking = submissionGateShouldBlock(checks, mode);
@@ -2018,6 +2059,7 @@ server.tool(
     return jsonResult({
       checks,
       fixes,
+      config_warnings: getSubmissionConfigWarnings(submission),
       blocking,
       summary: {
         total: checks.length,

--- a/mcp/src/submission-checks/detector-policy.ts
+++ b/mcp/src/submission-checks/detector-policy.ts
@@ -1,0 +1,103 @@
+// Resolve submission detector policy from `.trailhead.yml` (issue #256).
+
+import type {
+  RemediationSeverity,
+  SubmissionCheckCode,
+  SubmissionConfig,
+  SubmissionDetectorPolicyEntry,
+} from "../types.js";
+import { SubmissionCheckCode as SubmissionCheckCodeEnum } from "../types.js";
+import {
+  compileRenamePattern,
+  compileSlugOnlyPatterns,
+  DEFAULT_ARTIFACT_FILE_GLOBS,
+  DEFAULT_RENAME_PATTERNS,
+  DEFAULT_SLUG_ONLY_PATTERN_SOURCES,
+  type RenamePatternEntry,
+} from "./policy-defaults.js";
+
+export type DetectorPolicyEntry = {
+  enabled?: boolean;
+  severity?: RemediationSeverity;
+  fileGlobs?: string[];
+  pathIgnore?: string[];
+};
+
+export type DetectorPolicyMap = Partial<Record<SubmissionCheckCode, DetectorPolicyEntry>>;
+
+function normalizeSeverity(
+  severity: NonNullable<SubmissionDetectorPolicyEntry["severity"]>,
+): RemediationSeverity {
+  if (severity === "block") return "blocking";
+  return severity as RemediationSeverity;
+}
+
+export function resolveDetectorPolicy(submission?: Partial<SubmissionConfig>): {
+  policy: DetectorPolicyMap;
+  warnings: string[];
+} {
+  const raw = submission?.detectors ?? {};
+  const warnings: string[] = [];
+  const policy: DetectorPolicyMap = {};
+
+  for (const [key, value] of Object.entries(raw)) {
+    const parsed = SubmissionCheckCodeEnum.safeParse(key);
+    if (!parsed.success) {
+      warnings.push(`Unknown submission.detectors key "${key}" will be ignored.`);
+      continue;
+    }
+    if (!value || typeof value !== "object") continue;
+
+    policy[parsed.data] = {
+      enabled: value.enabled,
+      severity: value.severity ? normalizeSeverity(value.severity) : undefined,
+      fileGlobs: value.file_globs,
+      pathIgnore: value.path_ignore,
+    };
+  }
+
+  return { policy, warnings };
+}
+
+export function buildRenamePatterns(
+  submission?: Partial<SubmissionConfig>,
+  options?: { includeKomatikDefaults?: boolean },
+): RenamePatternEntry[] {
+  const custom = (submission?.rename_patterns ?? []).map(({ old, new: newName }) =>
+    compileRenamePattern(old, newName),
+  );
+  const defaults = options?.includeKomatikDefaults ? DEFAULT_RENAME_PATTERNS : [];
+  return [...defaults, ...custom];
+}
+
+export function buildSlugOnlyPatterns(submission?: Partial<SubmissionConfig>): RegExp[] {
+  const sources = [
+    ...DEFAULT_SLUG_ONLY_PATTERN_SOURCES,
+    ...(submission?.slug_only_patterns ?? []),
+  ];
+  return compileSlugOnlyPatterns(sources);
+}
+
+export function artifactFileGlobs(policy: DetectorPolicyMap): string[] {
+  return policy.artifact_integrity?.fileGlobs ?? DEFAULT_ARTIFACT_FILE_GLOBS;
+}
+
+export function applyDetectorPolicy(
+  code: SubmissionCheckCode,
+  check: import("../types.js").SubmissionCheckResult | null,
+  policy: DetectorPolicyMap,
+): import("../types.js").SubmissionCheckResult | null {
+  const entry = policy[code];
+  if (entry?.enabled === false) return null;
+  if (!check) return null;
+  if (entry?.severity) {
+    return { ...check, severity: entry.severity };
+  }
+  return check;
+}
+
+export function getSubmissionConfigWarnings(
+  submission?: Partial<SubmissionConfig>,
+): string[] {
+  return resolveDetectorPolicy(submission).warnings;
+}

--- a/mcp/src/submission-checks/detectors.ts
+++ b/mcp/src/submission-checks/detectors.ts
@@ -1,17 +1,22 @@
 // Gate 1 detectors — ported from komatik-agents agent-gate-checks (patch/content based).
 
 import type { SubmissionCheckResult } from "../types.js";
-import type { SubmissionCheckContext, SubmissionFileInfo } from "./types.js";
+import type { SubmissionCheckContext } from "./types.js";
 import {
   addedLines,
   extensionOf,
+  extractAllImports,
   fileContent,
+  isStaleArchivedPath,
   isTestPath,
   lineCountFromPatch,
+  linesForFreshnessScan,
   normalizePath,
   scanAddedContent,
 } from "./helpers.js";
+import type { NamingAllowlistConfig } from "./types.js";
 import { runPhase0Detectors } from "./phase0-detectors.js";
+import { validateFileSyntax } from "./syntax-validity.js";
 
 export const OLD_NAME_PATTERNS: Array<{
   oldName: string;
@@ -27,6 +32,17 @@ export const OLD_NAME_PATTERNS: Array<{
   },
   { oldName: "Cognitive Debt", newName: "Drift", pattern: /\bCognitive Debt\b/g },
   { oldName: "cognitive-debt", newName: "Drift", pattern: /\bcognitive-debt\b/g },
+  { oldName: "Undercurrent", newName: "Slipstream", pattern: /\bUndercurrent\b/g },
+  { oldName: "Yggdrasil", newName: "Cairn", pattern: /\bYggdrasil\b/g },
+  { oldName: "Bored", newName: "Lodge", pattern: /\bBored\b/g },
+  { oldName: "Forge", newName: "Pack", pattern: /\bForge\b/g },
+];
+
+const SLUG_ONLY_PATTERNS = [
+  /\bcognitive-debt\b/,
+  /\bstoryboard-studio\b/,
+  /\bdaydream-studio\b/,
+  /\bshadow-ai-governance\b/,
 ];
 
 const MOCK_PATTERNS = [
@@ -39,6 +55,7 @@ const MOCK_PATTERNS = [
   /\b(?:mockData|fakeData|sampleData|dummyData|testData)\b/g,
   /\bTODO:\s*implement\b/gi,
   /\bFIXME\b/g,
+  /\bIn production,\s*use\b/i,
   /\bplaceholder\b/gi,
   /\blorem ipsum\b/gi,
 ];
@@ -158,20 +175,42 @@ export function detectDestructiveSql(
   });
 }
 
+// Only code files can carry hard file references; prose (.md/.mdx/.txt) merely
+// *mentions* paths and was the dominant artifact_integrity false-positive source.
+const ARTIFACT_CODE_EXTS = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"]);
+// Repo-ubiquitous manifests are referenced everywhere and are never the kind of
+// "hallucinated/missing artifact" this check is meant to catch.
+const ARTIFACT_BARE_IGNORE = new Set([
+  "package.json",
+  "package-lock.json",
+  "tsconfig.json",
+  "readme.md",
+]);
+
 export function detectArtifactIntegrity(
   ctx: SubmissionCheckContext,
 ): SubmissionCheckResult | null {
   const referenced = new Set<string>();
-  const pathRefPattern =
-    /(?:^|\s|['"`])([\w@./-]+\.(?:ts|tsx|js|jsx|md|sql|yml|yaml|json))(?:['"`]|\s|:)/g;
+  // Only treat a path *literal* inside an import/require/export-from statement
+  // as a hard reference — natural-language "see X" / "fix Y" / "update Z" in
+  // prose is not a code dependency (the old prose trigger over-flagged docs).
+  const importRefPattern =
+    /(?:\bimport\b|\bfrom\b|\brequire\s*\(|\bexport\b[^'"`]*\bfrom\b)\s*['"`]([\w@./-]+\.(?:ts|tsx|js|jsx|sql|yml|yaml|json))['"`]/g;
 
   for (const file of ctx.files) {
+    // Prose/doc files only mention paths; never flag them as missing code refs.
+    if (!ARTIFACT_CODE_EXTS.has(extensionOf(file.filename))) continue;
+
     for (const line of addedLines(file.patch)) {
-      if (!/(?:import|from|require|see|fix|update)\s/i.test(line)) continue;
-      for (const match of line.matchAll(pathRefPattern)) {
+      importRefPattern.lastIndex = 0;
+      for (const match of line.matchAll(importRefPattern)) {
         const candidate = match[1]?.replace(/^\.\//, "");
         if (!candidate || candidate.includes("*")) continue;
-        if (!ctx.prPaths.has(candidate) && !candidate.startsWith("node:")) {
+        if (candidate.startsWith("node:")) continue;
+        // Skip bare, repo-ubiquitous manifest names (package.json, etc.).
+        const base = candidate.split("/").pop()?.toLowerCase() ?? "";
+        if (!candidate.includes("/") && ARTIFACT_BARE_IGNORE.has(base)) continue;
+        if (!ctx.prPaths.has(candidate)) {
           referenced.add(candidate);
         }
       }
@@ -190,29 +229,74 @@ export function detectArtifactIntegrity(
   });
 }
 
-function isNamingAllowlisted(filename: string, line: string): boolean {
+function isNamingAllowlisted(
+  filename: string,
+  line: string,
+  allowlist: NamingAllowlistConfig = {},
+): boolean {
   const trimmed = line.trim();
-  if (/^import\s|^from\s|require\(/.test(trimmed)) return true;
-  if (/\.sql$/i.test(filename)) return true;
-  if (/(?:^|\/)migrations\//.test(filename)) return true;
-  if (/(?:^|\/)memory\//.test(filename)) return true;
-  if (/RESEARCH\.md$|BRAND\.md$|CHANGELOG\.md$/.test(filename)) return true;
-  if (/^\[.*\]\(.*\)/.test(trimmed)) return true;
+  const path = normalizePath(filename);
+  const ext = extensionOf(filename);
+  const skipExtensions = allowlist.skip_extensions ?? [".sql"];
+  const skipPathPatterns = allowlist.skip_path_patterns ?? ["migrations/", "schema/"];
+  const skipCommentMarkers = allowlist.skip_comment_markers ?? [
+    "historical:",
+    "migration:",
+    "deprecated:",
+  ];
+
+  if (
+    allowlist.skip_in_imports !== false &&
+    /^import\s|^from\s|require\(/.test(trimmed)
+  ) {
+    return true;
+  }
+  if (skipExtensions.includes(ext)) return true;
+  if (skipPathPatterns.some((pattern) => path.includes(pattern))) return true;
+  if (
+    skipCommentMarkers.some((marker) =>
+      trimmed.toLowerCase().includes(marker.toLowerCase()),
+    )
+  ) {
+    return true;
+  }
+  if (/\/memory\//.test(path)) return true;
+  if (/RESEARCH\.md$|BRAND\.md$|CHANGELOG\.md$/.test(path)) return true;
+  if (/^\[.*\]\(.*\)/.test(trimmed) || /\]\(http/.test(trimmed)) return true;
+
+  if (
+    SLUG_ONLY_PATTERNS.some((p) => p.test(trimmed)) &&
+    !/[A-Z]/.test(
+      trimmed.match(
+        /(?:cognitive-debt|storyboard-studio|daydream-studio|shadow-ai-governance)/,
+      )?.[0] ?? "",
+    )
+  ) {
+    return true;
+  }
+
+  if (/["'`/]/.test(trimmed)) {
+    const inStringOrPath =
+      /["'`/][^"'`]*(?:deployguard|storyboard-studio|daydream-studio|cognitive-debt|shadow-ai-governance|komatik-yggdrasil)[^"'`]*["'`/]/i;
+    if (inStringOrPath.test(trimmed)) return true;
+  }
+
   return false;
 }
 
 export function detectContextFreshness(
   ctx: SubmissionCheckContext,
 ): SubmissionCheckResult | null {
-  if (ctx.staleTerms.length === 0 && !ctx.komatikInstance) return null;
+  if (!ctx.komatikInstance && ctx.staleTerms.length === 0) return null;
 
   const hits: string[] = [];
   for (const file of ctx.files) {
-    for (const line of addedLines(file.patch)) {
-      if (isNamingAllowlisted(file.filename, line)) continue;
+    if (isStaleArchivedPath(file.filename, ctx.pathIgnorePatterns)) continue;
 
-      const terms = ctx.staleTerms.length > 0 ? ctx.staleTerms : [];
-      for (const term of terms) {
+    for (const line of linesForFreshnessScan(file)) {
+      if (isNamingAllowlisted(file.filename, line, ctx.namingAllowlist)) continue;
+
+      for (const term of ctx.staleTerms) {
         if (line.toLowerCase().includes(term.toLowerCase())) hits.push(file.filename);
       }
 
@@ -459,10 +543,12 @@ export function detectExternalPackageDeps(
 
   for (const file of ctx.files) {
     if (!codeExts.has(extensionOf(file.filename))) continue;
-    const importPattern = /\b(?:import|from|require)\s*(?:\([^)]*|\(?)?['"]([^'"]+)['"]/g;
-    for (const match of fileContent(file).matchAll(importPattern)) {
-      const specifier = match[1];
-      if (!specifier || specifier.startsWith(".") || specifier.startsWith("@/")) continue;
+
+    for (const imp of extractAllImports(fileContent(file))) {
+      const specifier = imp.specifier;
+      if (specifier.startsWith(".") || specifier.startsWith("/")) continue;
+      if (specifier.startsWith("@/") || specifier.startsWith("~/")) continue;
+      if (specifier.startsWith("http:") || specifier.startsWith("https:")) continue;
       if (isNodeBuiltin(specifier)) continue;
       const pkg = packageNameFromSpecifier(specifier);
       if (!ctx.declaredPackages.has(pkg)) hits.push(`${file.filename} → ${pkg}`);
@@ -480,116 +566,62 @@ export function detectExternalPackageDeps(
   });
 }
 
+function stripSqlComments(content: string): string {
+  return content.replace(/--[^\n]*/g, "").replace(/\/\*[\s\S]*?\*\//g, "");
+}
+
+function countPlpgsqlBlockBegins(sql: string): number {
+  const re = /\bBEGIN\b(?!\s+(?:TRANSACTION|WORK)\b)/gi;
+  return (sql.match(re) || []).length;
+}
+
+function countPlpgsqlBlockEnds(sql: string): number {
+  const re = /\bEND\s*(?!IF\b|LOOP\b|CASE\b)\s*(?:;|\$\$)/gi;
+  return (sql.match(re) || []).length;
+}
+
 export function detectSqlSyntaxBasic(
   ctx: SubmissionCheckContext,
 ): SubmissionCheckResult | null {
   const hits: string[] = [];
   for (const file of ctx.files.filter((f) => extensionOf(f.filename) === ".sql")) {
-    const content = fileContent(file);
-    const stripped = content.replace(/--[^\n]*/g, "").replace(/\/\*[\s\S]*?\*\//g, "");
-    const beginCount = (stripped.match(/\bBEGIN\b/gi) || []).length;
-    const endCount = (stripped.match(/\bEND\b\s*;/gi) || []).length;
-    if (beginCount > 0 && endCount === 0) hits.push(file.filename);
-    else if (endCount > beginCount) hits.push(file.filename);
+    const stripped = stripSqlComments(fileContent(file));
+    const beginCount = countPlpgsqlBlockBegins(stripped);
+    const endCount = countPlpgsqlBlockEnds(stripped);
+    if (beginCount > 0 && beginCount > endCount) hits.push(file.filename);
   }
   if (hits.length === 0) return null;
   return result({
     code: "sql_syntax_basic",
-    severity: "blocking",
+    severity: "warn",
     title: "SQL block balance issue",
-    detail: `Possible unmatched BEGIN/END in ${hits.join(", ")}.`,
+    detail: `Possible unclosed BEGIN block in ${hits.join(", ")}.`,
     files: hits,
-    suggested_action: "Fix PL/pgSQL block structure before merging.",
+    suggested_action: "Verify PL/pgSQL block structure before merging.",
   });
-}
-
-type SwcParseSync = (code: string, options: Record<string, unknown>) => unknown;
-
-let cachedSwcParse: SwcParseSync | null | undefined;
-
-function getSwcParse(): SwcParseSync | null {
-  if (cachedSwcParse !== undefined) return cachedSwcParse;
-  try {
-    // Optional — install @swc/core locally for full parse; Action uses bracket fallback.
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const swc = require("@swc/core") as { parseSync: SwcParseSync };
-    cachedSwcParse = swc.parseSync;
-  } catch {
-    cachedSwcParse = null;
-  }
-  return cachedSwcParse;
-}
-
-function basicBracketBalance(content: string): string | null {
-  let braces = 0;
-  let parens = 0;
-  let brackets = 0;
-  for (const ch of content) {
-    if (ch === "{") braces += 1;
-    if (ch === "}") braces -= 1;
-    if (ch === "(") parens += 1;
-    if (ch === ")") parens -= 1;
-    if (ch === "[") brackets += 1;
-    if (ch === "]") brackets -= 1;
-    if (braces < 0 || parens < 0 || brackets < 0) return "Unbalanced brackets/parens";
-  }
-  if (braces !== 0 || parens !== 0 || brackets !== 0) {
-    return "Unclosed brackets/parens in diff hunk";
-  }
-  return null;
-}
-
-function parserOptionsFor(file: SubmissionFileInfo): Record<string, unknown> {
-  const ext = extensionOf(file.filename);
-  const isTs = ext === ".ts" || ext === ".tsx";
-  return {
-    syntax: isTs ? "typescript" : "ecmascript",
-    tsx: ext === ".tsx",
-    jsx: ext === ".jsx",
-    decorators: true,
-    dynamicImport: true,
-  };
 }
 
 export function detectSyntaxValidity(
   ctx: SubmissionCheckContext,
 ): SubmissionCheckResult | null {
-  const errors: Array<{ file: string; message: string }> = [];
-  const codeExts = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"]);
-  const swcParse = getSwcParse();
+  const errors: string[] = [];
 
   for (const file of ctx.files) {
-    const ext = extensionOf(file.filename);
-    const content = fileContent(file);
-    if (!content.trim()) continue;
+    // Real parsers need the whole file — skip patch-only inputs (PR diff fragments).
+    if (typeof file.content !== "string") continue;
 
-    try {
-      if (codeExts.has(ext)) {
-        if (swcParse) {
-          swcParse(content, parserOptionsFor(file));
-        } else {
-          const balance = basicBracketBalance(content);
-          if (balance) throw new Error(balance);
-        }
-      } else if (ext === ".json") {
-        JSON.parse(content);
-      }
-    } catch (error) {
-      errors.push({
-        file: file.filename,
-        message: error instanceof Error ? error.message.split("\n")[0] : String(error),
-      });
-    }
+    const message = validateFileSyntax(file.filename, file.content);
+    if (message) errors.push(`${file.filename}: ${message}`);
   }
 
   if (errors.length === 0) return null;
   return result({
     code: "syntax_validity",
     severity: "blocking",
-    title: "Syntax error in changed file",
-    detail: errors.map((e) => `${e.file}: ${e.message}`).join("; "),
-    files: errors.map((e) => e.file),
-    suggested_action: "Fix parse errors before resubmitting.",
+    title: "Syntax error in submitted file",
+    detail: errors.slice(0, 12).join("; "),
+    files: errors.map((e) => e.split(": ")[0] ?? e),
+    suggested_action: "Fix the parse error before submitting.",
   });
 }
 

--- a/mcp/src/submission-checks/detectors.ts
+++ b/mcp/src/submission-checks/detectors.ts
@@ -1,6 +1,6 @@
 // Gate 1 detectors — ported from komatik-agents agent-gate-checks (patch/content based).
 
-import type { SubmissionCheckResult } from "../types.js";
+import type { SubmissionCheckResult, SubmissionCheckCode } from "../types.js";
 import type { SubmissionCheckContext } from "./types.js";
 import {
   addedLines,
@@ -17,33 +17,9 @@ import {
 import type { NamingAllowlistConfig } from "./types.js";
 import { runPhase0Detectors } from "./phase0-detectors.js";
 import { validateFileSyntax } from "./syntax-validity.js";
-
-export const OLD_NAME_PATTERNS: Array<{
-  oldName: string;
-  newName: string;
-  pattern: RegExp;
-}> = [
-  { oldName: "DeployGuard", newName: "Trailhead", pattern: /\bDeployGuard\b/g },
-  { oldName: "Daydream Studio", newName: "Sundog", pattern: /\bDaydream Studio\b/g },
-  {
-    oldName: "Storyboard Studio",
-    newName: "Kindling",
-    pattern: /\bStoryboard Studio\b/g,
-  },
-  { oldName: "Cognitive Debt", newName: "Drift", pattern: /\bCognitive Debt\b/g },
-  { oldName: "cognitive-debt", newName: "Drift", pattern: /\bcognitive-debt\b/g },
-  { oldName: "Undercurrent", newName: "Slipstream", pattern: /\bUndercurrent\b/g },
-  { oldName: "Yggdrasil", newName: "Cairn", pattern: /\bYggdrasil\b/g },
-  { oldName: "Bored", newName: "Lodge", pattern: /\bBored\b/g },
-  { oldName: "Forge", newName: "Pack", pattern: /\bForge\b/g },
-];
-
-const SLUG_ONLY_PATTERNS = [
-  /\bcognitive-debt\b/,
-  /\bstoryboard-studio\b/,
-  /\bdaydream-studio\b/,
-  /\bshadow-ai-governance\b/,
-];
+import { matchesGlobs } from "../risk-engine.js";
+import { applyDetectorPolicy, artifactFileGlobs } from "./detector-policy.js";
+export { DEFAULT_RENAME_PATTERNS, OLD_NAME_PATTERNS } from "./policy-defaults.js";
 
 const MOCK_PATTERNS = [
   /\bTODO\s*\(\s*mock\s*\)/i,
@@ -177,9 +153,6 @@ export function detectDestructiveSql(
 
 // Only code files can carry hard file references; prose (.md/.mdx/.txt) merely
 // *mentions* paths and was the dominant artifact_integrity false-positive source.
-const ARTIFACT_CODE_EXTS = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"]);
-// Repo-ubiquitous manifests are referenced everywhere and are never the kind of
-// "hallucinated/missing artifact" this check is meant to catch.
 const ARTIFACT_BARE_IGNORE = new Set([
   "package.json",
   "package-lock.json",
@@ -191,6 +164,8 @@ export function detectArtifactIntegrity(
   ctx: SubmissionCheckContext,
 ): SubmissionCheckResult | null {
   const referenced = new Set<string>();
+  const fileGlobs = artifactFileGlobs(ctx.detectorPolicy);
+  const pathIgnore = ctx.detectorPolicy.artifact_integrity?.pathIgnore ?? [];
   // Only treat a path *literal* inside an import/require/export-from statement
   // as a hard reference — natural-language "see X" / "fix Y" / "update Z" in
   // prose is not a code dependency (the old prose trigger over-flagged docs).
@@ -198,8 +173,8 @@ export function detectArtifactIntegrity(
     /(?:\bimport\b|\bfrom\b|\brequire\s*\(|\bexport\b[^'"`]*\bfrom\b)\s*['"`]([\w@./-]+\.(?:ts|tsx|js|jsx|sql|yml|yaml|json))['"`]/g;
 
   for (const file of ctx.files) {
-    // Prose/doc files only mention paths; never flag them as missing code refs.
-    if (!ARTIFACT_CODE_EXTS.has(extensionOf(file.filename))) continue;
+    if (!matchesGlobs(file.filename, fileGlobs)) continue;
+    if (pathIgnore.length > 0 && matchesGlobs(file.filename, pathIgnore)) continue;
 
     for (const line of addedLines(file.patch)) {
       importRefPattern.lastIndex = 0;
@@ -233,6 +208,7 @@ function isNamingAllowlisted(
   filename: string,
   line: string,
   allowlist: NamingAllowlistConfig = {},
+  slugOnlyPatterns: RegExp[] = [],
 ): boolean {
   const trimmed = line.trim();
   const path = normalizePath(filename);
@@ -265,7 +241,7 @@ function isNamingAllowlisted(
   if (/^\[.*\]\(.*\)/.test(trimmed) || /\]\(http/.test(trimmed)) return true;
 
   if (
-    SLUG_ONLY_PATTERNS.some((p) => p.test(trimmed)) &&
+    slugOnlyPatterns.some((p) => p.test(trimmed)) &&
     !/[A-Z]/.test(
       trimmed.match(
         /(?:cognitive-debt|storyboard-studio|daydream-studio|shadow-ai-governance)/,
@@ -287,24 +263,33 @@ function isNamingAllowlisted(
 export function detectContextFreshness(
   ctx: SubmissionCheckContext,
 ): SubmissionCheckResult | null {
-  if (!ctx.komatikInstance && ctx.staleTerms.length === 0) return null;
+  if (ctx.staleTerms.length === 0 && ctx.renamePatterns.length === 0) {
+    return null;
+  }
 
   const hits: string[] = [];
   for (const file of ctx.files) {
     if (isStaleArchivedPath(file.filename, ctx.pathIgnorePatterns)) continue;
 
     for (const line of linesForFreshnessScan(file)) {
-      if (isNamingAllowlisted(file.filename, line, ctx.namingAllowlist)) continue;
+      if (
+        isNamingAllowlisted(
+          file.filename,
+          line,
+          ctx.namingAllowlist,
+          ctx.slugOnlyPatterns,
+        )
+      ) {
+        continue;
+      }
 
       for (const term of ctx.staleTerms) {
         if (line.toLowerCase().includes(term.toLowerCase())) hits.push(file.filename);
       }
 
-      if (ctx.komatikInstance) {
-        for (const entry of OLD_NAME_PATTERNS) {
-          entry.pattern.lastIndex = 0;
-          if (entry.pattern.test(line)) hits.push(file.filename);
-        }
+      for (const entry of ctx.renamePatterns) {
+        entry.pattern.lastIndex = 0;
+        if (entry.pattern.test(line)) hits.push(file.filename);
       }
     }
   }
@@ -644,23 +629,33 @@ export function detectSoulIntegrity(
 }
 
 export function runAllDetectors(ctx: SubmissionCheckContext): SubmissionCheckResult[] {
+  const policy = ctx.detectorPolicy;
+  const finalize = (
+    code: SubmissionCheckCode,
+    check: SubmissionCheckResult | null,
+  ): SubmissionCheckResult | null => applyDetectorPolicy(code, check, policy);
+
   const gate1 = [
-    detectMockPlaceholder(ctx),
-    detectSecrets(ctx),
-    detectDestructiveSql(ctx),
-    detectSyntaxValidity(ctx),
-    detectImportResolution(ctx),
-    detectRlsNewTables(ctx),
-    detectAuthRouteAuth(ctx),
-    detectHardcodedEnv(ctx),
-    detectExternalPackageDeps(ctx),
-    detectSqlSyntaxBasic(ctx),
-    detectLargeFile(ctx),
-    detectArtifactIntegrity(ctx),
-    detectContextFreshness(ctx),
-    detectSoulIntegrity(ctx),
-    detectPathFormat(ctx),
+    finalize("mock_placeholder", detectMockPlaceholder(ctx)),
+    finalize("secrets", detectSecrets(ctx)),
+    finalize("destructive_sql", detectDestructiveSql(ctx)),
+    finalize("syntax_validity", detectSyntaxValidity(ctx)),
+    finalize("import_resolution", detectImportResolution(ctx)),
+    finalize("rls_new_tables", detectRlsNewTables(ctx)),
+    finalize("auth_route_auth", detectAuthRouteAuth(ctx)),
+    finalize("hardcoded_env", detectHardcodedEnv(ctx)),
+    finalize("external_package_deps", detectExternalPackageDeps(ctx)),
+    finalize("sql_syntax_basic", detectSqlSyntaxBasic(ctx)),
+    finalize("large_file", detectLargeFile(ctx)),
+    finalize("artifact_integrity", detectArtifactIntegrity(ctx)),
+    finalize("context_freshness", detectContextFreshness(ctx)),
+    finalize("soul_integrity", detectSoulIntegrity(ctx)),
+    finalize("path_format", detectPathFormat(ctx)),
   ].filter((check): check is SubmissionCheckResult => check !== null);
 
-  return [...gate1, ...runPhase0Detectors(ctx)];
+  const phase0 = runPhase0Detectors(ctx)
+    .map((check) => finalize(check.code, check))
+    .filter((check): check is SubmissionCheckResult => check !== null);
+
+  return [...gate1, ...phase0];
 }

--- a/mcp/src/submission-checks/helpers.ts
+++ b/mcp/src/submission-checks/helpers.ts
@@ -81,3 +81,70 @@ export function prPathSet(files: SubmissionFileInfo[]): Set<string> {
 export function isTestPath(filename: string): boolean {
   return /\/__tests__\/|\/test\/|\/fixtures\/|\.test\.|\.spec\./.test(filename);
 }
+
+/** Default archived/stale path segments skipped by context_freshness. */
+export const DEFAULT_STALE_PATH_IGNORE = ["/_stale/", "/_archive/", "/.archive/"];
+
+export function isStaleArchivedPath(
+  filename: string,
+  extraPatterns: string[] = [],
+): boolean {
+  const path = normalizePath(filename);
+  return [...DEFAULT_STALE_PATH_IGNORE, ...extraPatterns].some((segment) =>
+    path.includes(segment),
+  );
+}
+
+export function packageJsonPathForFile(
+  filename: string,
+  prPaths: Set<string>,
+): string | null {
+  const parts = normalizePath(filename).split("/");
+  for (let i = parts.length - 1; i >= 0; i--) {
+    const candidate = [...parts.slice(0, i), "package.json"].filter(Boolean).join("/");
+    if (prPaths.has(candidate)) return candidate;
+  }
+  return prPaths.has("package.json") ? "package.json" : null;
+}
+
+const VALID_PACKAGE_SPECIFIER = /^(@[\w.-]+\/[\w.-]+|[\w@][\w.-]*)(?:\/[\w./-]*)?$/;
+
+export function isValidPackageSpecifier(specifier: string): boolean {
+  if (!specifier || specifier.startsWith(".") || specifier.startsWith("@/")) return false;
+  if (/^https?:|^node:/.test(specifier)) return false;
+  if (/[:()\\]/.test(specifier)) return false;
+  return VALID_PACKAGE_SPECIFIER.test(specifier);
+}
+
+/** Extract module specifiers from full file content (legacy agent-gate parity). */
+export function extractAllImports(
+  content: string,
+): Array<{ specifier: string; line: number }> {
+  const results: Array<{ specifier: string; line: number }> = [];
+  const patterns = [
+    /\bimport\s+(?:type\s+)?(?:[^'"]+\s+from\s+)?['"]([^'"]+)['"]/g,
+    /\bexport\s+(?:type\s+)?(?:[^'"]+\s+from\s+)['"]([^'"]+)['"]/g,
+    /\brequire\(\s*['"]([^'"]+)['"]\s*\)/g,
+    /\bimport\(\s*['"]([^'"]+)['"]\s*\)/g,
+  ];
+
+  for (const pattern of patterns) {
+    pattern.lastIndex = 0;
+    for (const match of content.matchAll(pattern)) {
+      const specifier = match[1];
+      if (!specifier) continue;
+      const line = content.slice(0, match.index ?? 0).split("\n").length;
+      results.push({ specifier, line });
+    }
+  }
+  return results;
+}
+
+export function linesForFreshnessScan(file: {
+  filename: string;
+  patch?: string;
+  content?: string;
+}): string[] {
+  if (typeof file.content === "string") return file.content.split("\n");
+  return addedLines(file.patch);
+}

--- a/mcp/src/submission-checks/policy-defaults.ts
+++ b/mcp/src/submission-checks/policy-defaults.ts
@@ -1,0 +1,54 @@
+// Default submission detector policy data (Komatik fleet rename vocabulary).
+
+export interface RenamePatternEntry {
+  oldName: string;
+  newName: string;
+  pattern: RegExp;
+}
+
+export const DEFAULT_RENAME_PATTERNS: RenamePatternEntry[] = [
+  { oldName: "DeployGuard", newName: "Trailhead", pattern: /\bDeployGuard\b/g },
+  { oldName: "Daydream Studio", newName: "Sundog", pattern: /\bDaydream Studio\b/g },
+  {
+    oldName: "Storyboard Studio",
+    newName: "Kindling",
+    pattern: /\bStoryboard Studio\b/g,
+  },
+  { oldName: "Cognitive Debt", newName: "Drift", pattern: /\bCognitive Debt\b/g },
+  { oldName: "cognitive-debt", newName: "Drift", pattern: /\bcognitive-debt\b/g },
+  { oldName: "Undercurrent", newName: "Slipstream", pattern: /\bUndercurrent\b/g },
+  { oldName: "Yggdrasil", newName: "Cairn", pattern: /\bYggdrasil\b/g },
+  { oldName: "Bored", newName: "Lodge", pattern: /\bBored\b/g },
+  { oldName: "Forge", newName: "Pack", pattern: /\bForge\b/g },
+];
+
+/** @deprecated use DEFAULT_RENAME_PATTERNS */
+export const OLD_NAME_PATTERNS = DEFAULT_RENAME_PATTERNS;
+
+export const DEFAULT_SLUG_ONLY_PATTERN_SOURCES = [
+  "\\bcognitive-debt\\b",
+  "\\bstoryboard-studio\\b",
+  "\\bdaydream-studio\\b",
+  "\\bshadow-ai-governance\\b",
+];
+
+export const DEFAULT_ARTIFACT_FILE_GLOBS = ["**/*.{ts,tsx,js,jsx,mjs,cjs}"];
+
+function escapeRegexLiteral(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function compileRenamePattern(
+  oldName: string,
+  newName: string,
+): RenamePatternEntry {
+  return {
+    oldName,
+    newName,
+    pattern: new RegExp(`\\b${escapeRegexLiteral(oldName)}\\b`, "g"),
+  };
+}
+
+export function compileSlugOnlyPatterns(sources: string[]): RegExp[] {
+  return sources.map((source) => new RegExp(source, "i"));
+}

--- a/mcp/src/submission-checks/syntax-validity.ts
+++ b/mcp/src/submission-checks/syntax-validity.ts
@@ -1,0 +1,42 @@
+// Real parse-based syntax validation for Gate 1 (no bracket-count fallback).
+// Parses full file content only — never a partial diff hunk (see submission-gate.md).
+
+import { parseSync, type ParseOptions } from "@swc/core";
+import yaml from "js-yaml";
+import { extensionOf } from "./helpers.js";
+
+const PARSEABLE = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"] as const;
+
+function parserOptionsFor(ext: string): ParseOptions {
+  const isTs = ext === ".ts" || ext === ".tsx";
+  return {
+    syntax: isTs ? "typescript" : "ecmascript",
+    tsx: ext === ".tsx",
+    jsx: ext === ".jsx",
+    decorators: true,
+    dynamicImport: true,
+  };
+}
+
+/** Returns a one-line error message, or null when content parses cleanly. */
+export function validateFileSyntax(filename: string, content: string): string | null {
+  if (!content.trim()) return null;
+
+  const ext = extensionOf(filename);
+  try {
+    if ((PARSEABLE as readonly string[]).includes(ext)) {
+      parseSync(content, parserOptionsFor(ext));
+    } else if (ext === ".json") {
+      JSON.parse(content);
+    } else if (ext === ".yaml" || ext === ".yml") {
+      yaml.load(content);
+    } else if (ext === ".md" && content.startsWith("---")) {
+      const end = content.indexOf("\n---", 3);
+      if (end > 0) yaml.load(content.slice(3, end));
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message.split("\n")[0] : String(error);
+    return message || "Parse error";
+  }
+  return null;
+}

--- a/mcp/src/submission-checks/types.ts
+++ b/mcp/src/submission-checks/types.ts
@@ -7,6 +7,9 @@ export interface SubmissionFileInfo {
   additions?: number;
 }
 
+import type { DetectorPolicyMap } from "./detector-policy.js";
+import type { RenamePatternEntry } from "./policy-defaults.js";
+
 export interface NamingAllowlistConfig {
   skip_extensions?: string[];
   skip_path_patterns?: string[];
@@ -25,6 +28,9 @@ export interface SubmissionCheckContext {
   declaredPackages: Set<string>;
   /** Extra path segments to skip for context_freshness (merged with defaults). */
   pathIgnorePatterns: string[];
+  renamePatterns: RenamePatternEntry[];
+  slugOnlyPatterns: RegExp[];
+  detectorPolicy: DetectorPolicyMap;
   /**
    * Full set of paths that exist in the target repo (e.g. `git ls-files`),
    * used to tell a fabricated reference from a reference to an existing,

--- a/mcp/src/submission-checks/types.ts
+++ b/mcp/src/submission-checks/types.ts
@@ -7,14 +7,24 @@ export interface SubmissionFileInfo {
   additions?: number;
 }
 
+export interface NamingAllowlistConfig {
+  skip_extensions?: string[];
+  skip_path_patterns?: string[];
+  skip_comment_markers?: string[];
+  skip_in_imports?: boolean;
+}
+
 export interface SubmissionCheckContext {
   files: SubmissionFileInfo[];
   prPaths: Set<string>;
   komatikInstance: boolean;
   staleTerms: string[];
+  namingAllowlist: NamingAllowlistConfig;
   authRouteAllowlist: string[];
   maxFileLines: number;
   declaredPackages: Set<string>;
+  /** Extra path segments to skip for context_freshness (merged with defaults). */
+  pathIgnorePatterns: string[];
   /**
    * Full set of paths that exist in the target repo (e.g. `git ls-files`),
    * used to tell a fabricated reference from a reference to an existing,

--- a/mcp/src/submission-engine.ts
+++ b/mcp/src/submission-engine.ts
@@ -4,11 +4,18 @@
 import { runAllDetectors } from "./submission-checks/detectors.js";
 import type { SubmissionCheckContext } from "./submission-checks/types.js";
 import { prPathSet } from "./submission-checks/helpers.js";
+import {
+  buildRenamePatterns,
+  buildSlugOnlyPatterns,
+  getSubmissionConfigWarnings,
+  resolveDetectorPolicy,
+} from "./submission-checks/detector-policy.js";
 import { SubmissionCheckCode } from "./types.js";
 import type { RepoConfig, SubmissionCheckResult } from "./types.js";
 
 export type { SubmissionFileInfo } from "./submission-checks/types.js";
 export type { SubmissionCheckCode, SubmissionCheckResult } from "./types.js";
+export { getSubmissionConfigWarnings };
 
 /** Gate 1 + Phase 0 submission check codes — keep in sync with A8 fixture manifest. */
 export const SUBMISSION_CHECK_CODES = SubmissionCheckCode.options;
@@ -51,6 +58,7 @@ function buildContext(options: SubmissionEngineOptions): SubmissionCheckContext 
   const staleTerms = repoConfig?.submission?.stale_terms ?? [];
 
   const declared = new Set(options.declaredPackages ?? []);
+  const { policy } = resolveDetectorPolicy(repoConfig?.submission);
 
   return {
     files,
@@ -63,6 +71,11 @@ function buildContext(options: SubmissionEngineOptions): SubmissionCheckContext 
     maxFileLines: repoConfig?.submission?.max_file_lines ?? 1000,
     declaredPackages: declared,
     pathIgnorePatterns: repoConfig?.submission?.path_ignore ?? [],
+    renamePatterns: buildRenamePatterns(repoConfig?.submission, {
+      includeKomatikDefaults: komatikInstance,
+    }),
+    slugOnlyPatterns: buildSlugOnlyPatterns(repoConfig?.submission),
+    detectorPolicy: policy,
     repoPaths: options.repoPaths ? new Set(options.repoPaths) : undefined,
   };
 }

--- a/mcp/src/submission-engine.ts
+++ b/mcp/src/submission-engine.ts
@@ -13,14 +13,27 @@ export type { SubmissionCheckCode, SubmissionCheckResult } from "./types.js";
 /** Gate 1 + Phase 0 submission check codes — keep in sync with A8 fixture manifest. */
 export const SUBMISSION_CHECK_CODES = SubmissionCheckCode.options;
 
-const DEFAULT_STALE_TERMS = ["deployguard", "DeployGuard"];
-
 const DEFAULT_AUTH_ROUTE_ALLOWLIST = [
   "/api/auth/",
   "/api/webhooks/",
   "/api/health/",
   "/api/metrics/",
 ];
+
+/** Package names declared in a package.json (legacy gate parity). */
+export function declaredPackageNamesFromPackageJson(
+  pkg: Record<string, unknown>,
+): string[] {
+  const sections = [
+    "dependencies",
+    "devDependencies",
+    "peerDependencies",
+    "optionalDependencies",
+  ] as const;
+  return sections.flatMap((key) =>
+    Object.keys((pkg[key] as Record<string, string> | undefined) ?? {}),
+  );
+}
 
 export interface SubmissionEngineOptions {
   files: import("./submission-checks/types.js").SubmissionFileInfo[];
@@ -35,8 +48,7 @@ export interface SubmissionEngineOptions {
 
 function buildContext(options: SubmissionEngineOptions): SubmissionCheckContext {
   const { files, repoConfig, komatikInstance = false } = options;
-  const staleTerms =
-    repoConfig?.submission?.stale_terms ?? (komatikInstance ? DEFAULT_STALE_TERMS : []);
+  const staleTerms = repoConfig?.submission?.stale_terms ?? [];
 
   const declared = new Set(options.declaredPackages ?? []);
 
@@ -45,10 +57,12 @@ function buildContext(options: SubmissionEngineOptions): SubmissionCheckContext 
     prPaths: prPathSet(files),
     komatikInstance,
     staleTerms,
+    namingAllowlist: repoConfig?.submission?.naming_allowlist ?? {},
     authRouteAllowlist:
       repoConfig?.submission?.auth_route_allowlist ?? DEFAULT_AUTH_ROUTE_ALLOWLIST,
     maxFileLines: repoConfig?.submission?.max_file_lines ?? 1000,
     declaredPackages: declared,
+    pathIgnorePatterns: repoConfig?.submission?.path_ignore ?? [],
     repoPaths: options.repoPaths ? new Set(options.repoPaths) : undefined,
   };
 }

--- a/mcp/src/trust-runtime.ts
+++ b/mcp/src/trust-runtime.ts
@@ -1,0 +1,24 @@
+// Shadow / enforce runtime for agent trust injection (issue #259).
+
+export interface TrustRuntime {
+  enabled: boolean;
+  /** Log trust profile without applying threshold delta. */
+  shadow: boolean;
+  /** Apply threshold delta and strictness adjustments from trust score. */
+  enforce: boolean;
+  /** Collector-only: inject TRAILHEAD_AGENT_TRUST_JSON (Komatik dogfood). */
+  injectTrustJson: boolean;
+}
+
+export function readTrustRuntime(env: NodeJS.ProcessEnv = process.env): TrustRuntime {
+  const enabled = env.TRAILHEAD_TRUST_ENABLED !== "false";
+  const shadow = enabled && env.TRAILHEAD_TRUST_SHADOW === "true";
+  const enforce = enabled && !shadow;
+
+  return {
+    enabled,
+    shadow,
+    enforce,
+    injectTrustJson: enabled && env.TRAILHEAD_TRUST_ENFORCE === "true",
+  };
+}

--- a/mcp/src/trust-score.ts
+++ b/mcp/src/trust-score.ts
@@ -1,17 +1,15 @@
 // Phase B3 — dynamic agent trust scoring (pure module).
 
-export type TrustProfileName = "fast-track" | "standard" | "probation";
+import {
+  assessColdStartFromMetrics,
+  DEFAULT_TRUST_COLLECTOR_CONFIG,
+  type AgentTrustMetrics,
+  type TrustCollectorConfig,
+} from "./agent-trust-metrics.js";
 
-export interface AgentTrustMetrics {
-  evaluations: number;
-  releaseReadyCount: number;
-  revertCount: number;
-  humanReviewRequiredCount: number;
-  policyViolationCount: number;
-  sensitivePathViolationCount: number;
-  /** Sum of loop rounds for PRs that reached release_ready. */
-  remediationRoundsToReady: number[];
-}
+export type { AgentTrustMetrics } from "./agent-trust-metrics.js";
+
+export type TrustProfileName = "fast-track" | "standard" | "probation";
 
 export interface AgentTrustResult {
   score: number;
@@ -23,9 +21,12 @@ export interface AgentTrustResult {
     remediation_efficiency: number;
     policy_violation_rate: number;
     sensitive_path_violation_rate: number;
+    penalty_clean_rate?: number;
+    penalty_mean_quality?: number;
   };
   thresholdDelta: number;
   autofixEnabled: boolean;
+  coldStart?: { reason: string };
 }
 
 const WEIGHTS = {
@@ -35,6 +36,7 @@ const WEIGHTS = {
   remediation_efficiency: 0.15,
   policy_violation_penalty: 0.075,
   sensitive_path_penalty: 0.075,
+  penalty_mean_quality: 0.05,
 };
 
 function rate(numerator: number, denominator: number): number {
@@ -48,36 +50,66 @@ function remediationEfficiency(rounds: number[]): number {
   return Math.max(0, Math.min(1, 1 - (avg - 1) / 4));
 }
 
-export function computeAgentTrustScore(metrics: AgentTrustMetrics): AgentTrustResult {
+function penaltyMeanQuality(
+  penaltyQuality: AgentTrustMetrics["penaltyQuality"],
+  noisyThreshold: number,
+): number | undefined {
+  if (!penaltyQuality || penaltyQuality.sampleCount <= 0) return undefined;
+  return Math.max(0, Math.min(1, 1 - penaltyQuality.mean / noisyThreshold));
+}
+
+export function computeAgentTrustScore(
+  metrics: AgentTrustMetrics,
+  options?: { config?: Partial<TrustCollectorConfig> },
+): AgentTrustResult | null {
+  const config = { ...DEFAULT_TRUST_COLLECTOR_CONFIG, ...options?.config };
+  const coldStart = assessColdStartFromMetrics(metrics, config);
+  if (!coldStart.emitTrust) {
+    return null;
+  }
+
   const n = Math.max(metrics.evaluations, 0);
   const releaseReadyRate = rate(metrics.releaseReadyCount, n);
+  const penaltyCleanRate = metrics.penaltyQuality?.cleanRate;
+  const releaseSignal =
+    penaltyCleanRate !== undefined
+      ? Math.max(releaseReadyRate, penaltyCleanRate)
+      : releaseReadyRate;
+
   const revertRate = rate(metrics.revertCount, n);
   const humanReviewRate = rate(metrics.humanReviewRequiredCount, n);
   const policyViolationRate = rate(metrics.policyViolationCount, n);
   const sensitiveRate = rate(metrics.sensitivePathViolationCount, n);
   const remEff = remediationEfficiency(metrics.remediationRoundsToReady);
+  const meanQuality = penaltyMeanQuality(
+    metrics.penaltyQuality,
+    config.noisyPenaltyThreshold,
+  );
 
   const factors = {
-    release_ready_rate: releaseReadyRate,
+    release_ready_rate: releaseSignal,
     revert_rate: revertRate,
     human_review_required_rate: humanReviewRate,
     remediation_efficiency: remEff,
     policy_violation_rate: policyViolationRate,
     sensitive_path_violation_rate: sensitiveRate,
+    ...(penaltyCleanRate !== undefined ? { penalty_clean_rate: penaltyCleanRate } : {}),
+    ...(meanQuality !== undefined ? { penalty_mean_quality: meanQuality } : {}),
   };
 
-  const score = Math.max(
-    0,
-    Math.min(
-      1,
-      WEIGHTS.release_ready_rate * releaseReadyRate +
-        WEIGHTS.revert_resistance * (1 - revertRate) +
-        WEIGHTS.human_free_rate * (1 - humanReviewRate) +
-        WEIGHTS.remediation_efficiency * remEff -
-        WEIGHTS.policy_violation_penalty * policyViolationRate -
-        WEIGHTS.sensitive_path_penalty * sensitiveRate,
-    ),
-  );
+  let score =
+    WEIGHTS.release_ready_rate * releaseSignal +
+    WEIGHTS.revert_resistance * (1 - revertRate) +
+    WEIGHTS.human_free_rate * (1 - humanReviewRate) +
+    WEIGHTS.remediation_efficiency * remEff -
+    WEIGHTS.policy_violation_penalty * policyViolationRate -
+    WEIGHTS.sensitive_path_penalty * sensitiveRate;
+
+  if (meanQuality !== undefined) {
+    score += WEIGHTS.penalty_mean_quality * meanQuality;
+  }
+
+  score = Math.max(0, Math.min(1, score));
 
   let profile: TrustProfileName = "standard";
   if (score >= 0.85) profile = "fast-track";

--- a/mcp/src/verdict.ts
+++ b/mcp/src/verdict.ts
@@ -1,0 +1,260 @@
+// Stable versioned gate verdict contract (epic #252 / issue #260).
+
+import { z } from "zod";
+import type { GateEvaluation, SubmissionCheckResult } from "./types.js";
+import { GateDecision, SubmissionCheckCode } from "./types.js";
+import type { TrustRuntime } from "./trust-runtime.js";
+import { DEFAULT_TRUST_COLLECTOR_CONFIG } from "./agent-trust-metrics.js";
+import type { PenaltyQualitySignal } from "./agent-trust-metrics.js";
+
+export const TRAILHEAD_VERDICT_SCHEMA = "trailhead.verdict.v1" as const;
+
+export const PENALTY_SEMANTICS = "lower_is_cleaner" as const;
+export const RISK_SEMANTICS = "higher_is_worse" as const;
+
+const SEVERITY_PENALTY: Record<SubmissionCheckResult["severity"], number> = {
+  blocking: 3,
+  warn: 2,
+  advisory: 1,
+};
+
+export const VerdictPenaltySchema = z.object({
+  total_score: z.number().min(0),
+  factor_scores: z.record(z.number().min(0)),
+  semantics: z.literal(PENALTY_SEMANTICS),
+});
+export type VerdictPenalty = z.infer<typeof VerdictPenaltySchema>;
+
+export const VerdictRiskSchema = z.object({
+  score: z.number().min(0).max(100),
+  semantics: z.literal(RISK_SEMANTICS),
+  factors: z.record(z.number().min(0).max(100)),
+});
+export type VerdictRisk = z.infer<typeof VerdictRiskSchema>;
+
+export const VerdictTrustProfileSchema = z.object({
+  shadow: z.boolean().optional(),
+  enforce: z.boolean().optional(),
+  score: z.number().min(0).max(1).optional(),
+  profile: z.enum(["fast-track", "standard", "probation"]).optional(),
+  strictness: z.enum(["baseline", "elevated", "strict"]),
+  reason: z.string(),
+  factors: z.record(z.number()).optional(),
+});
+export type VerdictTrustProfile = z.infer<typeof VerdictTrustProfileSchema>;
+
+export const VerdictRemediationSchema = z.object({
+  loop_round: z.number().int().min(0).optional(),
+  max_loop_rounds: z.number().int().min(0).optional(),
+  next_action: z.string().optional(),
+  fix_count: z.number().int().min(0).optional(),
+});
+export type VerdictRemediation = z.infer<typeof VerdictRemediationSchema>;
+
+export const TrailheadVerdictSchema = z.object({
+  schema: z.literal(TRAILHEAD_VERDICT_SCHEMA),
+  evaluation_id: z.string(),
+  repo_id: z.string(),
+  commit_sha: z.string(),
+  pr_number: z.number().int().positive().optional(),
+  head_ref: z.string().optional(),
+  agent_id: z.string().optional(),
+  decision: GateDecision,
+  gate_mode: z.enum(["risk-only", "advisory", "release-ready"]).optional(),
+  release_ready: z.boolean().optional(),
+  penalty: VerdictPenaltySchema,
+  risk: VerdictRiskSchema,
+  trust_profile: VerdictTrustProfileSchema.optional(),
+  submission_checks: z.array(
+    z.object({
+      code: SubmissionCheckCode,
+      severity: z.enum(["blocking", "warn", "advisory"]),
+      title: z.string(),
+      detail: z.string(),
+      files: z.array(z.string()).default([]),
+    }),
+  ),
+  remediation: VerdictRemediationSchema.optional(),
+  reasons: z.array(z.string()),
+  evaluated_at: z.string(),
+  /** Deprecated flat fields — remove after one release (#260). */
+  _legacy: z
+    .object({
+      riskScore: z.number(),
+      healthScore: z.number(),
+      releaseReadyReasons: z.array(z.string()).optional(),
+      policyFindings: z.array(z.string()).optional(),
+    })
+    .optional(),
+});
+export type TrailheadVerdict = z.infer<typeof TrailheadVerdictSchema>;
+
+export function computeSubmissionPenalty(
+  checks: SubmissionCheckResult[] = [],
+): VerdictPenalty {
+  const factor_scores: Record<string, number> = {};
+  for (const check of checks) {
+    const penalty = SEVERITY_PENALTY[check.severity] ?? 0;
+    factor_scores[check.code] = Math.max(factor_scores[check.code] ?? 0, penalty);
+  }
+
+  const values = Object.values(factor_scores);
+  const total_score =
+    values.length === 0
+      ? 0
+      : Math.round((values.reduce((sum, value) => sum + value, 0) / values.length) * 10) /
+        10;
+
+  return {
+    total_score,
+    factor_scores,
+    semantics: PENALTY_SEMANTICS,
+  };
+}
+
+export function collectVerdictReasons(evaluation: GateEvaluation): string[] {
+  const reasons = new Set<string>();
+
+  for (const finding of evaluation.policyFindings ?? []) {
+    reasons.add(finding);
+  }
+  for (const reason of evaluation.releaseReadyReasons ?? []) {
+    reasons.add(reason);
+  }
+  if (evaluation.remediation?.next_action) {
+    reasons.add(`Remediation next action: ${evaluation.remediation.next_action}`);
+  }
+  if (evaluation.trust_profile?.reason) {
+    reasons.add(evaluation.trust_profile.reason);
+  }
+  if (evaluation.gateDecision === "block") {
+    reasons.add("Gate decision is BLOCK");
+  } else if (evaluation.gateDecision === "warn") {
+    reasons.add("Gate decision is WARN");
+  }
+
+  return [...reasons];
+}
+
+export interface BuildGateVerdictOptions {
+  evaluatedAt?: string;
+  trustRuntime?: TrustRuntime;
+  agentId?: string | null;
+}
+
+export function buildGateVerdict(
+  evaluation: GateEvaluation,
+  options: BuildGateVerdictOptions = {},
+): TrailheadVerdict {
+  const checks = evaluation.submissionChecks ?? [];
+  const penalty = computeSubmissionPenalty(checks);
+  const trustRuntime = options.trustRuntime;
+
+  const verdict: TrailheadVerdict = {
+    schema: TRAILHEAD_VERDICT_SCHEMA,
+    evaluation_id: evaluation.id,
+    repo_id: evaluation.repoId,
+    commit_sha: evaluation.commitSha,
+    pr_number: evaluation.prNumber,
+    head_ref: evaluation.pr?.headRef,
+    agent_id: options.agentId ?? undefined,
+    decision: evaluation.gateDecision,
+    gate_mode: evaluation.gateMode,
+    release_ready: evaluation.releaseReady,
+    penalty,
+    risk: {
+      score: evaluation.riskScore,
+      semantics: RISK_SEMANTICS,
+      factors: Object.fromEntries(
+        evaluation.riskFactors.map((factor) => [factor.type, factor.score]),
+      ),
+    },
+    trust_profile: evaluation.trust_profile
+      ? {
+          shadow: trustRuntime?.shadow,
+          enforce: trustRuntime?.enforce,
+          score: evaluation.trust_profile.score,
+          profile: evaluation.trust_profile.profile,
+          strictness: evaluation.trust_profile.strictness,
+          reason: evaluation.trust_profile.reason,
+          factors: evaluation.trust_profile.factors,
+        }
+      : undefined,
+    submission_checks: checks.map((check) => ({
+      code: check.code,
+      severity: check.severity,
+      title: check.title,
+      detail: check.detail,
+      files: check.files ?? [],
+    })),
+    remediation: evaluation.remediation
+      ? {
+          loop_round: evaluation.remediation.loop_round,
+          max_loop_rounds: evaluation.remediation.max_loop_rounds,
+          next_action: evaluation.remediation.next_action,
+          fix_count: evaluation.remediation.fixes?.length,
+        }
+      : undefined,
+    reasons: collectVerdictReasons(evaluation),
+    evaluated_at: options.evaluatedAt ?? new Date().toISOString(),
+    _legacy: {
+      riskScore: evaluation.riskScore,
+      healthScore: evaluation.healthScore,
+      releaseReadyReasons: evaluation.releaseReadyReasons,
+      policyFindings: evaluation.policyFindings,
+    },
+  };
+
+  return TrailheadVerdictSchema.parse(verdict);
+}
+
+export function parseGateVerdict(raw: string | unknown): TrailheadVerdict | null {
+  try {
+    const value = typeof raw === "string" ? JSON.parse(raw) : raw;
+    const parsed = TrailheadVerdictSchema.safeParse(value);
+    return parsed.success ? parsed.data : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Collector helper: map penalty verdicts to trust penaltyQuality stats. */
+export function aggregateVerdictPenaltyQuality(
+  verdicts: TrailheadVerdict[],
+): PenaltyQualitySignal | null {
+  const scores = verdicts.map((verdict) => verdict.penalty.total_score);
+  if (scores.length === 0) return null;
+
+  const count = scores.length;
+  const mean = scores.reduce((sum, value) => sum + value, 0) / count;
+  const variance =
+    count === 1 ? 0 : scores.reduce((sum, value) => sum + (value - mean) ** 2, 0) / count;
+  const stdDev = Math.sqrt(variance);
+  const cleanThreshold = DEFAULT_TRUST_COLLECTOR_CONFIG.cleanPenaltyThreshold;
+  const cleanCount = scores.filter((score) => score <= cleanThreshold).length;
+
+  return {
+    mean: Math.round(mean * 10) / 10,
+    stdDev: Math.round(stdDev * 10) / 10,
+    cleanRate: Math.round((cleanCount / count) * 1000) / 1000,
+    sampleCount: count,
+  };
+}
+
+/** Example collector projection: one verdict → trust correlation fields. */
+export function projectVerdictToTrustCorrelation(verdict: TrailheadVerdict): {
+  evaluation_id: string;
+  agent_id?: string;
+  head_ref?: string;
+  penalty: VerdictPenalty;
+  release_ready_clean: boolean;
+} {
+  return {
+    evaluation_id: verdict.evaluation_id,
+    agent_id: verdict.agent_id,
+    head_ref: verdict.head_ref,
+    penalty: verdict.penalty,
+    release_ready_clean:
+      verdict.penalty.total_score <= DEFAULT_TRUST_COLLECTOR_CONFIG.cleanPenaltyThreshold,
+  };
+}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "ncc build src/main.ts -o dist --source-map --license licenses.txt && node scripts/copy-swc-bindings.mjs",
+    "build:cli": "node scripts/build-cli-bundle.mjs",
     "typecheck": "tsc --noEmit",
     "lint": "eslint . && tsc --noEmit",
     "format": "prettier --write .",

--- a/scripts/build-cli-bundle.mjs
+++ b/scripts/build-cli-bundle.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+/**
+ * Build a self-contained Trailhead CLI bundle (ncc + vendored @swc/core bindings).
+ * Output: cli/dist/index.js (+ swc.*.node) — no consumer npm install of @swc/core.
+ */
+import { execSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, "..");
+const cliDist = path.join(root, "cli", "dist");
+
+function run(cmd, opts = {}) {
+  execSync(cmd, { cwd: root, stdio: "inherit", ...opts });
+}
+
+fs.rmSync(cliDist, { recursive: true, force: true });
+fs.mkdirSync(cliDist, { recursive: true });
+
+run("node scripts/copy-shared-src.mjs cli");
+run("npx ncc build cli/src/index.ts -o cli/dist --source-map --license licenses.txt");
+run("node scripts/copy-swc-bindings.mjs cli/dist");
+
+// ncc emits stray .d.ts trees; npm tarball should ship the runnable bundle only.
+const keepNames = new Set([
+  "index.js",
+  "index.js.map",
+  "licenses.txt",
+  "sourcemap-register.js",
+]);
+for (const name of fs.readdirSync(cliDist)) {
+  if (name.startsWith("swc.") && name.endsWith(".node")) continue;
+  if (keepNames.has(name)) continue;
+  fs.rmSync(path.join(cliDist, name), { recursive: true, force: true });
+}
+
+if (!fs.existsSync(path.join(cliDist, "index.js"))) {
+  console.error("build-cli-bundle: cli/dist/index.js missing after ncc build");
+  process.exit(1);
+}
+
+console.log("build-cli-bundle: ok → cli/dist/index.js");

--- a/scripts/copy-shared-src.mjs
+++ b/scripts/copy-shared-src.mjs
@@ -38,6 +38,8 @@ const sharedFiles = [
   "submission-engine.ts",
   "fixer-core.ts",
   "trust-score.ts",
+  "agent-trust-metrics.ts",
+  "trust-runtime.ts",
   "remediation-lanes.ts",
   "trailhead-events.ts",
 ];

--- a/scripts/copy-shared-src.mjs
+++ b/scripts/copy-shared-src.mjs
@@ -39,6 +39,7 @@ const sharedFiles = [
   "fixer-core.ts",
   "trust-score.ts",
   "agent-trust-metrics.ts",
+  "agent-trust-feedback.ts",
   "trust-runtime.ts",
   "remediation-lanes.ts",
   "trailhead-events.ts",

--- a/scripts/copy-shared-src.mjs
+++ b/scripts/copy-shared-src.mjs
@@ -57,6 +57,7 @@ const cliFiles = [
   "ci-manifest.ts",
   "release-ready.ts",
   "doctor.ts",
+  "risk-engine.ts",
   "submission-engine.ts",
 ];
 

--- a/scripts/copy-shared-src.mjs
+++ b/scripts/copy-shared-src.mjs
@@ -40,6 +40,7 @@ const sharedFiles = [
   "trust-score.ts",
   "agent-trust-metrics.ts",
   "agent-trust-feedback.ts",
+  "verdict.ts",
   "trust-runtime.ts",
   "remediation-lanes.ts",
   "trailhead-events.ts",

--- a/scripts/copy-swc-bindings.mjs
+++ b/scripts/copy-swc-bindings.mjs
@@ -11,8 +11,14 @@ import { fileURLToPath } from "node:url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, "..");
-const distDir = path.join(root, "dist");
+const distArg = process.argv[2];
+const distDir = distArg ? path.resolve(distArg) : path.join(root, "dist");
 const swcRoot = path.join(root, "node_modules", "@swc");
+
+if (!fs.existsSync(distDir)) {
+  console.error(`copy-swc-bindings: dist directory not found: ${distDir}`);
+  process.exit(1);
+}
 
 const pkgJson = JSON.parse(fs.readFileSync(path.join(root, "package.json"), "utf-8"));
 const swcVersion = (pkgJson.dependencies?.["@swc/core"] ?? "1.15.40").replace(

--- a/scripts/shadow-compare-gates.mjs
+++ b/scripts/shadow-compare-gates.mjs
@@ -130,7 +130,7 @@ function projectSlugFromBundle(suggestionRoot) {
 const args = parseArgs(process.argv);
 if (!fs.existsSync(TRAILHEAD_CLI)) {
   console.error(
-    `Trailhead CLI not found at ${TRAILHEAD_CLI}. Run: cd cli && npm run build`,
+    `Trailhead CLI not found at ${TRAILHEAD_CLI}. Run: npm run build:cli (or npx @komatikai/trailhead)`,
   );
   process.exit(2);
 }

--- a/src/__tests__/agent-trust-feedback.test.ts
+++ b/src/__tests__/agent-trust-feedback.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import {
+  mergeFeedbackIntoMetrics,
+  resolveAgentIdFromFeedbackEvent,
+  rollupFeedbackForAgent,
+} from "../agent-trust-feedback.js";
+
+describe("agent-trust-feedback", () => {
+  it("resolves agent id from head_ref", () => {
+    expect(
+      resolveAgentIdFromFeedbackEvent({
+        outcome: "ci_fail",
+        head_ref: "agent/pixel/suggestions/pack/ui",
+        observed_at: "2026-05-29T00:00:00.000Z",
+      }),
+    ).toBe("pixel");
+  });
+
+  it("rolls up CI failure into feedback counts", () => {
+    const rollup = rollupFeedbackForAgent(
+      [
+        {
+          agent_id: "forge",
+          outcome: "ci_fail",
+          observed_at: "2026-05-29T00:00:00.000Z",
+        },
+      ],
+      "forge",
+    );
+    expect(rollup.feedback.ciFailures).toBe(1);
+    expect(rollup.attributed).toBe(1);
+  });
+
+  it("rolls up revert and remediation rounds", () => {
+    const rollup = rollupFeedbackForAgent(
+      [
+        {
+          agent_id: "vault",
+          outcome: "revert",
+          observed_at: "2026-05-29T00:00:00.000Z",
+        },
+        {
+          agent_id: "vault",
+          outcome: "rounds_to_green",
+          remediation_rounds: 2,
+          observed_at: "2026-05-29T01:00:00.000Z",
+        },
+      ],
+      "vault",
+    );
+    expect(rollup.feedback.reverts).toBe(1);
+    expect(rollup.remediationRoundsToReady).toEqual([2]);
+  });
+
+  it("does not attribute events without agent correlation", () => {
+    const rollup = rollupFeedbackForAgent(
+      [
+        {
+          outcome: "ci_fail",
+          project_slug: "pack",
+          observed_at: "2026-05-29T00:00:00.000Z",
+        },
+      ],
+      "pixel",
+    );
+    expect(rollup.attributed).toBe(0);
+    expect(rollup.unattributed).toBe(1);
+  });
+
+  it("merges rollup into AgentTrustMetrics counters", () => {
+    const merged = mergeFeedbackIntoMetrics(
+      {
+        revertCount: 0,
+        humanReviewRequiredCount: 1,
+        policyViolationCount: 0,
+        remediationRoundsToReady: [1],
+        feedback: { ciFailures: 0, reverts: 0, humanReview: 0 },
+      },
+      {
+        feedback: { ciFailures: 1, reverts: 1, humanReview: 0 },
+        remediationRoundsToReady: [3],
+        attributed: 2,
+        unattributed: 0,
+      },
+    );
+    expect(merged.revertCount).toBe(1);
+    expect(merged.humanReviewRequiredCount).toBe(2);
+    expect(merged.policyViolationCount).toBe(1);
+    expect(merged.remediationRoundsToReady).toEqual([1, 3]);
+    expect(merged.feedback?.ciFailures).toBe(1);
+  });
+});

--- a/src/__tests__/agent-trust-metrics.test.ts
+++ b/src/__tests__/agent-trust-metrics.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import {
+  AGENT_TRUST_METRICS_SCHEMA,
+  assessColdStart,
+  assessColdStartFromMetrics,
+  computeScoreDistribution,
+  parseAgentTrustMetrics,
+} from "../agent-trust-metrics.js";
+
+describe("agent-trust-metrics", () => {
+  it("parses bare metrics JSON", () => {
+    const metrics = parseAgentTrustMetrics(
+      JSON.stringify({
+        evaluations: 10,
+        releaseReadyCount: 8,
+        revertCount: 1,
+        humanReviewRequiredCount: 2,
+        policyViolationCount: 0,
+        sensitivePathViolationCount: 0,
+        remediationRoundsToReady: [1, 2],
+      }),
+    );
+    expect(metrics?.evaluations).toBe(10);
+    expect(metrics?.releaseReadyCount).toBe(8);
+  });
+
+  it("parses versioned envelope and returns inner trust", () => {
+    const metrics = parseAgentTrustMetrics(
+      JSON.stringify({
+        schema: AGENT_TRUST_METRICS_SCHEMA,
+        agent_id: "pixel",
+        collected_at: "2026-05-29T00:00:00.000Z",
+        window_days: 30,
+        trust: {
+          evaluations: 12,
+          releaseReadyCount: 10,
+          revertCount: 0,
+          humanReviewRequiredCount: 1,
+          policyViolationCount: 0,
+          sensitivePathViolationCount: 0,
+          remediationRoundsToReady: [],
+          penaltyQuality: {
+            mean: 0.8,
+            stdDev: 1.1,
+            cleanRate: 0.83,
+            sampleCount: 12,
+          },
+        },
+        cold_start: { emitTrust: true, reason: null },
+      }),
+    );
+    expect(metrics?.penaltyQuality?.cleanRate).toBeCloseTo(0.83);
+  });
+
+  it("returns null for envelope with trust=null (cold start)", () => {
+    const metrics = parseAgentTrustMetrics(
+      JSON.stringify({
+        schema: AGENT_TRUST_METRICS_SCHEMA,
+        agent_id: "forge",
+        collected_at: "2026-05-29T00:00:00.000Z",
+        window_days: 30,
+        trust: null,
+        cold_start: {
+          emitTrust: false,
+          reason: "insufficient_evaluations (2 < 5)",
+        },
+      }),
+    );
+    expect(metrics).toBeNull();
+  });
+
+  it("blocks cold start on insufficient evaluations", () => {
+    const result = assessColdStart({ evaluations: 2 });
+    expect(result.emitTrust).toBe(false);
+    expect(result.reason).toContain("insufficient_evaluations");
+  });
+
+  it("blocks cold start on flat allow-only signals", () => {
+    const result = assessColdStartFromMetrics({
+      evaluations: 20,
+      releaseReadyCount: 20,
+      revertCount: 0,
+      humanReviewRequiredCount: 0,
+      policyViolationCount: 0,
+      sensitivePathViolationCount: 0,
+      remediationRoundsToReady: [1, 1],
+    });
+    expect(result.emitTrust).toBe(false);
+    expect(result.reason).toContain("flat_signals");
+  });
+
+  it("allows cold start when penalty distribution has variance", () => {
+    const result = assessColdStartFromMetrics({
+      evaluations: 20,
+      releaseReadyCount: 20,
+      revertCount: 0,
+      humanReviewRequiredCount: 0,
+      policyViolationCount: 0,
+      sensitivePathViolationCount: 0,
+      remediationRoundsToReady: [1, 1],
+      penaltyQuality: {
+        mean: 0.9,
+        stdDev: 1.4,
+        cleanRate: 1,
+        sampleCount: 20,
+      },
+    });
+    expect(result.emitTrust).toBe(true);
+  });
+
+  it("computes penalty score distribution", () => {
+    const distribution = computeScoreDistribution([0, 0, 2, 4, 6], {
+      minScoreStdDev: 1,
+    });
+    expect(distribution?.hasVariance).toBe(true);
+    expect(distribution?.mean).toBeGreaterThan(0);
+  });
+});

--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -99,6 +99,10 @@ describe("run (main entrypoint)", () => {
       expect.stringContaining('"gateDecision":"allow"'),
     );
     expect(core.setOutput).toHaveBeenCalledWith(
+      "verdict-json",
+      expect.stringContaining('"schema":"trailhead.verdict.v1"'),
+    );
+    expect(core.setOutput).toHaveBeenCalledWith(
       "rollout-readiness-json",
       expect.stringContaining('"band"'),
     );

--- a/src/__tests__/phase0-detectors.test.ts
+++ b/src/__tests__/phase0-detectors.test.ts
@@ -9,6 +9,10 @@ import {
 } from "../submission-checks/phase0-detectors.js";
 import type { SubmissionCheckContext } from "../submission-checks/types.js";
 import { prPathSet } from "../submission-checks/helpers.js";
+import {
+  buildRenamePatterns,
+  buildSlugOnlyPatterns,
+} from "../submission-checks/detector-policy.js";
 
 function ctx(
   files: Array<{ filename: string; content?: string; patch?: string }>,
@@ -29,6 +33,9 @@ function ctx(
     declaredPackages: new Set(),
     namingAllowlist: {},
     pathIgnorePatterns: [],
+    renamePatterns: buildRenamePatterns(undefined, { includeKomatikDefaults: true }),
+    slugOnlyPatterns: buildSlugOnlyPatterns(undefined),
+    detectorPolicy: {},
     repoPaths: repoPaths ? new Set(repoPaths) : undefined,
   };
 }

--- a/src/__tests__/submission-detector-policy.test.ts
+++ b/src/__tests__/submission-detector-policy.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyDetectorPolicy,
+  buildRenamePatterns,
+  getSubmissionConfigWarnings,
+  resolveDetectorPolicy,
+} from "../submission-checks/detector-policy.js";
+import type { SubmissionConfig } from "../types.js";
+
+describe("submission detector policy", () => {
+  it("warns on unknown detector keys", () => {
+    const warnings = getSubmissionConfigWarnings({
+      detectors: {
+        not_a_real_detector: { enabled: false },
+      },
+    } as Partial<SubmissionConfig>);
+    expect(warnings[0]).toContain("not_a_real_detector");
+  });
+
+  it("merges Komatik defaults with custom rename patterns", () => {
+    const patterns = buildRenamePatterns(
+      {
+        rename_patterns: [{ old: "AcmeCorp", new: "BetaInc" }],
+      },
+      { includeKomatikDefaults: true },
+    );
+    expect(patterns.some((p) => p.oldName === "DeployGuard")).toBe(true);
+    expect(patterns.some((p) => p.oldName === "AcmeCorp")).toBe(true);
+  });
+
+  it("disables detectors via policy", () => {
+    const { policy } = resolveDetectorPolicy({
+      detectors: { mock_placeholder: { enabled: false } },
+    });
+    const check = applyDetectorPolicy(
+      "mock_placeholder",
+      {
+        code: "mock_placeholder",
+        severity: "blocking",
+        title: "mock",
+        detail: "mock",
+        files: [],
+        autofix_eligible: false,
+      },
+      policy,
+    );
+    expect(check).toBeNull();
+  });
+
+  it("maps block severity override to blocking", () => {
+    const { policy } = resolveDetectorPolicy({
+      detectors: { context_freshness: { severity: "block" } },
+    });
+    const check = applyDetectorPolicy(
+      "context_freshness",
+      {
+        code: "context_freshness",
+        severity: "warn",
+        title: "stale",
+        detail: "stale",
+        files: [],
+        autofix_eligible: false,
+      },
+      policy,
+    );
+    expect(check?.severity).toBe("blocking");
+  });
+});

--- a/src/__tests__/submission-detectors-precision.test.ts
+++ b/src/__tests__/submission-detectors-precision.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  detectArtifactIntegrity,
   detectContextFreshness,
   detectExternalPackageDeps,
   detectMockPlaceholder,
@@ -7,19 +8,29 @@ import {
   detectSyntaxValidity,
 } from "../submission-checks/detectors.js";
 import type { SubmissionCheckContext } from "../submission-checks/types.js";
+import {
+  buildRenamePatterns,
+  buildSlugOnlyPatterns,
+} from "../submission-checks/detector-policy.js";
 import { validateFileSyntax } from "../submission-checks/syntax-validity.js";
 
 function ctx(partial: Partial<SubmissionCheckContext>): SubmissionCheckContext {
+  const komatikInstance = partial.komatikInstance ?? false;
   return {
     files: [],
     prPaths: new Set(),
-    komatikInstance: false,
+    komatikInstance,
     staleTerms: [],
     namingAllowlist: {},
     authRouteAllowlist: [],
     maxFileLines: 1000,
     declaredPackages: new Set(),
     pathIgnorePatterns: [],
+    renamePatterns:
+      partial.renamePatterns ??
+      buildRenamePatterns(undefined, { includeKomatikDefaults: komatikInstance }),
+    slugOnlyPatterns: partial.slugOnlyPatterns ?? buildSlugOnlyPatterns(undefined),
+    detectorPolicy: partial.detectorPolicy ?? {},
     ...partial,
   };
 }
@@ -211,5 +222,47 @@ describe("mock_placeholder", () => {
       }),
     );
     expect(check?.code).toBe("mock_placeholder");
+  });
+});
+
+describe("artifact_integrity config scope", () => {
+  it("does not flag markdown when scoped to code file globs", () => {
+    const check = detectArtifactIntegrity(
+      ctx({
+        files: [
+          {
+            filename: "docs/guide.md",
+            patch: "@@\n+See src/missing.ts for details\n",
+          },
+        ],
+        prPaths: new Set(["docs/guide.md"]),
+        detectorPolicy: {
+          artifact_integrity: {
+            fileGlobs: ["**/*.{ts,tsx,js,jsx,mjs,cjs}"],
+          },
+        },
+      }),
+    );
+    expect(check).toBeNull();
+  });
+});
+
+describe("context_freshness custom rename patterns", () => {
+  it("flags configured rename vocabulary without Komatik defaults", () => {
+    const check = detectContextFreshness(
+      ctx({
+        komatikInstance: false,
+        renamePatterns: buildRenamePatterns({
+          rename_patterns: [{ old: "AcmeCorp", new: "BetaInc" }],
+        }),
+        files: [
+          {
+            filename: "README.md",
+            content: "Welcome to AcmeCorp platform\n",
+          },
+        ],
+      }),
+    );
+    expect(check?.code).toBe("context_freshness");
   });
 });

--- a/src/__tests__/trust-runtime.test.ts
+++ b/src/__tests__/trust-runtime.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { readTrustRuntime } from "../trust-runtime.js";
+
+describe("trust-runtime", () => {
+  it("defaults to enforce mode for backward-compatible gate behavior", () => {
+    const runtime = readTrustRuntime({});
+    expect(runtime.enabled).toBe(true);
+    expect(runtime.shadow).toBe(false);
+    expect(runtime.enforce).toBe(true);
+    expect(runtime.injectTrustJson).toBe(false);
+  });
+
+  it("enters shadow mode only when TRAILHEAD_TRUST_SHADOW=true", () => {
+    const runtime = readTrustRuntime({
+      TRAILHEAD_TRUST_SHADOW: "true",
+    });
+    expect(runtime.shadow).toBe(true);
+    expect(runtime.enforce).toBe(false);
+  });
+
+  it("enables collector injection when TRAILHEAD_TRUST_ENFORCE=true", () => {
+    const runtime = readTrustRuntime({
+      TRAILHEAD_TRUST_ENFORCE: "true",
+    });
+    expect(runtime.enforce).toBe(true);
+    expect(runtime.injectTrustJson).toBe(true);
+  });
+
+  it("disables all trust paths when kill switch is set", () => {
+    const runtime = readTrustRuntime({
+      TRAILHEAD_TRUST_ENABLED: "false",
+      TRAILHEAD_TRUST_ENFORCE: "true",
+    });
+    expect(runtime.enabled).toBe(false);
+    expect(runtime.enforce).toBe(false);
+    expect(runtime.injectTrustJson).toBe(false);
+  });
+});

--- a/src/__tests__/trust-score.test.ts
+++ b/src/__tests__/trust-score.test.ts
@@ -1,8 +1,28 @@
 import { describe, expect, it } from "vitest";
 import { computeAgentTrustScore, strictnessFromTrust } from "../trust-score.js";
 
+const penaltyVariance = {
+  mean: 0.6,
+  stdDev: 1.2,
+  cleanRate: 0.95,
+  sampleCount: 20,
+};
+
 describe("trust-score", () => {
-  it("assigns fast-track for high release-ready rate", () => {
+  it("returns null below minimum evidence", () => {
+    const trust = computeAgentTrustScore({
+      evaluations: 2,
+      releaseReadyCount: 2,
+      revertCount: 0,
+      humanReviewRequiredCount: 0,
+      policyViolationCount: 0,
+      sensitivePathViolationCount: 0,
+      remediationRoundsToReady: [],
+    });
+    expect(trust).toBeNull();
+  });
+
+  it("returns null for flat perfect signals without penalty variance", () => {
     const trust = computeAgentTrustScore({
       evaluations: 20,
       releaseReadyCount: 20,
@@ -12,9 +32,24 @@ describe("trust-score", () => {
       sensitivePathViolationCount: 0,
       remediationRoundsToReady: [1, 1, 1, 1],
     });
-    expect(trust.profile).toBe("fast-track");
-    expect(trust.score).toBeGreaterThanOrEqual(0.85);
-    expect(trust.thresholdDelta).toBe(10);
+    expect(trust).toBeNull();
+  });
+
+  it("assigns fast-track for high release-ready rate", () => {
+    const trust = computeAgentTrustScore({
+      evaluations: 20,
+      releaseReadyCount: 20,
+      revertCount: 0,
+      humanReviewRequiredCount: 0,
+      policyViolationCount: 0,
+      sensitivePathViolationCount: 0,
+      remediationRoundsToReady: [1, 1, 1, 1],
+      penaltyQuality: penaltyVariance,
+    });
+    expect(trust?.profile).toBe("fast-track");
+    expect(trust?.score).toBeGreaterThanOrEqual(0.85);
+    expect(trust?.thresholdDelta).toBe(10);
+    expect(trust?.factors.penalty_clean_rate).toBeCloseTo(0.95);
   });
 
   it("assigns probation for poor outcomes", () => {
@@ -27,8 +62,8 @@ describe("trust-score", () => {
       sensitivePathViolationCount: 2,
       remediationRoundsToReady: [5, 4, 5],
     });
-    expect(trust.profile).toBe("probation");
-    expect(trust.autofixEnabled).toBe(false);
+    expect(trust?.profile).toBe("probation");
+    expect(trust?.autofixEnabled).toBe(false);
   });
 
   it("maps probation to strict trust profile", () => {
@@ -41,8 +76,29 @@ describe("trust-score", () => {
       sensitivePathViolationCount: 3,
       remediationRoundsToReady: [],
     });
+    expect(trust).not.toBeNull();
     const profile = strictnessFromTrust(trust, 30);
     expect(profile.strictness).toBe("strict");
     expect(profile.profile).toBe("probation");
+  });
+
+  it("uses penalty clean rate when present", () => {
+    const trust = computeAgentTrustScore({
+      evaluations: 10,
+      releaseReadyCount: 0,
+      revertCount: 0,
+      humanReviewRequiredCount: 0,
+      policyViolationCount: 1,
+      sensitivePathViolationCount: 0,
+      remediationRoundsToReady: [],
+      penaltyQuality: {
+        mean: 0.4,
+        stdDev: 1.5,
+        cleanRate: 0.9,
+        sampleCount: 10,
+      },
+    });
+    expect(trust).not.toBeNull();
+    expect(trust?.factors.release_ready_rate).toBeGreaterThanOrEqual(0.9);
   });
 });

--- a/src/__tests__/verdict.test.ts
+++ b/src/__tests__/verdict.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import type { GateEvaluation } from "../types.js";
+import {
+  aggregateVerdictPenaltyQuality,
+  buildGateVerdict,
+  computeSubmissionPenalty,
+  parseGateVerdict,
+  projectVerdictToTrustCorrelation,
+  TRAILHEAD_VERDICT_SCHEMA,
+  TrailheadVerdictSchema,
+} from "../verdict.js";
+
+const fixtureDir = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../examples/verdict",
+);
+
+function baseEvaluation(overrides: Partial<GateEvaluation> = {}): GateEvaluation {
+  return {
+    id: "dg-abc1234-1710000000000",
+    repoId: "KomatikAI/agents",
+    commitSha: "abc1234567890abcdef1234567890abcdef12345678",
+    prNumber: 203,
+    healthScore: 100,
+    riskScore: 42,
+    gateDecision: "allow",
+    healthChecks: [],
+    riskFactors: [{ type: "file_count", score: 35 }],
+    evaluationMs: 120,
+    gateMode: "release-ready",
+    releaseReady: true,
+    pr: {
+      headRef: "agent/pixel/suggestions/pack/ui-tweak",
+      provenance: { type: "custom-bot", confidence: 0.9, source: "pixel" },
+    },
+    submissionChecks: [
+      {
+        code: "context_freshness",
+        severity: "warn",
+        title: "Stale naming",
+        detail: "Deprecated term found",
+        files: ["README.md"],
+        autofix_eligible: true,
+      },
+    ],
+    trust_profile: {
+      strictness: "elevated",
+      reason: "Agent trust score 0.72 (standard)",
+      score: 0.72,
+      profile: "standard",
+    },
+    ...overrides,
+  };
+}
+
+describe("verdict", () => {
+  it("builds trailhead.verdict.v1 from GateEvaluation", () => {
+    const verdict = buildGateVerdict(baseEvaluation(), {
+      evaluatedAt: "2026-05-30T12:00:00.000Z",
+      agentId: "pixel",
+      trustRuntime: {
+        enabled: true,
+        shadow: true,
+        enforce: false,
+        injectTrustJson: false,
+      },
+    });
+
+    expect(verdict.schema).toBe(TRAILHEAD_VERDICT_SCHEMA);
+    expect(verdict.agent_id).toBe("pixel");
+    expect(verdict.penalty.semantics).toBe("lower_is_cleaner");
+    expect(verdict.penalty.factor_scores.context_freshness).toBe(2);
+    expect(verdict.risk.semantics).toBe("higher_is_worse");
+    expect(verdict.trust_profile?.shadow).toBe(true);
+    expect(verdict._legacy?.riskScore).toBe(42);
+  });
+
+  it("round-trips through JSON parse", () => {
+    const raw = JSON.stringify(buildGateVerdict(baseEvaluation()));
+    const parsed = parseGateVerdict(raw);
+    expect(parsed?.evaluation_id).toBe("dg-abc1234-1710000000000");
+    expect(TrailheadVerdictSchema.safeParse(parsed).success).toBe(true);
+  });
+
+  it("validates committed example fixture", () => {
+    const fixture = JSON.parse(
+      readFileSync(path.join(fixtureDir, "gate-allow-clean.v1.json"), "utf8"),
+    );
+    expect(TrailheadVerdictSchema.safeParse(fixture).success).toBe(true);
+  });
+
+  it("aggregates penalty quality for trust collectors", () => {
+    const verdicts = [0.5, 1.0, 2.5].map((total_score, index) => {
+      const verdict = buildGateVerdict(baseEvaluation({ id: `dg-${index}` }));
+      return {
+        ...verdict,
+        penalty: {
+          ...verdict.penalty,
+          total_score,
+          factor_scores: { mock: total_score },
+        },
+      };
+    });
+
+    const quality = aggregateVerdictPenaltyQuality(verdicts);
+    expect(quality?.sampleCount).toBe(3);
+    expect(quality?.cleanRate).toBeCloseTo(2 / 3, 2);
+  });
+
+  it("projects verdict to trust correlation ids", () => {
+    const verdict = buildGateVerdict(baseEvaluation(), { agentId: "pixel" });
+    const correlation = projectVerdictToTrustCorrelation(verdict);
+    expect(correlation.evaluation_id).toBe(verdict.evaluation_id);
+    expect(correlation.agent_id).toBe("pixel");
+  });
+
+  it("computes zero penalty for clean submissions", () => {
+    expect(computeSubmissionPenalty([]).total_score).toBe(0);
+  });
+});

--- a/src/agent-trust-feedback.ts
+++ b/src/agent-trust-feedback.ts
@@ -1,0 +1,175 @@
+// Post-merge outcome feedback contract (epic #252 / issue #257).
+
+import { z } from "zod";
+import type { TrustFeedbackCounts } from "./agent-trust-metrics.js";
+
+export const AGENT_TRUST_FEEDBACK_SCHEMA = "trailhead.feedback.v1" as const;
+
+export const TrustFeedbackOutcome = z.enum([
+  "ci_pass",
+  "ci_fail",
+  "revert",
+  "rollback",
+  "rounds_to_green",
+  "human_review",
+]);
+export type TrustFeedbackOutcome = z.infer<typeof TrustFeedbackOutcome>;
+
+export const TrustFeedbackEventSchema = z.object({
+  schema: z.literal(AGENT_TRUST_FEEDBACK_SCHEMA).optional(),
+  submission_id: z.string().optional(),
+  pr_number: z.number().int().positive().optional(),
+  evaluation_id: z.string().optional(),
+  agent_id: z.string().optional(),
+  head_ref: z.string().optional(),
+  project_slug: z.string().optional(),
+  outcome: TrustFeedbackOutcome,
+  remediation_rounds: z.number().int().min(0).optional(),
+  observed_at: z.string(),
+  metadata: z.record(z.unknown()).optional(),
+});
+export type TrustFeedbackEvent = z.infer<typeof TrustFeedbackEventSchema>;
+
+export const TrustFeedbackBatchSchema = z.object({
+  schema: z.literal(AGENT_TRUST_FEEDBACK_SCHEMA),
+  collected_at: z.string(),
+  events: z.array(TrustFeedbackEventSchema),
+  unattributed: z
+    .object({
+      ci_failures: z.number().int().min(0).optional(),
+      reverts: z.number().int().min(0).optional(),
+      human_review: z.number().int().min(0).optional(),
+    })
+    .optional(),
+});
+export type TrustFeedbackBatch = z.infer<typeof TrustFeedbackBatchSchema>;
+
+export interface TrustFeedbackRollup {
+  feedback: TrustFeedbackCounts;
+  remediationRoundsToReady: number[];
+  attributed: number;
+  unattributed: number;
+}
+
+const AGENT_HEAD_REF = /^agent\/([a-z][a-z0-9-]*)\//;
+
+export function resolveAgentIdFromFeedbackEvent(
+  event: TrustFeedbackEvent,
+): string | null {
+  if (event.agent_id?.trim()) return event.agent_id.trim();
+
+  const headRef = event.head_ref?.trim();
+  if (headRef) {
+    const match = headRef.match(AGENT_HEAD_REF);
+    if (match) return match[1];
+  }
+
+  const metaRef =
+    typeof event.metadata?.head_ref === "string"
+      ? event.metadata.head_ref
+      : typeof event.metadata?.ref === "string"
+        ? event.metadata.ref.replace(/^refs\/heads\//, "")
+        : null;
+  if (metaRef) {
+    const match = metaRef.match(AGENT_HEAD_REF);
+    if (match) return match[1];
+  }
+
+  return null;
+}
+
+export function parseTrustFeedbackEvent(raw: unknown): TrustFeedbackEvent | null {
+  const parsed = TrustFeedbackEventSchema.safeParse(raw);
+  return parsed.success ? parsed.data : null;
+}
+
+export function parseTrustFeedbackBatch(
+  raw: string | unknown,
+): TrustFeedbackBatch | null {
+  try {
+    const value = typeof raw === "string" ? JSON.parse(raw) : raw;
+    const parsed = TrustFeedbackBatchSchema.safeParse(value);
+    return parsed.success ? parsed.data : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Map feedback events for a single agent into AgentTrustMetrics partial fields. */
+export function rollupFeedbackForAgent(
+  events: TrustFeedbackEvent[],
+  agentId: string,
+): TrustFeedbackRollup {
+  const feedback: TrustFeedbackCounts = {
+    ciFailures: 0,
+    reverts: 0,
+    humanReview: 0,
+  };
+  const remediationRoundsToReady: number[] = [];
+  let attributed = 0;
+  let unattributed = 0;
+
+  for (const event of events) {
+    const resolved = resolveAgentIdFromFeedbackEvent(event);
+    if (resolved !== agentId) {
+      if (resolved === null && !event.agent_id) unattributed += 1;
+      continue;
+    }
+    attributed += 1;
+
+    switch (event.outcome) {
+      case "ci_fail":
+        feedback.ciFailures = (feedback.ciFailures ?? 0) + 1;
+        break;
+      case "revert":
+      case "rollback":
+        feedback.reverts = (feedback.reverts ?? 0) + 1;
+        break;
+      case "human_review":
+        feedback.humanReview = (feedback.humanReview ?? 0) + 1;
+        break;
+      case "rounds_to_green":
+        if (typeof event.remediation_rounds === "number") {
+          remediationRoundsToReady.push(event.remediation_rounds);
+        }
+        break;
+      case "ci_pass":
+        break;
+    }
+  }
+
+  return {
+    feedback,
+    remediationRoundsToReady,
+    attributed,
+    unattributed,
+  };
+}
+
+export function mergeFeedbackIntoMetrics<
+  T extends {
+    revertCount: number;
+    humanReviewRequiredCount: number;
+    policyViolationCount: number;
+    remediationRoundsToReady: number[];
+    feedback?: TrustFeedbackCounts;
+  },
+>(metrics: T, rollup: TrustFeedbackRollup): T {
+  const fb = rollup.feedback;
+  return {
+    ...metrics,
+    revertCount: metrics.revertCount + (fb.reverts ?? 0),
+    humanReviewRequiredCount:
+      metrics.humanReviewRequiredCount + (fb.humanReview ?? 0) + (fb.ciFailures ?? 0),
+    policyViolationCount: metrics.policyViolationCount + (fb.ciFailures ?? 0),
+    remediationRoundsToReady: [
+      ...metrics.remediationRoundsToReady,
+      ...rollup.remediationRoundsToReady,
+    ],
+    feedback: {
+      ciFailures: (metrics.feedback?.ciFailures ?? 0) + (fb.ciFailures ?? 0),
+      reverts: (metrics.feedback?.reverts ?? 0) + (fb.reverts ?? 0),
+      humanReview: (metrics.feedback?.humanReview ?? 0) + (fb.humanReview ?? 0),
+    },
+  };
+}

--- a/src/agent-trust-metrics.ts
+++ b/src/agent-trust-metrics.ts
@@ -1,0 +1,217 @@
+// Versioned ingestion contract for dynamic agent trust (Phase B3 / epic #252).
+
+import { z } from "zod";
+
+export const AGENT_TRUST_METRICS_SCHEMA = "trailhead.agent_trust_metrics.v1" as const;
+
+export const DEFAULT_TRUST_COLLECTOR_CONFIG = {
+  windowDays: 30,
+  minEvidenceEvaluations: 5,
+  /** Minimum std-dev on gate penalty total_score to treat distribution as informative. */
+  minScoreStdDev: 1,
+  /** Gate penalty total_score at or below this is "clean" (lower = cleaner). */
+  cleanPenaltyThreshold: 1,
+  /** Gate penalty total_score at or above this is "noisy". */
+  noisyPenaltyThreshold: 3,
+} as const;
+
+export type TrustCollectorConfig = typeof DEFAULT_TRUST_COLLECTOR_CONFIG;
+
+export const PenaltyQualitySignalSchema = z.object({
+  mean: z.number().describe("Mean gate penalty total_score (lower = cleaner)"),
+  stdDev: z.number().min(0),
+  cleanRate: z.number().min(0).max(1),
+  sampleCount: z.number().int().min(0),
+});
+export type PenaltyQualitySignal = z.infer<typeof PenaltyQualitySignalSchema>;
+
+export const TrustFeedbackCountsSchema = z.object({
+  ciFailures: z.number().int().min(0).optional(),
+  reverts: z.number().int().min(0).optional(),
+  humanReview: z.number().int().min(0).optional(),
+});
+export type TrustFeedbackCounts = z.infer<typeof TrustFeedbackCountsSchema>;
+
+export const AgentTrustMetricsSchema = z.object({
+  evaluations: z.number().int().min(0),
+  releaseReadyCount: z.number().int().min(0).default(0),
+  revertCount: z.number().int().min(0).default(0),
+  humanReviewRequiredCount: z.number().int().min(0).default(0),
+  policyViolationCount: z.number().int().min(0).default(0),
+  sensitivePathViolationCount: z.number().int().min(0).default(0),
+  remediationRoundsToReady: z.array(z.number().int().min(0)).default([]),
+  penaltyQuality: PenaltyQualitySignalSchema.optional(),
+  feedback: TrustFeedbackCountsSchema.optional(),
+});
+export type AgentTrustMetrics = z.infer<typeof AgentTrustMetricsSchema>;
+
+export const ScoreDistributionSchema = z.object({
+  count: z.number().int().min(0),
+  mean: z.number(),
+  stdDev: z.number().min(0),
+  min: z.number(),
+  max: z.number(),
+  hasVariance: z.boolean(),
+});
+export type ScoreDistribution = z.infer<typeof ScoreDistributionSchema>;
+
+export const AgentTrustColdStartSchema = z.object({
+  emitTrust: z.boolean(),
+  reason: z.string().nullable(),
+});
+export type AgentTrustColdStart = z.infer<typeof AgentTrustColdStartSchema>;
+
+export const AgentTrustEnvelopeSchema = z.object({
+  schema: z.literal(AGENT_TRUST_METRICS_SCHEMA),
+  agent_id: z.string(),
+  collected_at: z.string(),
+  window_days: z.number().int().min(1),
+  trust: AgentTrustMetricsSchema.nullable(),
+  cold_start: AgentTrustColdStartSchema,
+  distribution: ScoreDistributionSchema.nullable().optional(),
+  feedback: TrustFeedbackCountsSchema.optional(),
+});
+export type AgentTrustEnvelope = z.infer<typeof AgentTrustEnvelopeSchema>;
+
+export function computeScoreDistribution(
+  scores: number[],
+  options: { minScoreStdDev?: number } = {},
+): ScoreDistribution | null {
+  const minScoreStdDev =
+    options.minScoreStdDev ?? DEFAULT_TRUST_COLLECTOR_CONFIG.minScoreStdDev;
+  const values = scores.filter((s) => typeof s === "number" && !Number.isNaN(s));
+  if (values.length === 0) return null;
+
+  const count = values.length;
+  const mean = values.reduce((sum, value) => sum + value, 0) / count;
+  const variance =
+    count === 1 ? 0 : values.reduce((sum, value) => sum + (value - mean) ** 2, 0) / count;
+  const stdDev = Math.sqrt(variance);
+
+  return {
+    count,
+    mean: Math.round(mean * 10) / 10,
+    stdDev: Math.round(stdDev * 10) / 10,
+    min: Math.min(...values),
+    max: Math.max(...values),
+    hasVariance: stdDev >= minScoreStdDev,
+  };
+}
+
+export function assessColdStart(params: {
+  evaluations: number;
+  distribution?: ScoreDistribution | null;
+  blockedCount?: number;
+  warnedCount?: number;
+  feedback?: TrustFeedbackCounts | null;
+  config?: Partial<TrustCollectorConfig>;
+}): AgentTrustColdStart {
+  const config = { ...DEFAULT_TRUST_COLLECTOR_CONFIG, ...params.config };
+  const feedback = params.feedback ?? null;
+  const feedbackEvaluations =
+    (feedback?.ciFailures ?? 0) + (feedback?.reverts ?? 0) + (feedback?.humanReview ?? 0);
+  const totalEvidence = params.evaluations + feedbackEvaluations;
+
+  if (totalEvidence < config.minEvidenceEvaluations) {
+    return {
+      emitTrust: false,
+      reason: `insufficient_evaluations (${totalEvidence} < ${config.minEvidenceEvaluations})`,
+    };
+  }
+
+  const hasOutcomeVariance =
+    (params.blockedCount ?? 0) > 0 ||
+    (params.warnedCount ?? 0) > 0 ||
+    (feedback?.reverts ?? 0) > 0 ||
+    (feedback?.ciFailures ?? 0) > 0 ||
+    (feedback?.humanReview ?? 0) > 0 ||
+    params.distribution?.hasVariance === true ||
+    (params.distribution?.stdDev ?? 0) >= config.minScoreStdDev;
+
+  if (!hasOutcomeVariance) {
+    return {
+      emitTrust: false,
+      reason: "flat_signals (no outcome variance and no penalty distribution variance)",
+    };
+  }
+
+  return { emitTrust: true, reason: null };
+}
+
+export function assessColdStartFromMetrics(
+  metrics: AgentTrustMetrics,
+  config?: Partial<TrustCollectorConfig>,
+): AgentTrustColdStart {
+  const mergedConfig = { ...DEFAULT_TRUST_COLLECTOR_CONFIG, ...config };
+  const feedbackEvidence =
+    (metrics.feedback?.ciFailures ?? 0) +
+    (metrics.feedback?.reverts ?? 0) +
+    (metrics.feedback?.humanReview ?? 0);
+  const totalEvidence = metrics.evaluations + feedbackEvidence;
+
+  if (totalEvidence < mergedConfig.minEvidenceEvaluations) {
+    return {
+      emitTrust: false,
+      reason: `insufficient_evaluations (${totalEvidence} < ${mergedConfig.minEvidenceEvaluations})`,
+    };
+  }
+
+  const penaltyVariance =
+    (metrics.penaltyQuality?.stdDev ?? 0) >= mergedConfig.minScoreStdDev;
+  const hasOutcomeVariance =
+    metrics.revertCount > 0 ||
+    metrics.humanReviewRequiredCount > 0 ||
+    metrics.policyViolationCount > 0 ||
+    metrics.sensitivePathViolationCount > 0 ||
+    penaltyVariance ||
+    feedbackEvidence > 0 ||
+    (metrics.releaseReadyCount > 0 && metrics.releaseReadyCount < metrics.evaluations);
+
+  if (!hasOutcomeVariance) {
+    return {
+      emitTrust: false,
+      reason: "flat_signals (no outcome variance and no penalty distribution variance)",
+    };
+  }
+
+  return { emitTrust: true, reason: null };
+}
+
+export function parseAgentTrustMetricsObject(raw: unknown): AgentTrustMetrics | null {
+  const parsed = AgentTrustMetricsSchema.safeParse(raw);
+  return parsed.success ? parsed.data : null;
+}
+
+export function parseAgentTrustMetrics(
+  raw: string | undefined,
+): AgentTrustMetrics | null {
+  if (!raw?.trim()) return null;
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      "schema" in parsed &&
+      (parsed as { schema?: string }).schema === AGENT_TRUST_METRICS_SCHEMA
+    ) {
+      const envelope = AgentTrustEnvelopeSchema.safeParse(parsed);
+      if (!envelope.success || !envelope.data.trust) return null;
+      return envelope.data.trust;
+    }
+    return parseAgentTrustMetricsObject(parsed);
+  } catch {
+    return null;
+  }
+}
+
+export function createEmptyAgentTrustMetrics(): AgentTrustMetrics {
+  return {
+    evaluations: 0,
+    releaseReadyCount: 0,
+    revertCount: 0,
+    humanReviewRequiredCount: 0,
+    policyViolationCount: 0,
+    sensitivePathViolationCount: 0,
+    remediationRoundsToReady: [],
+  };
+}

--- a/src/gate.ts
+++ b/src/gate.ts
@@ -65,7 +65,11 @@ import {
   hasOverrideLabel,
   resolveLabelOverride,
 } from "./override.js";
-import { runSubmissionGate, submissionGateShouldBlock } from "./submission-engine.js";
+import {
+  runSubmissionGate,
+  getSubmissionConfigWarnings,
+  submissionGateShouldBlock,
+} from "./submission-engine.js";
 import type { SubmissionCheckResult } from "./types.js";
 import { computeAgentTrustScore, strictnessFromTrust } from "./trust-score.js";
 import { parseAgentTrustMetrics } from "./agent-trust-metrics.js";
@@ -1742,6 +1746,9 @@ export async function evaluateGate(
   const submissionEnabled =
     config.submissionGate === true || repoConfig?.submission?.enabled === true;
   if (submissionEnabled && files.length > 0) {
+    for (const warning of getSubmissionConfigWarnings(repoConfig?.submission)) {
+      core.warning(warning);
+    }
     submissionChecks = runSubmissionGate({
       files: files.map((f) => ({
         filename: f.filename,

--- a/src/gate.ts
+++ b/src/gate.ts
@@ -67,11 +67,9 @@ import {
 } from "./override.js";
 import { runSubmissionGate, submissionGateShouldBlock } from "./submission-engine.js";
 import type { SubmissionCheckResult } from "./types.js";
-import {
-  computeAgentTrustScore,
-  strictnessFromTrust,
-  type AgentTrustMetrics,
-} from "./trust-score.js";
+import { computeAgentTrustScore, strictnessFromTrust } from "./trust-score.js";
+import { parseAgentTrustMetrics } from "./agent-trust-metrics.js";
+import { readTrustRuntime } from "./trust-runtime.js";
 
 export {
   isSensitiveFile,
@@ -103,29 +101,6 @@ function parseDeclaredPackages(raw: string | undefined): string[] | undefined {
       .filter(Boolean);
   }
   return undefined;
-}
-
-function parseAgentTrustMetrics(raw: string | undefined): AgentTrustMetrics | null {
-  if (!raw?.trim()) return null;
-  try {
-    const parsed = JSON.parse(raw) as Partial<AgentTrustMetrics>;
-    if (typeof parsed.evaluations !== "number") return null;
-    return {
-      evaluations: parsed.evaluations,
-      releaseReadyCount: parsed.releaseReadyCount ?? 0,
-      revertCount: parsed.revertCount ?? 0,
-      humanReviewRequiredCount: parsed.humanReviewRequiredCount ?? 0,
-      policyViolationCount: parsed.policyViolationCount ?? 0,
-      sensitivePathViolationCount: parsed.sensitivePathViolationCount ?? 0,
-      remediationRoundsToReady: Array.isArray(parsed.remediationRoundsToReady)
-        ? parsed.remediationRoundsToReady.filter(
-            (n): n is number => typeof n === "number",
-          )
-        : [],
-    };
-  } catch {
-    return null;
-  }
 }
 
 // ---------------------------------------------------------------------------
@@ -1910,14 +1885,31 @@ export async function evaluateGate(
   const trustProfile =
     provenance?.type && provenance.type !== "human"
       ? (() => {
-          const metrics = parseAgentTrustMetrics(process.env.TRAILHEAD_AGENT_TRUST_JSON);
+          const trustRuntime = readTrustRuntime();
+          const metrics = trustRuntime.enabled
+            ? parseAgentTrustMetrics(process.env.TRAILHEAD_AGENT_TRUST_JSON)
+            : null;
           const trust = metrics ? computeAgentTrustScore(metrics) : null;
-          if (trust && trust.thresholdDelta !== 0) {
-            adjustedRiskThreshold = Math.max(
-              0,
-              Math.min(100, adjustedRiskThreshold + trust.thresholdDelta),
-            );
+
+          if (trustRuntime.enabled && metrics) {
+            if (trust) {
+              core.info(
+                `[agent-trust] profile=${trust.profile} score=${trust.score}` +
+                  (trustRuntime.shadow ? " (shadow — threshold delta not applied)" : ""),
+              );
+              if (trustRuntime.enforce && trust.thresholdDelta !== 0) {
+                adjustedRiskThreshold = Math.max(
+                  0,
+                  Math.min(100, adjustedRiskThreshold + trust.thresholdDelta),
+                );
+              }
+            } else {
+              core.info(
+                "[agent-trust] metrics present but trust=null (cold start — insufficient evidence or flat signals)",
+              );
+            }
           }
+
           return strictnessFromTrust(trust, riskScore);
         })()
       : {

--- a/src/main.ts
+++ b/src/main.ts
@@ -31,6 +31,9 @@ import { fetchCodeScanningAlerts, formatSecuritySection } from "./security.js";
 import { resolveEvaluationStoreUrl } from "./cloud-config.js";
 import { resolveCiManifests } from "./ci-external.js";
 import { computeRolloutReadiness } from "./rollout-readiness.js";
+import { resolveAgentProvenanceId } from "./agent-provenance.js";
+import { readTrustRuntime } from "./trust-runtime.js";
+import { buildGateVerdict } from "./verdict.js";
 import type { TrailheadConfig, TestRepairResult, PolicyOverrideAudit } from "./types.js";
 
 class PolicyOverrideError extends Error {
@@ -371,6 +374,11 @@ async function run(): Promise<void> {
       evaluation.releaseReady !== undefined ? String(evaluation.releaseReady) : "",
     );
     core.setOutput("evaluation-json", JSON.stringify(evaluation));
+    const verdict = buildGateVerdict(evaluation, {
+      trustRuntime: readTrustRuntime(),
+      agentId: resolveAgentProvenanceId(evaluation),
+    });
+    core.setOutput("verdict-json", JSON.stringify(verdict));
     core.setOutput(
       "rollout-readiness-json",
       JSON.stringify(computeRolloutReadiness(evaluation)),

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -2,6 +2,8 @@ import * as core from "@actions/core";
 import * as github from "@actions/github";
 import type { GateEvaluation } from "./types.js";
 import { resolveAgentProvenanceId } from "./agent-provenance.js";
+import { readTrustRuntime } from "./trust-runtime.js";
+import { buildGateVerdict } from "./verdict.js";
 import {
   resolveWebhookDeliveries,
   type ResolveTrailheadEventsOptions,
@@ -107,6 +109,10 @@ function buildTrailheadEventPayload(
     loopRound: evaluation.remediation?.loop_round,
     maxLoopRounds: evaluation.remediation?.max_loop_rounds,
     policyOverride: evaluation.policyOverride,
+    verdict: buildGateVerdict(evaluation, {
+      trustRuntime: readTrustRuntime(),
+      agentId: resolveAgentProvenanceId(evaluation),
+    }),
     timestamp: new Date().toISOString(),
   };
 }

--- a/src/submission-checks/detector-policy.ts
+++ b/src/submission-checks/detector-policy.ts
@@ -1,0 +1,103 @@
+// Resolve submission detector policy from `.trailhead.yml` (issue #256).
+
+import type {
+  RemediationSeverity,
+  SubmissionCheckCode,
+  SubmissionConfig,
+  SubmissionDetectorPolicyEntry,
+} from "../types.js";
+import { SubmissionCheckCode as SubmissionCheckCodeEnum } from "../types.js";
+import {
+  compileRenamePattern,
+  compileSlugOnlyPatterns,
+  DEFAULT_ARTIFACT_FILE_GLOBS,
+  DEFAULT_RENAME_PATTERNS,
+  DEFAULT_SLUG_ONLY_PATTERN_SOURCES,
+  type RenamePatternEntry,
+} from "./policy-defaults.js";
+
+export type DetectorPolicyEntry = {
+  enabled?: boolean;
+  severity?: RemediationSeverity;
+  fileGlobs?: string[];
+  pathIgnore?: string[];
+};
+
+export type DetectorPolicyMap = Partial<Record<SubmissionCheckCode, DetectorPolicyEntry>>;
+
+function normalizeSeverity(
+  severity: NonNullable<SubmissionDetectorPolicyEntry["severity"]>,
+): RemediationSeverity {
+  if (severity === "block") return "blocking";
+  return severity as RemediationSeverity;
+}
+
+export function resolveDetectorPolicy(submission?: Partial<SubmissionConfig>): {
+  policy: DetectorPolicyMap;
+  warnings: string[];
+} {
+  const raw = submission?.detectors ?? {};
+  const warnings: string[] = [];
+  const policy: DetectorPolicyMap = {};
+
+  for (const [key, value] of Object.entries(raw)) {
+    const parsed = SubmissionCheckCodeEnum.safeParse(key);
+    if (!parsed.success) {
+      warnings.push(`Unknown submission.detectors key "${key}" will be ignored.`);
+      continue;
+    }
+    if (!value || typeof value !== "object") continue;
+
+    policy[parsed.data] = {
+      enabled: value.enabled,
+      severity: value.severity ? normalizeSeverity(value.severity) : undefined,
+      fileGlobs: value.file_globs,
+      pathIgnore: value.path_ignore,
+    };
+  }
+
+  return { policy, warnings };
+}
+
+export function buildRenamePatterns(
+  submission?: Partial<SubmissionConfig>,
+  options?: { includeKomatikDefaults?: boolean },
+): RenamePatternEntry[] {
+  const custom = (submission?.rename_patterns ?? []).map(({ old, new: newName }) =>
+    compileRenamePattern(old, newName),
+  );
+  const defaults = options?.includeKomatikDefaults ? DEFAULT_RENAME_PATTERNS : [];
+  return [...defaults, ...custom];
+}
+
+export function buildSlugOnlyPatterns(submission?: Partial<SubmissionConfig>): RegExp[] {
+  const sources = [
+    ...DEFAULT_SLUG_ONLY_PATTERN_SOURCES,
+    ...(submission?.slug_only_patterns ?? []),
+  ];
+  return compileSlugOnlyPatterns(sources);
+}
+
+export function artifactFileGlobs(policy: DetectorPolicyMap): string[] {
+  return policy.artifact_integrity?.fileGlobs ?? DEFAULT_ARTIFACT_FILE_GLOBS;
+}
+
+export function applyDetectorPolicy(
+  code: SubmissionCheckCode,
+  check: import("../types.js").SubmissionCheckResult | null,
+  policy: DetectorPolicyMap,
+): import("../types.js").SubmissionCheckResult | null {
+  const entry = policy[code];
+  if (entry?.enabled === false) return null;
+  if (!check) return null;
+  if (entry?.severity) {
+    return { ...check, severity: entry.severity };
+  }
+  return check;
+}
+
+export function getSubmissionConfigWarnings(
+  submission?: Partial<SubmissionConfig>,
+): string[] {
+  return resolveDetectorPolicy(submission).warnings;
+}

--- a/src/submission-checks/detectors.ts
+++ b/src/submission-checks/detectors.ts
@@ -1,6 +1,6 @@
 // Gate 1 detectors — ported from komatik-agents agent-gate-checks (patch/content based).
 
-import type { SubmissionCheckResult } from "../types.js";
+import type { SubmissionCheckResult, SubmissionCheckCode } from "../types.js";
 import type { SubmissionCheckContext } from "./types.js";
 import {
   addedLines,
@@ -17,33 +17,9 @@ import {
 import type { NamingAllowlistConfig } from "./types.js";
 import { runPhase0Detectors } from "./phase0-detectors.js";
 import { validateFileSyntax } from "./syntax-validity.js";
-
-export const OLD_NAME_PATTERNS: Array<{
-  oldName: string;
-  newName: string;
-  pattern: RegExp;
-}> = [
-  { oldName: "DeployGuard", newName: "Trailhead", pattern: /\bDeployGuard\b/g },
-  { oldName: "Daydream Studio", newName: "Sundog", pattern: /\bDaydream Studio\b/g },
-  {
-    oldName: "Storyboard Studio",
-    newName: "Kindling",
-    pattern: /\bStoryboard Studio\b/g,
-  },
-  { oldName: "Cognitive Debt", newName: "Drift", pattern: /\bCognitive Debt\b/g },
-  { oldName: "cognitive-debt", newName: "Drift", pattern: /\bcognitive-debt\b/g },
-  { oldName: "Undercurrent", newName: "Slipstream", pattern: /\bUndercurrent\b/g },
-  { oldName: "Yggdrasil", newName: "Cairn", pattern: /\bYggdrasil\b/g },
-  { oldName: "Bored", newName: "Lodge", pattern: /\bBored\b/g },
-  { oldName: "Forge", newName: "Pack", pattern: /\bForge\b/g },
-];
-
-const SLUG_ONLY_PATTERNS = [
-  /\bcognitive-debt\b/,
-  /\bstoryboard-studio\b/,
-  /\bdaydream-studio\b/,
-  /\bshadow-ai-governance\b/,
-];
+import { matchesGlobs } from "../risk-engine.js";
+import { applyDetectorPolicy, artifactFileGlobs } from "./detector-policy.js";
+export { DEFAULT_RENAME_PATTERNS, OLD_NAME_PATTERNS } from "./policy-defaults.js";
 
 const MOCK_PATTERNS = [
   /\bTODO\s*\(\s*mock\s*\)/i,
@@ -177,9 +153,6 @@ export function detectDestructiveSql(
 
 // Only code files can carry hard file references; prose (.md/.mdx/.txt) merely
 // *mentions* paths and was the dominant artifact_integrity false-positive source.
-const ARTIFACT_CODE_EXTS = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"]);
-// Repo-ubiquitous manifests are referenced everywhere and are never the kind of
-// "hallucinated/missing artifact" this check is meant to catch.
 const ARTIFACT_BARE_IGNORE = new Set([
   "package.json",
   "package-lock.json",
@@ -191,6 +164,8 @@ export function detectArtifactIntegrity(
   ctx: SubmissionCheckContext,
 ): SubmissionCheckResult | null {
   const referenced = new Set<string>();
+  const fileGlobs = artifactFileGlobs(ctx.detectorPolicy);
+  const pathIgnore = ctx.detectorPolicy.artifact_integrity?.pathIgnore ?? [];
   // Only treat a path *literal* inside an import/require/export-from statement
   // as a hard reference — natural-language "see X" / "fix Y" / "update Z" in
   // prose is not a code dependency (the old prose trigger over-flagged docs).
@@ -198,8 +173,8 @@ export function detectArtifactIntegrity(
     /(?:\bimport\b|\bfrom\b|\brequire\s*\(|\bexport\b[^'"`]*\bfrom\b)\s*['"`]([\w@./-]+\.(?:ts|tsx|js|jsx|sql|yml|yaml|json))['"`]/g;
 
   for (const file of ctx.files) {
-    // Prose/doc files only mention paths; never flag them as missing code refs.
-    if (!ARTIFACT_CODE_EXTS.has(extensionOf(file.filename))) continue;
+    if (!matchesGlobs(file.filename, fileGlobs)) continue;
+    if (pathIgnore.length > 0 && matchesGlobs(file.filename, pathIgnore)) continue;
 
     for (const line of addedLines(file.patch)) {
       importRefPattern.lastIndex = 0;
@@ -233,6 +208,7 @@ function isNamingAllowlisted(
   filename: string,
   line: string,
   allowlist: NamingAllowlistConfig = {},
+  slugOnlyPatterns: RegExp[] = [],
 ): boolean {
   const trimmed = line.trim();
   const path = normalizePath(filename);
@@ -265,7 +241,7 @@ function isNamingAllowlisted(
   if (/^\[.*\]\(.*\)/.test(trimmed) || /\]\(http/.test(trimmed)) return true;
 
   if (
-    SLUG_ONLY_PATTERNS.some((p) => p.test(trimmed)) &&
+    slugOnlyPatterns.some((p) => p.test(trimmed)) &&
     !/[A-Z]/.test(
       trimmed.match(
         /(?:cognitive-debt|storyboard-studio|daydream-studio|shadow-ai-governance)/,
@@ -287,24 +263,33 @@ function isNamingAllowlisted(
 export function detectContextFreshness(
   ctx: SubmissionCheckContext,
 ): SubmissionCheckResult | null {
-  if (!ctx.komatikInstance && ctx.staleTerms.length === 0) return null;
+  if (ctx.staleTerms.length === 0 && ctx.renamePatterns.length === 0) {
+    return null;
+  }
 
   const hits: string[] = [];
   for (const file of ctx.files) {
     if (isStaleArchivedPath(file.filename, ctx.pathIgnorePatterns)) continue;
 
     for (const line of linesForFreshnessScan(file)) {
-      if (isNamingAllowlisted(file.filename, line, ctx.namingAllowlist)) continue;
+      if (
+        isNamingAllowlisted(
+          file.filename,
+          line,
+          ctx.namingAllowlist,
+          ctx.slugOnlyPatterns,
+        )
+      ) {
+        continue;
+      }
 
       for (const term of ctx.staleTerms) {
         if (line.toLowerCase().includes(term.toLowerCase())) hits.push(file.filename);
       }
 
-      if (ctx.komatikInstance) {
-        for (const entry of OLD_NAME_PATTERNS) {
-          entry.pattern.lastIndex = 0;
-          if (entry.pattern.test(line)) hits.push(file.filename);
-        }
+      for (const entry of ctx.renamePatterns) {
+        entry.pattern.lastIndex = 0;
+        if (entry.pattern.test(line)) hits.push(file.filename);
       }
     }
   }
@@ -644,23 +629,33 @@ export function detectSoulIntegrity(
 }
 
 export function runAllDetectors(ctx: SubmissionCheckContext): SubmissionCheckResult[] {
+  const policy = ctx.detectorPolicy;
+  const finalize = (
+    code: SubmissionCheckCode,
+    check: SubmissionCheckResult | null,
+  ): SubmissionCheckResult | null => applyDetectorPolicy(code, check, policy);
+
   const gate1 = [
-    detectMockPlaceholder(ctx),
-    detectSecrets(ctx),
-    detectDestructiveSql(ctx),
-    detectSyntaxValidity(ctx),
-    detectImportResolution(ctx),
-    detectRlsNewTables(ctx),
-    detectAuthRouteAuth(ctx),
-    detectHardcodedEnv(ctx),
-    detectExternalPackageDeps(ctx),
-    detectSqlSyntaxBasic(ctx),
-    detectLargeFile(ctx),
-    detectArtifactIntegrity(ctx),
-    detectContextFreshness(ctx),
-    detectSoulIntegrity(ctx),
-    detectPathFormat(ctx),
+    finalize("mock_placeholder", detectMockPlaceholder(ctx)),
+    finalize("secrets", detectSecrets(ctx)),
+    finalize("destructive_sql", detectDestructiveSql(ctx)),
+    finalize("syntax_validity", detectSyntaxValidity(ctx)),
+    finalize("import_resolution", detectImportResolution(ctx)),
+    finalize("rls_new_tables", detectRlsNewTables(ctx)),
+    finalize("auth_route_auth", detectAuthRouteAuth(ctx)),
+    finalize("hardcoded_env", detectHardcodedEnv(ctx)),
+    finalize("external_package_deps", detectExternalPackageDeps(ctx)),
+    finalize("sql_syntax_basic", detectSqlSyntaxBasic(ctx)),
+    finalize("large_file", detectLargeFile(ctx)),
+    finalize("artifact_integrity", detectArtifactIntegrity(ctx)),
+    finalize("context_freshness", detectContextFreshness(ctx)),
+    finalize("soul_integrity", detectSoulIntegrity(ctx)),
+    finalize("path_format", detectPathFormat(ctx)),
   ].filter((check): check is SubmissionCheckResult => check !== null);
 
-  return [...gate1, ...runPhase0Detectors(ctx)];
+  const phase0 = runPhase0Detectors(ctx)
+    .map((check) => finalize(check.code, check))
+    .filter((check): check is SubmissionCheckResult => check !== null);
+
+  return [...gate1, ...phase0];
 }

--- a/src/submission-checks/policy-defaults.ts
+++ b/src/submission-checks/policy-defaults.ts
@@ -1,0 +1,54 @@
+// Default submission detector policy data (Komatik fleet rename vocabulary).
+
+export interface RenamePatternEntry {
+  oldName: string;
+  newName: string;
+  pattern: RegExp;
+}
+
+export const DEFAULT_RENAME_PATTERNS: RenamePatternEntry[] = [
+  { oldName: "DeployGuard", newName: "Trailhead", pattern: /\bDeployGuard\b/g },
+  { oldName: "Daydream Studio", newName: "Sundog", pattern: /\bDaydream Studio\b/g },
+  {
+    oldName: "Storyboard Studio",
+    newName: "Kindling",
+    pattern: /\bStoryboard Studio\b/g,
+  },
+  { oldName: "Cognitive Debt", newName: "Drift", pattern: /\bCognitive Debt\b/g },
+  { oldName: "cognitive-debt", newName: "Drift", pattern: /\bcognitive-debt\b/g },
+  { oldName: "Undercurrent", newName: "Slipstream", pattern: /\bUndercurrent\b/g },
+  { oldName: "Yggdrasil", newName: "Cairn", pattern: /\bYggdrasil\b/g },
+  { oldName: "Bored", newName: "Lodge", pattern: /\bBored\b/g },
+  { oldName: "Forge", newName: "Pack", pattern: /\bForge\b/g },
+];
+
+/** @deprecated use DEFAULT_RENAME_PATTERNS */
+export const OLD_NAME_PATTERNS = DEFAULT_RENAME_PATTERNS;
+
+export const DEFAULT_SLUG_ONLY_PATTERN_SOURCES = [
+  "\\bcognitive-debt\\b",
+  "\\bstoryboard-studio\\b",
+  "\\bdaydream-studio\\b",
+  "\\bshadow-ai-governance\\b",
+];
+
+export const DEFAULT_ARTIFACT_FILE_GLOBS = ["**/*.{ts,tsx,js,jsx,mjs,cjs}"];
+
+function escapeRegexLiteral(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function compileRenamePattern(
+  oldName: string,
+  newName: string,
+): RenamePatternEntry {
+  return {
+    oldName,
+    newName,
+    pattern: new RegExp(`\\b${escapeRegexLiteral(oldName)}\\b`, "g"),
+  };
+}
+
+export function compileSlugOnlyPatterns(sources: string[]): RegExp[] {
+  return sources.map((source) => new RegExp(source, "i"));
+}

--- a/src/submission-checks/types.ts
+++ b/src/submission-checks/types.ts
@@ -7,6 +7,9 @@ export interface SubmissionFileInfo {
   additions?: number;
 }
 
+import type { DetectorPolicyMap } from "./detector-policy.js";
+import type { RenamePatternEntry } from "./policy-defaults.js";
+
 export interface NamingAllowlistConfig {
   skip_extensions?: string[];
   skip_path_patterns?: string[];
@@ -25,6 +28,9 @@ export interface SubmissionCheckContext {
   declaredPackages: Set<string>;
   /** Extra path segments to skip for context_freshness (merged with defaults). */
   pathIgnorePatterns: string[];
+  renamePatterns: RenamePatternEntry[];
+  slugOnlyPatterns: RegExp[];
+  detectorPolicy: DetectorPolicyMap;
   /**
    * Full set of paths that exist in the target repo (e.g. `git ls-files`),
    * used to tell a fabricated reference from a reference to an existing,

--- a/src/submission-engine.ts
+++ b/src/submission-engine.ts
@@ -4,11 +4,18 @@
 import { runAllDetectors } from "./submission-checks/detectors.js";
 import type { SubmissionCheckContext } from "./submission-checks/types.js";
 import { prPathSet } from "./submission-checks/helpers.js";
+import {
+  buildRenamePatterns,
+  buildSlugOnlyPatterns,
+  getSubmissionConfigWarnings,
+  resolveDetectorPolicy,
+} from "./submission-checks/detector-policy.js";
 import { SubmissionCheckCode } from "./types.js";
 import type { RepoConfig, SubmissionCheckResult } from "./types.js";
 
 export type { SubmissionFileInfo } from "./submission-checks/types.js";
 export type { SubmissionCheckCode, SubmissionCheckResult } from "./types.js";
+export { getSubmissionConfigWarnings };
 
 /** Gate 1 + Phase 0 submission check codes — keep in sync with A8 fixture manifest. */
 export const SUBMISSION_CHECK_CODES = SubmissionCheckCode.options;
@@ -51,6 +58,7 @@ function buildContext(options: SubmissionEngineOptions): SubmissionCheckContext 
   const staleTerms = repoConfig?.submission?.stale_terms ?? [];
 
   const declared = new Set(options.declaredPackages ?? []);
+  const { policy } = resolveDetectorPolicy(repoConfig?.submission);
 
   return {
     files,
@@ -63,6 +71,11 @@ function buildContext(options: SubmissionEngineOptions): SubmissionCheckContext 
     maxFileLines: repoConfig?.submission?.max_file_lines ?? 1000,
     declaredPackages: declared,
     pathIgnorePatterns: repoConfig?.submission?.path_ignore ?? [],
+    renamePatterns: buildRenamePatterns(repoConfig?.submission, {
+      includeKomatikDefaults: komatikInstance,
+    }),
+    slugOnlyPatterns: buildSlugOnlyPatterns(repoConfig?.submission),
+    detectorPolicy: policy,
     repoPaths: options.repoPaths ? new Set(options.repoPaths) : undefined,
   };
 }

--- a/src/trust-runtime.ts
+++ b/src/trust-runtime.ts
@@ -1,0 +1,24 @@
+// Shadow / enforce runtime for agent trust injection (issue #259).
+
+export interface TrustRuntime {
+  enabled: boolean;
+  /** Log trust profile without applying threshold delta. */
+  shadow: boolean;
+  /** Apply threshold delta and strictness adjustments from trust score. */
+  enforce: boolean;
+  /** Collector-only: inject TRAILHEAD_AGENT_TRUST_JSON (Komatik dogfood). */
+  injectTrustJson: boolean;
+}
+
+export function readTrustRuntime(env: NodeJS.ProcessEnv = process.env): TrustRuntime {
+  const enabled = env.TRAILHEAD_TRUST_ENABLED !== "false";
+  const shadow = enabled && env.TRAILHEAD_TRUST_SHADOW === "true";
+  const enforce = enabled && !shadow;
+
+  return {
+    enabled,
+    shadow,
+    enforce,
+    injectTrustJson: enabled && env.TRAILHEAD_TRUST_ENFORCE === "true",
+  };
+}

--- a/src/trust-score.ts
+++ b/src/trust-score.ts
@@ -1,17 +1,15 @@
 // Phase B3 — dynamic agent trust scoring (pure module).
 
-export type TrustProfileName = "fast-track" | "standard" | "probation";
+import {
+  assessColdStartFromMetrics,
+  DEFAULT_TRUST_COLLECTOR_CONFIG,
+  type AgentTrustMetrics,
+  type TrustCollectorConfig,
+} from "./agent-trust-metrics.js";
 
-export interface AgentTrustMetrics {
-  evaluations: number;
-  releaseReadyCount: number;
-  revertCount: number;
-  humanReviewRequiredCount: number;
-  policyViolationCount: number;
-  sensitivePathViolationCount: number;
-  /** Sum of loop rounds for PRs that reached release_ready. */
-  remediationRoundsToReady: number[];
-}
+export type { AgentTrustMetrics } from "./agent-trust-metrics.js";
+
+export type TrustProfileName = "fast-track" | "standard" | "probation";
 
 export interface AgentTrustResult {
   score: number;
@@ -23,9 +21,12 @@ export interface AgentTrustResult {
     remediation_efficiency: number;
     policy_violation_rate: number;
     sensitive_path_violation_rate: number;
+    penalty_clean_rate?: number;
+    penalty_mean_quality?: number;
   };
   thresholdDelta: number;
   autofixEnabled: boolean;
+  coldStart?: { reason: string };
 }
 
 const WEIGHTS = {
@@ -35,6 +36,7 @@ const WEIGHTS = {
   remediation_efficiency: 0.15,
   policy_violation_penalty: 0.075,
   sensitive_path_penalty: 0.075,
+  penalty_mean_quality: 0.05,
 };
 
 function rate(numerator: number, denominator: number): number {
@@ -48,36 +50,66 @@ function remediationEfficiency(rounds: number[]): number {
   return Math.max(0, Math.min(1, 1 - (avg - 1) / 4));
 }
 
-export function computeAgentTrustScore(metrics: AgentTrustMetrics): AgentTrustResult {
+function penaltyMeanQuality(
+  penaltyQuality: AgentTrustMetrics["penaltyQuality"],
+  noisyThreshold: number,
+): number | undefined {
+  if (!penaltyQuality || penaltyQuality.sampleCount <= 0) return undefined;
+  return Math.max(0, Math.min(1, 1 - penaltyQuality.mean / noisyThreshold));
+}
+
+export function computeAgentTrustScore(
+  metrics: AgentTrustMetrics,
+  options?: { config?: Partial<TrustCollectorConfig> },
+): AgentTrustResult | null {
+  const config = { ...DEFAULT_TRUST_COLLECTOR_CONFIG, ...options?.config };
+  const coldStart = assessColdStartFromMetrics(metrics, config);
+  if (!coldStart.emitTrust) {
+    return null;
+  }
+
   const n = Math.max(metrics.evaluations, 0);
   const releaseReadyRate = rate(metrics.releaseReadyCount, n);
+  const penaltyCleanRate = metrics.penaltyQuality?.cleanRate;
+  const releaseSignal =
+    penaltyCleanRate !== undefined
+      ? Math.max(releaseReadyRate, penaltyCleanRate)
+      : releaseReadyRate;
+
   const revertRate = rate(metrics.revertCount, n);
   const humanReviewRate = rate(metrics.humanReviewRequiredCount, n);
   const policyViolationRate = rate(metrics.policyViolationCount, n);
   const sensitiveRate = rate(metrics.sensitivePathViolationCount, n);
   const remEff = remediationEfficiency(metrics.remediationRoundsToReady);
+  const meanQuality = penaltyMeanQuality(
+    metrics.penaltyQuality,
+    config.noisyPenaltyThreshold,
+  );
 
   const factors = {
-    release_ready_rate: releaseReadyRate,
+    release_ready_rate: releaseSignal,
     revert_rate: revertRate,
     human_review_required_rate: humanReviewRate,
     remediation_efficiency: remEff,
     policy_violation_rate: policyViolationRate,
     sensitive_path_violation_rate: sensitiveRate,
+    ...(penaltyCleanRate !== undefined ? { penalty_clean_rate: penaltyCleanRate } : {}),
+    ...(meanQuality !== undefined ? { penalty_mean_quality: meanQuality } : {}),
   };
 
-  const score = Math.max(
-    0,
-    Math.min(
-      1,
-      WEIGHTS.release_ready_rate * releaseReadyRate +
-        WEIGHTS.revert_resistance * (1 - revertRate) +
-        WEIGHTS.human_free_rate * (1 - humanReviewRate) +
-        WEIGHTS.remediation_efficiency * remEff -
-        WEIGHTS.policy_violation_penalty * policyViolationRate -
-        WEIGHTS.sensitive_path_penalty * sensitiveRate,
-    ),
-  );
+  let score =
+    WEIGHTS.release_ready_rate * releaseSignal +
+    WEIGHTS.revert_resistance * (1 - revertRate) +
+    WEIGHTS.human_free_rate * (1 - humanReviewRate) +
+    WEIGHTS.remediation_efficiency * remEff -
+    WEIGHTS.policy_violation_penalty * policyViolationRate -
+    WEIGHTS.sensitive_path_penalty * sensitiveRate;
+
+  if (meanQuality !== undefined) {
+    score += WEIGHTS.penalty_mean_quality * meanQuality;
+  }
+
+  score = Math.max(0, Math.min(1, score));
 
   let profile: TrustProfileName = "standard";
   if (score >= 0.85) profile = "fast-track";

--- a/src/types.ts
+++ b/src/types.ts
@@ -440,6 +440,21 @@ export const TuningConfig = z.object({
 });
 export type TuningConfig = z.infer<typeof TuningConfig>;
 
+export const SubmissionDetectorPolicyEntry = z.object({
+  enabled: z.boolean().optional(),
+  severity: z.enum(["block", "warn", "advisory", "blocking"]).optional(),
+  file_globs: z.array(z.string()).optional(),
+  path_ignore: z.array(z.string()).optional(),
+  weight: z.number().optional(),
+});
+export type SubmissionDetectorPolicyEntry = z.infer<typeof SubmissionDetectorPolicyEntry>;
+
+export const SubmissionRenamePattern = z.object({
+  old: z.string().min(1),
+  new: z.string().min(1),
+});
+export type SubmissionRenamePattern = z.infer<typeof SubmissionRenamePattern>;
+
 export const SubmissionConfig = z.object({
   enabled: z.boolean().default(false),
   mode: z.enum(["warn", "block"]).default("block"),
@@ -457,6 +472,12 @@ export const SubmissionConfig = z.object({
       skip_in_imports: z.boolean().optional(),
     })
     .optional(),
+  /** Project rename vocabulary — extends Komatik defaults when KOMATIK_INSTANCE=true. */
+  rename_patterns: z.array(SubmissionRenamePattern).optional(),
+  /** Extra slug-only regex sources (merged with product defaults). */
+  slug_only_patterns: z.array(z.string()).optional(),
+  /** Per-detector policy overrides (enable/severity/file scope). */
+  detectors: z.record(SubmissionDetectorPolicyEntry).optional(),
 });
 export type SubmissionConfig = z.infer<typeof SubmissionConfig>;
 

--- a/src/verdict.ts
+++ b/src/verdict.ts
@@ -1,0 +1,260 @@
+// Stable versioned gate verdict contract (epic #252 / issue #260).
+
+import { z } from "zod";
+import type { GateEvaluation, SubmissionCheckResult } from "./types.js";
+import { GateDecision, SubmissionCheckCode } from "./types.js";
+import type { TrustRuntime } from "./trust-runtime.js";
+import { DEFAULT_TRUST_COLLECTOR_CONFIG } from "./agent-trust-metrics.js";
+import type { PenaltyQualitySignal } from "./agent-trust-metrics.js";
+
+export const TRAILHEAD_VERDICT_SCHEMA = "trailhead.verdict.v1" as const;
+
+export const PENALTY_SEMANTICS = "lower_is_cleaner" as const;
+export const RISK_SEMANTICS = "higher_is_worse" as const;
+
+const SEVERITY_PENALTY: Record<SubmissionCheckResult["severity"], number> = {
+  blocking: 3,
+  warn: 2,
+  advisory: 1,
+};
+
+export const VerdictPenaltySchema = z.object({
+  total_score: z.number().min(0),
+  factor_scores: z.record(z.number().min(0)),
+  semantics: z.literal(PENALTY_SEMANTICS),
+});
+export type VerdictPenalty = z.infer<typeof VerdictPenaltySchema>;
+
+export const VerdictRiskSchema = z.object({
+  score: z.number().min(0).max(100),
+  semantics: z.literal(RISK_SEMANTICS),
+  factors: z.record(z.number().min(0).max(100)),
+});
+export type VerdictRisk = z.infer<typeof VerdictRiskSchema>;
+
+export const VerdictTrustProfileSchema = z.object({
+  shadow: z.boolean().optional(),
+  enforce: z.boolean().optional(),
+  score: z.number().min(0).max(1).optional(),
+  profile: z.enum(["fast-track", "standard", "probation"]).optional(),
+  strictness: z.enum(["baseline", "elevated", "strict"]),
+  reason: z.string(),
+  factors: z.record(z.number()).optional(),
+});
+export type VerdictTrustProfile = z.infer<typeof VerdictTrustProfileSchema>;
+
+export const VerdictRemediationSchema = z.object({
+  loop_round: z.number().int().min(0).optional(),
+  max_loop_rounds: z.number().int().min(0).optional(),
+  next_action: z.string().optional(),
+  fix_count: z.number().int().min(0).optional(),
+});
+export type VerdictRemediation = z.infer<typeof VerdictRemediationSchema>;
+
+export const TrailheadVerdictSchema = z.object({
+  schema: z.literal(TRAILHEAD_VERDICT_SCHEMA),
+  evaluation_id: z.string(),
+  repo_id: z.string(),
+  commit_sha: z.string(),
+  pr_number: z.number().int().positive().optional(),
+  head_ref: z.string().optional(),
+  agent_id: z.string().optional(),
+  decision: GateDecision,
+  gate_mode: z.enum(["risk-only", "advisory", "release-ready"]).optional(),
+  release_ready: z.boolean().optional(),
+  penalty: VerdictPenaltySchema,
+  risk: VerdictRiskSchema,
+  trust_profile: VerdictTrustProfileSchema.optional(),
+  submission_checks: z.array(
+    z.object({
+      code: SubmissionCheckCode,
+      severity: z.enum(["blocking", "warn", "advisory"]),
+      title: z.string(),
+      detail: z.string(),
+      files: z.array(z.string()).default([]),
+    }),
+  ),
+  remediation: VerdictRemediationSchema.optional(),
+  reasons: z.array(z.string()),
+  evaluated_at: z.string(),
+  /** Deprecated flat fields — remove after one release (#260). */
+  _legacy: z
+    .object({
+      riskScore: z.number(),
+      healthScore: z.number(),
+      releaseReadyReasons: z.array(z.string()).optional(),
+      policyFindings: z.array(z.string()).optional(),
+    })
+    .optional(),
+});
+export type TrailheadVerdict = z.infer<typeof TrailheadVerdictSchema>;
+
+export function computeSubmissionPenalty(
+  checks: SubmissionCheckResult[] = [],
+): VerdictPenalty {
+  const factor_scores: Record<string, number> = {};
+  for (const check of checks) {
+    const penalty = SEVERITY_PENALTY[check.severity] ?? 0;
+    factor_scores[check.code] = Math.max(factor_scores[check.code] ?? 0, penalty);
+  }
+
+  const values = Object.values(factor_scores);
+  const total_score =
+    values.length === 0
+      ? 0
+      : Math.round((values.reduce((sum, value) => sum + value, 0) / values.length) * 10) /
+        10;
+
+  return {
+    total_score,
+    factor_scores,
+    semantics: PENALTY_SEMANTICS,
+  };
+}
+
+export function collectVerdictReasons(evaluation: GateEvaluation): string[] {
+  const reasons = new Set<string>();
+
+  for (const finding of evaluation.policyFindings ?? []) {
+    reasons.add(finding);
+  }
+  for (const reason of evaluation.releaseReadyReasons ?? []) {
+    reasons.add(reason);
+  }
+  if (evaluation.remediation?.next_action) {
+    reasons.add(`Remediation next action: ${evaluation.remediation.next_action}`);
+  }
+  if (evaluation.trust_profile?.reason) {
+    reasons.add(evaluation.trust_profile.reason);
+  }
+  if (evaluation.gateDecision === "block") {
+    reasons.add("Gate decision is BLOCK");
+  } else if (evaluation.gateDecision === "warn") {
+    reasons.add("Gate decision is WARN");
+  }
+
+  return [...reasons];
+}
+
+export interface BuildGateVerdictOptions {
+  evaluatedAt?: string;
+  trustRuntime?: TrustRuntime;
+  agentId?: string | null;
+}
+
+export function buildGateVerdict(
+  evaluation: GateEvaluation,
+  options: BuildGateVerdictOptions = {},
+): TrailheadVerdict {
+  const checks = evaluation.submissionChecks ?? [];
+  const penalty = computeSubmissionPenalty(checks);
+  const trustRuntime = options.trustRuntime;
+
+  const verdict: TrailheadVerdict = {
+    schema: TRAILHEAD_VERDICT_SCHEMA,
+    evaluation_id: evaluation.id,
+    repo_id: evaluation.repoId,
+    commit_sha: evaluation.commitSha,
+    pr_number: evaluation.prNumber,
+    head_ref: evaluation.pr?.headRef,
+    agent_id: options.agentId ?? undefined,
+    decision: evaluation.gateDecision,
+    gate_mode: evaluation.gateMode,
+    release_ready: evaluation.releaseReady,
+    penalty,
+    risk: {
+      score: evaluation.riskScore,
+      semantics: RISK_SEMANTICS,
+      factors: Object.fromEntries(
+        evaluation.riskFactors.map((factor) => [factor.type, factor.score]),
+      ),
+    },
+    trust_profile: evaluation.trust_profile
+      ? {
+          shadow: trustRuntime?.shadow,
+          enforce: trustRuntime?.enforce,
+          score: evaluation.trust_profile.score,
+          profile: evaluation.trust_profile.profile,
+          strictness: evaluation.trust_profile.strictness,
+          reason: evaluation.trust_profile.reason,
+          factors: evaluation.trust_profile.factors,
+        }
+      : undefined,
+    submission_checks: checks.map((check) => ({
+      code: check.code,
+      severity: check.severity,
+      title: check.title,
+      detail: check.detail,
+      files: check.files ?? [],
+    })),
+    remediation: evaluation.remediation
+      ? {
+          loop_round: evaluation.remediation.loop_round,
+          max_loop_rounds: evaluation.remediation.max_loop_rounds,
+          next_action: evaluation.remediation.next_action,
+          fix_count: evaluation.remediation.fixes?.length,
+        }
+      : undefined,
+    reasons: collectVerdictReasons(evaluation),
+    evaluated_at: options.evaluatedAt ?? new Date().toISOString(),
+    _legacy: {
+      riskScore: evaluation.riskScore,
+      healthScore: evaluation.healthScore,
+      releaseReadyReasons: evaluation.releaseReadyReasons,
+      policyFindings: evaluation.policyFindings,
+    },
+  };
+
+  return TrailheadVerdictSchema.parse(verdict);
+}
+
+export function parseGateVerdict(raw: string | unknown): TrailheadVerdict | null {
+  try {
+    const value = typeof raw === "string" ? JSON.parse(raw) : raw;
+    const parsed = TrailheadVerdictSchema.safeParse(value);
+    return parsed.success ? parsed.data : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Collector helper: map penalty verdicts to trust penaltyQuality stats. */
+export function aggregateVerdictPenaltyQuality(
+  verdicts: TrailheadVerdict[],
+): PenaltyQualitySignal | null {
+  const scores = verdicts.map((verdict) => verdict.penalty.total_score);
+  if (scores.length === 0) return null;
+
+  const count = scores.length;
+  const mean = scores.reduce((sum, value) => sum + value, 0) / count;
+  const variance =
+    count === 1 ? 0 : scores.reduce((sum, value) => sum + (value - mean) ** 2, 0) / count;
+  const stdDev = Math.sqrt(variance);
+  const cleanThreshold = DEFAULT_TRUST_COLLECTOR_CONFIG.cleanPenaltyThreshold;
+  const cleanCount = scores.filter((score) => score <= cleanThreshold).length;
+
+  return {
+    mean: Math.round(mean * 10) / 10,
+    stdDev: Math.round(stdDev * 10) / 10,
+    cleanRate: Math.round((cleanCount / count) * 1000) / 1000,
+    sampleCount: count,
+  };
+}
+
+/** Example collector projection: one verdict → trust correlation fields. */
+export function projectVerdictToTrustCorrelation(verdict: TrailheadVerdict): {
+  evaluation_id: string;
+  agent_id?: string;
+  head_ref?: string;
+  penalty: VerdictPenalty;
+  release_ready_clean: boolean;
+} {
+  return {
+    evaluation_id: verdict.evaluation_id,
+    agent_id: verdict.agent_id,
+    head_ref: verdict.head_ref,
+    penalty: verdict.penalty,
+    release_ready_clean:
+      verdict.penalty.total_score <= DEFAULT_TRUST_COLLECTOR_CONFIG.cleanPenaltyThreshold,
+  };
+}


### PR DESCRIPTION
## Summary

Closes epic **#252** — makes the agent-trust loop and detector customization end-user-ready across Trailhead core, CLI, MCP, and webhook surfaces.

### P0 — Agent trust metrics (#253, #254, #255, #259)

- Versioned **`trailhead.agent_trust_metrics.v1`** schema, parser, example JSON, and docs — graduation target for Komatik agents collector output.
- **`computeAgentTrustScore()`** returns **`null` on cold start** (insufficient evidence or flat signals) instead of a falsely-confident score; optional `penaltyQuality` / `feedback` fields feed continuous penalty signals.
- Gate + MCP gain **shadow/enforce runtime** (`TRAILHEAD_TRUST_SHADOW`, kill switch) with backward-compatible default: threshold delta still applies when JSON is present unless shadow is explicitly on.

### P1 — Config-driven submission detectors (#256)

- `.trailhead.yml` **`submission`** block extensions: `rename_patterns`, `slug_only_patterns`, per-detector `detectors.<code>` (enabled, severity, file_globs, path_ignore).
- Policy resolution in `detector-policy.ts` with warnings for unknown detector keys; wired through Action, MCP `validate-submission`, and config warnings in gate logs.

### P1 — Post-merge feedback contract (#257)

- **`trailhead.feedback.v1`** Zod schema, rollup helpers (`rollupFeedbackForAgent`, `mergeFeedbackIntoMetrics`), docs, and example JSON for post-merge trust loop closure.

### P2 — Versioned gate verdict (#260)

- **`trailhead.verdict.v1`** with explicit **penalty** (lower = cleaner) vs **risk** (higher = worse) semantics, trust profile shadow fields, collector helpers, and `_legacy` compat block.
- Emitted via Action **`verdict-json`** output, semantic webhooks, and MCP `validate-submission` / `evaluate-policy`.

### P2 — Prebuilt CLI bundle (#258)

- CLI ships as **ncc bundle + vendored `swc.*.node`** — no runtime `@swc/core` install for consumers.
- CI verifies `node cli/dist/index.js doctor --offline`; release workflow builds bundle before npm publish.
- Migration note for vendored `komatik-agents/trailhead/cli-dist/` → `npx @komatikai/trailhead`.

## Follow-ups (out of scope for this PR)

- Komatik **agents** repo: wire collector to `verdict.penalty` / product schemas; drop hand-vendored `cli-dist` in favor of npm pin.
- Enable **enforce** mode for submission gate after FP metrics (B4 dogfood).

## Test plan

- [x] Trust: `agent-trust-metrics`, `trust-score`, `trust-runtime`, `agent-trust-feedback`
- [x] Submission: `submission-detector-policy`, precision/phase0 updates
- [x] Verdict: `verdict.test.ts`, `main.test.ts` (`verdict-json`), notify webhook shape
- [x] CLI: `npm run build:cli` + `doctor --offline` + `validate-submission` syntax check
- [x] Gate/MCP: `gate.test.ts`, `mcp.test.ts`
- [x] `npm run lint`
- [ ] CI green on PR

Closes #253, #254, #255, #256, #257, #258, #259, #260. Epic #252 complete in Trailhead; agents-side collector injection remains a follow-up PR.