### PR TITLE
fix(data): warehouse audit remediations

### DIFF
--- a/cloud/migrations/004_analytics_columns.sql
+++ b/cloud/migrations/004_analytics_columns.sql
@@ -1,0 +1,12 @@
+-- Trailhead Cloud analytics columns (reference copy for hosted tier).
+-- Komatik fleet store uses docs/komatik-migrations/20260606120000_trailhead_analytics_columns.sql
+
+ALTER TABLE trailhead_evaluations
+  ADD COLUMN IF NOT EXISTS gate_mode text,
+  ADD COLUMN IF NOT EXISTS submission_checks jsonb,
+  ADD COLUMN IF NOT EXISTS policy_findings jsonb,
+  ADD COLUMN IF NOT EXISTS release_ready_reasons jsonb,
+  ADD COLUMN IF NOT EXISTS trust_profile jsonb,
+  ADD COLUMN IF NOT EXISTS verdict jsonb,
+  ADD COLUMN IF NOT EXISTS ci jsonb,
+  ADD COLUMN IF NOT EXISTS context jsonb;

--- a/docs/komatik-hosted-store.md
+++ b/docs/komatik-hosted-store.md
@@ -24,6 +24,8 @@ The store accepts **both**:
 
 Persisted loop columns (v4.3+): `remediation`, `loop_round`, `previous_evaluation_id`, `fixes_resolved`, `fixes_introduced`, `release_ready`, `pr`.
 
+Analytics columns (v4.5+ warehouse audit): `gate_mode`, `submission_checks`, `policy_findings`, `release_ready_reasons`, `trust_profile`, `verdict`, `ci`, `context` — migration `docs/komatik-migrations/20260606120000_trailhead_analytics_columns.sql`.
+
 ## Credit metering (Komatik wallet)
 
 Trailhead can record `deploy_check` deliverables against the Komatik prepaid credit ledger via `credit-meter-ingest`. See **[komatik-credit-metering.md](./komatik-credit-metering.md)**.

--- a/docs/komatik-migrations/20260529180000_trailhead_a5_agent_provenance.sql
+++ b/docs/komatik-migrations/20260529180000_trailhead_a5_agent_provenance.sql
@@ -12,13 +12,18 @@ CREATE INDEX IF NOT EXISTS idx_trailhead_evals_agent_provenance
   WHERE agent_provenance_id IS NOT NULL;
 
 COMMENT ON COLUMN public.trailhead_evaluations.agent_provenance_id IS
-  'Denormalised pr.provenance.source for agent group-by (Trailhead A5).';
+  'Denormalised agent id for group-by (headRef agent/*, then provenance.type, then identity source).';
 
--- Best-effort backfill from pr JSONB
+-- Best-effort backfill from pr JSONB (matches resolveAgentProvenanceId in Trailhead)
 UPDATE public.trailhead_evaluations
 SET agent_provenance_id = COALESCE(
-  pr->'provenance'->>'source',
-  substring(pr->>'headRef' from '^agent/([^/]+)/')
+  substring(pr->>'headRef' from '^agent/([^/]+)/'),
+  NULLIF(pr->'provenance'->>'type', 'human'),
+  NULLIF(pr->'provenance'->>'type', 'unknown'),
+  CASE
+    WHEN pr->'provenance'->>'source' IN ('author/branch/commit-signals') THEN NULL
+    ELSE pr->'provenance'->>'source'
+  END
 )
 WHERE agent_provenance_id IS NULL
   AND pr IS NOT NULL;

--- a/docs/komatik-migrations/20260606120000_trailhead_analytics_columns.sql
+++ b/docs/komatik-migrations/20260606120000_trailhead_analytics_columns.sql
@@ -1,0 +1,22 @@
+-- Analytics columns for trailhead_evaluations (warehouse completeness audit Jun 2026)
+-- Copy into Komatik/supabase/migrations/ via PR. Do NOT apply via MCP to prod.
+--
+-- Trailhead reference: cloud/migrations/004_analytics_columns.sql
+-- Update platform/web/lib/trailhead/evaluation-store.ts mapEvaluationStoreRow to persist these fields.
+
+ALTER TABLE public.trailhead_evaluations
+  ADD COLUMN IF NOT EXISTS gate_mode text,
+  ADD COLUMN IF NOT EXISTS submission_checks jsonb,
+  ADD COLUMN IF NOT EXISTS policy_findings jsonb,
+  ADD COLUMN IF NOT EXISTS release_ready_reasons jsonb,
+  ADD COLUMN IF NOT EXISTS trust_profile jsonb,
+  ADD COLUMN IF NOT EXISTS verdict jsonb,
+  ADD COLUMN IF NOT EXISTS ci jsonb,
+  ADD COLUMN IF NOT EXISTS context jsonb;
+
+COMMENT ON COLUMN public.trailhead_evaluations.gate_mode IS
+  'Gate mode at evaluation time: release-ready | advisory | risk-only.';
+COMMENT ON COLUMN public.trailhead_evaluations.verdict IS
+  'trailhead.verdict.v1 snapshot — agent trust collectors should read penalty from here.';
+COMMENT ON COLUMN public.trailhead_evaluations.submission_checks IS
+  'Gate 1 + Phase 0 submission check results when submission gate enabled.';

--- a/examples/github-actions/trailhead-deploy-tracker.yml
+++ b/examples/github-actions/trailhead-deploy-tracker.yml
@@ -40,10 +40,10 @@ jobs:
           REST="${SUPABASE_URL%/}/rest/v1/trailhead_evaluations"
           DEPLOYED_AT="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
 
-          fetch_eval_id() {
+          fetch_eval_row() {
             local query="$1"
             curl -sS -G "${REST}" \
-              --data-urlencode "select=id" \
+              --data-urlencode "select=id,gate_decision,release_ready" \
               --data-urlencode "repo_id=eq.${REPO_ID}" \
               ${query} \
               --data-urlencode "order=created_at.desc" \
@@ -52,18 +52,27 @@ jobs:
               -H "Authorization: Bearer ${SUPABASE_SERVICE_ROLE_KEY}"
           }
 
-          MATCH="$(fetch_eval_id "commit_sha=eq.${COMMIT_SHA}")"
+          MATCH="$(fetch_eval_row "commit_sha=eq.${COMMIT_SHA}")"
           EVAL_ID="$(echo "${MATCH}" | jq -r '.[0].id // empty')"
+          GATE_DECISION="$(echo "${MATCH}" | jq -r '.[0].gate_decision // empty')"
+          RELEASE_READY="$(echo "${MATCH}" | jq -r '.[0].release_ready // empty')"
 
           if [ -z "${EVAL_ID}" ] && [ -n "${TRAILHEAD_DEPLOY_MATCH_WINDOW_HOURS:-}" ]; then
             CUTOFF="$(date -u -d "-${TRAILHEAD_DEPLOY_MATCH_WINDOW_HOURS} hours" '+%Y-%m-%dT%H:%M:%SZ')"
             echo "No exact SHA match — trying fallback window (${TRAILHEAD_DEPLOY_MATCH_WINDOW_HOURS}h since ${CUTOFF})"
-            MATCH="$(fetch_eval_id "created_at=gte.${CUTOFF}")"
+            MATCH="$(fetch_eval_row "created_at=gte.${CUTOFF}")"
             EVAL_ID="$(echo "${MATCH}" | jq -r '.[0].id // empty')"
+            GATE_DECISION="$(echo "${MATCH}" | jq -r '.[0].gate_decision // empty')"
+            RELEASE_READY="$(echo "${MATCH}" | jq -r '.[0].release_ready // empty')"
           fi
 
           if [ -z "${EVAL_ID}" ]; then
             echo "No trailhead_evaluations row for commit ${COMMIT_SHA} — nothing to update."
+            exit 0
+          fi
+
+          if [ "${GATE_DECISION}" = "block" ] || [ "${RELEASE_READY}" = "false" ]; then
+            echo "Skipping deploy correlation for ${EVAL_ID} — gate was ${GATE_DECISION} (release_ready=${RELEASE_READY})."
             exit 0
           fi
 

--- a/src/__tests__/agent-provenance.test.ts
+++ b/src/__tests__/agent-provenance.test.ts
@@ -7,7 +7,7 @@ function evaluation(pr: GateEvaluation["pr"]): Pick<GateEvaluation, "pr"> {
 }
 
 describe("resolveAgentProvenanceId", () => {
-  it("prefers provenance.source", () => {
+  it("prefers agent branch headRef over provenance source", () => {
     expect(
       resolveAgentProvenanceId(
         evaluation({
@@ -16,6 +16,21 @@ describe("resolveAgentProvenanceId", () => {
         }),
       ),
     ).toBe("frontend-dev");
+  });
+
+  it("ignores detection-method provenance.source values", () => {
+    expect(
+      resolveAgentProvenanceId(
+        evaluation({
+          headRef: "feat/some-branch",
+          provenance: {
+            type: "claude",
+            confidence: 0.55,
+            source: "author/branch/commit-signals",
+          },
+        }),
+      ),
+    ).toBe("claude");
   });
 
   it("parses agent branch headRef", () => {

--- a/src/__tests__/notify.test.ts
+++ b/src/__tests__/notify.test.ts
@@ -1,6 +1,7 @@
 import { vi } from "vitest";
 
 import {
+  buildEvaluationStoreRow,
   deliverWebhooks,
   deliverWebhookEvent,
   sendWebhook,
@@ -168,6 +169,56 @@ describe("deliverWebhooks", () => {
     const body = JSON.parse(vi.mocked(fetch).mock.calls[0][1]!.body as string);
     expect(body.event).toBe("trailhead.ready");
     expect(body.releaseReady).toBe(true);
+  });
+});
+
+describe("buildEvaluationStoreRow", () => {
+  it("persists analytics fields for warehouse queries", () => {
+    const row = buildEvaluationStoreRow(
+      makeEvaluation({
+        gateMode: "release-ready",
+        releaseReady: false,
+        releaseReadyReasons: ["Risk score 85 exceeds threshold 70"],
+        policyFindings: ["CI integrity blocking patterns detected (1)."],
+        submissionChecks: [
+          {
+            code: "syntax_validity",
+            severity: "blocking",
+            title: "Syntax error",
+            detail: "bad ts",
+            files: ["src/x.ts"],
+            autofix_eligible: false,
+          },
+        ],
+        trust_profile: {
+          strictness: "baseline",
+          reason: "Human provenance",
+        },
+        ci: {
+          checks: [],
+          allRequiredPassed: true,
+          pendingCount: 0,
+          failedCount: 0,
+          missingCount: 0,
+        },
+        pr: {
+          headRef: "agent/pixel/fix-nav",
+          provenance: { type: "claude", confidence: 0.9 },
+        },
+      }),
+    );
+
+    expect(row.gate_mode).toBe("release-ready");
+    expect(row.release_ready_reasons).toEqual(["Risk score 85 exceeds threshold 70"]);
+    expect(row.policy_findings).toContain("CI integrity blocking patterns detected (1).");
+    expect(row.submission_checks).toHaveLength(1);
+    expect(row.trust_profile).toMatchObject({ strictness: "baseline" });
+    expect(row.ci).toMatchObject({ allRequiredPassed: true });
+    expect(row.agent_provenance_id).toBe("pixel");
+    expect(row.verdict).toMatchObject({
+      schema: "trailhead.verdict.v1",
+      agent_id: "pixel",
+    });
   });
 });
 

--- a/src/__tests__/security.test.ts
+++ b/src/__tests__/security.test.ts
@@ -15,6 +15,7 @@ vi.mock("@actions/github", () => ({
 
 import * as github from "@actions/github";
 import {
+  alertTouchesChangedFile,
   fetchCodeScanningAlerts,
   computeSecurityRiskFactor,
   formatSecuritySection,
@@ -22,6 +23,24 @@ import {
 
 beforeEach(() => {
   vi.clearAllMocks();
+});
+
+describe("alertTouchesChangedFile", () => {
+  it("matches exact and suffix paths", () => {
+    const alert = {
+      number: 1,
+      state: "open",
+      rule: { id: "r", severity: "error", description: "d" },
+      tool: { name: "CodeQL" },
+      most_recent_instance: {
+        ref: "main",
+        state: "open",
+        location: { path: "src/auth/login.ts", start_line: 1 },
+      },
+    };
+    expect(alertTouchesChangedFile(alert, new Set(["src/auth/login.ts"]))).toBe(true);
+    expect(alertTouchesChangedFile(alert, new Set(["docs/readme.md"]))).toBe(false);
+  });
 });
 
 describe("fetchCodeScanningAlerts", () => {
@@ -132,6 +151,86 @@ describe("fetchCodeScanningAlerts", () => {
     });
     expect(result.total).toBe(1);
     expect(result.high).toBe(1);
+  });
+
+  it("scopes alerts to PR changed files when changedFiles is set", async () => {
+    const alerts = [
+      {
+        number: 1,
+        state: "open",
+        rule: {
+          id: "js/xss",
+          severity: "error",
+          security_severity_level: "high",
+          description: "XSS in src",
+        },
+        tool: { name: "CodeQL" },
+        most_recent_instance: {
+          ref: "main",
+          state: "open",
+          location: { path: "src/auth/login.ts", start_line: 10 },
+        },
+      },
+      {
+        number: 2,
+        state: "open",
+        rule: {
+          id: "js/other",
+          severity: "error",
+          security_severity_level: "high",
+          description: "Elsewhere",
+        },
+        tool: { name: "CodeQL" },
+        most_recent_instance: {
+          ref: "main",
+          state: "open",
+          location: { path: "lib/legacy/util.ts", start_line: 3 },
+        },
+      },
+    ];
+
+    const octokit = {
+      request: vi.fn().mockResolvedValue({ data: alerts }),
+    };
+    vi.mocked(github.getOctokit).mockReturnValue(
+      octokit as unknown as ReturnType<typeof github.getOctokit>,
+    );
+
+    const result = await fetchCodeScanningAlerts("ghp_test", undefined, {
+      changedFiles: ["src/auth/login.ts"],
+    });
+    expect(result.total).toBe(1);
+    expect(result.high).toBe(1);
+    expect(result.topRules).toEqual(["js/xss (1)"]);
+  });
+
+  it("returns empty counts when changedFiles is an empty array", async () => {
+    const octokit = {
+      request: vi.fn().mockResolvedValue({
+        data: [
+          {
+            number: 1,
+            state: "open",
+            rule: { id: "js/xss", severity: "error", description: "XSS" },
+            tool: { name: "CodeQL" },
+            most_recent_instance: {
+              ref: "main",
+              state: "open",
+              location: { path: "src/x.ts", start_line: 1 },
+            },
+          },
+        ],
+      }),
+    };
+    vi.mocked(github.getOctokit).mockReturnValue(
+      octokit as unknown as ReturnType<typeof github.getOctokit>,
+    );
+
+    const result = await fetchCodeScanningAlerts("ghp_test", undefined, {
+      changedFiles: [],
+    });
+    expect(result.total).toBe(0);
+    expect(octokit.request).not.toHaveBeenCalled();
   });
 
   it("handles 403/404 gracefully", async () => {

--- a/src/agent-provenance.ts
+++ b/src/agent-provenance.ts
@@ -1,14 +1,18 @@
 import type { GateEvaluation } from "./types.js";
 
+/** Provenance `source` values that describe detection heuristics, not agent identity. */
+const DETECTION_METHOD_SOURCES = new Set(["author/branch/commit-signals"]);
+
+function isAgentIdentitySource(source: string): boolean {
+  return !DETECTION_METHOD_SOURCES.has(source);
+}
+
 /** Denormalised agent id for evaluation store group-by (A5). */
 export function resolveAgentProvenanceId(
   evaluation: Pick<GateEvaluation, "pr">,
 ): string | null {
   const pr = evaluation.pr;
   if (!pr) return null;
-
-  const source = pr.provenance?.source?.trim();
-  if (source) return source;
 
   const headRef = pr.headRef;
   if (headRef) {
@@ -17,7 +21,10 @@ export function resolveAgentProvenanceId(
   }
 
   const type = pr.provenance?.type;
-  if (type && type !== "human") return type;
+  if (type && type !== "human" && type !== "unknown") return type;
+
+  const source = pr.provenance?.source?.trim();
+  if (source && isAgentIdentitySource(source)) return source;
 
   return null;
 }

--- a/src/gate.ts
+++ b/src/gate.ts
@@ -1528,8 +1528,13 @@ export async function evaluateGate(
     core.info("Merge queue detected — adjusting evaluation (skipping author_history)");
   }
 
+  const [files, repoConfig] = await Promise.all([
+    prNumber ? fetchPrFiles(prNumber, config.githubToken) : Promise.resolve([]),
+    loadRepoConfig(config.githubToken),
+  ]);
+  const changedFiles = files.map((f) => f.filename);
+
   const [
-    files,
     authorFactor,
     prAgeFactor,
     provenance,
@@ -1537,10 +1542,8 @@ export async function evaluateGate(
     vercelCheck,
     supabaseCheck,
     mcpCheck,
-    repoConfig,
     securityAlerts,
   ] = await Promise.all([
-    prNumber ? fetchPrFiles(prNumber, config.githubToken) : Promise.resolve([]),
     prNumber && config.githubToken && !isMergeQueue
       ? computeAuthorHistory(prNumber, config.githubToken)
       : Promise.resolve(null),
@@ -1556,9 +1559,10 @@ export async function evaluateGate(
     checkVercelHealth(),
     checkSupabaseHealth(),
     checkMcpHealth(),
-    loadRepoConfig(config.githubToken),
     config.securityGate !== false && config.githubToken
-      ? fetchCodeScanningAlerts(config.githubToken)
+      ? fetchCodeScanningAlerts(config.githubToken, repoConfig?.security, {
+          changedFiles: prNumber ? changedFiles : undefined,
+        })
       : Promise.resolve(null),
   ]);
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -522,7 +522,9 @@ async function run(): Promise<void> {
     let securityReport = "";
     if (config.securityGate !== false && config.githubToken) {
       try {
-        const alerts = await fetchCodeScanningAlerts(config.githubToken);
+        const alerts = await fetchCodeScanningAlerts(config.githubToken, undefined, {
+          changedFiles: evaluation.files,
+        });
         if (alerts.total > 0) {
           core.setOutput("security-alerts-json", JSON.stringify(alerts));
           securityReport = formatSecuritySection(alerts);

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -307,6 +307,11 @@ export function buildEvaluationStoreRow(
   evaluation: GateEvaluation,
 ): Record<string, unknown> {
   const remediation = evaluation.remediation;
+  const agentId = resolveAgentProvenanceId(evaluation);
+  const verdict = buildGateVerdict(evaluation, {
+    trustRuntime: readTrustRuntime(),
+    agentId: agentId ?? undefined,
+  });
   return {
     id: evaluation.id,
     repo_id: evaluation.repoId,
@@ -321,6 +326,7 @@ export function buildEvaluationStoreRow(
     evaluation_ms: evaluation.evaluationMs,
     report_url: evaluation.reportUrl ?? null,
     release_ready: evaluation.releaseReady ?? null,
+    release_ready_reasons: evaluation.releaseReadyReasons ?? null,
     remediation: remediation ?? null,
     loop_round: remediation?.loop_round ?? 0,
     previous_evaluation_id: remediation?.previous_evaluation_id ?? null,
@@ -328,7 +334,14 @@ export function buildEvaluationStoreRow(
     fixes_introduced: remediation?.fixes_introduced ?? [],
     pr: evaluation.pr ?? null,
     policy_override: evaluation.policyOverride ?? null,
-    agent_provenance_id: resolveAgentProvenanceId(evaluation),
+    gate_mode: evaluation.gateMode ?? null,
+    submission_checks: evaluation.submissionChecks ?? null,
+    policy_findings: evaluation.policyFindings ?? null,
+    trust_profile: evaluation.trust_profile ?? null,
+    verdict,
+    ci: evaluation.ci ?? null,
+    context: evaluation.context ?? null,
+    agent_provenance_id: agentId,
   };
 }
 

--- a/src/security.ts
+++ b/src/security.ts
@@ -62,6 +62,61 @@ function normalizeSeverity(alert: CodeScanningAlert): SeverityLevel {
   return "medium";
 }
 
+function normalizeRepoPath(path: string): string {
+  return path.replace(/\\/g, "/").replace(/^\.\//, "");
+}
+
+/** True when the alert's reported path intersects a PR changed file. */
+export function alertTouchesChangedFile(
+  alert: CodeScanningAlert,
+  changedFiles: Set<string>,
+): boolean {
+  const alertPath = alert.most_recent_instance?.location?.path;
+  if (!alertPath) return false;
+
+  const normalized = normalizeRepoPath(alertPath);
+  if (changedFiles.has(normalized)) return true;
+
+  for (const file of changedFiles) {
+    const changed = normalizeRepoPath(file);
+    if (
+      normalized === changed ||
+      normalized.endsWith(`/${changed}`) ||
+      changed.endsWith(`/${normalized}`)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function countAlerts(alerts: CodeScanningAlert[]): SecurityAlertCounts {
+  const counts: SecurityAlertCounts = {
+    critical: 0,
+    high: 0,
+    medium: 0,
+    low: 0,
+    total: alerts.length,
+    topRules: [],
+  };
+
+  const ruleCount = new Map<string, number>();
+
+  for (const alert of alerts) {
+    const sev = normalizeSeverity(alert);
+    const bucket = severityToBucket(sev);
+    counts[bucket]++;
+    ruleCount.set(alert.rule.id, (ruleCount.get(alert.rule.id) ?? 0) + 1);
+  }
+
+  counts.topRules = [...ruleCount.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 5)
+    .map(([ruleId, count]) => `${ruleId} (${count})`);
+
+  return counts;
+}
+
 function severityToBucket(
   severity: SeverityLevel,
 ): keyof Omit<SecurityAlertCounts, "total" | "topRules"> {
@@ -86,9 +141,15 @@ function severityToBucket(
 // Fetch alerts from GitHub Code Scanning API
 // ---------------------------------------------------------------------------
 
+export interface FetchCodeScanningAlertsOptions {
+  /** When set, only alerts touching these PR paths are counted. Empty array → no alerts. */
+  changedFiles?: string[];
+}
+
 export async function fetchCodeScanningAlerts(
   token: string,
   config?: SecurityConfig | null,
+  options?: FetchCodeScanningAlertsOptions,
 ): Promise<SecurityAlertCounts> {
   const empty: SecurityAlertCounts = {
     critical: 0,
@@ -98,6 +159,10 @@ export async function fetchCodeScanningAlerts(
     total: 0,
     topRules: [],
   };
+
+  if (options?.changedFiles !== undefined && options.changedFiles.length === 0) {
+    return empty;
+  }
 
   try {
     const octokit = github.getOctokit(token);
@@ -119,37 +184,19 @@ export async function fetchCodeScanningAlerts(
     const thresholdOrder = SEVERITY_ORDER[threshold] ?? 2;
     const ignoreRules = new Set(config?.ignore_rules ?? []);
 
-    const filtered = alerts.filter((a) => {
+    let filtered = alerts.filter((a) => {
       if (ignoreRules.has(a.rule.id)) return false;
       const sev = normalizeSeverity(a);
       return (SEVERITY_ORDER[sev] ?? 3) <= thresholdOrder;
     });
 
-    const counts: SecurityAlertCounts = {
-      critical: 0,
-      high: 0,
-      medium: 0,
-      low: 0,
-      total: filtered.length,
-      topRules: [],
-    };
-
-    const ruleCount = new Map<string, number>();
-
-    for (const alert of filtered) {
-      const sev = normalizeSeverity(alert);
-      const bucket = severityToBucket(sev);
-      counts[bucket]++;
-
-      ruleCount.set(alert.rule.id, (ruleCount.get(alert.rule.id) ?? 0) + 1);
+    if (options?.changedFiles !== undefined) {
+      const changedSet = new Set(options.changedFiles.map(normalizeRepoPath));
+      filtered = filtered.filter((alert) => alertTouchesChangedFile(alert, changedSet));
+      if (filtered.length === 0) return empty;
     }
 
-    counts.topRules = [...ruleCount.entries()]
-      .sort((a, b) => b[1] - a[1])
-      .slice(0, 5)
-      .map(([ruleId, count]) => `${ruleId} (${count})`);
-
-    return counts;
+    return countAlerts(filtered);
   } catch (error) {
     const msg = String(error);
     if (msg.includes("403") || msg.includes("Advanced Security")) {


### PR DESCRIPTION
## Summary

- **PR-scoped security alerts** — `fetchCodeScanningAlerts` filters Code Scanning results to paths in the PR diff, eliminating repo-wide alert inflation on doc-only changes
- **Agent provenance ID** — `resolveAgentProvenanceId` prefers `agent/<id>/` branches and `provenance.type` over heuristic `source` values like `author/branch/commit-signals`
- **Store row completeness** — `buildEvaluationStoreRow` persists `gate_mode`, `submission_checks`, `policy_findings`, `release_ready_reasons`, `trust_profile`, `verdict`, `ci`, and `context` for warehouse analytics
- **Deploy correlation guard** — deploy tracker example skips `deploy_outcome=success` when the matched evaluation was `block` or `release_ready=false`
- **Migrations** — Komatik + Cloud reference SQL for analytics columns; corrected A5 `agent_provenance_id` backfill

## Komatik follow-up (separate PR)

Copy `docs/komatik-migrations/20260606120000_trailhead_analytics_columns.sql` into Komatik and update `evaluation-store.ts` mapper so new fields land in `trailhead_evaluations`.

## Test plan

- [x] `vitest run` — security, agent-provenance, notify, gate suites (163 tests)
- [ ] Merge to dev; confirm komatik gate run stores `verdict` + `agent_provenance_id` on next agent PR
- [ ] Komatik migration PR for analytics columns


Made with [Cursor](https://cursor.com)