### PR TITLE
feat(gate-3): health_score warn-only — stop blocking release on a noisy factor

### DIFF
--- a/src/__tests__/release-ready.test.ts
+++ b/src/__tests__/release-ready.test.ts
@@ -29,6 +29,27 @@ describe("computeReleaseReady", () => {
     expect(result.reasons).toHaveLength(0);
   });
 
+  it("does NOT block on low health_score (GATE-3: warn-only)", () => {
+    const result = computeReleaseReady({
+      gateMode: "release-ready",
+      gateDecision: "allow",
+      riskScore: 40,
+      riskThreshold: 70,
+      healthScore: 20,
+      healthChecksConfigured: true,
+      ciSummary: {
+        checks: [],
+        allRequiredPassed: true,
+        pendingCount: 0,
+        failedCount: 0,
+        missingCount: 0,
+      },
+      freezeActive: false,
+    });
+    expect(result.releaseReady).toBe(true);
+    expect(result.reasons.some((r) => /health/i.test(r))).toBe(false);
+  });
+
   it("fails when required CI check failed", () => {
     const result = computeReleaseReady({
       gateMode: "release-ready",

--- a/src/release-ready.ts
+++ b/src/release-ready.ts
@@ -72,9 +72,12 @@ export function computeReleaseReady(input: ReleaseReadyInput): ReleaseReadyResul
     );
   }
 
-  if (input.healthChecksConfigured && input.healthScore < 50) {
-    reasons.push(`Health score ${input.healthScore} below minimum (50)`);
-  }
+  // health_score is WARN-ONLY (GATE-3): it no longer blocks release-readiness.
+  // Rationale: across 1,500+ stored evaluations health_score barely discriminates
+  // (release_ready true=88.1 vs false=81.8 → ~6pt = noise) while risk_score carries
+  // the signal (44.2 vs 78.9 → ~35pt). A low health_score still surfaces as a `warn`
+  // gate decision (see decideGate in risk-engine.ts: `healthScore < 50` → "warn"),
+  // so the genuine-outage signal stays visible — it just doesn't flip releaseReady.
 
   if (input.requireSecurityClear && input.securityBlocked) {
     reasons.push("Security gate requires clearance — blocking alerts present");


### PR DESCRIPTION
## GATE-3, Phase 1 — data-grounded
Stops `health_score` from blocking release-readiness. It stays a **warn** signal, just not a blocker.

### Why (current `trailhead_evaluations`, 1,500+ evals)
| release_ready | n | avg health | avg risk |
|---|---|---|---|
| true | 375 | 88.1 | **44.2** |
| false | 168 | 81.8 | **78.9** |

health_score spread = **6.3pt (noise)**; risk_score spread = **34.7pt (signal)**. So health_score's release-blocking role added false-positives without discriminating.

### Change
- `release-ready.ts`: removed the `healthScore < 50 → not release-ready` reason.
- `decideGate` (risk-engine.ts) **unchanged** — `healthScore < 50 → "warn"` stays, so a genuine outage still surfaces as an advisory warn; it just won't flip `releaseReady`.
- +1 test (warn-only health); 169 gate/risk/release-ready tests pass; typecheck clean.

## Honest scope notes on the other two phases
- **Phase 2 (risk_factor severity penalties): not shipped — doesn't fit the code.** `computeRiskScore` factors carry no `detail.severity`, so the suggestion's `filter(f => f.detail.severity === 'critical')` matches nothing (no-op). The real weakness is that the final score is a **weighted average** (`weightedAverageScores`) that dilutes any single high-risk factor — the right fix is *critical-factor hard-escalation* (bypass the average → block), a separate design change worth doing deliberately, not bolting on speculative penalties with no validation data.
- **Phase 3 (threshold recalibration): blocked.** `deploy_outcome` has **614 `success`, 0 `failed`/`incident`** — there is no failure signal to calibrate a threshold against. The self-labeling loop is capturing successes but no failures; that gap must close before any data-driven threshold move.

@security-gate note: this edits gate logic, so `security-guard` will (correctly) block until a maintainer adds `security-reviewed`. Thanks to #289 the label now clears it immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)