### PR TITLE
chore(deps): bump hono → ^4.12.18 (5 moderate CVEs)

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "trailhead-app",
-  "version": "4.2.1",
+  "version": "4.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "trailhead-app",
-      "version": "4.2.1",
+      "version": "4.5.2",
       "dependencies": {
         "@hono/node-server": "^1.19.13",
         "@octokit/auth-app": "^7.0.0",
         "@octokit/webhooks": "^13.0.0",
-        "hono": "^4.12.15",
+        "hono": "^4.12.18",
         "zod": "^3.24.0"
       },
       "devDependencies": {
@@ -733,9 +733,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.15",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
-      "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
+      "version": "4.12.23",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/app/package.json
+++ b/app/package.json
@@ -14,7 +14,7 @@
     "@hono/node-server": "^1.19.13",
     "@octokit/auth-app": "^7.0.0",
     "@octokit/webhooks": "^13.0.0",
-    "hono": "^4.12.15",
+    "hono": "^4.12.18",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/cloud/package-lock.json
+++ b/cloud/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "trailhead-cloud",
-  "version": "4.2.1",
+  "version": "4.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "trailhead-cloud",
-      "version": "4.2.1",
+      "version": "4.5.2",
       "dependencies": {
         "@hono/node-server": "^1.19.13",
-        "hono": "^4.12.15",
+        "hono": "^4.12.18",
         "zod": "^3.24.0"
       },
       "devDependencies": {

--- a/cloud/package.json
+++ b/cloud/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hono/node-server": "^1.19.13",
-    "hono": "^4.12.15",
+    "hono": "^4.12.18",
     "zod": "^3.24.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## What
Bump `hono` from `^4.12.15` → `^4.12.18` in `app/` and `cloud/`, regenerate both lockfiles.

- Lockfiles were pinning **hono 4.12.15** (vulnerable); now resolve **4.12.23** (app) / **4.12.22** (cloud) — both ≥ 4.12.18.
- No npm workspaces, so each package's `package-lock.json` was updated independently (`npm install --package-lock-only`).

## Why — 5 moderate advisories fixed in 4.12.18
- `GHSA-9vqf-7f2p-gf9v` — bodyLimit() bypass for chunked requests (CVSS 6.5)
- `GHSA-xrhx-7g5j-rcj5` — IP-restriction bypass for non-canonical IPv6 (CVSS 5.9)
- `GHSA-p77w-8qqv-26rm` — cache middleware ignores Vary headers (CVSS 5.3)
- `GHSA-69xw-7hcm-h432` — unvalidated JSX tag names (CVSS 4.7)
- `GHSA-qp7p-654g-cw7p` — CSS injection via style object values (CVSS 4.3)

Dependency-only change. Closes the `pipeline-ops` suggestion *"Hono Dependency Upgrade — Security Vulnerability Fix."*

🤖 Generated with [Claude Code](https://claude.com/claude-code)