### PR TITLE
feat(autofix): invoke the git-write executor from the gate (ADR-010)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -195,6 +195,10 @@ inputs:
     description: "When true and credit meter returns allowed:false, emit a blocking warning. Does not block the gate unless paired with strict policy (fail-open default)."
     required: false
     default: "false"
+  autofix:
+    description: "When true, commit auto-fixes for autofix-eligible findings (e.g. contract_integrity catalog stubs) to the PR's HEAD branch. Default false = dry-run (plan only, logged). Requires contents:write and a non-fork PR."
+    required: false
+    default: "false"
 
 outputs:
   health-score:

--- a/docs/adr/010-architecture-lifecycle-gates.md
+++ b/docs/adr/010-architecture-lifecycle-gates.md
@@ -119,6 +119,17 @@ red-lane / one-commit-per-round gating is inherited from `fixer-core`. **This
 lights up commits for every autofix class, not just `contract_integrity`** — the
 catalog healer is simply the first registered builder.
 
+The executor is now **invoked from the gate** (`src/gate-autofix.ts` →
+`runGateAutofix`, called in `main.ts` after `evaluateGate`). It derives the
+autofix-eligible fixes from the evaluation's remediation, fetches the current
+content of the files they touch (octokit `getContent` on the PR HEAD), builds a
+`GithubGitWriter`, and runs the executor. Safety: **opt-in** via the `autofix`
+action input (default `false` → dry-run/plan-only, logged with "set autofix:
+true to apply"), **fork-guarded** (won't write to a fork's branch), and wrapped
+**fail-soft** in `main.ts` so autofix never blocks the gate. Requires
+`contents: write`. The App (`app/src/fixer.ts`) shares the same executor for when
+it gains a PR webhook path.
+
 `safe_deprecation` **v1 (catalog coherence)** is implemented
 (`src/submission-checks/safe-deprecation.ts`): when an entity is retired
 (`spec.lifecycle: deprecated`), a still-_live_ entity that keeps depending on it

--- a/src/__tests__/gate-autofix.test.ts
+++ b/src/__tests__/gate-autofix.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it, vi } from "vitest";
+import { runGateAutofix, type GateAutofixClient } from "../gate-autofix.js";
+import { detectContractIntegrity } from "../submission-checks/contract-integrity.js";
+import { deriveSubmissionFixes } from "../submission-remediation.js";
+import type {
+  SubmissionCheckContext,
+  SubmissionFileInfo,
+} from "../submission-checks/types.js";
+
+const MISSING_LOCAL = `
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: trace-drift
+spec:
+  type: library
+  owner: komatik
+  system: trace
+`;
+
+function ctx(files: SubmissionFileInfo[]): SubmissionCheckContext {
+  return {
+    files,
+    prPaths: new Set(files.map((f) => f.filename)),
+    komatikInstance: false,
+    staleTerms: [],
+    namingAllowlist: {},
+    authRouteAllowlist: [],
+    maxFileLines: 1000,
+    declaredPackages: new Set(),
+    pathIgnorePatterns: [],
+    renamePatterns: [],
+    slugOnlyPatterns: [],
+    detectorPolicy: {},
+  };
+}
+
+function contractFixes() {
+  const check = detectContractIntegrity(
+    ctx([{ filename: "catalog-info.yaml", content: MISSING_LOCAL, status: "modified" }]),
+  )!;
+  return deriveSubmissionFixes([check]);
+}
+
+function mockClient(): GateAutofixClient {
+  return {
+    rest: {
+      repos: {
+        getContent: vi.fn(async () => ({
+          data: {
+            content: Buffer.from(MISSING_LOCAL, "utf8").toString("base64"),
+            encoding: "base64",
+          },
+        })),
+      },
+      git: {
+        getRef: vi.fn(async () => ({ data: { object: { sha: "base-sha" } } })),
+        getCommit: vi.fn(async () => ({ data: { tree: { sha: "base-tree" } } })),
+        createBlob: vi.fn(async () => ({ data: { sha: "blob-sha" } })),
+        createTree: vi.fn(async () => ({ data: { sha: "new-tree" } })),
+        createCommit: vi.fn(async () => ({ data: { sha: "new-commit" } })),
+        updateRef: vi.fn(async () => ({})),
+      },
+    },
+  };
+}
+
+const baseOpts = {
+  owner: "KomatikAI",
+  repo: "trace",
+  evaluationId: "eval-1",
+  headBranch: "feat/x",
+  headRepoFullName: "KomatikAI/trace",
+  baseRepoFullName: "KomatikAI/trace",
+};
+
+describe("runGateAutofix (ADR-010 App/Action invocation)", () => {
+  it("commits when enabled: fetches content, builds the stub, writes one commit", async () => {
+    const client = mockClient();
+    const res = await runGateAutofix({
+      ...baseOpts,
+      client,
+      fixes: contractFixes(),
+      enabled: true,
+    });
+    expect(res.committed).toBe(true);
+    expect(res.commitSha).toBe("new-commit");
+    expect(client.rest.repos.getContent).toHaveBeenCalledWith(
+      expect.objectContaining({ path: "catalog-info.yaml", ref: "feat/x" }),
+    );
+    expect(client.rest.git.createCommit).toHaveBeenCalledTimes(1);
+    expect(client.rest.git.updateRef).toHaveBeenCalledWith(
+      expect.objectContaining({ ref: "heads/feat/x", sha: "new-commit" }),
+    );
+  });
+
+  it("dry-run by default (enabled omitted): plans edits, writes nothing", async () => {
+    const client = mockClient();
+    const res = await runGateAutofix({ ...baseOpts, client, fixes: contractFixes() });
+    expect(res.committed).toBe(false);
+    expect(res.edits?.length).toBeGreaterThan(0);
+    expect(client.rest.git.createCommit).not.toHaveBeenCalled();
+    expect(client.rest.git.updateRef).not.toHaveBeenCalled();
+  });
+
+  it("skips fork PRs (head repo differs from base)", async () => {
+    const client = mockClient();
+    const res = await runGateAutofix({
+      ...baseOpts,
+      client,
+      fixes: contractFixes(),
+      enabled: true,
+      headRepoFullName: "someone-else/trace",
+    });
+    expect(res.committed).toBe(false);
+    expect(res.skippedReason).toContain("Fork");
+    expect(client.rest.repos.getContent).not.toHaveBeenCalled();
+  });
+
+  it("skips when there is no head branch", async () => {
+    const client = mockClient();
+    const res = await runGateAutofix({
+      ...baseOpts,
+      client,
+      fixes: contractFixes(),
+      enabled: true,
+      headBranch: undefined,
+    });
+    expect(res.committed).toBe(false);
+    expect(res.skippedReason).toContain("head branch");
+  });
+
+  it("skips when no fixes are autofix-eligible", async () => {
+    const client = mockClient();
+    const res = await runGateAutofix({
+      ...baseOpts,
+      client,
+      fixes: [],
+      enabled: true,
+    });
+    expect(res.committed).toBe(false);
+    expect(res.skippedReason).toContain("No autofix-eligible");
+    expect(client.rest.repos.getContent).not.toHaveBeenCalled();
+  });
+});

--- a/src/gate-autofix.ts
+++ b/src/gate-autofix.ts
@@ -1,0 +1,115 @@
+// Gate-side autofix invocation (ADR-010). Bridges the Action's evaluation to the
+// shared git-write executor: from the remediation fixes, fetch the current
+// content of the files an eligible fix touches, then run the executor against a
+// GithubGitWriter on the PR's HEAD branch.
+//
+// Safety: opt-in (`enabled` defaults the executor to dry-run when false), fork-
+// guarded (can't write to a fork's branch), and the caller wraps it fail-soft so
+// autofix never blocks the gate.
+
+import type { RemediationFix } from "./types.js";
+import type { SubmissionFileInfo } from "./submission-checks/types.js";
+import { GithubGitWriter, type GitRestClient } from "./github-git-writer.js";
+import { executeAutofixRound, type AutofixExecuteResult } from "./autofix-executor.js";
+import { DEFAULT_AUTOFIX_BUILDERS } from "./autofix-builders.js";
+
+/** Octokit subset this needs: git-data writes (via GithubGitWriter) + getContent. */
+export interface GateAutofixClient extends GitRestClient {
+  rest: GitRestClient["rest"] & {
+    repos: {
+      getContent(p: {
+        owner: string;
+        repo: string;
+        path: string;
+        ref?: string;
+      }): Promise<{ data: unknown }>;
+    };
+  };
+}
+
+export interface RunGateAutofixOptions {
+  client: GateAutofixClient;
+  fixes: RemediationFix[];
+  owner: string;
+  repo: string;
+  evaluationId: string;
+  /** PR head branch — the autofix commit target. */
+  headBranch?: string;
+  /** Fork detection: skip when the PR head is a different repo. */
+  headRepoFullName?: string;
+  baseRepoFullName?: string;
+  /** When false, the executor only plans (dry-run) — no commit. Default false. */
+  enabled?: boolean;
+  trustAutofixEnabled?: boolean;
+  catalogKnownEntities?: Set<string>;
+}
+
+function skip(evaluationId: string, reason: string): AutofixExecuteResult {
+  return { committed: false, evaluationId, skippedReason: reason };
+}
+
+async function readContent(
+  client: GateAutofixClient,
+  owner: string,
+  repo: string,
+  path: string,
+  ref?: string,
+): Promise<string | null> {
+  try {
+    const res = await client.rest.repos.getContent({ owner, repo, path, ref });
+    const data = res.data as { content?: string; encoding?: string } | undefined;
+    if (data && typeof data.content === "string") {
+      const encoding = (data.encoding as BufferEncoding) || "base64";
+      return Buffer.from(data.content, encoding).toString("utf8");
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export async function runGateAutofix(
+  opts: RunGateAutofixOptions,
+): Promise<AutofixExecuteResult> {
+  if (!opts.headBranch) return skip(opts.evaluationId, "No PR head branch");
+  if (
+    opts.headRepoFullName &&
+    opts.baseRepoFullName &&
+    opts.headRepoFullName !== opts.baseRepoFullName
+  ) {
+    return skip(opts.evaluationId, "Fork PR — cannot write to head branch");
+  }
+
+  // Nothing to do unless something is autofix-eligible.
+  const eligible = opts.fixes.filter((f) => f.autofix_eligible);
+  if (eligible.length === 0) {
+    return skip(opts.evaluationId, "No autofix-eligible fixes in remediation payload");
+  }
+
+  // Fetch current content for the files those fixes touch (HEAD branch).
+  const paths = [...new Set(eligible.flatMap((f) => f.files))].filter(Boolean);
+  const files: SubmissionFileInfo[] = [];
+  for (const path of paths) {
+    const content = await readContent(
+      opts.client,
+      opts.owner,
+      opts.repo,
+      path,
+      opts.headBranch,
+    );
+    files.push({ filename: path, content: content ?? "" });
+  }
+
+  const writer = new GithubGitWriter(opts.client, opts.owner, opts.repo);
+  return executeAutofixRound({
+    fixes: opts.fixes,
+    files,
+    builders: DEFAULT_AUTOFIX_BUILDERS,
+    writer,
+    branch: opts.headBranch,
+    evaluationId: opts.evaluationId,
+    trustAutofixEnabled: opts.trustAutofixEnabled,
+    dryRun: opts.enabled !== true,
+    buildContext: { catalogKnownEntities: opts.catalogKnownEntities },
+  });
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -34,6 +34,7 @@ import { computeRolloutReadiness } from "./rollout-readiness.js";
 import { resolveAgentProvenanceId } from "./agent-provenance.js";
 import { readTrustRuntime } from "./trust-runtime.js";
 import { buildGateVerdict } from "./verdict.js";
+import { runGateAutofix, type GateAutofixClient } from "./gate-autofix.js";
 import type { TrailheadConfig, TestRepairResult, PolicyOverrideAudit } from "./types.js";
 
 class PolicyOverrideError extends Error {
@@ -363,6 +364,46 @@ async function run(): Promise<void> {
         }
       } catch (err) {
         core.warning(`Credit metering failed (non-blocking): ${err}`);
+      }
+    }
+
+    // Autofix self-heal (ADR-010) — opt-in; dry-run (plan only) unless enabled.
+    const autofixFixes = evaluation.remediation?.fixes ?? [];
+    if (config.githubToken && prNumber && autofixFixes.some((f) => f.autofix_eligible)) {
+      try {
+        const autofixEnabled =
+          core.getInput("autofix") === "true" || readEnv("TRAILHEAD_AUTOFIX") === "true";
+        const prPayload = context.payload.pull_request as
+          | {
+              head?: { ref?: string; repo?: { full_name?: string } };
+              base?: { repo?: { full_name?: string } };
+            }
+          | undefined;
+        const autofixResult = await runGateAutofix({
+          client: github.getOctokit(config.githubToken) as unknown as GateAutofixClient,
+          fixes: autofixFixes,
+          owner: context.repo.owner,
+          repo: context.repo.repo,
+          evaluationId: evaluation.id,
+          headBranch: prPayload?.head?.ref,
+          headRepoFullName: prPayload?.head?.repo?.full_name,
+          baseRepoFullName: prPayload?.base?.repo?.full_name,
+          enabled: autofixEnabled,
+        });
+        core.setOutput("autofix-json", JSON.stringify(autofixResult));
+        if (autofixResult.committed) {
+          core.info(
+            `Trailhead self-heal committed ${autofixResult.fixCode} → ${autofixResult.commitSha} on ${prPayload?.head?.ref}`,
+          );
+        } else if (autofixResult.edits?.length) {
+          core.info(
+            `Trailhead self-heal (dry-run): would fix ${autofixResult.fixCode} (${autofixResult.files?.join(", ")}). Set autofix: true to apply.`,
+          );
+        } else if (autofixResult.skippedReason) {
+          core.debug(`Autofix skipped: ${autofixResult.skippedReason}`);
+        }
+      } catch (err) {
+        core.warning(`Autofix failed (non-blocking): ${err}`);
       }
     }
 


### PR DESCRIPTION
## The final hop — auto-fix commits fire on real PRs

The executor (#269) could commit; now the gate actually **calls it**.

### Wiring
- **`src/gate-autofix.ts` (`runGateAutofix`)** — from the evaluation's remediation, derive the autofix-eligible fixes, fetch the current content of the files they touch (octokit `getContent` on the PR **HEAD**), build a `GithubGitWriter`, and run `executeAutofixRound`. The octokit client is injected → unit-testable.
- **`main.ts`** — invokes it right after `evaluateGate`, **fail-soft** (a thrown autofix never blocks the gate). Emits `autofix-json` output + an info log: the commit SHA when applied, or a dry-run *"would fix … set autofix: true to apply"* line.

### Safety (this writes to PRs)
- **Opt-in**: new `autofix` action input, **default `false` → dry-run** (plans + logs, commits nothing).
- **Fork-guarded**: skips when the PR head is a different repo (can't write to a fork's branch).
- Requires `contents: write`. Inherits trust-flag / red-lane / one-commit-per-round from `fixer-core`.

### Verification
- **5 new tests**: commit path (mock octokit — `getContent` → stub built → one `createCommit`/`updateRef`), dry-run default (writes nothing), fork skip, no-head-branch skip, no-eligible skip. `tsc` + `eslint .` clean; **full suite 775/775**.

### Self-heal program: complete
detector → planner → content builder → git writer → **gate invocation**. Turning on `autofix: true` in a repo's workflow now makes `contract_integrity` (and any future eligible lane) open the fix as a real commit on the PR.

### Remaining follow-up
The **cross-repo PR opener** (declare a missing API in the *owning* repo) — the one `contract_integrity` case that can't be fixed on the gated PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)