### PR TITLE
feat(self-heal): contract_integrity catalog healer (ADR-010)

### DIFF
--- a/docs/adr/010-architecture-lifecycle-gates.md
+++ b/docs/adr/010-architecture-lifecycle-gates.md
@@ -96,6 +96,18 @@ ADR — **all five detectors are now implemented** (see Implementation status).
 - dogfood index: `examples/komatik-catalog-index.json` — 53 entities across the
   live org; with it configured, `consumesApis: [komatik-v3-prebuild]` resolves
   instead of flagging.
+- **self-heal lane** (`src/healers/catalog.ts`, `planCatalogHeal`): for an
+  in-repo LOCAL ref (`spec.system` / `spec.subcomponentOf` whose target isn't
+  declared), it auto-generates a minimal stub entity (System/Component, owner
+  reused from a sibling) to append to the same `catalog-info.yaml` — verified to
+  make `contract_integrity` pass after applying. The detector marks such findings
+  `autofix_eligible`; `deriveSubmissionFixes` classifies them `doc-update`, which
+  the fixer plans (catalog-info.yaml is not a red-lane path). Cross-repo refs
+  (`consumesApis`/`dependsOn`/`providesApis`) become **suggestions** — the fix
+  belongs in the owning repo; opening that cross-repo PR is the remaining
+  follow-up (the fixer commits to the gated PR, not other repos). Commit
+  execution rides the platform's shared autofix git-write path (dry-run in
+  v4.4.x, same as every other autofix class).
 
 `safe_deprecation` **v1 (catalog coherence)** is implemented
 (`src/submission-checks/safe-deprecation.ts`): when an entity is retired

--- a/src/__tests__/catalog-heal.test.ts
+++ b/src/__tests__/catalog-heal.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import yaml from "js-yaml";
+import { planCatalogHeal } from "../healers/catalog.js";
+import { detectContractIntegrity } from "../submission-checks/contract-integrity.js";
+import { deriveSubmissionFixes } from "../submission-remediation.js";
+import { buildAutofixPlan } from "../fixer-core.js";
+import type {
+  SubmissionCheckContext,
+  SubmissionFileInfo,
+} from "../submission-checks/types.js";
+
+function ctx(files: SubmissionFileInfo[]): SubmissionCheckContext {
+  return {
+    files,
+    prPaths: new Set(files.map((f) => f.filename)),
+    komatikInstance: false,
+    staleTerms: [],
+    namingAllowlist: {},
+    authRouteAllowlist: [],
+    maxFileLines: 1000,
+    declaredPackages: new Set(),
+    pathIgnorePatterns: [],
+    renamePatterns: [],
+    slugOnlyPatterns: [],
+    detectorPolicy: {},
+  };
+}
+
+const catalog = (content: string): SubmissionFileInfo => ({
+  filename: "catalog-info.yaml",
+  content,
+  status: "modified",
+});
+
+// A Component pointing at an undeclared System + parent Component (local refs).
+const MISSING_LOCAL = `
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: trace-drift
+spec:
+  type: library
+  owner: komatik
+  system: trace
+  subcomponentOf: trace-core
+`;
+
+describe("catalog self-heal lane (ADR-010)", () => {
+  it("generates a System stub for a missing spec.system target", () => {
+    const plan = planCatalogHeal(ctx([catalog(MISSING_LOCAL)]));
+    expect(plan.edits).toHaveLength(1);
+    const edit = plan.edits[0]!;
+    expect(edit.file).toBe("catalog-info.yaml");
+    expect(edit.entities).toContain("trace");
+    expect(edit.entities).toContain("trace-core");
+    // The appended YAML is valid and declares the missing entities.
+    const docs = [...yaml.loadAll(edit.append)].filter(Boolean) as Array<
+      Record<string, any>
+    >;
+    const byName = new Map(docs.map((d) => [d.metadata.name, d]));
+    expect(byName.get("trace")!.kind).toBe("System");
+    expect(byName.get("trace-core")!.kind).toBe("Component");
+    // Owner is reused from the sibling entity.
+    expect(byName.get("trace")!.spec.owner).toBe("komatik");
+  });
+
+  it("applying the stub makes contract_integrity pass (self-heal closes the loop)", () => {
+    const plan = planCatalogHeal(ctx([catalog(MISSING_LOCAL)]));
+    const healed = MISSING_LOCAL + plan.edits[0]!.append;
+    // After appending the generated stubs, the local refs now resolve.
+    expect(detectContractIntegrity(ctx([catalog(healed)]))).toBeNull();
+  });
+
+  it("emits a suggestion (not an edit) for cross-repo refs", () => {
+    const crossRepo = `
+apiVersion: backstage.io/v1alpha1
+kind: System
+metadata:
+  name: sundog
+spec:
+  owner: komatik
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: sundog
+spec:
+  type: service
+  owner: komatik
+  system: sundog
+  consumesApis: [komatik-v3-prebuild]
+`;
+    const plan = planCatalogHeal(ctx([catalog(crossRepo)]));
+    expect(plan.edits).toHaveLength(0);
+    expect(plan.suggestions.join(" ")).toContain("komatik-v3-prebuild");
+  });
+
+  it("detector marks local-fixable findings autofix_eligible", () => {
+    const res = detectContractIntegrity(ctx([catalog(MISSING_LOCAL)]));
+    expect(res?.autofix_eligible).toBe(true);
+  });
+
+  it("detector does NOT mark a pure cross-repo finding autofix_eligible", () => {
+    const onlyContract = `
+apiVersion: backstage.io/v1alpha1
+kind: System
+metadata:
+  name: sundog
+spec:
+  owner: komatik
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: sundog
+spec:
+  type: service
+  owner: komatik
+  system: sundog
+  consumesApis: [komatik-v3-prebuild]
+`;
+    const res = detectContractIntegrity(ctx([catalog(onlyContract)]));
+    expect(res?.autofix_eligible).toBe(false);
+  });
+
+  it("flows through remediation as a planned doc-update autofix (lane wired)", () => {
+    const check = detectContractIntegrity(ctx([catalog(MISSING_LOCAL)]))!;
+    const fixes = deriveSubmissionFixes([check]);
+    const fix = fixes.find((f) => f.code === "submission.contract_integrity")!;
+    expect(fix.autofix_eligible).toBe(true);
+    expect(fix.autofix_class).toBe("doc-update");
+    // catalog-info.yaml is not a red-lane path, so the autofix is plannable.
+    const plan = buildAutofixPlan(fixes);
+    expect(plan.items.some((i) => i.fix.code === "submission.contract_integrity")).toBe(
+      true,
+    );
+    expect(plan.blocked).toHaveLength(0);
+  });
+});

--- a/src/__tests__/catalog-heal.test.ts
+++ b/src/__tests__/catalog-heal.test.ts
@@ -54,9 +54,12 @@ describe("catalog self-heal lane (ADR-010)", () => {
     expect(edit.entities).toContain("trace");
     expect(edit.entities).toContain("trace-core");
     // The appended YAML is valid and declares the missing entities.
-    const docs = [...yaml.loadAll(edit.append)].filter(Boolean) as Array<
-      Record<string, any>
-    >;
+    type StubDoc = {
+      kind: string;
+      metadata: { name: string };
+      spec: { owner: string };
+    };
+    const docs = [...yaml.loadAll(edit.append)].filter(Boolean) as StubDoc[];
     const byName = new Map(docs.map((d) => [d.metadata.name, d]));
     expect(byName.get("trace")!.kind).toBe("System");
     expect(byName.get("trace-core")!.kind).toBe("Component");

--- a/src/healers/catalog.ts
+++ b/src/healers/catalog.ts
@@ -1,0 +1,128 @@
+// Catalog self-heal lane (ADR-010) for the contract_integrity detector.
+//
+// When a catalog-info.yaml reference doesn't resolve, the in-repo-fixable case is
+// a LOCAL structural ref — `spec.system` / `spec.subcomponentOf` pointing at an
+// entity that simply isn't declared in the same repo's catalog. The fix is to add
+// a minimal stub for that entity, which this healer generates as YAML to append.
+//
+// Cross-repo refs (consumesApis / dependsOn / providesApis to something another
+// repo owns) can't be fixed in this PR — the fix belongs in the owning repo. For
+// those we emit a human-actionable suggestion rather than an edit. (Opening the
+// cross-repo PR is a follow-up that needs a cross-repo PR opener the fixer lacks.)
+
+import yaml from "js-yaml";
+import {
+  analyzeCatalogRefs,
+  type ContractRefFinding,
+} from "../submission-checks/contract-integrity.js";
+import type { SubmissionCheckContext } from "../submission-checks/types.js";
+import { fileContent, normalizePath } from "../submission-checks/helpers.js";
+
+export interface CatalogHealEdit {
+  /** catalog-info.yaml to append to. */
+  file: string;
+  /** YAML to append (one or more `---`-separated stub entities). */
+  append: string;
+  /** Entity names declared by this edit. */
+  entities: string[];
+}
+
+export interface CatalogHealPlan {
+  /** In-repo edits that auto-declare missing local entities. */
+  edits: CatalogHealEdit[];
+  /** Cross-repo / owned refs that need a declaration in another repo. */
+  suggestions: string[];
+}
+
+/** Best-effort owner for stubs: reuse a sibling entity's owner, else "unknown". */
+function ownerHint(content: string): string {
+  try {
+    let owner: string | undefined;
+    yaml.loadAll(content, (doc) => {
+      if (owner) return;
+      const spec = (doc as Record<string, unknown>)?.spec as
+        | Record<string, unknown>
+        | undefined;
+      if (typeof spec?.owner === "string") owner = spec.owner;
+    });
+    return owner ?? "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+function systemStub(name: string, owner: string): string {
+  return [
+    "apiVersion: backstage.io/v1alpha1",
+    "kind: System",
+    "metadata:",
+    `  name: ${name}`,
+    `  description: "TODO: auto-declared by Trailhead self-heal (contract_integrity)"`,
+    "spec:",
+    `  owner: ${owner}`,
+  ].join("\n");
+}
+
+function componentStub(name: string, owner: string): string {
+  return [
+    "apiVersion: backstage.io/v1alpha1",
+    "kind: Component",
+    "metadata:",
+    `  name: ${name}`,
+    `  description: "TODO: auto-declared by Trailhead self-heal (contract_integrity)"`,
+    "spec:",
+    "  type: service",
+    "  lifecycle: experimental",
+    `  owner: ${owner}`,
+  ].join("\n");
+}
+
+/**
+ * Plan the catalog self-heal for a PR: auto-declare missing LOCAL entities,
+ * and surface cross-repo refs as suggestions.
+ */
+export function planCatalogHeal(ctx: SubmissionCheckContext): CatalogHealPlan {
+  const analysis = analyzeCatalogRefs(ctx);
+  if (!analysis) return { edits: [], suggestions: [] };
+
+  const local = analysis.findings.filter((f) => f.kind === "local");
+  const crossRepo = analysis.findings.filter((f) => f.kind !== "local");
+
+  // Group local findings by file, dedupe by entity name (a System ref wins over
+  // a Component ref for the same name — a System is the broader container).
+  const byFile = new Map<string, Map<string, ContractRefFinding>>();
+  for (const f of local) {
+    const fileMap = byFile.get(f.file) ?? new Map<string, ContractRefFinding>();
+    const existing = fileMap.get(f.name);
+    if (!existing || (existing.field !== "system" && f.field === "system")) {
+      fileMap.set(f.name, f);
+    }
+    byFile.set(f.file, fileMap);
+  }
+
+  const edits: CatalogHealEdit[] = [];
+  for (const [file, entityMap] of byFile) {
+    const original = ctx.files.find((cf) => normalizePath(cf.filename) === file);
+    const owner = original ? ownerHint(fileContent(original)) : "unknown";
+    const stubs: string[] = [];
+    const entities: string[] = [];
+    for (const finding of entityMap.values()) {
+      const stub =
+        finding.field === "system"
+          ? systemStub(finding.name, owner)
+          : componentStub(finding.name, owner);
+      stubs.push(stub);
+      entities.push(finding.name);
+    }
+    if (stubs.length === 0) continue;
+    const append = "\n---\n" + stubs.join("\n---\n") + "\n";
+    edits.push({ file, append, entities });
+  }
+
+  const suggestions = crossRepo.map(
+    (f) =>
+      `Declare ${f.kind === "owned" ? "API" : "the referenced entity"} "${f.name}" in its owning repo's catalog-info.yaml (referenced via spec.${f.field} in ${f.file}).`,
+  );
+
+  return { edits, suggestions };
+}

--- a/src/submission-checks/contract-integrity.ts
+++ b/src/submission-checks/contract-integrity.ts
@@ -20,9 +20,9 @@ import { fileContent, normalizePath } from "./helpers.js";
 
 const CATALOG_FILE = /(?:^|\/)catalog-info\.ya?ml$/i;
 
-type RefKind = "local" | "owned" | "contract";
+export type RefKind = "local" | "owned" | "contract";
 
-interface Finding {
+export interface ContractRefFinding {
   file: string;
   field: string;
   ref: string;
@@ -30,7 +30,7 @@ interface Finding {
   kind: RefKind;
 }
 
-function isCatalogFile(file: SubmissionFileInfo): boolean {
+export function isCatalogFile(file: SubmissionFileInfo): boolean {
   return CATALOG_FILE.test(normalizePath(file.filename));
 }
 
@@ -70,9 +70,14 @@ function entityName(doc: Record<string, unknown>): string | null {
   return typeof name === "string" ? name : null;
 }
 
-export function detectContractIntegrity(
+/**
+ * Core analysis shared by the detector and the self-heal lane: parse the PR's
+ * catalog files, build the resolution universe, and return every reference that
+ * doesn't resolve. Returns null when there are no catalog files to analyze.
+ */
+export function analyzeCatalogRefs(
   ctx: SubmissionCheckContext,
-): SubmissionCheckResult | null {
+): { findings: ContractRefFinding[]; hasOrgIndex: boolean } | null {
   const catalogFiles = ctx.files.filter(isCatalogFile);
   if (catalogFiles.length === 0) return null;
 
@@ -95,7 +100,7 @@ export function detectContractIntegrity(
   const hasOrgIndex = (ctx.catalogKnownEntities?.size ?? 0) > 0;
 
   // 2. Walk references and collect anything that doesn't resolve.
-  const findings: Finding[] = [];
+  const findings: ContractRefFinding[] = [];
   const checkRef = (
     file: SubmissionFileInfo,
     field: string,
@@ -122,6 +127,16 @@ export function detectContractIntegrity(
     }
   }
 
+  return { findings, hasOrgIndex };
+}
+
+export function detectContractIntegrity(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const analysis = analyzeCatalogRefs(ctx);
+  if (!analysis) return null;
+  const { findings, hasOrgIndex } = analysis;
+
   if (findings.length === 0) return null;
 
   // 3. Severity: local/owned refs are structural (always warn). Cross-repo
@@ -131,6 +146,10 @@ export function detectContractIntegrity(
   const contract = findings.filter((f) => f.kind === "contract");
   const severity: SubmissionCheckResult["severity"] =
     structural.length > 0 || hasOrgIndex ? "warn" : "advisory";
+
+  // Self-heal lane (ADR-010): a missing LOCAL entity (system / subcomponentOf
+  // target) can be auto-declared in the same catalog file. See healers/catalog.ts.
+  const localHealable = findings.some((f) => f.kind === "local");
 
   const lines = findings.map(
     (f) => `${f.file}: spec.${f.field} → "${f.ref}" (no declared entity "${f.name}")`,
@@ -153,7 +172,10 @@ export function detectContractIntegrity(
     files: [...new Set(findings.map((f) => f.file))],
     suggested_action:
       "Declare the referenced entity in the owning repo's catalog-info.yaml (or fix the reference). " +
-      "For cross-repo contracts, ensure the publishing repo declares the API and that it is in the org catalog index.",
-    autofix_eligible: false,
+      "For cross-repo contracts, ensure the publishing repo declares the API and that it is in the org catalog index." +
+      (localHealable
+        ? " A missing local entity (system / subcomponentOf target) can be auto-declared — Trailhead self-heal."
+        : ""),
+    autofix_eligible: localHealable,
   };
 }

--- a/src/submission-remediation.ts
+++ b/src/submission-remediation.ts
@@ -23,7 +23,8 @@ export function deriveSubmissionFixes(
       suggested_action: check.suggested_action,
       autofix_eligible: check.autofix_eligible ?? false,
       autofix_class:
-        check.autofix_eligible && check.code === "context_freshness"
+        check.autofix_eligible &&
+        (check.code === "context_freshness" || check.code === "contract_integrity")
           ? "doc-update"
           : undefined,
     }),


### PR DESCRIPTION
## Wire the `contract_integrity` self-heal lane

The ADR-010 differentiator: don't just flag a dangling catalog ref — **fix it**. This wires the in-repo self-heal.

### What it does
When a `catalog-info.yaml` **LOCAL** ref (`spec.system` / `spec.subcomponentOf`) points at an entity that isn't declared in the same repo, `planCatalogHeal` (`src/healers/catalog.ts`) auto-generates a minimal stub entity (System/Component, `owner` reused from a sibling) to append to that `catalog-info.yaml`. Tested to **make `contract_integrity` pass after applying** — the loop closes.

Cross-repo refs (`consumesApis` / `dependsOn` / `providesApis`) can't be fixed in this PR (the fix belongs in the *owning* repo), so they're emitted as **suggestions** rather than edits.

### How it's wired into the existing fixer pipeline
- `contract-integrity.ts`: extracted `analyzeCatalogRefs` (shared by the detector + healer); the detector now sets `autofix_eligible` when there's a local-fixable finding.
- `submission-remediation.ts`: `contract_integrity` → `doc-update` `autofix_class`.
- That flows through `buildAutofixPlan` — `catalog-info.yaml` is not a red-lane path, so the fix is **planned** (selected, not blocked).

### Verification
- **6 tests**: stub generation, **loop-closure** (apply stub → detector passes), cross-repo→suggestion, eligibility (local yes / cross-repo no), and end-to-end plan wiring. `tsc` clean; **full suite 764/764**; Prettier clean.

### Follow-ups (noted in ADR)
- The **cross-repo PR opener** (auto-declare the API in the owning repo) — the fixer commits to the *gated* PR, not other repos; needs a cross-repo opener.
- Commit execution rides the platform's shared autofix **git-write path** (dry-run in v4.4.x, same for every autofix class).

🤖 Generated with [Claude Code](https://claude.com/claude-code)