### PR TITLE
chore(release): v4.5.4 — publish the CLI (fix version drift)

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@komatikai/trailhead",
-  "version": "4.4.6",
+  "version": "4.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@komatikai/trailhead",
-      "version": "4.4.6",
+      "version": "4.5.4",
       "license": "MIT",
       "dependencies": {
         "@swc/core": "^1.15.40"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@komatikai/trailhead",
-  "version": "4.5.2",
+  "version": "4.5.4",
   "description": "Trailhead CLI — setup wizard and utilities for the Trailhead deployment gate",
   "bin": {
     "trailhead": "dist/index.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trailhead",
-  "version": "4.5.3",
+  "version": "4.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "trailhead",
-      "version": "4.5.3",
+      "version": "4.5.4",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trailhead",
-  "version": "4.5.3",
+  "version": "4.5.4",
   "private": true,
   "description": "Release readiness gate for GitHub PRs — waits for CI, scores code risk, checks production health, and blocks merges that are not release-ready.",
   "license": "MIT",
@@ -16,6 +16,7 @@
   "scripts": {
     "build": "ncc build src/main.ts -o dist --source-map --license licenses.txt && node scripts/copy-swc-bindings.mjs",
     "build:cli": "node scripts/build-cli-bundle.mjs",
+    "version": "npm --prefix cli version \"$npm_package_version\" --no-git-tag-version --allow-same-version && git add cli/package.json cli/package-lock.json",
     "typecheck": "tsc --noEmit",
     "lint": "eslint . && tsc --noEmit",
     "format": "prettier --write .",


### PR DESCRIPTION
v4.5.3's CLI publish failed (cli sub-package still 4.5.2, already on npm). Bump root+cli to 4.5.4 + add a version-sync script so they never drift again. Tagging v4.5.4 republishes the CLI; Action code is unchanged from v4.5.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)