### PR TITLE
feat: claim_anchoring + promotion_coherence — ADR-010 complete (5/5)

### DIFF
--- a/docs/adr/010-architecture-lifecycle-gates.md
+++ b/docs/adr/010-architecture-lifecycle-gates.md
@@ -57,9 +57,9 @@ against real PRs.
 This ADR is the umbrella. The first wave lands two catalog-native detectors —
 **`contract_integrity`** (the reference implementation; it prevents the most
 common and generalizable failure, with a live multi-repo catalog to validate
-against) and **`safe_deprecation`** (catalog-coherence v1). The remaining three
-(`claim_anchoring`, `destructive_change`, `promotion_coherence`) follow as
-separate PRs under this ADR.
+against) and **`safe_deprecation`** (catalog-coherence v1). `destructive_change`,
+`claim_anchoring`, and `promotion_coherence` followed in subsequent PRs under this
+ADR — **all five detectors are now implemented** (see Implementation status).
 
 ### `contract_integrity` design (the first detector)
 
@@ -128,6 +128,28 @@ Required fields: `fk-refs`, `affected-rows`, `reversible`, `ack` — i.e. the ex
 FK / row-count / reversibility check done by hand for the `cognitive-debt` row
 delete, now machine-required. **Self-heal follow-up:** auto-run the FK/row probes
 against a DB branch and attach the evidence.
+
+`claim_anchoring` is implemented (`src/submission-checks/claim-anchoring.ts`).
+It scans changed docs (`.md`/`.mdx`, outside code fences) for assertive
+_behavioral_ claims ("redirects exist", "is enforced", "always/never …", "fully
+covered", …) that carry **no anchor** — a backtick file/path, a link, a
+`verified-by:` pointer, or an explicit `<!-- claim-ok -->`. It doesn't judge
+truth; it asks the author to cite where the behavior lives so docs and code can be
+cross-checked. `advisory` (the doc-vs-reality drift that let "redirects exist"
+outlive the missing `/apps` redirect).
+
+`promotion_coherence` is implemented (`src/submission-checks/promotion-coherence.ts`).
+It reads the PR's branch topology (`GITHUB_BASE_REF` / `GITHUB_HEAD_REF`, threaded
+as `ctx.promotion`) and, on an env-branch→env-branch **promotion**, warns on two
+in-reach signals: (1) a **stage skip** into a production branch (`dev → master`,
+bypassing staging), and (2) **migrations riding a promotion into production**
+(confirm they belong in this release + carry `destructive_change` evidence — the
+`cognitive-debt`-delete-on-#2151 class). `warn`. **Follow-up:** the "source has
+commits not in this PR" (omitted-work) check needs an octokit branch-compare,
+beyond the file-diff model; tracked.
+
+**All five ADR-010 detectors are implemented.** Each ships `warn`/`advisory`
+(phase-0); promotion to `blocking` is the calibration step below.
 
 ### Rollout
 

--- a/src/__tests__/claim-anchoring.test.ts
+++ b/src/__tests__/claim-anchoring.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { detectClaimAnchoring } from "../submission-checks/claim-anchoring.js";
+import type {
+  SubmissionCheckContext,
+  SubmissionFileInfo,
+} from "../submission-checks/types.js";
+
+function ctx(files: SubmissionFileInfo[]): SubmissionCheckContext {
+  return {
+    files,
+    prPaths: new Set(files.map((f) => f.filename)),
+    komatikInstance: false,
+    staleTerms: [],
+    namingAllowlist: {},
+    authRouteAllowlist: [],
+    maxFileLines: 1000,
+    declaredPackages: new Set(),
+    pathIgnorePatterns: [],
+    renamePatterns: [],
+    slugOnlyPatterns: [],
+    detectorPolicy: {},
+  };
+}
+
+const md = (content: string): SubmissionFileInfo => ({
+  filename: "docs/notes.md",
+  content,
+  status: "modified",
+});
+
+describe("claim_anchoring (ADR-010)", () => {
+  it("flags an unanchored behavioral claim (the redirects-exist incident)", () => {
+    const res = detectClaimAnchoring(
+      ctx([md("Legacy redirects exist for all old slugs.")]),
+    );
+    expect(res).not.toBeNull();
+    expect(res!.code).toBe("claim_anchoring");
+    expect(res!.severity).toBe("advisory");
+    expect(res!.detail).toContain("redirects exist");
+  });
+
+  it("passes when the claim cites a file/path anchor", () => {
+    expect(
+      detectClaimAnchoring(ctx([md("Legacy redirects exist (see `proxy.ts`).")])),
+    ).toBeNull();
+  });
+
+  it("passes when an adjacent line links to a test", () => {
+    const doc =
+      "Every legacy slug is redirected.\nVerified-by: [redirect test](src/__tests__/redirects.test.ts)";
+    expect(detectClaimAnchoring(ctx([md(doc)]))).toBeNull();
+  });
+
+  it("honors the <!-- claim-ok --> override", () => {
+    expect(
+      detectClaimAnchoring(ctx([md("This is guaranteed to work. <!-- claim-ok -->")])),
+    ).toBeNull();
+  });
+
+  it("ignores claims inside fenced code blocks", () => {
+    const doc = "```\nredirects exist\n```\n";
+    expect(detectClaimAnchoring(ctx([md(doc)]))).toBeNull();
+  });
+
+  it("ignores non-doc files and prose without behavioral claims", () => {
+    expect(
+      detectClaimAnchoring(
+        ctx([
+          { filename: "src/x.ts", content: "// redirects exist", status: "added" },
+          md("This document describes the architecture and the team."),
+        ]),
+      ),
+    ).toBeNull();
+  });
+});

--- a/src/__tests__/fixtures/agent-failures/manifest.json
+++ b/src/__tests__/fixtures/agent-failures/manifest.json
@@ -30,6 +30,8 @@
     "contract_integrity",
     "safe_deprecation",
     "destructive_change",
+    "claim_anchoring",
+    "promotion_coherence",
     "output_size_min",
     "action_extraction_present",
     "delta_section_present",

--- a/src/__tests__/promotion-coherence.test.ts
+++ b/src/__tests__/promotion-coherence.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { detectPromotionCoherence } from "../submission-checks/promotion-coherence.js";
+import type {
+  SubmissionCheckContext,
+  SubmissionFileInfo,
+} from "../submission-checks/types.js";
+
+function ctx(
+  promotion: { baseBranch?: string; headBranch?: string } | undefined,
+  files: SubmissionFileInfo[] = [],
+): SubmissionCheckContext {
+  return {
+    files,
+    prPaths: new Set(files.map((f) => f.filename)),
+    komatikInstance: false,
+    staleTerms: [],
+    namingAllowlist: {},
+    authRouteAllowlist: [],
+    maxFileLines: 1000,
+    declaredPackages: new Set(),
+    pathIgnorePatterns: [],
+    renamePatterns: [],
+    slugOnlyPatterns: [],
+    detectorPolicy: {},
+    promotion,
+  };
+}
+
+const migration = (name: string): SubmissionFileInfo => ({
+  filename: name,
+  content: "DELETE FROM t WHERE id = 1;",
+  status: "added",
+});
+
+describe("promotion_coherence (ADR-010)", () => {
+  it("is dormant without promotion context (local / non-PR run)", () => {
+    expect(detectPromotionCoherence(ctx(undefined))).toBeNull();
+  });
+
+  it("is dormant for a normal feature → dev PR", () => {
+    expect(
+      detectPromotionCoherence(ctx({ baseBranch: "dev", headBranch: "feat/x" })),
+    ).toBeNull();
+  });
+
+  it("warns on a stage skip (dev → master)", () => {
+    const res = detectPromotionCoherence(
+      ctx({ baseBranch: "master", headBranch: "dev" }),
+    );
+    expect(res).not.toBeNull();
+    expect(res!.code).toBe("promotion_coherence");
+    expect(res!.severity).toBe("warn");
+    expect(res!.detail).toContain("skipping the pre-prod stage");
+  });
+
+  it("warns when a migration rides a promotion into production (cognitive-debt class)", () => {
+    const res = detectPromotionCoherence(
+      ctx({ baseBranch: "master", headBranch: "staging" }, [
+        migration("supabase/migrations/0050_retire.sql"),
+      ]),
+    );
+    expect(res).not.toBeNull();
+    expect(res!.detail).toContain("migration(s) into production");
+    expect(res!.detail).toContain("0050_retire.sql");
+  });
+
+  it("is quiet on a clean staging → master promotion with no migrations", () => {
+    expect(
+      detectPromotionCoherence(ctx({ baseBranch: "master", headBranch: "staging" })),
+    ).toBeNull();
+  });
+
+  it("normalizes refs/heads/ prefixes", () => {
+    const res = detectPromotionCoherence(
+      ctx({ baseBranch: "refs/heads/main", headBranch: "refs/heads/dev" }),
+    );
+    expect(res).not.toBeNull();
+    expect(res!.detail).toContain("dev → main");
+  });
+});

--- a/src/gate.ts
+++ b/src/gate.ts
@@ -1777,6 +1777,14 @@ export async function evaluateGate(
       mode: submissionMode,
       declaredPackages: parseDeclaredPackages(process.env.TRAILHEAD_DECLARED_PACKAGES),
       catalogKnownEntities,
+      // promotion_coherence (ADR-010): branch topology from the Actions env.
+      promotion:
+        process.env.GITHUB_BASE_REF || process.env.GITHUB_HEAD_REF
+          ? {
+              baseBranch: process.env.GITHUB_BASE_REF,
+              headBranch: process.env.GITHUB_HEAD_REF,
+            }
+          : undefined,
     });
     if (submissionChecks.length > 0) {
       policyFindings.push(`Submission gate: ${submissionChecks.length} finding(s).`);

--- a/src/submission-checks/claim-anchoring.ts
+++ b/src/submission-checks/claim-anchoring.ts
@@ -1,0 +1,110 @@
+// Claim Anchoring detector (ADR-010) — doc assertions should cite where they're true.
+//
+// Incident #3: a doc asserted "redirects exist" while the live canonical path had
+// none — the claim outlived the code. This detector flags assertive, *behavioral*
+// claims added to docs that carry no anchor (a file/path reference, a link, or a
+// `verified-by:` / `see:` pointer). It does NOT judge whether the claim is true —
+// it asks the author to point at where it's enforced/tested, so the claim and the
+// code can be cross-checked later. Advisory only (per ADR-008): informational, no
+// block. Self-heal follow-up: comment + open a test stub for the claim.
+
+import type { SubmissionCheckResult } from "../types.js";
+import type { SubmissionCheckContext, SubmissionFileInfo } from "./types.js";
+import { fileContent, normalizePath } from "./helpers.js";
+
+const DOC_FILE = /\.mdx?$/i;
+
+// High-signal, behavioral, testable assertions. Kept tight to limit noise.
+const CLAIM_PATTERNS: RegExp[] = [
+  /\bredirects?\s+(?:exist|are\s+in\s+place|are\s+configured|are\s+handled)\b/i,
+  /\bis\s+(?:enforced|guaranteed|wired\s+up|fully\s+covered)\b/i,
+  /\b(?:always|never)\s+(?:redirects?|returns?|blocks?|allows?|runs?|fires?|resolves?)\b/i,
+  /\bfully\s+(?:covered|tested|implemented|wired)\b/i,
+  /\b(?:every|all)\s+\w+\s+(?:are\s+)?(?:redirected|covered|validated|enforced)\b/i,
+  /\bguaranteed\s+to\b/i,
+];
+
+// An anchor lets a reviewer cross-check the claim against reality.
+const ANCHOR_PATTERNS: RegExp[] = [
+  /`[^`]*[\w.-]+\.(?:ts|tsx|js|jsx|mjs|cjs|sql|ya?ml|json|py|go|rs)`/i, // code/path in backticks
+  /`[^`]*\/[^`]*`/, // any path-ish backtick span
+  /\]\([^)]+\)/, // markdown link
+  /\b(?:verified[ -]by|tested in|see|ref|test)\s*[:=]/i, // explicit pointer
+  /<!--\s*claim-ok/i, // author override
+];
+
+function isDocFile(file: SubmissionFileInfo): boolean {
+  return DOC_FILE.test(normalizePath(file.filename));
+}
+
+function hasAnchor(window: string): boolean {
+  return ANCHOR_PATTERNS.some((re) => re.test(window));
+}
+
+interface Unanchored {
+  file: string;
+  line: number;
+  text: string;
+}
+
+export function detectClaimAnchoring(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const docs = ctx.files.filter(isDocFile);
+  if (docs.length === 0) return null;
+
+  const unanchored: Unanchored[] = [];
+  for (const file of docs) {
+    const content = fileContent(file);
+    if (!content) continue;
+    const lines = content.split("\n");
+    let inFence = false;
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i] ?? "";
+      if (/^\s*```/.test(line)) {
+        inFence = !inFence;
+        continue;
+      }
+      if (inFence) continue; // claims inside code examples aren't doc assertions
+
+      if (!CLAIM_PATTERNS.some((re) => re.test(line))) continue;
+
+      // Anchor may sit on the claim line or an adjacent line.
+      const windowText = [lines[i - 1] ?? "", line, lines[i + 1] ?? ""].join("\n");
+      if (hasAnchor(windowText)) continue;
+
+      unanchored.push({
+        file: normalizePath(file.filename),
+        line: i + 1,
+        text: line.trim().slice(0, 120),
+      });
+    }
+  }
+
+  if (unanchored.length === 0) return null;
+
+  const shown = unanchored.slice(0, 8);
+  const lines = shown.map((u) => `${u.file}:${u.line} — "${u.text}"`);
+  const more =
+    unanchored.length > shown.length
+      ? ` (+${unanchored.length - shown.length} more)`
+      : "";
+
+  return {
+    code: "claim_anchoring",
+    severity: "advisory",
+    title: "Behavioral claim in docs has no anchor",
+    detail:
+      `Assertive claims with no reference to where they're enforced/tested: ${lines.join(
+        "; ",
+      )}${more}. ` +
+      "Cite the code/test (a backtick path, a link, or `verified-by:`), or add `<!-- claim-ok -->` if intentional.",
+    files: [...new Set(unanchored.map((u) => u.file))],
+    suggested_action:
+      "Anchor each claim to where it lives (e.g. `proxy.ts`, a test path, or a link), " +
+      "so docs and reality can be cross-checked. This is the doc-vs-reality drift that let " +
+      '"redirects exist" outlive the missing /apps redirect.',
+    autofix_eligible: false,
+  };
+}

--- a/src/submission-checks/detectors.ts
+++ b/src/submission-checks/detectors.ts
@@ -19,6 +19,8 @@ import { runPhase0Detectors } from "./phase0-detectors.js";
 import { detectContractIntegrity } from "./contract-integrity.js";
 import { detectSafeDeprecation } from "./safe-deprecation.js";
 import { detectDestructiveChange } from "./destructive-change.js";
+import { detectClaimAnchoring } from "./claim-anchoring.js";
+import { detectPromotionCoherence } from "./promotion-coherence.js";
 import { validateFileSyntax } from "./syntax-validity.js";
 import { matchesGlobs } from "../risk-engine.js";
 import { applyDetectorPolicy, artifactFileGlobs } from "./detector-policy.js";
@@ -657,6 +659,8 @@ export function runAllDetectors(ctx: SubmissionCheckContext): SubmissionCheckRes
     finalize("contract_integrity", detectContractIntegrity(ctx)),
     finalize("safe_deprecation", detectSafeDeprecation(ctx)),
     finalize("destructive_change", detectDestructiveChange(ctx)),
+    finalize("claim_anchoring", detectClaimAnchoring(ctx)),
+    finalize("promotion_coherence", detectPromotionCoherence(ctx)),
   ].filter((check): check is SubmissionCheckResult => check !== null);
 
   const phase0 = runPhase0Detectors(ctx)

--- a/src/submission-checks/promotion-coherence.ts
+++ b/src/submission-checks/promotion-coherence.ts
@@ -1,0 +1,84 @@
+// Promotion Coherence detector (ADR-010) — guard env-branch promotions.
+//
+// Incident #5: work landed on `dev` behind an in-flight promotion, so the open
+// production release silently shipped without it — and a destructive migration
+// rode a staging→prod release to production. Ordinary detectors look at the diff;
+// this one looks at the *branch topology* of a promotion PR (base/head from
+// GITHUB_BASE_REF / GITHUB_HEAD_REF, threaded via ctx.promotion).
+//
+// v1 catches two in-reach signals on a promotion PR (env branch → env branch):
+//   1. Stage skip — a promotion straight into a production branch from `dev`
+//      (bypassing staging). The ladder is dev → staging → master/main.
+//   2. Risky payload to prod — a promotion into production that carries SQL
+//      migrations: confirm they belong in THIS release and carry destructive
+//      evidence (see `destructive_change`).
+// Ships `warn` (phase-0). Follow-up: "source has commits not in this PR" (omitted
+// work) needs an octokit branch-compare, beyond the file-diff model — tracked.
+
+import type { SubmissionCheckResult } from "../types.js";
+import type { SubmissionCheckContext } from "./types.js";
+import { normalizePath } from "./helpers.js";
+
+const DEV_BRANCHES = new Set(["dev", "develop", "development"]);
+const PREPROD_BRANCHES = new Set(["staging", "stage", "preprod", "pre-prod", "release"]);
+const PROD_BRANCHES = new Set(["master", "main", "production", "prod"]);
+const ENV_BRANCHES = new Set([...DEV_BRANCHES, ...PREPROD_BRANCHES, ...PROD_BRANCHES]);
+
+/** Strip refs/heads/ and any owner prefix; lower-case the bare branch name. */
+function bareBranch(ref: string | undefined): string {
+  if (!ref) return "";
+  let b = ref.trim();
+  b = b.replace(/^refs\/heads\//, "");
+  const slash = b.lastIndexOf(":");
+  if (slash >= 0) b = b.slice(slash + 1);
+  return b.toLowerCase();
+}
+
+function isMigration(path: string): boolean {
+  return /\.sql$/i.test(path);
+}
+
+export function detectPromotionCoherence(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const base = bareBranch(ctx.promotion?.baseBranch);
+  const head = bareBranch(ctx.promotion?.headBranch);
+  // Dormant unless we actually have a promotion (env branch → env branch).
+  if (!base || !head) return null;
+  if (!ENV_BRANCHES.has(base) || !ENV_BRANCHES.has(head)) return null;
+
+  const findings: string[] = [];
+
+  // 1. Stage skip into production.
+  if (PROD_BRANCHES.has(base) && DEV_BRANCHES.has(head)) {
+    findings.push(
+      `promotes ${head} → ${base}, skipping the pre-prod stage (ladder: dev → staging → ${base})`,
+    );
+  }
+
+  // 2. Migrations entering production via a promotion.
+  const migrations = ctx.files.map((f) => normalizePath(f.filename)).filter(isMigration);
+  if (PROD_BRANCHES.has(base) && migrations.length > 0) {
+    findings.push(
+      `carries ${migrations.length} migration(s) into production (${migrations
+        .slice(0, 5)
+        .join(
+          ", ",
+        )}) — confirm they belong in this release and carry destructive_change evidence`,
+    );
+  }
+
+  if (findings.length === 0) return null;
+
+  return {
+    code: "promotion_coherence",
+    severity: "warn",
+    title: "Promotion coherence",
+    detail: `This promotion ${findings.join("; ")}.`,
+    files: migrations,
+    suggested_action:
+      "Promote through the full ladder (dev → staging → master/main), and double-check " +
+      "the release contents (especially destructive migrations) match what you intend to ship.",
+    autofix_eligible: false,
+  };
+}

--- a/src/submission-checks/types.ts
+++ b/src/submission-checks/types.ts
@@ -47,4 +47,10 @@ export interface SubmissionCheckContext {
    * single-repo PR doesn't false-positive on a legitimately external contract.
    */
   catalogKnownEntities?: Set<string>;
+  /**
+   * Promotion topology for `promotion_coherence` (ADR-010) — the PR's target and
+   * source branches (from GITHUB_BASE_REF / GITHUB_HEAD_REF, set by the gate I/O
+   * layer). Absent for non-PR / local runs, leaving the detector dormant.
+   */
+  promotion?: { baseBranch?: string; headBranch?: string };
 }

--- a/src/submission-engine.ts
+++ b/src/submission-engine.ts
@@ -57,6 +57,8 @@ export interface SubmissionEngineOptions {
    * inline `known_entities` config for the `contract_integrity` detector.
    */
   catalogKnownEntities?: string[];
+  /** Promotion branch topology (GITHUB_BASE_REF / GITHUB_HEAD_REF), set by the gate. */
+  promotion?: { baseBranch?: string; headBranch?: string };
 }
 
 function buildContext(options: SubmissionEngineOptions): SubmissionCheckContext {
@@ -92,6 +94,7 @@ function buildContext(options: SubmissionEngineOptions): SubmissionCheckContext 
     repoPaths: options.repoPaths ? new Set(options.repoPaths) : undefined,
     catalogKnownEntities:
       catalogKnownEntities.size > 0 ? catalogKnownEntities : undefined,
+    promotion: options.promotion,
   };
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -115,6 +115,8 @@ export const SubmissionCheckCode = z.enum([
   "contract_integrity",
   "safe_deprecation",
   "destructive_change",
+  "claim_anchoring",
+  "promotion_coherence",
   // Phase 0 — agent suggestion quality (advisory / weight=0 in komatik-agents)
   "output_size_min",
   "action_extraction_present",


### PR DESCRIPTION
## ADR-010 detectors #4 and #5 — the family is complete

The final two Architecture & Lifecycle detectors. With these, **all five ADR-010 detectors are implemented.**

### `claim_anchoring` (advisory)
Scans changed docs (`.md`/`.mdx`, skipping fenced code) for assertive **behavioral** claims — "redirects exist", "is enforced", "always/never …", "fully covered", "every X is redirected" — that carry **no anchor** (a backtick path, a markdown link, a `verified-by:` pointer, or an explicit `<!-- claim-ok -->`). It doesn't judge truth; it asks the author to cite where the behavior lives so docs and code stay cross-checkable. This is the **doc-vs-reality drift** that let *"redirects exist"* outlive the missing `/apps` redirect.

### `promotion_coherence` (warn)
Reads the PR's **branch topology** (`GITHUB_BASE_REF` / `GITHUB_HEAD_REF`, threaded as `ctx.promotion`) and, on an env-branch→env-branch **promotion**, warns on:
1. **Stage skip** into production — `dev → master`, bypassing staging (ladder is dev → staging → master/main).
2. **Migrations riding a promotion into production** — confirm they belong in this release and carry `destructive_change` evidence (the `cognitive-debt`-delete-on-#2151 class).

Dormant for normal feature→dev PRs and local runs. **Follow-up:** the "source has commits not in this PR" (omitted-work) check needs an octokit branch-compare, beyond the file-diff model — tracked in the ADR.

### Wiring & verification
- `ctx.promotion` plumbed through `SubmissionCheckContext` → `SubmissionEngineOptions` → `buildContext`; `gate.ts` populates it from the Actions env.
- enum + `runAllDetectors` + fixture-manifest coverage for both.
- **12 new tests**; `tsc --noEmit` clean; **full suite 758/758**; Prettier clean.

### ADR-010 status: ✅ complete
`contract_integrity` · `safe_deprecation` · `destructive_change` · `claim_anchoring` · `promotion_coherence` — all shipping `warn`/`advisory` (phase-0); blocking promotion is the calibration step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)