### PR TITLE
ci(security-guard): trigger on labeled/unlabeled so the override clears immediately

### DIFF
--- a/.github/workflows/security-guard.yml
+++ b/.github/workflows/security-guard.yml
@@ -12,6 +12,10 @@ name: security-guard
 
 on:
   pull_request:
+    # `labeled`/`unlabeled` so a maintainer's `security-reviewed` label re-runs the
+    # guard immediately (it reads labels from the event payload). Without these, the
+    # label only takes effect on the next synchronize, forcing an empty-commit dance.
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     branches: [dev, staging, main]
   # Reusable across repos: a consumer adds a 3-line caller (see docs/SECURITY-GUARD.md).
   workflow_call: {}


### PR DESCRIPTION
## What
Add `types: [opened, synchronize, reopened, labeled, unlabeled]` to `security-guard.yml`'s `pull_request` trigger.

## Why
`security-guard.mjs` reads the `security-reviewed` label from the **event payload** (`$GITHUB_EVENT_PATH` → `pull_request.labels`). The workflow had no `types:`, so it defaulted to `opened`/`synchronize`/`reopened` — meaning:
- adding the label **didn't** re-run the guard, and
- `gh run rerun` replays the *original* (label-less) payload, so it stays blocked.

The override only landed on the next `synchronize` (the empty-commit workaround used on #288). Adding `labeled` makes a maintainer's sign-off clear the check **immediately**; `unlabeled` re-blocks if the label is pulled. No change to guard logic — same `reviewed = labels.includes("security-reviewed")` override path.

## Heads-up (expected)
This PR **edits a workflow file**, which is one of the high-risk classes `security-guard` itself flags — so the guard will block *this* PR too. Clearing it still needs the pre-fix dance (label + a synchronize), since the fix isn't merged yet. After it merges, the label alone clears future PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)