### PR TITLE
feat(catalog): declare bounded context + platform contracts (supporting-subdomain)

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,56 @@
+# Backstage catalog-info.yaml — Trailhead (supporting-subdomain).
+# Org pattern: separate by bounded context, unify by platform contract (v3 engine).
+# Structural source of truth: KomatikAI/komatik docs/org-context-map.md §4.
+# Generated from docs/catalog/satellite-template.yaml.
+
+apiVersion: backstage.io/v1alpha1
+kind: System
+metadata:
+  name: trailhead
+  title: "Trailhead"
+  description: >-
+    Self-healing CI/CD ship gate. Also a consumer product surface. Owns the GitHub Action interface + risk-eval store.
+  tags: [supporting-subdomain]
+spec:
+  owner: komatik
+  domain: komatik-platform
+
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: trailhead
+  title: "Trailhead"
+  description: >-
+    Self-healing CI/CD ship gate. Also a consumer product surface. Owns the GitHub Action interface + risk-eval store.
+  tags:
+    - supporting-subdomain
+  annotations:
+    komatik.xyz/bounded-context: ship-gate
+    komatik.xyz/integration: supporting-subdomain
+  links:
+    - url: https://github.com/KomatikAI/trailhead
+      title: Repo
+spec:
+  type: service
+  lifecycle: production
+  owner: komatik
+  system: trailhead
+  providesApis: [trailhead-action]
+  consumesApis: [identity]
+
+---
+apiVersion: backstage.io/v1alpha1
+kind: API
+metadata:
+  name: trailhead-action
+  title: "Ship-gate Action + risk-eval store"
+  description: >-
+    The GitHub Action interface projects gate on, plus the risk-eval store. Canonical gate = npx trailhead.
+spec:
+  type: openapi
+  lifecycle: production
+  owner: komatik
+  system: trailhead
+  definition: |
+    See KomatikAI/trailhead GitHub Action + risk-eval store.


### PR DESCRIPTION
## Eco Wave 2 — form this satellite into the ecosystem architecture

Part of the **full-ecosystem v3 integration** (continuing Totem ↔ v3). The org context map (`KomatikAI/komatik` `docs/org-context-map.md`) classifies every repo; this PR makes that classification **machine-real** for this repo by adding the root `catalog-info.yaml` (Backstage) from the org satellite template.

It declares:
- the **bounded context** this repo owns + its **integration relationship** (conformist / acl-bridge / consumer-surface / supporting-subdomain / research),
- the **platform contracts it consumes** by their canonical facade names (`identity`, and where applicable `komatik-v3-prebuild` / `komatik-pack-meter` / `komatik-stash`), and
- any **contract this repo owns** (supporting-subdomain repos declare the API others consume).

Depends on hub PR **KomatikAI/komatik#2150** (publishes `identity` / `komatik-v3-prebuild` / `komatik-slipstream` so these references resolve).

### Scope / safety
- **Single new file** (`catalog-info.yaml`). No code or runtime change.
- Validated with `yaml.safe_load_all`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)