### PR TITLE
chore(release): prepare v4.5.1 (warehouse audit + remediation fix)

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trailhead-app",
-  "version": "4.4.6",
+  "version": "4.5.1",
   "private": true,
   "type": "module",
   "description": "Trailhead GitHub App — Deployment Protection Rule webhook handler",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@komatikai/trailhead",
-  "version": "4.4.6",
+  "version": "4.5.1",
   "description": "Trailhead CLI — setup wizard and utilities for the Trailhead deployment gate",
   "bin": {
     "trailhead": "dist/index.js"

--- a/cloud/package.json
+++ b/cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trailhead-cloud",
-  "version": "4.4.6",
+  "version": "4.5.1",
   "private": true,
   "type": "module",
   "description": "Trailhead Cloud API — evaluation store, org/repo registry, deploy events",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trailhead/mcp-server",
-  "version": "4.4.6",
+  "version": "4.5.1",
   "private": true,
   "description": "MCP server exposing Trailhead deployment gate — health checks, risk scoring, DORA metrics, and policy enforcement as tools",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trailhead",
-  "version": "4.4.6",
+  "version": "4.5.1",
   "private": true,
   "description": "Release readiness gate for GitHub PRs — waits for CI, scores code risk, checks production health, and blocks merges that are not release-ready.",
   "license": "MIT",

--- a/scripts/batch-v4.5.1-rollout-prs.mjs
+++ b/scripts/batch-v4.5.1-rollout-prs.mjs
@@ -1,0 +1,199 @@
+#!/usr/bin/env node
+/**
+ * Pin fleet consumers to Trailhead v4.5.1 (warehouse audit release).
+ *
+ * Usage:
+ *   node scripts/batch-v4.5.1-rollout-prs.mjs
+ *   node scripts/batch-v4.5.1-rollout-prs.mjs --apply
+ *   node scripts/batch-v4.5.1-rollout-prs.mjs --only=komatik,agents
+ */
+
+import { execFileSync } from "node:child_process";
+
+const ORG = "KomatikAI";
+const ACTION_REPO = "KomatikAI/trailhead";
+const BRANCH = "cursor/trailhead-v4.5.1-rollout";
+const WORKFLOW_CANDIDATES = [
+  ".github/workflows/trailhead.yml",
+  ".github/workflows/deployguard.yml",
+];
+const TARGET_VERSION = process.env.TRAILHEAD_ROLLOUT_VERSION || "4.5.1";
+const TARGET_REF = `@v${TARGET_VERSION}`;
+
+const REPOS = [
+  { name: "komatik" },
+  { name: "agents", workflowPath: ".github/workflows/ci.yml" },
+  { name: "cairn" },
+  { name: "frontier" },
+  { name: "kindling" },
+  { name: "pack" },
+  { name: "slipstream" },
+  { name: "sundog" },
+  { name: "trace" },
+];
+
+const args = new Set(process.argv.slice(2));
+const apply = args.has("--apply");
+const onlyArg = process.argv.find((a) => a.startsWith("--only="));
+const onlyList = onlyArg
+  ? new Set(onlyArg.replace("--only=", "").split(",").map((s) => s.trim()).filter(Boolean))
+  : null;
+
+function gh(ghArgs) {
+  return execFileSync("gh", ghArgs, { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }).trim();
+}
+
+function tryGh(ghArgs) {
+  try {
+    return { ok: true, out: gh(ghArgs) };
+  } catch (err) {
+    return { ok: false, err: err.stderr?.toString?.() || err.message || String(err) };
+  }
+}
+
+function getRepoMeta(name) {
+  return JSON.parse(gh(["api", `repos/${ORG}/${name}`, "--jq", "{default_branch, archived}"]));
+}
+
+function getFile(name, ref, path) {
+  const res = tryGh([
+    "api",
+    `repos/${ORG}/${name}/contents/${path}?ref=${ref}`,
+    "--jq",
+    "{sha: .sha, content: .content}",
+  ]);
+  if (!res.ok) return null;
+  const { sha, content: b64 } = JSON.parse(res.out);
+  return { sha, content: Buffer.from(b64, "base64").toString("utf8"), path };
+}
+
+function findWorkflow(name, base, preferredPath) {
+  const paths = preferredPath ? [preferredPath, ...WORKFLOW_CANDIDATES] : WORKFLOW_CANDIDATES;
+  for (const path of [...new Set(paths)]) {
+    const file = getFile(name, base, path);
+    if (file) return file;
+  }
+  return null;
+}
+
+function patchWorkflow(content, { addReleaseReady = false } = {}) {
+  let actionChanged = false;
+  const actionRegex =
+    /(uses:\s*)(?:KomatikAI\/(?:trailhead|deployguard)|dschirmer-shiftkey\/deployguard)@[^\s#]+/g;
+  let next = content.replace(actionRegex, (_, prefix) => {
+    actionChanged = true;
+    return `${prefix}${ACTION_REPO}${TARGET_REF}`;
+  });
+
+  let gateModeChanged = false;
+  if (addReleaseReady && !/gate-mode:\s*["']?release-ready/.test(next)) {
+    next = next.replace(
+      /(uses:\s*KomatikAI\/trailhead@v[^\n]+\n\s+id:\s*gate\n\s+with:\s*\n)/,
+      `$1          gate-mode: "release-ready"\n`,
+    );
+    gateModeChanged = /gate-mode:\s*["']?release-ready/.test(next);
+  }
+
+  const alreadyPinned = new RegExp(
+    `${ACTION_REPO.replace("/", "\\/")}${TARGET_REF.replace(".", "\\.")}`,
+  ).test(content);
+
+  return {
+    content: next,
+    actionChanged: actionChanged && !alreadyPinned,
+    gateModeChanged,
+    alreadyPinned,
+  };
+}
+
+function planRepo({ name, workflowPath }) {
+  const { default_branch: base, archived } = getRepoMeta(name);
+  if (archived) return { base, skip: true, reason: "archived" };
+  const workflow = findWorkflow(name, base, workflowPath);
+  if (!workflow) return { base, skip: true, reason: "no workflow" };
+  const patch = patchWorkflow(workflow.content, { addReleaseReady: name === "komatik" });
+  const noop = !patch.actionChanged && !patch.gateModeChanged;
+  return {
+    base,
+    skip: noop,
+    reason: noop ? `already on ${TARGET_REF}` : null,
+    workflow: { ...workflow, content: patch.content },
+    workflowPath: workflow.path,
+    actionChanged: patch.actionChanged,
+    gateModeChanged: patch.gateModeChanged,
+  };
+}
+
+async function applyRepo({ name }, plan) {
+  const baseSha = gh([
+    "api",
+    `repos/${ORG}/${name}/git/ref/heads/${plan.base}`,
+    "--jq",
+    ".object.sha",
+  ]);
+  tryGh([
+    "api",
+    `repos/${ORG}/${name}/git/refs`,
+    "-f",
+    `ref=refs/heads/${BRANCH}`,
+    "-f",
+    `sha=${baseSha}`,
+  ]);
+  const encoded = Buffer.from(plan.workflow.content, "utf8").toString("base64");
+  const msg = [
+    plan.actionChanged ? `pin ${TARGET_REF}` : null,
+    plan.gateModeChanged ? "gate-mode release-ready" : null,
+  ]
+    .filter(Boolean)
+    .join(" + ");
+  gh([
+    "api",
+    `repos/${ORG}/${name}/contents/${plan.workflowPath}`,
+    "-X",
+    "PUT",
+    "-f",
+    `message=chore(trailhead): ${msg}`,
+    "-f",
+    `content=${encoded}`,
+    "-f",
+    `sha=${plan.workflow.sha}`,
+    "-f",
+    `branch=${BRANCH}`,
+  ]);
+  return gh([
+    "pr",
+    "create",
+    "--repo",
+    `${ORG}/${name}`,
+    "--base",
+    plan.base,
+    "--head",
+    BRANCH,
+    "--title",
+    `chore(trailhead): pin ${TARGET_REF}${plan.gateModeChanged ? " + release-ready mode" : ""}`,
+    "--body",
+    `Pin Trailhead to **${TARGET_REF}** (warehouse audit release #280).\n\nRun \`node scripts/check-fleet-trailhead-pins.mjs\` after merge.`,
+  ]);
+}
+
+const selected = REPOS.filter((r) => !onlyList || onlyList.has(r.name));
+console.log(`Target: ${ACTION_REPO}${TARGET_REF} (${selected.length} repos)\n`);
+
+for (const repo of selected) {
+  const plan = planRepo(repo);
+  if (plan.skip) {
+    console.log(`SKIP ${repo.name}: ${plan.reason}`);
+    continue;
+  }
+  console.log(
+    `PLAN ${repo.name}: ${plan.workflowPath}` +
+      (plan.actionChanged ? " pin" : "") +
+      (plan.gateModeChanged ? " gate-mode" : ""),
+  );
+  if (apply) {
+    const url = await applyRepo(repo, plan);
+    console.log(`  PR ${url}`);
+  }
+}
+
+if (!apply) console.log("\nDry-run — pass --apply to open PRs");

--- a/scripts/check-fleet-trailhead-pins.mjs
+++ b/scripts/check-fleet-trailhead-pins.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+/**
+ * Audit fleet repos for Trailhead action pin drift.
+ *
+ * Fails (exit 1) when any consumer uses @v4 floating, an unexpected tag,
+ * or a tag older than EXPECTED_VERSION.
+ *
+ * Usage:
+ *   node scripts/check-fleet-trailhead-pins.mjs
+ *   EXPECTED_VERSION=4.5.1 node scripts/check-fleet-trailhead-pins.mjs
+ *   node scripts/check-fleet-trailhead-pins.mjs --json
+ */
+
+import { execFileSync } from "node:child_process";
+
+const ORG = "KomatikAI";
+const EXPECTED_VERSION = process.env.EXPECTED_VERSION || "4.5.1";
+const EXPECTED_REF = `@v${EXPECTED_VERSION}`;
+const FLOATING_REF = "@v4";
+const jsonOut = process.argv.includes("--json");
+
+const REPOS = [
+  "komatik",
+  "agents",
+  "cairn",
+  "frontier",
+  "kindling",
+  "pack",
+  "slipstream",
+  "sundog",
+  "trace",
+];
+
+const WORKFLOW_CANDIDATES = [
+  ".github/workflows/trailhead.yml",
+  ".github/workflows/deployguard.yml",
+  ".github/workflows/ci.yml",
+];
+
+const ACTION_REGEX =
+  /uses:\s*(KomatikAI\/(?:trailhead|deployguard)|dschirmer-shiftkey\/deployguard)@([^\s#]+)/g;
+
+function gh(args) {
+  return execFileSync("gh", args, { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }).trim();
+}
+
+function tryGh(args) {
+  try {
+    return { ok: true, out: gh(args) };
+  } catch (err) {
+    return { ok: false, err: err.stderr?.toString?.() || err.message || String(err) };
+  }
+}
+
+function parseVersion(ref) {
+  const m = ref.match(/^v(\d+)\.(\d+)\.(\d+)$/);
+  if (!m) return null;
+  return [Number(m[1]), Number(m[2]), Number(m[3])];
+}
+
+function isOlderThanExpected(ref) {
+  const got = parseVersion(ref);
+  const want = parseVersion(`v${EXPECTED_VERSION}`);
+  if (!got || !want) return false;
+  for (let i = 0; i < 3; i++) {
+    if (got[i] < want[i]) return true;
+    if (got[i] > want[i]) return false;
+  }
+  return false;
+}
+
+function scanRepo(name) {
+  const meta = JSON.parse(
+    gh(["api", `repos/${ORG}/${name}`, "--jq", "{default_branch, archived}"]),
+  );
+  if (meta.archived) {
+    return { name, archived: true, pins: [], issues: [] };
+  }
+
+  const pins = [];
+  const issues = [];
+
+  for (const path of WORKFLOW_CANDIDATES) {
+    const res = tryGh([
+      "api",
+      `repos/${ORG}/${name}/contents/${path}?ref=${meta.default_branch}`,
+      "--jq",
+      ".content",
+    ]);
+    if (!res.ok) continue;
+    const content = Buffer.from(JSON.parse(res.out), "base64").toString("utf8");
+    for (const match of content.matchAll(ACTION_REGEX)) {
+      pins.push({ workflow: path, ref: match[2] });
+    }
+  }
+
+  if (pins.length === 0) {
+    issues.push("no trailhead action ref found");
+    return { name, default_branch: meta.default_branch, pins, issues };
+  }
+
+  for (const pin of pins) {
+    if (pin.ref === "v4" || pin.ref === FLOATING_REF.replace("@", "")) {
+      issues.push(`${pin.workflow}: floating @v4`);
+    } else if (isOlderThanExpected(pin.ref)) {
+      issues.push(`${pin.workflow}: ${pin.ref} older than ${EXPECTED_REF}`);
+    } else if (pin.ref !== `v${EXPECTED_VERSION}`) {
+      issues.push(`${pin.workflow}: ${pin.ref} (expected ${EXPECTED_REF})`);
+    }
+  }
+
+  return { name, default_branch: meta.default_branch, pins, issues };
+}
+
+const results = REPOS.map(scanRepo);
+const failing = results.filter((r) => r.issues.length > 0);
+
+if (jsonOut) {
+  console.log(JSON.stringify({ expected: EXPECTED_REF, results, failing: failing.length }, null, 2));
+} else {
+  console.log(`Expected pin: KomatikAI/trailhead${EXPECTED_REF}\n`);
+  for (const row of results) {
+    if (row.archived) {
+      console.log(`- ${row.name}: archived (skipped)`);
+      continue;
+    }
+    const pinSummary =
+      row.pins.length === 0
+        ? "no workflow"
+        : row.pins.map((p) => `${p.workflow} → @${p.ref}`).join(", ");
+    const status = row.issues.length === 0 ? "ok" : "DRIFT";
+    console.log(`- ${row.name}: ${status} — ${pinSummary}`);
+    for (const issue of row.issues) {
+      console.log(`    · ${issue}`);
+    }
+  }
+  console.log(`\n${failing.length} repo(s) with drift`);
+}
+
+process.exit(failing.length > 0 ? 1 : 0);

--- a/src/__tests__/remediation.test.ts
+++ b/src/__tests__/remediation.test.ts
@@ -208,6 +208,22 @@ describe("buildRemediation", () => {
     });
   });
 
+  describe("release_ready semantics", () => {
+    it("does not trust evaluation.releaseReady when blocking fixes remain", () => {
+      const remediation = buildRemediation({
+        evaluation: evaluationFixture({
+          releaseReady: true,
+          gateDecision: "allow",
+          riskFactors: [
+            factor("test_coverage", 80, { missing_tests: ["src/foo.ts"] }),
+          ],
+        }),
+      });
+      expect(remediation.blocking_count).toBe(1);
+      expect(remediation.release_ready).toBe(false);
+    });
+  });
+
   describe("loop bookkeeping", () => {
     it("computes resolved and introduced codes vs. previous evaluation", () => {
       const previous = {

--- a/src/remediation.ts
+++ b/src/remediation.ts
@@ -328,8 +328,8 @@ export function buildRemediation(input: BuildRemediationInput): Remediation {
   const loopRound = input.loopRound ?? resolveLoopRound(input.previousEvaluation);
   const maxLoopRounds = input.maxLoopRounds ?? 3;
   const releaseReady =
-    input.evaluation.releaseReady ??
-    (input.evaluation.gateDecision !== "block" && blocking_count === 0);
+    blocking_count === 0 &&
+    (input.evaluation.releaseReady ?? input.evaluation.gateDecision !== "block");
 
   const { resolved, introduced } = diffFixCodes(
     dedupedFixes,


### PR DESCRIPTION
## Summary
- Bump package versions to **4.5.1** for npm publish on tag
- Tighten `remediation.release_ready` — blocking fixes always veto `evaluation.releaseReady`
- Add `scripts/check-fleet-trailhead-pins.mjs` and `scripts/batch-v4.5.1-rollout-prs.mjs`

## Test plan
- [x] `vitest run src/__tests__/remediation.test.ts -t "does not trust"`
- [ ] CI green on merge → promote chain → tag `v4.5.1`


Made with [Cursor](https://cursor.com)