### PR TITLE
feat(gate-3): critical-factor hard-escalation (sensitive_files + security precision)

### DIFF
--- a/src/__tests__/cross-repo-impact.test.ts
+++ b/src/__tests__/cross-repo-impact.test.ts
@@ -77,6 +77,7 @@ const baseConfig = {
     },
     duplicate_logic: { enabled: true, mode: "warn" },
     cross_repo_impact: { enabled: true, mode: "warn" as const },
+    sensitive_files: { enabled: true, mode: "warn" as const, threshold: 100 },
   },
 } satisfies RepoConfig;
 

--- a/src/__tests__/risk-engine.test.ts
+++ b/src/__tests__/risk-engine.test.ts
@@ -36,13 +36,20 @@ describe("decideSensitiveFilesEscalation (GATE-3 2b)", () => {
     expect(r.warn).toBe(false);
   });
   it("does not escalate below threshold", () => {
-    expect(decideSensitiveFilesEscalation(mild)).toMatchObject({ block: false, warn: false, reason: null });
+    expect(decideSensitiveFilesEscalation(mild)).toMatchObject({
+      block: false,
+      warn: false,
+      reason: null,
+    });
   });
   it("honors a custom threshold", () => {
     expect(decideSensitiveFilesEscalation(mild, { threshold: 50 }).warn).toBe(true);
   });
   it("never escalates on non-sensitive factors (noise excluded by design)", () => {
-    expect(decideSensitiveFilesEscalation(other)).toMatchObject({ block: false, warn: false });
+    expect(decideSensitiveFilesEscalation(other)).toMatchObject({
+      block: false,
+      warn: false,
+    });
   });
   it("respects enabled:false", () => {
     expect(decideSensitiveFilesEscalation(crit, { enabled: false }).warn).toBe(false);

--- a/src/__tests__/risk-engine.test.ts
+++ b/src/__tests__/risk-engine.test.ts
@@ -15,8 +15,39 @@ import {
   isInFreezeWindow,
   computeSecurityFactor,
   computeDeploymentHistoryFactor,
+  decideSensitiveFilesEscalation,
   FACTOR_WEIGHTS,
 } from "../risk-engine.js";
+
+describe("decideSensitiveFilesEscalation (GATE-3 2b)", () => {
+  const crit = [{ type: "sensitive_files", score: 100 }];
+  const mild = [{ type: "sensitive_files", score: 75 }];
+  const other = [{ type: "code_churn", score: 100 }];
+
+  it("warns by default at/above threshold (soak mode)", () => {
+    const r = decideSensitiveFilesEscalation(crit);
+    expect(r.warn).toBe(true);
+    expect(r.block).toBe(false);
+    expect(r.reason).toMatch(/sensitive_files score 100/);
+  });
+  it("blocks when mode is block", () => {
+    const r = decideSensitiveFilesEscalation(crit, { mode: "block" });
+    expect(r.block).toBe(true);
+    expect(r.warn).toBe(false);
+  });
+  it("does not escalate below threshold", () => {
+    expect(decideSensitiveFilesEscalation(mild)).toMatchObject({ block: false, warn: false, reason: null });
+  });
+  it("honors a custom threshold", () => {
+    expect(decideSensitiveFilesEscalation(mild, { threshold: 50 }).warn).toBe(true);
+  });
+  it("never escalates on non-sensitive factors (noise excluded by design)", () => {
+    expect(decideSensitiveFilesEscalation(other)).toMatchObject({ block: false, warn: false });
+  });
+  it("respects enabled:false", () => {
+    expect(decideSensitiveFilesEscalation(crit, { enabled: false }).warn).toBe(false);
+  });
+});
 
 describe("risk-engine", () => {
   describe("matchesGlobs", () => {

--- a/src/__tests__/security.test.ts
+++ b/src/__tests__/security.test.ts
@@ -32,17 +32,11 @@ describe("decideSecurityBlock (GATE-3 2a)", () => {
 
   it("block_on_critical blocks ONLY on critical alerts, not low/medium total", () => {
     // 3 non-critical alerts, block_on_critical on → must NOT block (the old total>0 bug)
-    expect(
-      decideSecurityBlock(counts(0, 3), { blockOnCritical: true }),
-    ).toBe(false);
-    expect(
-      decideSecurityBlock(counts(1, 3), { blockOnCritical: true }),
-    ).toBe(true);
+    expect(decideSecurityBlock(counts(0, 3), { blockOnCritical: true })).toBe(false);
+    expect(decideSecurityBlock(counts(1, 3), { blockOnCritical: true })).toBe(true);
   });
   it("require_security_clear blocks on ANY alert (clear-all semantics)", () => {
-    expect(
-      decideSecurityBlock(counts(0, 2), { requireSecurityClear: true }),
-    ).toBe(true);
+    expect(decideSecurityBlock(counts(0, 2), { requireSecurityClear: true })).toBe(true);
   });
   it("no policy / no alerts → no block", () => {
     expect(decideSecurityBlock(counts(5, 9), {})).toBe(false);

--- a/src/__tests__/security.test.ts
+++ b/src/__tests__/security.test.ts
@@ -19,10 +19,35 @@ import {
   fetchCodeScanningAlerts,
   computeSecurityRiskFactor,
   formatSecuritySection,
+  decideSecurityBlock,
 } from "../security.js";
 
 beforeEach(() => {
   vi.clearAllMocks();
+});
+
+describe("decideSecurityBlock (GATE-3 2a)", () => {
+  const counts = (critical: number, total: number) =>
+    ({ critical, high: 0, medium: 0, low: 0, total, topRules: [] }) as never;
+
+  it("block_on_critical blocks ONLY on critical alerts, not low/medium total", () => {
+    // 3 non-critical alerts, block_on_critical on → must NOT block (the old total>0 bug)
+    expect(
+      decideSecurityBlock(counts(0, 3), { blockOnCritical: true }),
+    ).toBe(false);
+    expect(
+      decideSecurityBlock(counts(1, 3), { blockOnCritical: true }),
+    ).toBe(true);
+  });
+  it("require_security_clear blocks on ANY alert (clear-all semantics)", () => {
+    expect(
+      decideSecurityBlock(counts(0, 2), { requireSecurityClear: true }),
+    ).toBe(true);
+  });
+  it("no policy / no alerts → no block", () => {
+    expect(decideSecurityBlock(counts(5, 9), {})).toBe(false);
+    expect(decideSecurityBlock(null, { blockOnCritical: true })).toBe(false);
+  });
 });
 
 describe("alertTouchesChangedFile", () => {

--- a/src/gate.ts
+++ b/src/gate.ts
@@ -41,6 +41,7 @@ import {
   weightedAverageScores,
   detectDependencyChanges,
   decideGate,
+  decideSensitiveFilesEscalation,
   isSensitiveFile,
   matchesGlobs,
   matchRiskProfile,
@@ -50,7 +51,11 @@ import {
   type FileInfo,
   type RiskFactorResult,
 } from "./risk-engine.js";
-import { fetchCodeScanningAlerts, computeSecurityRiskFactor } from "./security.js";
+import {
+  fetchCodeScanningAlerts,
+  computeSecurityRiskFactor,
+  decideSecurityBlock,
+} from "./security.js";
 import {
   buildRemediation,
   formatAgentBrief,
@@ -1830,8 +1835,16 @@ export async function evaluateGate(
         adjustedRiskThreshold,
         effectiveWarnThreshold,
       ) as GateDecision);
+  // GATE-3 (2b): critical sensitive_files change escalates out of the risk average.
+  const sensitiveEscalation = decideSensitiveFilesEscalation(
+    riskFactors,
+    repoConfig?.policies?.sensitive_files,
+  );
+  if (sensitiveEscalation.reason) policyFindings.push(sensitiveEscalation.reason);
+
   const gateDecision =
     agentPolicy?.forceBlock === true ||
+    sensitiveEscalation.block ||
     (ciIntegrity.blockingPatterns.length > 0 &&
       (ciIntegrityConfig?.mode ?? "block") === "block") ||
     (workflowSecurity.blockingPatterns.length > 0 &&
@@ -1852,7 +1865,9 @@ export async function evaluateGate(
     (submissionChecks.length > 0 &&
       submissionGateShouldBlock(submissionChecks, submissionMode))
       ? ("block" as GateDecision)
-      : baselineDecision;
+      : sensitiveEscalation.warn && baselineDecision === "allow"
+        ? ("warn" as GateDecision)
+        : baselineDecision;
 
   if (ciIntegrity.blockingPatterns.length > 0) {
     policyFindings.push(
@@ -2054,11 +2069,11 @@ export async function evaluateGate(
     }
   }
 
-  const securityBlocked =
-    securityAlerts !== null &&
-    securityAlerts.total > 0 &&
-    (envConfig?.require_security_clear === true ||
-      repoConfig?.security?.block_on_critical === true);
+  // GATE-3 (2a): block_on_critical keys on CRITICAL severity (not raw total).
+  const securityBlocked = decideSecurityBlock(securityAlerts, {
+    requireSecurityClear: envConfig?.require_security_clear === true,
+    blockOnCritical: repoConfig?.security?.block_on_critical === true,
+  });
 
   const releaseResult = computeReleaseReady({
     gateMode,

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ export {
   detectDependencyChanges,
   computeSecurityFactor,
   computeDeploymentHistoryFactor,
+  decideSensitiveFilesEscalation,
 } from "./risk-engine.js";
 export type {
   FileInfo,
@@ -36,6 +37,7 @@ export type {
 export {
   fetchCodeScanningAlerts,
   computeSecurityRiskFactor,
+  decideSecurityBlock,
   formatSecuritySection,
 } from "./security.js";
 export {

--- a/src/risk-engine.ts
+++ b/src/risk-engine.ts
@@ -635,6 +635,34 @@ export function decideGate(
   return "allow";
 }
 
+/**
+ * GATE-3 (2b): critical-factor hard-escalation for sensitive_files.
+ *
+ * The final risk score is a weighted AVERAGE, so a single critical factor can be
+ * diluted by clean ones. Most genuinely-critical conditions (destructive SQL,
+ * supply-chain critical vulns, prompt injection, CI/workflow integrity) already
+ * bypass the average via forceBlock. `sensitive_files` did NOT — a change touching
+ * auth/payment/infra-critical files (score up to 100) only fed the average.
+ *
+ * This escalates it OUT of the average: at/above the threshold it forces at least
+ * a warn (mode: "warn", the soak default) or a block (mode: "block"). Scoped to
+ * the sensitive_files factor by design — the noisy factors (file_count, code_churn,
+ * test_coverage, external deps, mock/placeholder) must never escalate.
+ */
+export function decideSensitiveFilesEscalation(
+  factors: Pick<RiskFactorResult, "type" | "score">[],
+  cfg?: { enabled?: boolean; mode?: "warn" | "block"; threshold?: number } | null,
+): { block: boolean; warn: boolean; reason: string | null } {
+  const none = { block: false, warn: false, reason: null };
+  if (cfg?.enabled === false) return none;
+  const factor = factors.find((f) => f.type === "sensitive_files");
+  const threshold = cfg?.threshold ?? 100;
+  if (!factor || factor.score < threshold) return none;
+  const mode = cfg?.mode ?? "warn";
+  const reason = `Sensitive-file change at critical level (sensitive_files score ${factor.score} ≥ ${threshold}) — escalated out of the risk average (${mode}).`;
+  return { block: mode === "block", warn: mode === "warn", reason };
+}
+
 // ---------------------------------------------------------------------------
 // Rollback detection
 // ---------------------------------------------------------------------------

--- a/src/security.ts
+++ b/src/security.ts
@@ -230,6 +230,28 @@ export function computeSecurityRiskFactor(
   return factor;
 }
 
+/**
+ * GATE-3 (2a): decide whether security alerts should block release.
+ *
+ * Two distinct policies — keyed on the RIGHT severity, not raw total:
+ *  - `requireSecurityClear`: gate until ALL alerts are cleared (any severity) — total > 0.
+ *  - `blockOnCritical`: block ONLY on critical-severity alerts — critical > 0.
+ *
+ * Previously the gate keyed `block_on_critical` off `total > 0`, so (since
+ * block_on_critical defaults to true) any low/medium alert blocked release —
+ * an over-flag. This matches computeSecurityRiskFactor, which already keys on
+ * `alerts.critical > 0`.
+ */
+export function decideSecurityBlock(
+  alerts: SecurityAlertCounts | null,
+  opts: { requireSecurityClear?: boolean; blockOnCritical?: boolean },
+): boolean {
+  if (!alerts) return false;
+  if (opts.requireSecurityClear && alerts.total > 0) return true;
+  if (opts.blockOnCritical && alerts.critical > 0) return true;
+  return false;
+}
+
 // ---------------------------------------------------------------------------
 // Markdown section for report
 // ---------------------------------------------------------------------------

--- a/src/types.ts
+++ b/src/types.ts
@@ -626,6 +626,15 @@ export const RepoConfig = z.object({
           consumer_registry_path: z.string().optional(),
         })
         .default({}),
+      // GATE-3 (2b): escalate a critical sensitive_files change OUT of the risk
+      // average. Default mode "warn" (soak) — flip to "block" per repo when ready.
+      sensitive_files: z
+        .object({
+          enabled: z.boolean().default(true),
+          mode: z.enum(["warn", "block"]).default("warn"),
+          threshold: z.number().min(0).max(100).default(100),
+        })
+        .default({}),
     })
     .default({}),
 });


### PR DESCRIPTION
## GATE-3, Phase 2 (reframed) — the genuine version
Scoping found hard-escalation is **mostly already built**: `gateDecision` is a `forceBlock` OR that bypasses the diluting weighted-average for destructive SQL, supply-chain critical vulns, prompt injection, CI/workflow integrity, agent policy, session, pr-scope, etc. Two real gaps remained — both fixed here as **pure, unit-tested helpers**.

### 2a — `security_alerts` precision (`decideSecurityBlock`)
`securityBlocked` keyed `block_on_critical` off `total > 0`. Since `block_on_critical` **defaults to true**, *any* low/medium alert blocked release — an over-flag. Now:
- `block_on_critical` → blocks only when **critical-severity > 0** (matches `computeSecurityRiskFactor`, security.ts:222)
- `require_security_clear` → keeps **clear-all** (`total > 0`) semantics

Net: fewer false blocks on non-critical alerts.

### 2b — `sensitive_files` escalation (`decideSensitiveFilesEscalation`)
A change touching auth/payment/infra-critical files (factor score up to 100) only fed the **average** and could be diluted to a pass. Now it escalates *out* of the average:
- at/above threshold (default **100**) → forces at least **warn** (mode `"warn"`, the **soak default**) or **block** (mode `"block"`), folded into the existing forceBlock chain
- **scoped to `sensitive_files` by design** — the noisy factors (`file_count`, `code_churn`, `test_coverage`, deps, mock/placeholder) never escalate (the FP allowlist)
- honors the global gate mode; warn-default means it's observable in soak before any flip to block

New config: `policies.sensitive_files { enabled, mode: warn|block (default warn), threshold (default 100) }`.

### Validation
- `decideSecurityBlock` + `decideSensitiveFilesEscalation` unit-tested (severity precision, threshold, mode, FP-exclusion, enabled:false)
- **Full suite: 806 tests / 60 files pass**; typecheck clean

### Deliberately deferred
Phase 3 (threshold recalibration) stays blocked — `deploy_outcome` has 614 `success` / 0 `failed`, no failure signal to calibrate against. Default modes here are **warn** (soak), to be flipped to block per the same baseline-data discipline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)