### PR TITLE
chore(release): prepare v4.5.2

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trailhead-app",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "private": true,
   "type": "module",
   "description": "Trailhead GitHub App — Deployment Protection Rule webhook handler",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@komatikai/trailhead",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "description": "Trailhead CLI — setup wizard and utilities for the Trailhead deployment gate",
   "bin": {
     "trailhead": "dist/index.js"

--- a/cloud/package.json
+++ b/cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trailhead-cloud",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "private": true,
   "type": "module",
   "description": "Trailhead Cloud API — evaluation store, org/repo registry, deploy events",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trailhead/mcp-server",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "private": true,
   "description": "MCP server exposing Trailhead deployment gate — health checks, risk scoring, DORA metrics, and policy enforcement as tools",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trailhead",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "private": true,
   "description": "Release readiness gate for GitHub PRs — waits for CI, scores code risk, checks production health, and blocks merges that are not release-ready.",
   "license": "MIT",

--- a/scripts/batch-v4.5.1-rollout-prs.mjs
+++ b/scripts/batch-v4.5.1-rollout-prs.mjs
@@ -12,7 +12,8 @@ import { execFileSync } from "node:child_process";
 
 const ORG = "KomatikAI";
 const ACTION_REPO = "KomatikAI/trailhead";
-const BRANCH = "cursor/trailhead-v4.5.1-rollout";
+const BRANCH =
+  process.env.TRAILHEAD_ROLLOUT_BRANCH || `cursor/trailhead-v${TARGET_VERSION}-rollout`;
 const WORKFLOW_CANDIDATES = [
   ".github/workflows/trailhead.yml",
   ".github/workflows/deployguard.yml",

--- a/scripts/check-fleet-trailhead-pins.mjs
+++ b/scripts/check-fleet-trailhead-pins.mjs
@@ -14,7 +14,7 @@
 import { execFileSync } from "node:child_process";
 
 const ORG = "KomatikAI";
-const EXPECTED_VERSION = process.env.EXPECTED_VERSION || "4.5.1";
+const EXPECTED_VERSION = process.env.EXPECTED_VERSION || "4.5.2";
 const EXPECTED_REF = `@v${EXPECTED_VERSION}`;
 const FLOATING_REF = "@v4";
 const jsonOut = process.argv.includes("--json");


### PR DESCRIPTION
Version bump for agents soak risk calibration (#284).

Made with [Cursor](https://cursor.com)