### PR TITLE
release: contract_integrity self-heal + autofix executor → main (staging → production)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -195,6 +195,10 @@ inputs:
     description: "When true and credit meter returns allowed:false, emit a blocking warning. Does not block the gate unless paired with strict policy (fail-open default)."
     required: false
     default: "false"
+  autofix:
+    description: "When true, commit auto-fixes for autofix-eligible findings (e.g. contract_integrity catalog stubs) to the PR's HEAD branch. Default false = dry-run (plan only, logged). Requires contents:write and a non-fork PR."
+    required: false
+    default: "false"
 
 outputs:
   health-score:

--- a/app/src/fixer.ts
+++ b/app/src/fixer.ts
@@ -1,18 +1,31 @@
 /**
  * Trailhead fixer — commits allowlisted autofixes to a PR branch (Phase B2).
  * Requires GitHub App `contents: write` on the target repo.
+ *
+ * The actual git write lives in the shared autofix-executor (ADR-010); this is
+ * the App-side entry point that supplies a GitWriter + the PR's files/branch.
  */
 
 import type { AutofixPlanItem } from "./fixer-core.js";
 import { buildAutofixPlan, selectAutofixCommit } from "./fixer-core.js";
 import type { RemediationFix } from "./types.js";
+import type { SubmissionFileInfo } from "./submission-checks/types.js";
+import {
+  executeAutofixRound,
+  type AutofixBuilderRegistry,
+  type AutofixBuildContext,
+  type GitWriter,
+} from "./autofix-executor.js";
+import { DEFAULT_AUTOFIX_BUILDERS } from "./autofix-builders.js";
 
 export interface FixerCommitResult {
   committed: boolean;
   evaluationId?: string;
   autofixClass?: string;
+  fixCode?: string;
   files?: string[];
   message?: string;
+  commitSha?: string;
   skippedReason?: string;
 }
 
@@ -20,8 +33,16 @@ export interface FixerOptions {
   fixes: RemediationFix[];
   evaluationId: string;
   trustAutofixEnabled?: boolean;
-  /** When true, compute plan only — no git write. */
+  /** When true, compute plan + edits only — no git write. */
   dryRun?: boolean;
+  /** The PR's changed files (with content) — required to build edit content. */
+  files?: SubmissionFileInfo[];
+  /** Git writer + target branch — when present, the round actually commits. */
+  writer?: GitWriter;
+  branch?: string;
+  /** Override the content-builder registry (defaults to DEFAULT_AUTOFIX_BUILDERS). */
+  builders?: AutofixBuilderRegistry;
+  buildContext?: AutofixBuildContext;
 }
 
 export function planAutofix(options: FixerOptions): {
@@ -40,31 +61,47 @@ export function planAutofix(options: FixerOptions): {
 }
 
 /**
- * Apply at most one autofix commit for this evaluation round.
- * GitHub write path is wired in a follow-up App handler PR.
+ * Apply at most one autofix commit for this evaluation round. When a GitWriter +
+ * branch + files are supplied, the shared executor builds the edit content and
+ * commits it; otherwise it falls back to plan-only (dry-run semantics).
  */
 export async function applyAutofixRound(
   options: FixerOptions,
 ): Promise<FixerCommitResult> {
-  const { selected, blockedCount } = planAutofix(options);
+  if (options.writer && options.branch && options.files) {
+    const result = await executeAutofixRound({
+      fixes: options.fixes,
+      files: options.files,
+      builders: options.builders ?? DEFAULT_AUTOFIX_BUILDERS,
+      writer: options.writer,
+      branch: options.branch,
+      evaluationId: options.evaluationId,
+      trustAutofixEnabled: options.trustAutofixEnabled,
+      dryRun: options.dryRun,
+      buildContext: options.buildContext,
+    });
+    return {
+      committed: result.committed,
+      evaluationId: result.evaluationId,
+      autofixClass: result.autofixClass,
+      fixCode: result.fixCode,
+      files: result.files,
+      message: result.message,
+      commitSha: result.commitSha,
+      skippedReason: result.skippedReason,
+    };
+  }
 
+  // No git writer configured → plan-only.
+  const { selected, blockedCount } = planAutofix(options);
   if (!selected) {
     return {
       committed: false,
+      evaluationId: options.evaluationId,
       skippedReason:
         blockedCount > 0
           ? "All autofix candidates blocked (red lane or disallowed class)"
           : "No autofix-eligible fixes in remediation payload",
-    };
-  }
-
-  if (options.dryRun) {
-    return {
-      committed: false,
-      evaluationId: options.evaluationId,
-      autofixClass: selected.autofix_class,
-      files: selected.files,
-      message: `[trailhead-fixer] dry-run: would apply ${selected.autofix_class}`,
     };
   }
 
@@ -73,6 +110,6 @@ export async function applyAutofixRound(
     evaluationId: options.evaluationId,
     autofixClass: selected.autofix_class,
     files: selected.files,
-    skippedReason: "Fixer git write not yet enabled — dry-run only in v4.4.0",
+    message: `[trailhead-fixer] plan-only: would apply ${selected.autofix_class} (no git writer configured)`,
   };
 }

--- a/docs/adr/010-architecture-lifecycle-gates.md
+++ b/docs/adr/010-architecture-lifecycle-gates.md
@@ -105,9 +105,19 @@ ADR — **all five detectors are now implemented** (see Implementation status).
   the fixer plans (catalog-info.yaml is not a red-lane path). Cross-repo refs
   (`consumesApis`/`dependsOn`/`providesApis`) become **suggestions** — the fix
   belongs in the owning repo; opening that cross-repo PR is the remaining
-  follow-up (the fixer commits to the gated PR, not other repos). Commit
-  execution rides the platform's shared autofix git-write path (dry-run in
-  v4.4.x, same as every other autofix class).
+  follow-up (the fixer commits to the gated PR, not other repos).
+
+The **shared autofix git-write executor** now exists (`src/autofix-executor.ts`):
+`executeAutofixRound` plans one fix (via `fixer-core`), asks a content builder
+(`src/autofix-builders.ts` — `contract_integrity` → catalog stub append) for the
+concrete `FileEdit[]`, and commits them through an injected `GitWriter`. The real
+writer (`src/github-git-writer.ts`, `GithubGitWriter`) makes one atomic commit
+via the git-data API (blobs → tree → commit → update ref) behind a structural
+octokit interface, so the same executor runs in the Action, the App
+(`app/src/fixer.ts` now delegates to it), or a unit-test mock. Trust-flag /
+red-lane / one-commit-per-round gating is inherited from `fixer-core`. **This
+lights up commits for every autofix class, not just `contract_integrity`** — the
+catalog healer is simply the first registered builder.
 
 `safe_deprecation` **v1 (catalog coherence)** is implemented
 (`src/submission-checks/safe-deprecation.ts`): when an entity is retired

--- a/docs/adr/010-architecture-lifecycle-gates.md
+++ b/docs/adr/010-architecture-lifecycle-gates.md
@@ -96,6 +96,18 @@ ADR — **all five detectors are now implemented** (see Implementation status).
 - dogfood index: `examples/komatik-catalog-index.json` — 53 entities across the
   live org; with it configured, `consumesApis: [komatik-v3-prebuild]` resolves
   instead of flagging.
+- **self-heal lane** (`src/healers/catalog.ts`, `planCatalogHeal`): for an
+  in-repo LOCAL ref (`spec.system` / `spec.subcomponentOf` whose target isn't
+  declared), it auto-generates a minimal stub entity (System/Component, owner
+  reused from a sibling) to append to the same `catalog-info.yaml` — verified to
+  make `contract_integrity` pass after applying. The detector marks such findings
+  `autofix_eligible`; `deriveSubmissionFixes` classifies them `doc-update`, which
+  the fixer plans (catalog-info.yaml is not a red-lane path). Cross-repo refs
+  (`consumesApis`/`dependsOn`/`providesApis`) become **suggestions** — the fix
+  belongs in the owning repo; opening that cross-repo PR is the remaining
+  follow-up (the fixer commits to the gated PR, not other repos). Commit
+  execution rides the platform's shared autofix git-write path (dry-run in
+  v4.4.x, same as every other autofix class).
 
 `safe_deprecation` **v1 (catalog coherence)** is implemented
 (`src/submission-checks/safe-deprecation.ts`): when an entity is retired

--- a/docs/adr/010-architecture-lifecycle-gates.md
+++ b/docs/adr/010-architecture-lifecycle-gates.md
@@ -119,6 +119,17 @@ red-lane / one-commit-per-round gating is inherited from `fixer-core`. **This
 lights up commits for every autofix class, not just `contract_integrity`** — the
 catalog healer is simply the first registered builder.
 
+The executor is now **invoked from the gate** (`src/gate-autofix.ts` →
+`runGateAutofix`, called in `main.ts` after `evaluateGate`). It derives the
+autofix-eligible fixes from the evaluation's remediation, fetches the current
+content of the files they touch (octokit `getContent` on the PR HEAD), builds a
+`GithubGitWriter`, and runs the executor. Safety: **opt-in** via the `autofix`
+action input (default `false` → dry-run/plan-only, logged with "set autofix:
+true to apply"), **fork-guarded** (won't write to a fork's branch), and wrapped
+**fail-soft** in `main.ts` so autofix never blocks the gate. Requires
+`contents: write`. The App (`app/src/fixer.ts`) shares the same executor for when
+it gains a PR webhook path.
+
 `safe_deprecation` **v1 (catalog coherence)** is implemented
 (`src/submission-checks/safe-deprecation.ts`): when an entity is retired
 (`spec.lifecycle: deprecated`), a still-_live_ entity that keeps depending on it

--- a/scripts/copy-shared-src.mjs
+++ b/scripts/copy-shared-src.mjs
@@ -44,6 +44,9 @@ const sharedFiles = [
   "trust-runtime.ts",
   "remediation-lanes.ts",
   "trailhead-events.ts",
+  "autofix-executor.ts",
+  "autofix-builders.ts",
+  "github-git-writer.ts",
 ];
 
 const adapterFiles = ["gitlab.ts", "circleci.ts"];
@@ -95,6 +98,14 @@ if (targetName === "app" || targetName === "mcp" || targetName === "cli") {
 }
 
 if (targetName === "app" || targetName === "mcp") {
+  // The catalog healer backs the contract_integrity autofix builder.
+  const healersDest = path.join(targetDir, "healers");
+  fs.mkdirSync(healersDest, { recursive: true });
+  fs.copyFileSync(
+    path.join(root, "src/healers", "catalog.ts"),
+    path.join(healersDest, "catalog.ts"),
+  );
+
   const adaptersDir = path.join(targetDir, "ci-adapters");
   fs.mkdirSync(adaptersDir, { recursive: true });
   for (const file of adapterFiles) {

--- a/src/__tests__/autofix-executor.test.ts
+++ b/src/__tests__/autofix-executor.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  executeAutofixRound,
+  type GitWriter,
+  type FileEdit,
+} from "../autofix-executor.js";
+import { DEFAULT_AUTOFIX_BUILDERS } from "../autofix-builders.js";
+import { GithubGitWriter, type GitRestClient } from "../github-git-writer.js";
+import { detectContractIntegrity } from "../submission-checks/contract-integrity.js";
+import { deriveSubmissionFixes } from "../submission-remediation.js";
+import type {
+  SubmissionCheckContext,
+  SubmissionFileInfo,
+} from "../submission-checks/types.js";
+
+function ctx(files: SubmissionFileInfo[]): SubmissionCheckContext {
+  return {
+    files,
+    prPaths: new Set(files.map((f) => f.filename)),
+    komatikInstance: false,
+    staleTerms: [],
+    namingAllowlist: {},
+    authRouteAllowlist: [],
+    maxFileLines: 1000,
+    declaredPackages: new Set(),
+    pathIgnorePatterns: [],
+    renamePatterns: [],
+    slugOnlyPatterns: [],
+    detectorPolicy: {},
+  };
+}
+
+const MISSING_LOCAL = `
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: trace-drift
+spec:
+  type: library
+  owner: komatik
+  system: trace
+`;
+
+const files: SubmissionFileInfo[] = [
+  { filename: "catalog-info.yaml", content: MISSING_LOCAL, status: "modified" },
+];
+
+function contractFixes() {
+  const check = detectContractIntegrity(ctx(files))!;
+  return deriveSubmissionFixes([check]);
+}
+
+function recordingWriter(): {
+  writer: GitWriter;
+  calls: Array<{ branch: string; edits: FileEdit[] }>;
+} {
+  const calls: Array<{ branch: string; edits: FileEdit[] }> = [];
+  const writer: GitWriter = {
+    async commitFiles(args) {
+      calls.push({ branch: args.branch, edits: args.edits });
+      return { commitSha: "commit-sha-123" };
+    },
+  };
+  return { writer, calls };
+}
+
+describe("executeAutofixRound (ADR-010 git-write executor)", () => {
+  it("builds edits and commits the selected fix via the writer", async () => {
+    const { writer, calls } = recordingWriter();
+    const res = await executeAutofixRound({
+      fixes: contractFixes(),
+      files,
+      builders: DEFAULT_AUTOFIX_BUILDERS,
+      writer,
+      branch: "feat/x",
+      evaluationId: "eval-1",
+    });
+    expect(res.committed).toBe(true);
+    expect(res.commitSha).toBe("commit-sha-123");
+    expect(res.fixCode).toBe("submission.contract_integrity");
+    expect(res.autofixClass).toBe("doc-update");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.branch).toBe("feat/x");
+    // The committed content is the original file plus the generated System stub.
+    const edit = calls[0]!.edits.find((e) => e.path === "catalog-info.yaml")!;
+    expect(edit.content).toContain("kind: Component"); // original
+    expect(edit.content).toContain("kind: System"); // appended stub
+    expect(edit.content).toContain("name: trace");
+  });
+
+  it("dry-run builds edits but does not call the writer", async () => {
+    const { writer, calls } = recordingWriter();
+    const res = await executeAutofixRound({
+      fixes: contractFixes(),
+      files,
+      builders: DEFAULT_AUTOFIX_BUILDERS,
+      writer,
+      branch: "feat/x",
+      evaluationId: "eval-1",
+      dryRun: true,
+    });
+    expect(res.committed).toBe(false);
+    expect(res.edits?.length).toBeGreaterThan(0);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("skips when trust autofix is disabled", async () => {
+    const { writer, calls } = recordingWriter();
+    const res = await executeAutofixRound({
+      fixes: contractFixes(),
+      files,
+      builders: DEFAULT_AUTOFIX_BUILDERS,
+      writer,
+      branch: "feat/x",
+      evaluationId: "eval-1",
+      trustAutofixEnabled: false,
+    });
+    expect(res.committed).toBe(false);
+    expect(res.skippedReason).toContain("Trust autofix disabled");
+    expect(calls).toHaveLength(0);
+  });
+
+  it("skips when there are no autofix-eligible fixes", async () => {
+    const { writer } = recordingWriter();
+    const res = await executeAutofixRound({
+      fixes: [],
+      files,
+      builders: DEFAULT_AUTOFIX_BUILDERS,
+      writer,
+      branch: "feat/x",
+      evaluationId: "eval-1",
+    });
+    expect(res.committed).toBe(false);
+    expect(res.skippedReason).toContain("No autofix-eligible");
+  });
+
+  it("skips when no content builder is registered for the fix", async () => {
+    const { writer, calls } = recordingWriter();
+    const res = await executeAutofixRound({
+      fixes: contractFixes(),
+      files,
+      builders: {}, // no builder for contract_integrity
+      writer,
+      branch: "feat/x",
+      evaluationId: "eval-1",
+    });
+    expect(res.committed).toBe(false);
+    expect(res.skippedReason).toContain("No content builder");
+    expect(calls).toHaveLength(0);
+  });
+});
+
+describe("GithubGitWriter", () => {
+  it("commits edits as one atomic commit via the git-data API", async () => {
+    const client: GitRestClient = {
+      rest: {
+        git: {
+          getRef: vi.fn(async () => ({ data: { object: { sha: "base-sha" } } })),
+          getCommit: vi.fn(async () => ({ data: { tree: { sha: "base-tree" } } })),
+          createBlob: vi.fn(async () => ({ data: { sha: "blob-sha" } })),
+          createTree: vi.fn(async () => ({ data: { sha: "new-tree" } })),
+          createCommit: vi.fn(async () => ({ data: { sha: "new-commit" } })),
+          updateRef: vi.fn(async () => ({})),
+        },
+      },
+    };
+    const writer = new GithubGitWriter(client, "KomatikAI", "trace");
+    const out = await writer.commitFiles({
+      branch: "feat/x",
+      message: "fix",
+      edits: [{ path: "catalog-info.yaml", content: "hello" }],
+    });
+
+    expect(out.commitSha).toBe("new-commit");
+    const git = client.rest.git;
+    expect(git.getRef).toHaveBeenCalledWith(
+      expect.objectContaining({ ref: "heads/feat/x" }),
+    );
+    expect(git.createBlob).toHaveBeenCalledWith(
+      expect.objectContaining({ content: "hello", encoding: "utf-8" }),
+    );
+    expect(git.createTree).toHaveBeenCalledWith(
+      expect.objectContaining({ base_tree: "base-tree" }),
+    );
+    expect(git.createCommit).toHaveBeenCalledWith(
+      expect.objectContaining({ tree: "new-tree", parents: ["base-sha"] }),
+    );
+    expect(git.updateRef).toHaveBeenCalledWith(
+      expect.objectContaining({ ref: "heads/feat/x", sha: "new-commit" }),
+    );
+  });
+});

--- a/src/__tests__/catalog-heal.test.ts
+++ b/src/__tests__/catalog-heal.test.ts
@@ -47,7 +47,7 @@ spec:
 
 describe("catalog self-heal lane (ADR-010)", () => {
   it("generates a System stub for a missing spec.system target", () => {
-    const plan = planCatalogHeal(ctx([catalog(MISSING_LOCAL)]));
+    const plan = planCatalogHeal([catalog(MISSING_LOCAL)]);
     expect(plan.edits).toHaveLength(1);
     const edit = plan.edits[0]!;
     expect(edit.file).toBe("catalog-info.yaml");
@@ -68,7 +68,7 @@ describe("catalog self-heal lane (ADR-010)", () => {
   });
 
   it("applying the stub makes contract_integrity pass (self-heal closes the loop)", () => {
-    const plan = planCatalogHeal(ctx([catalog(MISSING_LOCAL)]));
+    const plan = planCatalogHeal([catalog(MISSING_LOCAL)]);
     const healed = MISSING_LOCAL + plan.edits[0]!.append;
     // After appending the generated stubs, the local refs now resolve.
     expect(detectContractIntegrity(ctx([catalog(healed)]))).toBeNull();
@@ -93,7 +93,7 @@ spec:
   system: sundog
   consumesApis: [komatik-v3-prebuild]
 `;
-    const plan = planCatalogHeal(ctx([catalog(crossRepo)]));
+    const plan = planCatalogHeal([catalog(crossRepo)]);
     expect(plan.edits).toHaveLength(0);
     expect(plan.suggestions.join(" ")).toContain("komatik-v3-prebuild");
   });

--- a/src/__tests__/catalog-heal.test.ts
+++ b/src/__tests__/catalog-heal.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+import yaml from "js-yaml";
+import { planCatalogHeal } from "../healers/catalog.js";
+import { detectContractIntegrity } from "../submission-checks/contract-integrity.js";
+import { deriveSubmissionFixes } from "../submission-remediation.js";
+import { buildAutofixPlan } from "../fixer-core.js";
+import type {
+  SubmissionCheckContext,
+  SubmissionFileInfo,
+} from "../submission-checks/types.js";
+
+function ctx(files: SubmissionFileInfo[]): SubmissionCheckContext {
+  return {
+    files,
+    prPaths: new Set(files.map((f) => f.filename)),
+    komatikInstance: false,
+    staleTerms: [],
+    namingAllowlist: {},
+    authRouteAllowlist: [],
+    maxFileLines: 1000,
+    declaredPackages: new Set(),
+    pathIgnorePatterns: [],
+    renamePatterns: [],
+    slugOnlyPatterns: [],
+    detectorPolicy: {},
+  };
+}
+
+const catalog = (content: string): SubmissionFileInfo => ({
+  filename: "catalog-info.yaml",
+  content,
+  status: "modified",
+});
+
+// A Component pointing at an undeclared System + parent Component (local refs).
+const MISSING_LOCAL = `
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: trace-drift
+spec:
+  type: library
+  owner: komatik
+  system: trace
+  subcomponentOf: trace-core
+`;
+
+describe("catalog self-heal lane (ADR-010)", () => {
+  it("generates a System stub for a missing spec.system target", () => {
+    const plan = planCatalogHeal(ctx([catalog(MISSING_LOCAL)]));
+    expect(plan.edits).toHaveLength(1);
+    const edit = plan.edits[0]!;
+    expect(edit.file).toBe("catalog-info.yaml");
+    expect(edit.entities).toContain("trace");
+    expect(edit.entities).toContain("trace-core");
+    // The appended YAML is valid and declares the missing entities.
+    type StubDoc = {
+      kind: string;
+      metadata: { name: string };
+      spec: { owner: string };
+    };
+    const docs = [...yaml.loadAll(edit.append)].filter(Boolean) as StubDoc[];
+    const byName = new Map(docs.map((d) => [d.metadata.name, d]));
+    expect(byName.get("trace")!.kind).toBe("System");
+    expect(byName.get("trace-core")!.kind).toBe("Component");
+    // Owner is reused from the sibling entity.
+    expect(byName.get("trace")!.spec.owner).toBe("komatik");
+  });
+
+  it("applying the stub makes contract_integrity pass (self-heal closes the loop)", () => {
+    const plan = planCatalogHeal(ctx([catalog(MISSING_LOCAL)]));
+    const healed = MISSING_LOCAL + plan.edits[0]!.append;
+    // After appending the generated stubs, the local refs now resolve.
+    expect(detectContractIntegrity(ctx([catalog(healed)]))).toBeNull();
+  });
+
+  it("emits a suggestion (not an edit) for cross-repo refs", () => {
+    const crossRepo = `
+apiVersion: backstage.io/v1alpha1
+kind: System
+metadata:
+  name: sundog
+spec:
+  owner: komatik
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: sundog
+spec:
+  type: service
+  owner: komatik
+  system: sundog
+  consumesApis: [komatik-v3-prebuild]
+`;
+    const plan = planCatalogHeal(ctx([catalog(crossRepo)]));
+    expect(plan.edits).toHaveLength(0);
+    expect(plan.suggestions.join(" ")).toContain("komatik-v3-prebuild");
+  });
+
+  it("detector marks local-fixable findings autofix_eligible", () => {
+    const res = detectContractIntegrity(ctx([catalog(MISSING_LOCAL)]));
+    expect(res?.autofix_eligible).toBe(true);
+  });
+
+  it("detector does NOT mark a pure cross-repo finding autofix_eligible", () => {
+    const onlyContract = `
+apiVersion: backstage.io/v1alpha1
+kind: System
+metadata:
+  name: sundog
+spec:
+  owner: komatik
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: sundog
+spec:
+  type: service
+  owner: komatik
+  system: sundog
+  consumesApis: [komatik-v3-prebuild]
+`;
+    const res = detectContractIntegrity(ctx([catalog(onlyContract)]));
+    expect(res?.autofix_eligible).toBe(false);
+  });
+
+  it("flows through remediation as a planned doc-update autofix (lane wired)", () => {
+    const check = detectContractIntegrity(ctx([catalog(MISSING_LOCAL)]))!;
+    const fixes = deriveSubmissionFixes([check]);
+    const fix = fixes.find((f) => f.code === "submission.contract_integrity")!;
+    expect(fix.autofix_eligible).toBe(true);
+    expect(fix.autofix_class).toBe("doc-update");
+    // catalog-info.yaml is not a red-lane path, so the autofix is plannable.
+    const plan = buildAutofixPlan(fixes);
+    expect(plan.items.some((i) => i.fix.code === "submission.contract_integrity")).toBe(
+      true,
+    );
+    expect(plan.blocked).toHaveLength(0);
+  });
+});

--- a/src/__tests__/gate-autofix.test.ts
+++ b/src/__tests__/gate-autofix.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it, vi } from "vitest";
+import { runGateAutofix, type GateAutofixClient } from "../gate-autofix.js";
+import { detectContractIntegrity } from "../submission-checks/contract-integrity.js";
+import { deriveSubmissionFixes } from "../submission-remediation.js";
+import type {
+  SubmissionCheckContext,
+  SubmissionFileInfo,
+} from "../submission-checks/types.js";
+
+const MISSING_LOCAL = `
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: trace-drift
+spec:
+  type: library
+  owner: komatik
+  system: trace
+`;
+
+function ctx(files: SubmissionFileInfo[]): SubmissionCheckContext {
+  return {
+    files,
+    prPaths: new Set(files.map((f) => f.filename)),
+    komatikInstance: false,
+    staleTerms: [],
+    namingAllowlist: {},
+    authRouteAllowlist: [],
+    maxFileLines: 1000,
+    declaredPackages: new Set(),
+    pathIgnorePatterns: [],
+    renamePatterns: [],
+    slugOnlyPatterns: [],
+    detectorPolicy: {},
+  };
+}
+
+function contractFixes() {
+  const check = detectContractIntegrity(
+    ctx([{ filename: "catalog-info.yaml", content: MISSING_LOCAL, status: "modified" }]),
+  )!;
+  return deriveSubmissionFixes([check]);
+}
+
+function mockClient(): GateAutofixClient {
+  return {
+    rest: {
+      repos: {
+        getContent: vi.fn(async () => ({
+          data: {
+            content: Buffer.from(MISSING_LOCAL, "utf8").toString("base64"),
+            encoding: "base64",
+          },
+        })),
+      },
+      git: {
+        getRef: vi.fn(async () => ({ data: { object: { sha: "base-sha" } } })),
+        getCommit: vi.fn(async () => ({ data: { tree: { sha: "base-tree" } } })),
+        createBlob: vi.fn(async () => ({ data: { sha: "blob-sha" } })),
+        createTree: vi.fn(async () => ({ data: { sha: "new-tree" } })),
+        createCommit: vi.fn(async () => ({ data: { sha: "new-commit" } })),
+        updateRef: vi.fn(async () => ({})),
+      },
+    },
+  };
+}
+
+const baseOpts = {
+  owner: "KomatikAI",
+  repo: "trace",
+  evaluationId: "eval-1",
+  headBranch: "feat/x",
+  headRepoFullName: "KomatikAI/trace",
+  baseRepoFullName: "KomatikAI/trace",
+};
+
+describe("runGateAutofix (ADR-010 App/Action invocation)", () => {
+  it("commits when enabled: fetches content, builds the stub, writes one commit", async () => {
+    const client = mockClient();
+    const res = await runGateAutofix({
+      ...baseOpts,
+      client,
+      fixes: contractFixes(),
+      enabled: true,
+    });
+    expect(res.committed).toBe(true);
+    expect(res.commitSha).toBe("new-commit");
+    expect(client.rest.repos.getContent).toHaveBeenCalledWith(
+      expect.objectContaining({ path: "catalog-info.yaml", ref: "feat/x" }),
+    );
+    expect(client.rest.git.createCommit).toHaveBeenCalledTimes(1);
+    expect(client.rest.git.updateRef).toHaveBeenCalledWith(
+      expect.objectContaining({ ref: "heads/feat/x", sha: "new-commit" }),
+    );
+  });
+
+  it("dry-run by default (enabled omitted): plans edits, writes nothing", async () => {
+    const client = mockClient();
+    const res = await runGateAutofix({ ...baseOpts, client, fixes: contractFixes() });
+    expect(res.committed).toBe(false);
+    expect(res.edits?.length).toBeGreaterThan(0);
+    expect(client.rest.git.createCommit).not.toHaveBeenCalled();
+    expect(client.rest.git.updateRef).not.toHaveBeenCalled();
+  });
+
+  it("skips fork PRs (head repo differs from base)", async () => {
+    const client = mockClient();
+    const res = await runGateAutofix({
+      ...baseOpts,
+      client,
+      fixes: contractFixes(),
+      enabled: true,
+      headRepoFullName: "someone-else/trace",
+    });
+    expect(res.committed).toBe(false);
+    expect(res.skippedReason).toContain("Fork");
+    expect(client.rest.repos.getContent).not.toHaveBeenCalled();
+  });
+
+  it("skips when there is no head branch", async () => {
+    const client = mockClient();
+    const res = await runGateAutofix({
+      ...baseOpts,
+      client,
+      fixes: contractFixes(),
+      enabled: true,
+      headBranch: undefined,
+    });
+    expect(res.committed).toBe(false);
+    expect(res.skippedReason).toContain("head branch");
+  });
+
+  it("skips when no fixes are autofix-eligible", async () => {
+    const client = mockClient();
+    const res = await runGateAutofix({
+      ...baseOpts,
+      client,
+      fixes: [],
+      enabled: true,
+    });
+    expect(res.committed).toBe(false);
+    expect(res.skippedReason).toContain("No autofix-eligible");
+    expect(client.rest.repos.getContent).not.toHaveBeenCalled();
+  });
+});

--- a/src/autofix-builders.ts
+++ b/src/autofix-builders.ts
@@ -1,0 +1,34 @@
+// Default autofix content builders (ADR-010). Maps a planned fix code to the
+// concrete file edits that resolve it. Builders are pure: (item, files, ctx) →
+// FileEdit[]. The executor commits the result via an injected GitWriter.
+
+import type {
+  AutofixBuilderRegistry,
+  AutofixContentBuilder,
+  FileEdit,
+} from "./autofix-executor.js";
+import { fileContent, normalizePath } from "./submission-checks/helpers.js";
+import { planCatalogHeal } from "./healers/catalog.js";
+
+/**
+ * contract_integrity → append the generated stub entities to each affected
+ * catalog-info.yaml (full-content edit = current file + heal append). Only LOCAL
+ * missing entities produce edits; cross-repo refs stay suggestions (no edit).
+ */
+export const contractIntegrityBuilder: AutofixContentBuilder = (_item, files, ctx) => {
+  const plan = planCatalogHeal(files, ctx.catalogKnownEntities);
+  const edits: FileEdit[] = [];
+  for (const healEdit of plan.edits) {
+    const original = files.find((f) => normalizePath(f.filename) === healEdit.file);
+    if (!original) continue;
+    edits.push({
+      path: healEdit.file,
+      content: fileContent(original) + healEdit.append,
+    });
+  }
+  return edits;
+};
+
+export const DEFAULT_AUTOFIX_BUILDERS: AutofixBuilderRegistry = {
+  "submission.contract_integrity": contractIntegrityBuilder,
+};

--- a/src/autofix-executor.ts
+++ b/src/autofix-executor.ts
@@ -1,0 +1,148 @@
+// Shared autofix git-write executor (ADR-010 / Phase B2 completion).
+//
+// fixer-core plans WHICH fix to apply (one per round, red-lane + class gated).
+// This module turns that plan into an actual commit: it asks a content builder
+// for the concrete file edits, then hands them to an injected GitWriter. The
+// GitWriter is an interface so the same executor runs in the Action, the App, or
+// a unit test (mock writer) — no package bound to a specific GitHub client.
+
+import type { AutofixPlanItem } from "./fixer-core.js";
+import { buildAutofixPlan, selectAutofixCommit } from "./fixer-core.js";
+import type { RemediationFix } from "./types.js";
+import type { SubmissionFileInfo } from "./submission-checks/types.js";
+
+/** A whole-file replacement (the executor builds full content, not patches). */
+export interface FileEdit {
+  path: string;
+  content: string;
+}
+
+/** Commits a set of file edits to a branch as ONE commit. */
+export interface GitWriter {
+  commitFiles(args: {
+    branch: string;
+    message: string;
+    edits: FileEdit[];
+  }): Promise<{ commitSha: string }>;
+}
+
+/** Context a builder may need beyond the changed files. */
+export interface AutofixBuildContext {
+  /** Org catalog index (for contract_integrity cross-repo resolution). */
+  catalogKnownEntities?: Set<string>;
+}
+
+/** Produces the concrete file edits that resolve a planned fix. */
+export type AutofixContentBuilder = (
+  item: AutofixPlanItem,
+  files: SubmissionFileInfo[],
+  context: AutofixBuildContext,
+) => FileEdit[];
+
+/** fix.code → content builder. */
+export type AutofixBuilderRegistry = Record<string, AutofixContentBuilder>;
+
+export interface AutofixExecuteOptions {
+  fixes: RemediationFix[];
+  files: SubmissionFileInfo[];
+  builders: AutofixBuilderRegistry;
+  writer: GitWriter;
+  branch: string;
+  evaluationId: string;
+  trustAutofixEnabled?: boolean;
+  /** Compute + build edits but do not commit. */
+  dryRun?: boolean;
+  /** Commit message override. */
+  message?: string;
+  buildContext?: AutofixBuildContext;
+}
+
+export interface AutofixExecuteResult {
+  committed: boolean;
+  evaluationId: string;
+  autofixClass?: string;
+  fixCode?: string;
+  files?: string[];
+  edits?: FileEdit[];
+  commitSha?: string;
+  message?: string;
+  skippedReason?: string;
+}
+
+const COMMIT_PREFIX = "[trailhead-fixer]";
+
+/**
+ * Apply at most one autofix commit for this evaluation round. Returns a
+ * structured result describing what was (or would be) committed, or why it was
+ * skipped. Never throws on "nothing to do" — only the writer may reject.
+ */
+export async function executeAutofixRound(
+  opts: AutofixExecuteOptions,
+): Promise<AutofixExecuteResult> {
+  const base = { committed: false as const, evaluationId: opts.evaluationId };
+
+  if (opts.trustAutofixEnabled === false) {
+    return { ...base, skippedReason: "Trust autofix disabled" };
+  }
+
+  const plan = buildAutofixPlan(opts.fixes);
+  const selected = selectAutofixCommit(plan);
+  if (!selected) {
+    return {
+      ...base,
+      skippedReason:
+        plan.blocked.length > 0
+          ? "All autofix candidates blocked (red lane or disallowed class)"
+          : "No autofix-eligible fixes in remediation payload",
+    };
+  }
+
+  const meta = {
+    autofixClass: selected.autofix_class,
+    fixCode: selected.fix.code,
+  };
+
+  const builder = opts.builders[selected.fix.code];
+  if (!builder) {
+    return {
+      ...base,
+      ...meta,
+      skippedReason: `No content builder for ${selected.fix.code}`,
+    };
+  }
+
+  const edits = builder(selected, opts.files, opts.buildContext ?? {});
+  if (edits.length === 0) {
+    return { ...base, ...meta, skippedReason: "Builder produced no edits" };
+  }
+
+  const message =
+    opts.message ??
+    `${COMMIT_PREFIX} ${selected.autofix_class}: ${selected.fix.code} (eval ${opts.evaluationId})`;
+
+  if (opts.dryRun) {
+    return {
+      ...base,
+      ...meta,
+      files: edits.map((e) => e.path),
+      edits,
+      message: `dry-run: would commit ${edits.length} file(s)`,
+    };
+  }
+
+  const { commitSha } = await opts.writer.commitFiles({
+    branch: opts.branch,
+    message,
+    edits,
+  });
+
+  return {
+    committed: true,
+    evaluationId: opts.evaluationId,
+    ...meta,
+    files: edits.map((e) => e.path),
+    edits,
+    commitSha,
+    message,
+  };
+}

--- a/src/gate-autofix.ts
+++ b/src/gate-autofix.ts
@@ -1,0 +1,115 @@
+// Gate-side autofix invocation (ADR-010). Bridges the Action's evaluation to the
+// shared git-write executor: from the remediation fixes, fetch the current
+// content of the files an eligible fix touches, then run the executor against a
+// GithubGitWriter on the PR's HEAD branch.
+//
+// Safety: opt-in (`enabled` defaults the executor to dry-run when false), fork-
+// guarded (can't write to a fork's branch), and the caller wraps it fail-soft so
+// autofix never blocks the gate.
+
+import type { RemediationFix } from "./types.js";
+import type { SubmissionFileInfo } from "./submission-checks/types.js";
+import { GithubGitWriter, type GitRestClient } from "./github-git-writer.js";
+import { executeAutofixRound, type AutofixExecuteResult } from "./autofix-executor.js";
+import { DEFAULT_AUTOFIX_BUILDERS } from "./autofix-builders.js";
+
+/** Octokit subset this needs: git-data writes (via GithubGitWriter) + getContent. */
+export interface GateAutofixClient extends GitRestClient {
+  rest: GitRestClient["rest"] & {
+    repos: {
+      getContent(p: {
+        owner: string;
+        repo: string;
+        path: string;
+        ref?: string;
+      }): Promise<{ data: unknown }>;
+    };
+  };
+}
+
+export interface RunGateAutofixOptions {
+  client: GateAutofixClient;
+  fixes: RemediationFix[];
+  owner: string;
+  repo: string;
+  evaluationId: string;
+  /** PR head branch — the autofix commit target. */
+  headBranch?: string;
+  /** Fork detection: skip when the PR head is a different repo. */
+  headRepoFullName?: string;
+  baseRepoFullName?: string;
+  /** When false, the executor only plans (dry-run) — no commit. Default false. */
+  enabled?: boolean;
+  trustAutofixEnabled?: boolean;
+  catalogKnownEntities?: Set<string>;
+}
+
+function skip(evaluationId: string, reason: string): AutofixExecuteResult {
+  return { committed: false, evaluationId, skippedReason: reason };
+}
+
+async function readContent(
+  client: GateAutofixClient,
+  owner: string,
+  repo: string,
+  path: string,
+  ref?: string,
+): Promise<string | null> {
+  try {
+    const res = await client.rest.repos.getContent({ owner, repo, path, ref });
+    const data = res.data as { content?: string; encoding?: string } | undefined;
+    if (data && typeof data.content === "string") {
+      const encoding = (data.encoding as BufferEncoding) || "base64";
+      return Buffer.from(data.content, encoding).toString("utf8");
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export async function runGateAutofix(
+  opts: RunGateAutofixOptions,
+): Promise<AutofixExecuteResult> {
+  if (!opts.headBranch) return skip(opts.evaluationId, "No PR head branch");
+  if (
+    opts.headRepoFullName &&
+    opts.baseRepoFullName &&
+    opts.headRepoFullName !== opts.baseRepoFullName
+  ) {
+    return skip(opts.evaluationId, "Fork PR — cannot write to head branch");
+  }
+
+  // Nothing to do unless something is autofix-eligible.
+  const eligible = opts.fixes.filter((f) => f.autofix_eligible);
+  if (eligible.length === 0) {
+    return skip(opts.evaluationId, "No autofix-eligible fixes in remediation payload");
+  }
+
+  // Fetch current content for the files those fixes touch (HEAD branch).
+  const paths = [...new Set(eligible.flatMap((f) => f.files))].filter(Boolean);
+  const files: SubmissionFileInfo[] = [];
+  for (const path of paths) {
+    const content = await readContent(
+      opts.client,
+      opts.owner,
+      opts.repo,
+      path,
+      opts.headBranch,
+    );
+    files.push({ filename: path, content: content ?? "" });
+  }
+
+  const writer = new GithubGitWriter(opts.client, opts.owner, opts.repo);
+  return executeAutofixRound({
+    fixes: opts.fixes,
+    files,
+    builders: DEFAULT_AUTOFIX_BUILDERS,
+    writer,
+    branch: opts.headBranch,
+    evaluationId: opts.evaluationId,
+    trustAutofixEnabled: opts.trustAutofixEnabled,
+    dryRun: opts.enabled !== true,
+    buildContext: { catalogKnownEntities: opts.catalogKnownEntities },
+  });
+}

--- a/src/github-git-writer.ts
+++ b/src/github-git-writer.ts
@@ -1,0 +1,99 @@
+// GitHub implementation of GitWriter (ADR-010). Commits a set of file edits as
+// ONE atomic commit via the git-data API (blobs → tree → commit → update ref).
+//
+// The client is typed structurally (the subset of octokit.rest.git this needs),
+// so an @actions/github `getOctokit(...)` instance satisfies it without this
+// module taking a hard dependency — and a unit test can pass a mock.
+
+import type { FileEdit, GitWriter } from "./autofix-executor.js";
+
+type GitTreeMode = "100644" | "100755" | "040000" | "160000" | "120000";
+
+export interface GitRestClient {
+  rest: {
+    git: {
+      getRef(p: { owner: string; repo: string; ref: string }): Promise<{
+        data: { object: { sha: string } };
+      }>;
+      getCommit(p: { owner: string; repo: string; commit_sha: string }): Promise<{
+        data: { tree: { sha: string } };
+      }>;
+      createBlob(p: {
+        owner: string;
+        repo: string;
+        content: string;
+        encoding: string;
+      }): Promise<{ data: { sha: string } }>;
+      createTree(p: {
+        owner: string;
+        repo: string;
+        base_tree: string;
+        tree: Array<{ path: string; mode: GitTreeMode; type: "blob"; sha: string }>;
+      }): Promise<{ data: { sha: string } }>;
+      createCommit(p: {
+        owner: string;
+        repo: string;
+        message: string;
+        tree: string;
+        parents: string[];
+      }): Promise<{ data: { sha: string } }>;
+      updateRef(p: {
+        owner: string;
+        repo: string;
+        ref: string;
+        sha: string;
+        force?: boolean;
+      }): Promise<unknown>;
+    };
+  };
+}
+
+export class GithubGitWriter implements GitWriter {
+  constructor(
+    private readonly client: GitRestClient,
+    private readonly owner: string,
+    private readonly repo: string,
+  ) {}
+
+  async commitFiles(args: {
+    branch: string;
+    message: string;
+    edits: FileEdit[];
+  }): Promise<{ commitSha: string }> {
+    const { owner, repo } = this;
+    const git = this.client.rest.git;
+    const ref = `heads/${args.branch}`;
+
+    // 1. Resolve the branch head + its base tree.
+    const head = await git.getRef({ owner, repo, ref });
+    const baseSha = head.data.object.sha;
+    const baseCommit = await git.getCommit({ owner, repo, commit_sha: baseSha });
+    const baseTree = baseCommit.data.tree.sha;
+
+    // 2. Blob each edited file, assemble a new tree on top of the base.
+    const tree: Array<{ path: string; mode: GitTreeMode; type: "blob"; sha: string }> =
+      [];
+    for (const edit of args.edits) {
+      const blob = await git.createBlob({
+        owner,
+        repo,
+        content: edit.content,
+        encoding: "utf-8",
+      });
+      tree.push({ path: edit.path, mode: "100644", type: "blob", sha: blob.data.sha });
+    }
+    const newTree = await git.createTree({ owner, repo, base_tree: baseTree, tree });
+
+    // 3. One commit on top of the head, then fast-forward the branch.
+    const commit = await git.createCommit({
+      owner,
+      repo,
+      message: args.message,
+      tree: newTree.data.sha,
+      parents: [baseSha],
+    });
+    await git.updateRef({ owner, repo, ref, sha: commit.data.sha });
+
+    return { commitSha: commit.data.sha };
+  }
+}

--- a/src/healers/catalog.ts
+++ b/src/healers/catalog.ts
@@ -15,7 +15,7 @@ import {
   analyzeCatalogRefs,
   type ContractRefFinding,
 } from "../submission-checks/contract-integrity.js";
-import type { SubmissionCheckContext } from "../submission-checks/types.js";
+import type { SubmissionFileInfo } from "../submission-checks/types.js";
 import { fileContent, normalizePath } from "../submission-checks/helpers.js";
 
 export interface CatalogHealEdit {
@@ -81,8 +81,11 @@ function componentStub(name: string, owner: string): string {
  * Plan the catalog self-heal for a PR: auto-declare missing LOCAL entities,
  * and surface cross-repo refs as suggestions.
  */
-export function planCatalogHeal(ctx: SubmissionCheckContext): CatalogHealPlan {
-  const analysis = analyzeCatalogRefs(ctx);
+export function planCatalogHeal(
+  files: SubmissionFileInfo[],
+  knownEntities?: Set<string>,
+): CatalogHealPlan {
+  const analysis = analyzeCatalogRefs(files, knownEntities);
   if (!analysis) return { edits: [], suggestions: [] };
 
   const local = analysis.findings.filter((f) => f.kind === "local");
@@ -102,7 +105,7 @@ export function planCatalogHeal(ctx: SubmissionCheckContext): CatalogHealPlan {
 
   const edits: CatalogHealEdit[] = [];
   for (const [file, entityMap] of byFile) {
-    const original = ctx.files.find((cf) => normalizePath(cf.filename) === file);
+    const original = files.find((cf) => normalizePath(cf.filename) === file);
     const owner = original ? ownerHint(fileContent(original)) : "unknown";
     const stubs: string[] = [];
     const entities: string[] = [];

--- a/src/healers/catalog.ts
+++ b/src/healers/catalog.ts
@@ -1,0 +1,128 @@
+// Catalog self-heal lane (ADR-010) for the contract_integrity detector.
+//
+// When a catalog-info.yaml reference doesn't resolve, the in-repo-fixable case is
+// a LOCAL structural ref — `spec.system` / `spec.subcomponentOf` pointing at an
+// entity that simply isn't declared in the same repo's catalog. The fix is to add
+// a minimal stub for that entity, which this healer generates as YAML to append.
+//
+// Cross-repo refs (consumesApis / dependsOn / providesApis to something another
+// repo owns) can't be fixed in this PR — the fix belongs in the owning repo. For
+// those we emit a human-actionable suggestion rather than an edit. (Opening the
+// cross-repo PR is a follow-up that needs a cross-repo PR opener the fixer lacks.)
+
+import yaml from "js-yaml";
+import {
+  analyzeCatalogRefs,
+  type ContractRefFinding,
+} from "../submission-checks/contract-integrity.js";
+import type { SubmissionCheckContext } from "../submission-checks/types.js";
+import { fileContent, normalizePath } from "../submission-checks/helpers.js";
+
+export interface CatalogHealEdit {
+  /** catalog-info.yaml to append to. */
+  file: string;
+  /** YAML to append (one or more `---`-separated stub entities). */
+  append: string;
+  /** Entity names declared by this edit. */
+  entities: string[];
+}
+
+export interface CatalogHealPlan {
+  /** In-repo edits that auto-declare missing local entities. */
+  edits: CatalogHealEdit[];
+  /** Cross-repo / owned refs that need a declaration in another repo. */
+  suggestions: string[];
+}
+
+/** Best-effort owner for stubs: reuse a sibling entity's owner, else "unknown". */
+function ownerHint(content: string): string {
+  try {
+    let owner: string | undefined;
+    yaml.loadAll(content, (doc) => {
+      if (owner) return;
+      const spec = (doc as Record<string, unknown>)?.spec as
+        | Record<string, unknown>
+        | undefined;
+      if (typeof spec?.owner === "string") owner = spec.owner;
+    });
+    return owner ?? "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+function systemStub(name: string, owner: string): string {
+  return [
+    "apiVersion: backstage.io/v1alpha1",
+    "kind: System",
+    "metadata:",
+    `  name: ${name}`,
+    `  description: "TODO: auto-declared by Trailhead self-heal (contract_integrity)"`,
+    "spec:",
+    `  owner: ${owner}`,
+  ].join("\n");
+}
+
+function componentStub(name: string, owner: string): string {
+  return [
+    "apiVersion: backstage.io/v1alpha1",
+    "kind: Component",
+    "metadata:",
+    `  name: ${name}`,
+    `  description: "TODO: auto-declared by Trailhead self-heal (contract_integrity)"`,
+    "spec:",
+    "  type: service",
+    "  lifecycle: experimental",
+    `  owner: ${owner}`,
+  ].join("\n");
+}
+
+/**
+ * Plan the catalog self-heal for a PR: auto-declare missing LOCAL entities,
+ * and surface cross-repo refs as suggestions.
+ */
+export function planCatalogHeal(ctx: SubmissionCheckContext): CatalogHealPlan {
+  const analysis = analyzeCatalogRefs(ctx);
+  if (!analysis) return { edits: [], suggestions: [] };
+
+  const local = analysis.findings.filter((f) => f.kind === "local");
+  const crossRepo = analysis.findings.filter((f) => f.kind !== "local");
+
+  // Group local findings by file, dedupe by entity name (a System ref wins over
+  // a Component ref for the same name — a System is the broader container).
+  const byFile = new Map<string, Map<string, ContractRefFinding>>();
+  for (const f of local) {
+    const fileMap = byFile.get(f.file) ?? new Map<string, ContractRefFinding>();
+    const existing = fileMap.get(f.name);
+    if (!existing || (existing.field !== "system" && f.field === "system")) {
+      fileMap.set(f.name, f);
+    }
+    byFile.set(f.file, fileMap);
+  }
+
+  const edits: CatalogHealEdit[] = [];
+  for (const [file, entityMap] of byFile) {
+    const original = ctx.files.find((cf) => normalizePath(cf.filename) === file);
+    const owner = original ? ownerHint(fileContent(original)) : "unknown";
+    const stubs: string[] = [];
+    const entities: string[] = [];
+    for (const finding of entityMap.values()) {
+      const stub =
+        finding.field === "system"
+          ? systemStub(finding.name, owner)
+          : componentStub(finding.name, owner);
+      stubs.push(stub);
+      entities.push(finding.name);
+    }
+    if (stubs.length === 0) continue;
+    const append = "\n---\n" + stubs.join("\n---\n") + "\n";
+    edits.push({ file, append, entities });
+  }
+
+  const suggestions = crossRepo.map(
+    (f) =>
+      `Declare ${f.kind === "owned" ? "API" : "the referenced entity"} "${f.name}" in its owning repo's catalog-info.yaml (referenced via spec.${f.field} in ${f.file}).`,
+  );
+
+  return { edits, suggestions };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -34,6 +34,7 @@ import { computeRolloutReadiness } from "./rollout-readiness.js";
 import { resolveAgentProvenanceId } from "./agent-provenance.js";
 import { readTrustRuntime } from "./trust-runtime.js";
 import { buildGateVerdict } from "./verdict.js";
+import { runGateAutofix, type GateAutofixClient } from "./gate-autofix.js";
 import type { TrailheadConfig, TestRepairResult, PolicyOverrideAudit } from "./types.js";
 
 class PolicyOverrideError extends Error {
@@ -363,6 +364,46 @@ async function run(): Promise<void> {
         }
       } catch (err) {
         core.warning(`Credit metering failed (non-blocking): ${err}`);
+      }
+    }
+
+    // Autofix self-heal (ADR-010) — opt-in; dry-run (plan only) unless enabled.
+    const autofixFixes = evaluation.remediation?.fixes ?? [];
+    if (config.githubToken && prNumber && autofixFixes.some((f) => f.autofix_eligible)) {
+      try {
+        const autofixEnabled =
+          core.getInput("autofix") === "true" || readEnv("TRAILHEAD_AUTOFIX") === "true";
+        const prPayload = context.payload.pull_request as
+          | {
+              head?: { ref?: string; repo?: { full_name?: string } };
+              base?: { repo?: { full_name?: string } };
+            }
+          | undefined;
+        const autofixResult = await runGateAutofix({
+          client: github.getOctokit(config.githubToken) as unknown as GateAutofixClient,
+          fixes: autofixFixes,
+          owner: context.repo.owner,
+          repo: context.repo.repo,
+          evaluationId: evaluation.id,
+          headBranch: prPayload?.head?.ref,
+          headRepoFullName: prPayload?.head?.repo?.full_name,
+          baseRepoFullName: prPayload?.base?.repo?.full_name,
+          enabled: autofixEnabled,
+        });
+        core.setOutput("autofix-json", JSON.stringify(autofixResult));
+        if (autofixResult.committed) {
+          core.info(
+            `Trailhead self-heal committed ${autofixResult.fixCode} → ${autofixResult.commitSha} on ${prPayload?.head?.ref}`,
+          );
+        } else if (autofixResult.edits?.length) {
+          core.info(
+            `Trailhead self-heal (dry-run): would fix ${autofixResult.fixCode} (${autofixResult.files?.join(", ")}). Set autofix: true to apply.`,
+          );
+        } else if (autofixResult.skippedReason) {
+          core.debug(`Autofix skipped: ${autofixResult.skippedReason}`);
+        }
+      } catch (err) {
+        core.warning(`Autofix failed (non-blocking): ${err}`);
       }
     }
 

--- a/src/submission-checks/contract-integrity.ts
+++ b/src/submission-checks/contract-integrity.ts
@@ -20,9 +20,9 @@ import { fileContent, normalizePath } from "./helpers.js";
 
 const CATALOG_FILE = /(?:^|\/)catalog-info\.ya?ml$/i;
 
-type RefKind = "local" | "owned" | "contract";
+export type RefKind = "local" | "owned" | "contract";
 
-interface Finding {
+export interface ContractRefFinding {
   file: string;
   field: string;
   ref: string;
@@ -30,7 +30,7 @@ interface Finding {
   kind: RefKind;
 }
 
-function isCatalogFile(file: SubmissionFileInfo): boolean {
+export function isCatalogFile(file: SubmissionFileInfo): boolean {
   return CATALOG_FILE.test(normalizePath(file.filename));
 }
 
@@ -70,9 +70,14 @@ function entityName(doc: Record<string, unknown>): string | null {
   return typeof name === "string" ? name : null;
 }
 
-export function detectContractIntegrity(
+/**
+ * Core analysis shared by the detector and the self-heal lane: parse the PR's
+ * catalog files, build the resolution universe, and return every reference that
+ * doesn't resolve. Returns null when there are no catalog files to analyze.
+ */
+export function analyzeCatalogRefs(
   ctx: SubmissionCheckContext,
-): SubmissionCheckResult | null {
+): { findings: ContractRefFinding[]; hasOrgIndex: boolean } | null {
   const catalogFiles = ctx.files.filter(isCatalogFile);
   if (catalogFiles.length === 0) return null;
 
@@ -95,7 +100,7 @@ export function detectContractIntegrity(
   const hasOrgIndex = (ctx.catalogKnownEntities?.size ?? 0) > 0;
 
   // 2. Walk references and collect anything that doesn't resolve.
-  const findings: Finding[] = [];
+  const findings: ContractRefFinding[] = [];
   const checkRef = (
     file: SubmissionFileInfo,
     field: string,
@@ -122,6 +127,16 @@ export function detectContractIntegrity(
     }
   }
 
+  return { findings, hasOrgIndex };
+}
+
+export function detectContractIntegrity(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const analysis = analyzeCatalogRefs(ctx);
+  if (!analysis) return null;
+  const { findings, hasOrgIndex } = analysis;
+
   if (findings.length === 0) return null;
 
   // 3. Severity: local/owned refs are structural (always warn). Cross-repo
@@ -131,6 +146,10 @@ export function detectContractIntegrity(
   const contract = findings.filter((f) => f.kind === "contract");
   const severity: SubmissionCheckResult["severity"] =
     structural.length > 0 || hasOrgIndex ? "warn" : "advisory";
+
+  // Self-heal lane (ADR-010): a missing LOCAL entity (system / subcomponentOf
+  // target) can be auto-declared in the same catalog file. See healers/catalog.ts.
+  const localHealable = findings.some((f) => f.kind === "local");
 
   const lines = findings.map(
     (f) => `${f.file}: spec.${f.field} → "${f.ref}" (no declared entity "${f.name}")`,
@@ -153,7 +172,10 @@ export function detectContractIntegrity(
     files: [...new Set(findings.map((f) => f.file))],
     suggested_action:
       "Declare the referenced entity in the owning repo's catalog-info.yaml (or fix the reference). " +
-      "For cross-repo contracts, ensure the publishing repo declares the API and that it is in the org catalog index.",
-    autofix_eligible: false,
+      "For cross-repo contracts, ensure the publishing repo declares the API and that it is in the org catalog index." +
+      (localHealable
+        ? " A missing local entity (system / subcomponentOf target) can be auto-declared — Trailhead self-heal."
+        : ""),
+    autofix_eligible: localHealable,
   };
 }

--- a/src/submission-checks/contract-integrity.ts
+++ b/src/submission-checks/contract-integrity.ts
@@ -76,9 +76,10 @@ function entityName(doc: Record<string, unknown>): string | null {
  * doesn't resolve. Returns null when there are no catalog files to analyze.
  */
 export function analyzeCatalogRefs(
-  ctx: SubmissionCheckContext,
+  files: SubmissionFileInfo[],
+  knownEntities?: Set<string>,
 ): { findings: ContractRefFinding[]; hasOrgIndex: boolean } | null {
-  const catalogFiles = ctx.files.filter(isCatalogFile);
+  const catalogFiles = files.filter(isCatalogFile);
   if (catalogFiles.length === 0) return null;
 
   // Parse once; remember which file each doc came from.
@@ -96,8 +97,8 @@ export function analyzeCatalogRefs(
     }
   }
   const known = new Set<string>(declared);
-  for (const name of ctx.catalogKnownEntities ?? []) known.add(name);
-  const hasOrgIndex = (ctx.catalogKnownEntities?.size ?? 0) > 0;
+  for (const name of knownEntities ?? []) known.add(name);
+  const hasOrgIndex = (knownEntities?.size ?? 0) > 0;
 
   // 2. Walk references and collect anything that doesn't resolve.
   const findings: ContractRefFinding[] = [];
@@ -133,7 +134,7 @@ export function analyzeCatalogRefs(
 export function detectContractIntegrity(
   ctx: SubmissionCheckContext,
 ): SubmissionCheckResult | null {
-  const analysis = analyzeCatalogRefs(ctx);
+  const analysis = analyzeCatalogRefs(ctx.files, ctx.catalogKnownEntities);
   if (!analysis) return null;
   const { findings, hasOrgIndex } = analysis;
 

--- a/src/submission-remediation.ts
+++ b/src/submission-remediation.ts
@@ -23,7 +23,8 @@ export function deriveSubmissionFixes(
       suggested_action: check.suggested_action,
       autofix_eligible: check.autofix_eligible ?? false,
       autofix_class:
-        check.autofix_eligible && check.code === "context_freshness"
+        check.autofix_eligible &&
+        (check.code === "context_freshness" || check.code === "contract_integrity")
           ? "doc-update"
           : undefined,
     }),


### PR DESCRIPTION
## Release: staging → main (production)

Ships the ADR-010 **self-heal** chain to production:
- #268 — contract_integrity catalog healer
- #269 — shared git-write executor + `GithubGitWriter`
- #270 — gate invocation (`runGateAutofix`; opt-in `autofix` input, **dry-run by default**, fork-guarded, fail-soft)

Net behavior change in prod: **none unless a repo opts in** with `autofix: true` — the gate only logs a dry-run plan otherwise. All earlier ADR-010 detectors already shipped.

**Ready for your approve + merge.** Production `main` requires human review (agent admin-merge disabled by policy). Note: the diff includes the `action.yml` `autofix` input, so `security-guard` will flag a CI-definition change — add the `security-reviewed` label (it's non-blocking for the merge, but clears the guard's autonomous-merge gate). REST one-liner if the label UI is hiding again:
`gh api --method POST repos/KomatikAI/trailhead/issues/<thisPR>/labels -f "labels[]=security-reviewed"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)