### PR TITLE
promote: dev → staging (IP-hygiene: genericize internal refs)

### DIFF
--- a/app/src/submission-checks/detectors.ts
+++ b/app/src/submission-checks/detectors.ts
@@ -1,4 +1,4 @@
-// Gate 1 detectors — ported from komatik-agents agent-gate-checks (patch/content based).
+// Gate 1 detectors (patch/content based).
 
 import type { SubmissionCheckResult, SubmissionCheckCode } from "../types.js";
 import type { SubmissionCheckContext } from "./types.js";
@@ -316,11 +316,18 @@ export function detectPathFormat(
   ctx: SubmissionCheckContext,
 ): SubmissionCheckResult | null {
   if (!ctx.komatikInstance) return null;
+  // A path that leaks a repo-name prefix before the canonical
+  // agents/<id>/suggestions/… convention is malformed. Use the configured home
+  // repo if set, otherwise match any repo-name segment generically — no
+  // hardcoded org repo.
+  const repoPrefixed = ctx.agentRepo
+    ? new RegExp(`^${ctx.agentRepo.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}/agents/`)
+    : /^[a-z][a-z0-9-]*\/agents\/[a-z][a-z0-9-]*\/suggestions\//;
   const hits = ctx.files
     .map((f) => normalizePath(f.filename))
     .filter(
       (name) =>
-        /^komatik-agents\/agents\//.test(name) ||
+        repoPrefixed.test(name) ||
         /\/agents\/agents\//.test(name) ||
         (!/^agents\/[a-z][a-z0-9-]*\/suggestions\//.test(name) &&
           /\/suggestions\//.test(name) &&

--- a/app/src/submission-checks/phase0-detectors.ts
+++ b/app/src/submission-checks/phase0-detectors.ts
@@ -1,5 +1,5 @@
 // Phase 0 agent suggestion checks (weight=0 / advisory in Trailhead).
-// Ported from komatik-agents agent-gate-checks Phase 0 stubs with real heuristics.
+// Heuristic detectors for agent-authored suggestion quality.
 
 import type { SubmissionCheckResult } from "../types.js";
 import type { SubmissionCheckContext, SubmissionFileInfo } from "./types.js";
@@ -375,7 +375,14 @@ export function detectExternalInterfaceValidation(
   const hits: string[] = [];
   for (const file of suggestionMarkdownFiles(ctx)) {
     const path = normalizePath(file.filename);
-    const crossRepo = /suggestions\/(?!komatik-agents)[^/]+\//.test(path);
+    // "Cross-repo" = a suggestion targeting a repo other than the configured home
+    // repo. With no home repo set (the public default), there's no cross-repo
+    // concept, so the check is inert.
+    const crossRepo = ctx.agentRepo
+      ? new RegExp(
+          `suggestions/(?!${ctx.agentRepo.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")})[^/]+/`,
+        ).test(path)
+      : false;
     if (!crossRepo) continue;
     const text = fileContent(file);
     if (!PROPOSAL_ONLY.test(text) && !SCHEMA_LINK.test(text)) {

--- a/app/src/submission-checks/types.ts
+++ b/app/src/submission-checks/types.ts
@@ -21,6 +21,12 @@ export interface SubmissionCheckContext {
   files: SubmissionFileInfo[];
   prPaths: Set<string>;
   komatikInstance: boolean;
+  /**
+   * Optional "home" repo slug for the agent-suggestions convention. When set,
+   * cross-repo suggestion detection treats this repo as home. Unset (the public
+   * default) disables home-repo-specific checks. Wired from AGENT_SUGGESTIONS_REPO.
+   */
+  agentRepo?: string;
   staleTerms: string[];
   namingAllowlist: NamingAllowlistConfig;
   authRouteAllowlist: string[];

--- a/app/src/submission-engine.ts
+++ b/app/src/submission-engine.ts
@@ -46,6 +46,8 @@ export interface SubmissionEngineOptions {
   files: import("./submission-checks/types.js").SubmissionFileInfo[];
   repoConfig?: RepoConfig | null;
   komatikInstance?: boolean;
+  /** Home repo slug for the agent-suggestions convention (cross-repo detection). */
+  agentRepo?: string;
   mode?: "warn" | "block";
   /** Declared npm package names from root package.json (optional). */
   declaredPackages?: string[];
@@ -62,7 +64,7 @@ export interface SubmissionEngineOptions {
 }
 
 function buildContext(options: SubmissionEngineOptions): SubmissionCheckContext {
-  const { files, repoConfig, komatikInstance = false } = options;
+  const { files, repoConfig, komatikInstance = false, agentRepo } = options;
   const staleTerms = repoConfig?.submission?.stale_terms ?? [];
 
   const declared = new Set(options.declaredPackages ?? []);
@@ -79,6 +81,7 @@ function buildContext(options: SubmissionEngineOptions): SubmissionCheckContext 
     files,
     prPaths: prPathSet(files),
     komatikInstance,
+    agentRepo,
     staleTerms,
     namingAllowlist: repoConfig?.submission?.naming_allowlist ?? {},
     authRouteAllowlist:

--- a/cli/README.md
+++ b/cli/README.md
@@ -66,7 +66,7 @@ Exit code `0` when there are no errors; `1` when config is missing/invalid or st
 
 ### `trailhead validate-submission`
 
-Runs the canonical Gate 1 engine on a JSON payload of files (used by komatik-agents and MCP). See `cli/src/index.ts` for input shape.
+Runs the canonical Gate 1 engine on a JSON payload of files (used by CI integrations and MCP). See `cli/src/index.ts` for input shape.
 
 ## Development (this repo)
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -41933,7 +41933,7 @@ const SubmissionCheckCode = enumType([
     "destructive_change",
     "claim_anchoring",
     "promotion_coherence",
-    // Phase 0 — agent suggestion quality (advisory / weight=0 in komatik-agents)
+    // Phase 0 — agent suggestion quality (advisory / weight=0)
     "output_size_min",
     "action_extraction_present",
     "delta_section_present",
@@ -44082,7 +44082,7 @@ function linesForFreshnessScan(file) {
 
 ;// CONCATENATED MODULE: ./src/submission-checks/phase0-detectors.ts
 // Phase 0 agent suggestion checks (weight=0 / advisory in Trailhead).
-// Ported from komatik-agents agent-gate-checks Phase 0 stubs with real heuristics.
+// Heuristic detectors for agent-authored suggestion quality.
 
 const SEVERITY = "advisory";
 const OUTPUT_SIZE_MIN_CHARS = 400;
@@ -44413,7 +44413,12 @@ function detectExternalInterfaceValidation(ctx) {
     const hits = [];
     for (const file of suggestionMarkdownFiles(ctx)) {
         const path = normalizePath(file.filename);
-        const crossRepo = /suggestions\/(?!komatik-agents)[^/]+\//.test(path);
+        // "Cross-repo" = a suggestion targeting a repo other than the configured home
+        // repo. With no home repo set (the public default), there's no cross-repo
+        // concept, so the check is inert.
+        const crossRepo = ctx.agentRepo
+            ? new RegExp(`suggestions/(?!${ctx.agentRepo.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")})[^/]+/`).test(path)
+            : false;
         if (!crossRepo)
             continue;
         const text = fileContent(file);
@@ -48970,7 +48975,7 @@ function getSubmissionConfigWarnings(submission) {
 }
 
 ;// CONCATENATED MODULE: ./src/submission-checks/detectors.ts
-// Gate 1 detectors — ported from komatik-agents agent-gate-checks (patch/content based).
+// Gate 1 detectors (patch/content based).
 
 
 
@@ -49224,9 +49229,16 @@ function detectContextFreshness(ctx) {
 function detectPathFormat(ctx) {
     if (!ctx.komatikInstance)
         return null;
+    // A path that leaks a repo-name prefix before the canonical
+    // agents/<id>/suggestions/… convention is malformed. Use the configured home
+    // repo if set, otherwise match any repo-name segment generically — no
+    // hardcoded org repo.
+    const repoPrefixed = ctx.agentRepo
+        ? new RegExp(`^${ctx.agentRepo.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}/agents/`)
+        : /^[a-z][a-z0-9-]*\/agents\/[a-z][a-z0-9-]*\/suggestions\//;
     const hits = ctx.files
         .map((f) => normalizePath(f.filename))
-        .filter((name) => /^komatik-agents\/agents\//.test(name) ||
+        .filter((name) => repoPrefixed.test(name) ||
         /\/agents\/agents\//.test(name) ||
         (!/^agents\/[a-z][a-z0-9-]*\/suggestions\//.test(name) &&
             /\/suggestions\//.test(name) &&
@@ -49567,7 +49579,7 @@ function declaredPackageNamesFromPackageJson(pkg) {
     return sections.flatMap((key) => Object.keys(pkg[key] ?? {}));
 }
 function buildContext(options) {
-    const { files, repoConfig, komatikInstance = false } = options;
+    const { files, repoConfig, komatikInstance = false, agentRepo } = options;
     const staleTerms = repoConfig?.submission?.stale_terms ?? [];
     const declared = new Set(options.declaredPackages ?? []);
     const { policy } = resolveDetectorPolicy(repoConfig?.submission);
@@ -49581,6 +49593,7 @@ function buildContext(options) {
         files,
         prPaths: prPathSet(files),
         komatikInstance,
+        agentRepo,
         staleTerms,
         namingAllowlist: repoConfig?.submission?.naming_allowlist ?? {},
         authRouteAllowlist: repoConfig?.submission?.auth_route_allowlist ?? DEFAULT_AUTH_ROUTE_ALLOWLIST,
@@ -52023,6 +52036,7 @@ async function evaluateGate(config, commitSha, prNumber) {
             })),
             repoConfig,
             komatikInstance: process.env.KOMATIK_INSTANCE === "true",
+            agentRepo: process.env.AGENT_SUGGESTIONS_REPO || undefined,
             mode: submissionMode,
             declaredPackages: parseDeclaredPackages(process.env.TRAILHEAD_DECLARED_PACKAGES),
             catalogKnownEntities,

--- a/mcp/src/submission-checks/detectors.ts
+++ b/mcp/src/submission-checks/detectors.ts
@@ -1,4 +1,4 @@
-// Gate 1 detectors — ported from komatik-agents agent-gate-checks (patch/content based).
+// Gate 1 detectors (patch/content based).
 
 import type { SubmissionCheckResult, SubmissionCheckCode } from "../types.js";
 import type { SubmissionCheckContext } from "./types.js";
@@ -316,11 +316,18 @@ export function detectPathFormat(
   ctx: SubmissionCheckContext,
 ): SubmissionCheckResult | null {
   if (!ctx.komatikInstance) return null;
+  // A path that leaks a repo-name prefix before the canonical
+  // agents/<id>/suggestions/… convention is malformed. Use the configured home
+  // repo if set, otherwise match any repo-name segment generically — no
+  // hardcoded org repo.
+  const repoPrefixed = ctx.agentRepo
+    ? new RegExp(`^${ctx.agentRepo.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}/agents/`)
+    : /^[a-z][a-z0-9-]*\/agents\/[a-z][a-z0-9-]*\/suggestions\//;
   const hits = ctx.files
     .map((f) => normalizePath(f.filename))
     .filter(
       (name) =>
-        /^komatik-agents\/agents\//.test(name) ||
+        repoPrefixed.test(name) ||
         /\/agents\/agents\//.test(name) ||
         (!/^agents\/[a-z][a-z0-9-]*\/suggestions\//.test(name) &&
           /\/suggestions\//.test(name) &&

--- a/mcp/src/submission-checks/phase0-detectors.ts
+++ b/mcp/src/submission-checks/phase0-detectors.ts
@@ -1,5 +1,5 @@
 // Phase 0 agent suggestion checks (weight=0 / advisory in Trailhead).
-// Ported from komatik-agents agent-gate-checks Phase 0 stubs with real heuristics.
+// Heuristic detectors for agent-authored suggestion quality.
 
 import type { SubmissionCheckResult } from "../types.js";
 import type { SubmissionCheckContext, SubmissionFileInfo } from "./types.js";
@@ -375,7 +375,14 @@ export function detectExternalInterfaceValidation(
   const hits: string[] = [];
   for (const file of suggestionMarkdownFiles(ctx)) {
     const path = normalizePath(file.filename);
-    const crossRepo = /suggestions\/(?!komatik-agents)[^/]+\//.test(path);
+    // "Cross-repo" = a suggestion targeting a repo other than the configured home
+    // repo. With no home repo set (the public default), there's no cross-repo
+    // concept, so the check is inert.
+    const crossRepo = ctx.agentRepo
+      ? new RegExp(
+          `suggestions/(?!${ctx.agentRepo.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")})[^/]+/`,
+        ).test(path)
+      : false;
     if (!crossRepo) continue;
     const text = fileContent(file);
     if (!PROPOSAL_ONLY.test(text) && !SCHEMA_LINK.test(text)) {

--- a/mcp/src/submission-checks/types.ts
+++ b/mcp/src/submission-checks/types.ts
@@ -21,6 +21,12 @@ export interface SubmissionCheckContext {
   files: SubmissionFileInfo[];
   prPaths: Set<string>;
   komatikInstance: boolean;
+  /**
+   * Optional "home" repo slug for the agent-suggestions convention. When set,
+   * cross-repo suggestion detection treats this repo as home. Unset (the public
+   * default) disables home-repo-specific checks. Wired from AGENT_SUGGESTIONS_REPO.
+   */
+  agentRepo?: string;
   staleTerms: string[];
   namingAllowlist: NamingAllowlistConfig;
   authRouteAllowlist: string[];

--- a/mcp/src/submission-engine.ts
+++ b/mcp/src/submission-engine.ts
@@ -46,6 +46,8 @@ export interface SubmissionEngineOptions {
   files: import("./submission-checks/types.js").SubmissionFileInfo[];
   repoConfig?: RepoConfig | null;
   komatikInstance?: boolean;
+  /** Home repo slug for the agent-suggestions convention (cross-repo detection). */
+  agentRepo?: string;
   mode?: "warn" | "block";
   /** Declared npm package names from root package.json (optional). */
   declaredPackages?: string[];
@@ -62,7 +64,7 @@ export interface SubmissionEngineOptions {
 }
 
 function buildContext(options: SubmissionEngineOptions): SubmissionCheckContext {
-  const { files, repoConfig, komatikInstance = false } = options;
+  const { files, repoConfig, komatikInstance = false, agentRepo } = options;
   const staleTerms = repoConfig?.submission?.stale_terms ?? [];
 
   const declared = new Set(options.declaredPackages ?? []);
@@ -79,6 +81,7 @@ function buildContext(options: SubmissionEngineOptions): SubmissionCheckContext 
     files,
     prPaths: prPathSet(files),
     komatikInstance,
+    agentRepo,
     staleTerms,
     namingAllowlist: repoConfig?.submission?.naming_allowlist ?? {},
     authRouteAllowlist:

--- a/src/__tests__/submission-detectors-precision.test.ts
+++ b/src/__tests__/submission-detectors-precision.test.ts
@@ -168,7 +168,7 @@ describe("context_freshness", () => {
         files: [
           {
             filename: "src/route.ts",
-            content: `const repo = "komatik-agents/deployguard/workflow";\n`,
+            content: `const repo = "example-org/deployguard/workflow";\n`,
           },
         ],
       }),

--- a/src/gate.ts
+++ b/src/gate.ts
@@ -1785,6 +1785,7 @@ export async function evaluateGate(
       })),
       repoConfig,
       komatikInstance: process.env.KOMATIK_INSTANCE === "true",
+      agentRepo: process.env.AGENT_SUGGESTIONS_REPO || undefined,
       mode: submissionMode,
       declaredPackages: parseDeclaredPackages(process.env.TRAILHEAD_DECLARED_PACKAGES),
       catalogKnownEntities,

--- a/src/submission-checks/detectors.ts
+++ b/src/submission-checks/detectors.ts
@@ -1,4 +1,4 @@
-// Gate 1 detectors — ported from komatik-agents agent-gate-checks (patch/content based).
+// Gate 1 detectors (patch/content based).
 
 import type { SubmissionCheckResult, SubmissionCheckCode } from "../types.js";
 import type { SubmissionCheckContext } from "./types.js";
@@ -316,11 +316,18 @@ export function detectPathFormat(
   ctx: SubmissionCheckContext,
 ): SubmissionCheckResult | null {
   if (!ctx.komatikInstance) return null;
+  // A path that leaks a repo-name prefix before the canonical
+  // agents/<id>/suggestions/… convention is malformed. Use the configured home
+  // repo if set, otherwise match any repo-name segment generically — no
+  // hardcoded org repo.
+  const repoPrefixed = ctx.agentRepo
+    ? new RegExp(`^${ctx.agentRepo.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}/agents/`)
+    : /^[a-z][a-z0-9-]*\/agents\/[a-z][a-z0-9-]*\/suggestions\//;
   const hits = ctx.files
     .map((f) => normalizePath(f.filename))
     .filter(
       (name) =>
-        /^komatik-agents\/agents\//.test(name) ||
+        repoPrefixed.test(name) ||
         /\/agents\/agents\//.test(name) ||
         (!/^agents\/[a-z][a-z0-9-]*\/suggestions\//.test(name) &&
           /\/suggestions\//.test(name) &&

--- a/src/submission-checks/phase0-detectors.ts
+++ b/src/submission-checks/phase0-detectors.ts
@@ -1,5 +1,5 @@
 // Phase 0 agent suggestion checks (weight=0 / advisory in Trailhead).
-// Ported from komatik-agents agent-gate-checks Phase 0 stubs with real heuristics.
+// Heuristic detectors for agent-authored suggestion quality.
 
 import type { SubmissionCheckResult } from "../types.js";
 import type { SubmissionCheckContext, SubmissionFileInfo } from "./types.js";
@@ -375,7 +375,14 @@ export function detectExternalInterfaceValidation(
   const hits: string[] = [];
   for (const file of suggestionMarkdownFiles(ctx)) {
     const path = normalizePath(file.filename);
-    const crossRepo = /suggestions\/(?!komatik-agents)[^/]+\//.test(path);
+    // "Cross-repo" = a suggestion targeting a repo other than the configured home
+    // repo. With no home repo set (the public default), there's no cross-repo
+    // concept, so the check is inert.
+    const crossRepo = ctx.agentRepo
+      ? new RegExp(
+          `suggestions/(?!${ctx.agentRepo.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")})[^/]+/`,
+        ).test(path)
+      : false;
     if (!crossRepo) continue;
     const text = fileContent(file);
     if (!PROPOSAL_ONLY.test(text) && !SCHEMA_LINK.test(text)) {

--- a/src/submission-checks/types.ts
+++ b/src/submission-checks/types.ts
@@ -21,6 +21,12 @@ export interface SubmissionCheckContext {
   files: SubmissionFileInfo[];
   prPaths: Set<string>;
   komatikInstance: boolean;
+  /**
+   * Optional "home" repo slug for the agent-suggestions convention. When set,
+   * cross-repo suggestion detection treats this repo as home. Unset (the public
+   * default) disables home-repo-specific checks. Wired from AGENT_SUGGESTIONS_REPO.
+   */
+  agentRepo?: string;
   staleTerms: string[];
   namingAllowlist: NamingAllowlistConfig;
   authRouteAllowlist: string[];

--- a/src/submission-engine.ts
+++ b/src/submission-engine.ts
@@ -46,6 +46,8 @@ export interface SubmissionEngineOptions {
   files: import("./submission-checks/types.js").SubmissionFileInfo[];
   repoConfig?: RepoConfig | null;
   komatikInstance?: boolean;
+  /** Home repo slug for the agent-suggestions convention (cross-repo detection). */
+  agentRepo?: string;
   mode?: "warn" | "block";
   /** Declared npm package names from root package.json (optional). */
   declaredPackages?: string[];
@@ -62,7 +64,7 @@ export interface SubmissionEngineOptions {
 }
 
 function buildContext(options: SubmissionEngineOptions): SubmissionCheckContext {
-  const { files, repoConfig, komatikInstance = false } = options;
+  const { files, repoConfig, komatikInstance = false, agentRepo } = options;
   const staleTerms = repoConfig?.submission?.stale_terms ?? [];
 
   const declared = new Set(options.declaredPackages ?? []);
@@ -79,6 +81,7 @@ function buildContext(options: SubmissionEngineOptions): SubmissionCheckContext 
     files,
     prPaths: prPathSet(files),
     komatikInstance,
+    agentRepo,
     staleTerms,
     namingAllowlist: repoConfig?.submission?.naming_allowlist ?? {},
     authRouteAllowlist:

--- a/src/types.ts
+++ b/src/types.ts
@@ -117,7 +117,7 @@ export const SubmissionCheckCode = z.enum([
   "destructive_change",
   "claim_anchoring",
   "promotion_coherence",
-  // Phase 0 — agent suggestion quality (advisory / weight=0 in komatik-agents)
+  // Phase 0 — agent suggestion quality (advisory / weight=0)
   "output_size_min",
   "action_extraction_present",
   "delta_section_present",


### PR DESCRIPTION
Scrub internal-repo tells from public detectors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)