### PR TITLE
feat(action): evaluate-pr — on-demand / backfill evaluation of any PR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Trailhead will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- **On-demand / backfill evaluation (`evaluate-pr`)** — new Action input to evaluate a specific PR by number instead of the triggering event's PR. Resolves the PR head commit via the API and scores the diff with the current engine, so historical PRs (open, closed, or merged) can be re-evaluated or backfilled with the latest version. Diff/author/age/provenance are fetched by PR number (no checkout required). In this mode the gate only scores and persists the evaluation — PR comments, labels, reviewer requests, self-heal, and autofix are skipped. Drivable from `workflow_dispatch` or a direct `node dist/index.js` run. See `examples/github-actions/trailhead-backfill.yml`.
+
 ## [4.5.7] - 2026-07-01
 
 ### Fixed

--- a/action.yml
+++ b/action.yml
@@ -211,6 +211,10 @@ inputs:
     description: "Set to 'false' to disable the cross-repo PR opener even when configured. Default enabled (the opener still requires submission.contract_integrity.cross_repo_opener.enabled, an api_owners map, and a cross-repo-token to actually open PRs)."
     required: false
     default: "true"
+  evaluate-pr:
+    description: "Evaluate a specific PR by number instead of the triggering event's PR. Enables backfill / on-demand re-evaluation of historical PRs (open, closed, or merged) with the current engine version — driven from workflow_dispatch or a direct `node dist/index.js` run. The diff, author history, age, and provenance are fetched from the GitHub API by PR number, so no checkout of the PR is required. In this mode the gate only scores and persists the evaluation; PR comments, labels, reviewer requests, self-heal, and autofix are skipped. Requires github-token."
+    required: false
+    default: ""
 
 outputs:
   health-score:

--- a/dist/index.js
+++ b/dist/index.js
@@ -56484,8 +56484,35 @@ async function run() {
         if (policyOverride) {
             core_warning(`Governed override active (${policyOverride.linkedTicket}) by ${policyOverride.owner}; expires ${policyOverride.expiresAt}.`);
         }
-        const commitSha = context.sha;
-        const prNumber = context.payload.pull_request?.number;
+        // On-demand evaluation: when `evaluate-pr` is set, score that PR by number
+        // instead of the triggering event's PR. Enables backfill / re-evaluation of
+        // historical PRs (open, closed, or merged) with the current engine version,
+        // driven from a workflow_dispatch or a direct `node dist/index.js` run.
+        // The diff/author/age/provenance are all fetched from the GitHub API by PR
+        // number (see evaluateGate), so no checkout of the PR is required.
+        let commitSha = context.sha;
+        let prNumber = context.payload.pull_request?.number;
+        const evaluatePrInput = getInput("evaluate-pr").trim();
+        const backfillMode = Boolean(evaluatePrInput);
+        if (evaluatePrInput) {
+            const parsedPr = parseInt(evaluatePrInput, 10);
+            if (Number.isNaN(parsedPr) || parsedPr <= 0) {
+                throw new Error(`evaluate-pr must be a positive PR number; got "${evaluatePrInput}".`);
+            }
+            if (!config.githubToken) {
+                throw new Error("evaluate-pr requires a github-token to resolve the PR head commit.");
+            }
+            const octokit = getOctokit(config.githubToken);
+            const { data: targetPr } = await octokit.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: parsedPr,
+            });
+            prNumber = parsedPr;
+            commitSha = targetPr.head.sha;
+            info(`evaluate-pr mode: PR #${parsedPr} (${targetPr.state}) @ ${commitSha.substring(0, 7)} ` +
+                `base=${targetPr.base.ref} — backfill/re-evaluation; PR comments, labels and autofix are skipped.`);
+        }
         info(`Evaluating deployment gate for ${commitSha.substring(0, 7)}`);
         const evaluation = await evaluateGate(config, commitSha, prNumber);
         if (policyOverride && !evaluation.policyOverride) {
@@ -56524,7 +56551,7 @@ async function run() {
         }
         // Autofix self-heal (ADR-010) — opt-in; dry-run (plan only) unless enabled.
         const autofixFixes = evaluation.remediation?.fixes ?? [];
-        if (config.githubToken && prNumber && autofixFixes.some((f) => f.autofix_eligible)) {
+        if (config.githubToken && prNumber && !backfillMode && autofixFixes.some((f) => f.autofix_eligible)) {
             try {
                 const autofixEnabled = getInput("autofix") === "true" || readEnv("TRAILHEAD_AUTOFIX") === "true";
                 const prPayload = context.payload.pull_request;
@@ -56750,7 +56777,7 @@ async function run() {
         }
         await summary.addRaw(fullReport).write();
         const checkName = resolveCheckName(evaluation.gateMode ?? "risk-only", config.checkName);
-        if (config.githubToken) {
+        if (config.githubToken && !backfillMode) {
             if (prNumber) {
                 await postPrComment(fullReport, prNumber, config.githubToken);
             }
@@ -56769,10 +56796,10 @@ async function run() {
         if (!blockMerge) {
             if (evaluation.gateDecision === "warn") {
                 core_warning(fullReport);
-                if (config.githubToken && prNumber && config.reviewersOnRisk.length > 0) {
+                if (config.githubToken && prNumber && !backfillMode && config.reviewersOnRisk.length > 0) {
                     await requestHighRiskReviewers(prNumber, config.reviewersOnRisk, config.githubToken);
                 }
-                if (config.selfHeal && prNumber) {
+                if (config.selfHeal && prNumber && !backfillMode) {
                     const repairs = await runSelfHeal(config, prNumber);
                     if (repairs.length > 0) {
                         info(`Self-heal attempted ${repairs.length} repair(s): ` +
@@ -56785,10 +56812,10 @@ async function run() {
             }
             return;
         }
-        if (config.githubToken && prNumber && config.reviewersOnRisk.length > 0) {
+        if (config.githubToken && prNumber && !backfillMode && config.reviewersOnRisk.length > 0) {
             await requestHighRiskReviewers(prNumber, config.reviewersOnRisk, config.githubToken);
         }
-        if (config.selfHeal && prNumber) {
+        if (config.selfHeal && prNumber && !backfillMode) {
             const repairs = await runSelfHeal(config, prNumber);
             const successes = repairs.filter((r) => r.success);
             if (successes.length > 0) {

--- a/examples/github-actions/trailhead-backfill.yml
+++ b/examples/github-actions/trailhead-backfill.yml
@@ -1,0 +1,36 @@
+# Backfill / re-evaluate a specific PR with the current Trailhead engine.
+#
+# Use this to populate the evaluation store for historical PRs (e.g. after a
+# version upgrade) or to re-score a single PR on demand. The gate fetches the
+# PR diff by number from the API — it works for open, closed, and merged PRs,
+# and requires no checkout of the PR. Only the evaluation is scored and
+# persisted; PR comments, labels, reviewers, self-heal, and autofix are skipped.
+#
+# Drive it across many PRs with:
+#   for pr in 2100 2101 2102; do
+#     gh workflow run trailhead-backfill.yml -f pr="$pr"
+#   done
+name: Trailhead Backfill
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "PR number to evaluate"
+        required: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  backfill:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: KomatikAI/trailhead@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          evaluate-pr: ${{ inputs.pr }}
+          evaluation-store-url: "https://komatik.ai/api/trailhead/store"
+          evaluation-store-secret: ${{ secrets.INTERNAL_API_SECRET }}
+          dora-metrics: "true"

--- a/src/main.ts
+++ b/src/main.ts
@@ -318,8 +318,42 @@ async function run(): Promise<void> {
       );
     }
 
-    const commitSha = context.sha;
-    const prNumber = context.payload.pull_request?.number;
+    // On-demand evaluation: when `evaluate-pr` is set, score that PR by number
+    // instead of the triggering event's PR. Enables backfill / re-evaluation of
+    // historical PRs (open, closed, or merged) with the current engine version,
+    // driven from a workflow_dispatch or a direct `node dist/index.js` run.
+    // The diff/author/age/provenance are all fetched from the GitHub API by PR
+    // number (see evaluateGate), so no checkout of the PR is required.
+    let commitSha = context.sha;
+    let prNumber = context.payload.pull_request?.number;
+
+    const evaluatePrInput = core.getInput("evaluate-pr").trim();
+    const backfillMode = Boolean(evaluatePrInput);
+    if (evaluatePrInput) {
+      const parsedPr = parseInt(evaluatePrInput, 10);
+      if (Number.isNaN(parsedPr) || parsedPr <= 0) {
+        throw new Error(
+          `evaluate-pr must be a positive PR number; got "${evaluatePrInput}".`,
+        );
+      }
+      if (!config.githubToken) {
+        throw new Error(
+          "evaluate-pr requires a github-token to resolve the PR head commit.",
+        );
+      }
+      const octokit = github.getOctokit(config.githubToken);
+      const { data: targetPr } = await octokit.rest.pulls.get({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        pull_number: parsedPr,
+      });
+      prNumber = parsedPr;
+      commitSha = targetPr.head.sha;
+      core.info(
+        `evaluate-pr mode: PR #${parsedPr} (${targetPr.state}) @ ${commitSha.substring(0, 7)} ` +
+          `base=${targetPr.base.ref} — backfill/re-evaluation; PR comments, labels and autofix are skipped.`,
+      );
+    }
 
     core.info(`Evaluating deployment gate for ${commitSha.substring(0, 7)}`);
 
@@ -374,7 +408,7 @@ async function run(): Promise<void> {
 
     // Autofix self-heal (ADR-010) — opt-in; dry-run (plan only) unless enabled.
     const autofixFixes = evaluation.remediation?.fixes ?? [];
-    if (config.githubToken && prNumber && autofixFixes.some((f) => f.autofix_eligible)) {
+    if (config.githubToken && prNumber && !backfillMode && autofixFixes.some((f) => f.autofix_eligible)) {
       try {
         const autofixEnabled =
           core.getInput("autofix") === "true" || readEnv("TRAILHEAD_AUTOFIX") === "true";
@@ -655,7 +689,7 @@ async function run(): Promise<void> {
       config.checkName,
     );
 
-    if (config.githubToken) {
+    if (config.githubToken && !backfillMode) {
       if (prNumber) {
         await postPrComment(fullReport, prNumber, config.githubToken);
       }
@@ -677,14 +711,14 @@ async function run(): Promise<void> {
     if (!blockMerge) {
       if (evaluation.gateDecision === "warn") {
         core.warning(fullReport);
-        if (config.githubToken && prNumber && config.reviewersOnRisk.length > 0) {
+        if (config.githubToken && prNumber && !backfillMode && config.reviewersOnRisk.length > 0) {
           await requestHighRiskReviewers(
             prNumber,
             config.reviewersOnRisk,
             config.githubToken,
           );
         }
-        if (config.selfHeal && prNumber) {
+        if (config.selfHeal && prNumber && !backfillMode) {
           const repairs = await runSelfHeal(config, prNumber);
           if (repairs.length > 0) {
             core.info(
@@ -699,14 +733,14 @@ async function run(): Promise<void> {
       return;
     }
 
-    if (config.githubToken && prNumber && config.reviewersOnRisk.length > 0) {
+    if (config.githubToken && prNumber && !backfillMode && config.reviewersOnRisk.length > 0) {
       await requestHighRiskReviewers(
         prNumber,
         config.reviewersOnRisk,
         config.githubToken,
       );
     }
-    if (config.selfHeal && prNumber) {
+    if (config.selfHeal && prNumber && !backfillMode) {
       const repairs = await runSelfHeal(config, prNumber);
       const successes = repairs.filter((r) => r.success);
       if (successes.length > 0) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -408,7 +408,12 @@ async function run(): Promise<void> {
 
     // Autofix self-heal (ADR-010) — opt-in; dry-run (plan only) unless enabled.
     const autofixFixes = evaluation.remediation?.fixes ?? [];
-    if (config.githubToken && prNumber && !backfillMode && autofixFixes.some((f) => f.autofix_eligible)) {
+    if (
+      config.githubToken &&
+      prNumber &&
+      !backfillMode &&
+      autofixFixes.some((f) => f.autofix_eligible)
+    ) {
       try {
         const autofixEnabled =
           core.getInput("autofix") === "true" || readEnv("TRAILHEAD_AUTOFIX") === "true";
@@ -711,7 +716,12 @@ async function run(): Promise<void> {
     if (!blockMerge) {
       if (evaluation.gateDecision === "warn") {
         core.warning(fullReport);
-        if (config.githubToken && prNumber && !backfillMode && config.reviewersOnRisk.length > 0) {
+        if (
+          config.githubToken &&
+          prNumber &&
+          !backfillMode &&
+          config.reviewersOnRisk.length > 0
+        ) {
           await requestHighRiskReviewers(
             prNumber,
             config.reviewersOnRisk,
@@ -733,7 +743,12 @@ async function run(): Promise<void> {
       return;
     }
 
-    if (config.githubToken && prNumber && !backfillMode && config.reviewersOnRisk.length > 0) {
+    if (
+      config.githubToken &&
+      prNumber &&
+      !backfillMode &&
+      config.reviewersOnRisk.length > 0
+    ) {
       await requestHighRiskReviewers(
         prNumber,
         config.reviewersOnRisk,


### PR DESCRIPTION
## What
Adds an **`evaluate-pr`** Action input that scores a specific PR *by number* instead of the triggering event's PR.

```yaml
- uses: KomatikAI/trailhead@v4
  with:
    github-token: ${{ secrets.GITHUB_TOKEN }}
    evaluate-pr: "2121"
    evaluation-store-url: "https://komatik.ai/api/trailhead/store"
    evaluation-store-secret: ${{ secrets.INTERNAL_API_SECRET }}
```

## Why
We need to **backfill the evaluation store** with current-engine (v4.5) verdicts across historical PRs, and to re-evaluate individual PRs on demand. The triggering event only exposes its own PR, and `gh run rerun` replays the *old* workflow version — neither lets us run the current engine against a past PR.

## How
`evaluateGate` already fetches the diff, author history, age, and provenance **by PR number via the API** — it never needed the local checkout. So this change just lets `prNumber`/`commitSha` come from the input (resolving the PR head commit through `pulls.get`) and then calls the exact same engine + store path. Works for **open, closed, and merged** PRs (`refs/pull/N/head` is always available).

A `backfillMode` guard ensures historical/closed PRs are never mutated: **PR comments, labels, reviewer requests, self-heal, and autofix are skipped**; only scoring + `storeEvaluation` run.

## Validation
Built (ncc) + typecheck clean. End-to-end: backfilled `KomatikAI/komatik#2121` (closed) →
stored a complete evaluation: `decision=block, risk=82, health=100, 8 risk_factors, 100 files`.

Also drivable outside Actions for batch backfill: `INPUT_EVALUATE-PR=<n> node dist/index.js` with the store env.

Includes `examples/github-actions/trailhead-backfill.yml` (workflow_dispatch driver) + CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)