### PR TITLE
feat(destructive_change): evidence-gated destructive migrations (ADR-010)

### DIFF
--- a/docs/adr/010-architecture-lifecycle-gates.md
+++ b/docs/adr/010-architecture-lifecycle-gates.md
@@ -107,6 +107,28 @@ non-catalog surface coverage (route/redirect maps, listing rows — the literal
 `/apps/{legacy}` zombie) needs full repo file _contents_ in the gate context, not
 just `repoPaths`; tracked as the next increment.
 
+`destructive_change` is implemented
+(`src/submission-checks/destructive-change.ts`). It **complements** the existing
+`destructive_sql` (which already _blocks_ `DROP TABLE` / `TRUNCATE` / `DELETE`
+without `WHERE`) by covering the _targeted_ destructive ops `destructive_sql`
+lets through but which still warrant due diligence — a `DELETE ... WHERE`, an
+`ALTER ... DROP COLUMN`, a `DROP VIEW/TYPE/INDEX/...`, or a wide `UPDATE` with no
+`WHERE`. Such an op must carry an inline **evidence block**; missing/incomplete →
+`warn` (phase-0; target `blocking` w/o evidence). The convention:
+
+```sql
+-- @destructive-change
+-- fk-refs: 0            -- or: referencing tables + how each is handled
+-- affected-rows: 1      -- or an estimate
+-- reversible: re-seed; the row carries no referenced data   -- or: no — <why ok>
+-- ack: <who/when>
+```
+
+Required fields: `fk-refs`, `affected-rows`, `reversible`, `ack` — i.e. the exact
+FK / row-count / reversibility check done by hand for the `cognitive-debt` row
+delete, now machine-required. **Self-heal follow-up:** auto-run the FK/row probes
+against a DB branch and attach the evidence.
+
 ### Rollout
 
 1. Land `contract_integrity` in **`warn`** (it is allow-only today per the gate

--- a/src/__tests__/destructive-change.test.ts
+++ b/src/__tests__/destructive-change.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { detectDestructiveChange } from "../submission-checks/destructive-change.js";
+import type {
+  SubmissionCheckContext,
+  SubmissionFileInfo,
+} from "../submission-checks/types.js";
+
+function ctx(files: SubmissionFileInfo[]): SubmissionCheckContext {
+  return {
+    files,
+    prPaths: new Set(files.map((f) => f.filename)),
+    komatikInstance: false,
+    staleTerms: [],
+    namingAllowlist: {},
+    authRouteAllowlist: [],
+    maxFileLines: 1000,
+    declaredPackages: new Set(),
+    pathIgnorePatterns: [],
+    renamePatterns: [],
+    slugOnlyPatterns: [],
+    detectorPolicy: {},
+  };
+}
+
+const sql = (name: string, content: string): SubmissionFileInfo => ({
+  filename: name,
+  content,
+  status: "added",
+});
+
+const EVIDENCE = `
+-- @destructive-change
+-- fk-refs: 0
+-- affected-rows: 1
+-- reversible: re-seed; the row carries no referenced data
+-- ack: dschirmer 2026-06-01
+`;
+
+describe("destructive_change (ADR-010)", () => {
+  it("flags a targeted DELETE ... WHERE with no evidence block", () => {
+    const m = `DELETE FROM public.portfolio_projects WHERE slug = 'cognitive-debt';`;
+    const res = detectDestructiveChange(ctx([sql("migrations/0001_retire.sql", m)]));
+    expect(res).not.toBeNull();
+    expect(res!.code).toBe("destructive_change");
+    expect(res!.severity).toBe("warn");
+    expect(res!.detail).toContain("DELETE ... WHERE");
+    expect(res!.detail).toContain("fk-refs");
+    expect(res!.detail).toContain("ack");
+  });
+
+  it("passes the same DELETE when a complete evidence block is present", () => {
+    const m = `${EVIDENCE}\nDELETE FROM public.portfolio_projects WHERE slug = 'cognitive-debt';`;
+    expect(
+      detectDestructiveChange(ctx([sql("migrations/0001_retire.sql", m)])),
+    ).toBeNull();
+  });
+
+  it("reports exactly which evidence fields are missing", () => {
+    const m = `-- fk-refs: 0\n-- affected-rows: 1\nDELETE FROM t WHERE id = 1;`;
+    const res = detectDestructiveChange(ctx([sql("m.sql", m)]));
+    expect(res).not.toBeNull();
+    expect(res!.detail).toContain("reversible");
+    expect(res!.detail).toContain("ack");
+    expect(res!.detail).not.toContain("missing evidence: fk-refs");
+  });
+
+  it("does NOT fire on DELETE without WHERE (that's destructive_sql's job)", () => {
+    expect(detectDestructiveChange(ctx([sql("m.sql", "DELETE FROM t;")]))).toBeNull();
+  });
+
+  it("flags ALTER ... DROP COLUMN without evidence", () => {
+    const m = `ALTER TABLE public.users DROP COLUMN legacy_field;`;
+    const res = detectDestructiveChange(ctx([sql("m.sql", m)]));
+    expect(res).not.toBeNull();
+    expect(res!.detail).toContain("DROP COLUMN");
+  });
+
+  it("flags a wide UPDATE (no WHERE) without evidence", () => {
+    const m = `UPDATE public.flags SET enabled = false;`;
+    const res = detectDestructiveChange(ctx([sql("m.sql", m)]));
+    expect(res).not.toBeNull();
+    expect(res!.detail).toContain("UPDATE without WHERE");
+  });
+
+  it("does NOT fire on a scoped UPDATE with WHERE", () => {
+    const m = `UPDATE public.flags SET enabled = false WHERE id = 3;`;
+    expect(detectDestructiveChange(ctx([sql("m.sql", m)]))).toBeNull();
+  });
+
+  it("ignores additive migrations and non-SQL files", () => {
+    expect(
+      detectDestructiveChange(
+        ctx([
+          sql("m.sql", "CREATE TABLE t (id int);\nINSERT INTO t VALUES (1);"),
+          { filename: "notes.md", content: "DELETE FROM t WHERE x=1", status: "added" },
+        ]),
+      ),
+    ).toBeNull();
+  });
+});

--- a/src/__tests__/fixtures/agent-failures/manifest.json
+++ b/src/__tests__/fixtures/agent-failures/manifest.json
@@ -29,6 +29,7 @@
     "soul_integrity",
     "contract_integrity",
     "safe_deprecation",
+    "destructive_change",
     "output_size_min",
     "action_extraction_present",
     "delta_section_present",

--- a/src/submission-checks/destructive-change.ts
+++ b/src/submission-checks/destructive-change.ts
@@ -1,0 +1,114 @@
+// Destructive Change detector (ADR-010) — evidence-gated destructive migrations.
+//
+// `destructive_sql` already BLOCKS the always-bad shapes (DROP TABLE / TRUNCATE /
+// DELETE without WHERE). But it deliberately lets through *targeted* destructive
+// ops that are legitimate WITH due diligence: a `DELETE ... WHERE`, an
+// `ALTER ... DROP COLUMN`, a `DROP VIEW/TYPE/INDEX/...`, or a wide `UPDATE` with
+// no WHERE. Those are exactly the changes that should ship only with recorded
+// evidence — the FK / row-count / reversibility check a human does by hand today.
+//
+// This detector requires that evidence, inline in the migration, as a block:
+//
+//   -- @destructive-change
+//   -- fk-refs: 0            (or: names of referencing tables + how handled)
+//   -- affected-rows: 1      (or an estimate)
+//   -- reversible: re-seed; row carries no referenced data   (or: no — <why ok>)
+//   -- ack: dschirmer 2026-06-01
+//
+// Found a targeted destructive op but no complete evidence block → finding.
+// Ships `warn` (phase-0, per ADR-008); target state is `blocking` w/o evidence.
+// Self-heal follow-up: auto-run the FK/row probes and attach the evidence.
+
+import type { SubmissionCheckResult } from "../types.js";
+import type { SubmissionCheckContext, SubmissionFileInfo } from "./types.js";
+import { fileContent, normalizePath } from "./helpers.js";
+
+const SQL_FILE = /\.sql$/i;
+
+/** Targeted destructive ops that `destructive_sql` allows but that warrant evidence. */
+const DESTRUCTIVE_OPS: Array<{ label: string; pattern: RegExp }> = [
+  // DELETE with a WHERE (destructive_sql only blocks DELETE *without* WHERE).
+  { label: "DELETE ... WHERE", pattern: /\bDELETE\s+FROM\s+[^\n;]*?\bWHERE\b/i },
+  // ALTER TABLE ... DROP COLUMN (data loss; not a bare DROP TABLE).
+  {
+    label: "DROP COLUMN",
+    pattern: /\bALTER\s+TABLE\b(?:(?!;)[\s\S])*?\bDROP\s+COLUMN\b/i,
+  },
+  // DROP of other objects (view/type/index/function/sequence/schema/mat-view).
+  {
+    label: "DROP <object>",
+    pattern:
+      /\bDROP\s+(?:MATERIALIZED\s+VIEW|VIEW|TYPE|INDEX|FUNCTION|SEQUENCE|SCHEMA)\b/i,
+  },
+  // Wide UPDATE — a SET with no WHERE before the statement terminator.
+  {
+    label: "UPDATE without WHERE",
+    pattern: /\bUPDATE\s+[^\n;]+?\bSET\b(?:(?!\bWHERE\b)[^;])*;/i,
+  },
+];
+
+const EVIDENCE_FIELDS: Array<{ key: string; pattern: RegExp }> = [
+  { key: "fk-refs", pattern: /\bfk-refs\s*:/i },
+  { key: "affected-rows", pattern: /\baffected-rows\s*:/i },
+  { key: "reversible", pattern: /\breversible\s*:/i },
+  { key: "ack", pattern: /\back\s*:/i },
+];
+
+function isSqlFile(file: SubmissionFileInfo): boolean {
+  return SQL_FILE.test(normalizePath(file.filename));
+}
+
+interface FileFinding {
+  file: string;
+  ops: string[];
+  missing: string[];
+}
+
+export function detectDestructiveChange(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const sqlFiles = ctx.files.filter(isSqlFile);
+  if (sqlFiles.length === 0) return null;
+
+  const findings: FileFinding[] = [];
+  for (const file of sqlFiles) {
+    const content = fileContent(file);
+    if (!content) continue;
+
+    const ops = DESTRUCTIVE_OPS.filter((op) => op.pattern.test(content)).map(
+      (op) => op.label,
+    );
+    if (ops.length === 0) continue;
+
+    const missing = EVIDENCE_FIELDS.filter((f) => !f.pattern.test(content)).map(
+      (f) => f.key,
+    );
+    if (missing.length === 0) continue; // op present, evidence complete → ok
+
+    findings.push({ file: normalizePath(file.filename), ops, missing });
+  }
+
+  if (findings.length === 0) return null;
+
+  const lines = findings.map(
+    (f) => `${f.file}: ${f.ops.join(", ")} — missing evidence: ${f.missing.join(", ")}`,
+  );
+
+  return {
+    code: "destructive_change",
+    severity: "warn",
+    title: "Destructive migration without an evidence bundle",
+    detail: `Targeted destructive op(s) lack a complete evidence block: ${lines.join(
+      "; ",
+    )}.`,
+    files: findings.map((f) => f.file),
+    suggested_action:
+      "Add an evidence block to the migration:\n" +
+      "  -- @destructive-change\n" +
+      "  -- fk-refs: <0 or referencing tables + how handled>\n" +
+      "  -- affected-rows: <count or estimate>\n" +
+      "  -- reversible: <how to undo, or 'no — <why acceptable>'>\n" +
+      "  -- ack: <who/when>",
+    autofix_eligible: false,
+  };
+}

--- a/src/submission-checks/detectors.ts
+++ b/src/submission-checks/detectors.ts
@@ -18,6 +18,7 @@ import type { NamingAllowlistConfig } from "./types.js";
 import { runPhase0Detectors } from "./phase0-detectors.js";
 import { detectContractIntegrity } from "./contract-integrity.js";
 import { detectSafeDeprecation } from "./safe-deprecation.js";
+import { detectDestructiveChange } from "./destructive-change.js";
 import { validateFileSyntax } from "./syntax-validity.js";
 import { matchesGlobs } from "../risk-engine.js";
 import { applyDetectorPolicy, artifactFileGlobs } from "./detector-policy.js";
@@ -655,6 +656,7 @@ export function runAllDetectors(ctx: SubmissionCheckContext): SubmissionCheckRes
     finalize("path_format", detectPathFormat(ctx)),
     finalize("contract_integrity", detectContractIntegrity(ctx)),
     finalize("safe_deprecation", detectSafeDeprecation(ctx)),
+    finalize("destructive_change", detectDestructiveChange(ctx)),
   ].filter((check): check is SubmissionCheckResult => check !== null);
 
   const phase0 = runPhase0Detectors(ctx)

--- a/src/types.ts
+++ b/src/types.ts
@@ -114,6 +114,7 @@ export const SubmissionCheckCode = z.enum([
   // ADR-010 — architecture & lifecycle gates
   "contract_integrity",
   "safe_deprecation",
+  "destructive_change",
   // Phase 0 — agent suggestion quality (advisory / weight=0 in komatik-agents)
   "output_size_min",
   "action_extraction_present",


### PR DESCRIPTION
## ADR-010 detector #3 — `destructive_change`

`destructive_sql` already **blocks** the always-bad shapes (`DROP TABLE` / `TRUNCATE` / `DELETE` without `WHERE`). But it deliberately **lets through targeted destructive ops** that are legitimate *with* due diligence — and those are exactly where we got burned (the `cognitive-debt` row `DELETE` shipped only because a human hand-checked FKs, row count, and reversibility).

`destructive_change` covers that complement and **requires the evidence inline**:
- **Ops gated:** `DELETE ... WHERE`, `ALTER ... DROP COLUMN`, `DROP VIEW/TYPE/INDEX/FUNCTION/SEQUENCE/SCHEMA`, wide `UPDATE` (no `WHERE`).
- **Evidence block (required fields):**
  ```sql
  -- @destructive-change
  -- fk-refs: 0
  -- affected-rows: 1
  -- reversible: re-seed; row carries no referenced data   -- or: no — <why ok>
  -- ack: <who/when>
  ```
- Missing/incomplete → **`warn`** (phase-0 per ADR-008; target `blocking` w/o evidence). It reports *exactly which fields* are missing.

It **composes with, doesn't duplicate** `destructive_sql` — the `DELETE ... WHERE` op pattern requires a `WHERE`, so the unguarded forms stay `destructive_sql`'s job.

### Verification
- 8 unit tests: the cognitive-debt `DELETE` with + without evidence, missing-field reporting, `DROP COLUMN`, wide `UPDATE`, scoped-`UPDATE` passes, additive/non-SQL ignored.
- `tsc --noEmit` clean; **full suite 746/746**; Prettier clean.

### ADR-010 status
contract_integrity ✅ · safe_deprecation ✅ · **destructive_change ✅ (this PR)**. Remaining: `claim_anchoring`, `promotion_coherence`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)