### PR TITLE
feat(phase0): close_on_ship_link detector — producer side of close-on-ship

### DIFF
--- a/src/__tests__/close-on-ship-link.test.ts
+++ b/src/__tests__/close-on-ship-link.test.ts
@@ -34,18 +34,24 @@ const SUG = "agents/backend-dev/suggestions/komatik/fix/idea.md";
 
 describe("detectCloseOnShipLink", () => {
   it("returns null when the PR has no suggestion files", () => {
-    expect(detectCloseOnShipLink(ctx([{ filename: "src/app.ts", content: "x" }]))).toBeNull();
+    expect(
+      detectCloseOnShipLink(ctx([{ filename: "src/app.ts", content: "x" }])),
+    ).toBeNull();
   });
 
   it("flags a suggestion missing a 'Task: <id>' provenance line", () => {
-    const r = detectCloseOnShipLink(ctx([{ filename: SUG, content: "# Proposal\nno task line here" }]));
+    const r = detectCloseOnShipLink(
+      ctx([{ filename: SUG, content: "# Proposal\nno task line here" }]),
+    );
     expect(r?.code).toBe("close_on_ship_link");
     expect(r?.severity).toBe("advisory");
     expect(r?.files).toContain(SUG);
   });
 
   it("is dormant on the body half when prBody is absent (provenance present)", () => {
-    const r = detectCloseOnShipLink(ctx([{ filename: SUG, content: `# Proposal\nTask: ${TASK}\n` }]));
+    const r = detectCloseOnShipLink(
+      ctx([{ filename: SUG, content: `# Proposal\nTask: ${TASK}\n` }]),
+    );
     expect(r).toBeNull();
   });
 
@@ -59,11 +65,16 @@ describe("detectCloseOnShipLink", () => {
 
   it("passes when the PR body carries 'Closes task: <id>' (full or short id)", () => {
     expect(
-      detectCloseOnShipLink(ctx([{ filename: SUG, content: `Task: ${TASK}` }], `Closes task: ${TASK}`)),
+      detectCloseOnShipLink(
+        ctx([{ filename: SUG, content: `Task: ${TASK}` }], `Closes task: ${TASK}`),
+      ),
     ).toBeNull();
     expect(
       detectCloseOnShipLink(
-        ctx([{ filename: SUG, content: `Task: ${TASK}` }], `Resolves task: ${TASK.slice(0, 8)}`),
+        ctx(
+          [{ filename: SUG, content: `Task: ${TASK}` }],
+          `Resolves task: ${TASK.slice(0, 8)}`,
+        ),
       ),
     ).toBeNull();
   });

--- a/src/__tests__/close-on-ship-link.test.ts
+++ b/src/__tests__/close-on-ship-link.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { detectCloseOnShipLink } from "../submission-checks/phase0-detectors.js";
+import type { SubmissionCheckContext } from "../submission-checks/types.js";
+import { prPathSet } from "../submission-checks/helpers.js";
+import {
+  buildRenamePatterns,
+  buildSlugOnlyPatterns,
+} from "../submission-checks/detector-policy.js";
+
+function ctx(
+  files: Array<{ filename: string; content?: string }>,
+  prBody?: string,
+): SubmissionCheckContext {
+  const normalized = files.map((f) => ({ filename: f.filename, content: f.content }));
+  return {
+    files: normalized,
+    prPaths: prPathSet(normalized),
+    komatikInstance: true,
+    staleTerms: [],
+    authRouteAllowlist: [],
+    maxFileLines: 1000,
+    declaredPackages: new Set(),
+    namingAllowlist: {},
+    pathIgnorePatterns: [],
+    renamePatterns: buildRenamePatterns(undefined, { includeKomatikDefaults: true }),
+    slugOnlyPatterns: buildSlugOnlyPatterns(undefined),
+    detectorPolicy: {},
+    prBody,
+  };
+}
+
+const TASK = "4139db4b-3993-4e1a-9b2c-aaaaaaaaaaaa";
+const SUG = "agents/backend-dev/suggestions/komatik/fix/idea.md";
+
+describe("detectCloseOnShipLink", () => {
+  it("returns null when the PR has no suggestion files", () => {
+    expect(detectCloseOnShipLink(ctx([{ filename: "src/app.ts", content: "x" }]))).toBeNull();
+  });
+
+  it("flags a suggestion missing a 'Task: <id>' provenance line", () => {
+    const r = detectCloseOnShipLink(ctx([{ filename: SUG, content: "# Proposal\nno task line here" }]));
+    expect(r?.code).toBe("close_on_ship_link");
+    expect(r?.severity).toBe("advisory");
+    expect(r?.files).toContain(SUG);
+  });
+
+  it("is dormant on the body half when prBody is absent (provenance present)", () => {
+    const r = detectCloseOnShipLink(ctx([{ filename: SUG, content: `# Proposal\nTask: ${TASK}\n` }]));
+    expect(r).toBeNull();
+  });
+
+  it("flags when the PR body lacks a 'Closes task: <id>' for a task-linked suggestion", () => {
+    const r = detectCloseOnShipLink(
+      ctx([{ filename: SUG, content: `Task: ${TASK}` }], "Ships the fix. No close link."),
+    );
+    expect(r?.code).toBe("close_on_ship_link");
+    expect(r?.detail).toMatch(/Closes task/i);
+  });
+
+  it("passes when the PR body carries 'Closes task: <id>' (full or short id)", () => {
+    expect(
+      detectCloseOnShipLink(ctx([{ filename: SUG, content: `Task: ${TASK}` }], `Closes task: ${TASK}`)),
+    ).toBeNull();
+    expect(
+      detectCloseOnShipLink(
+        ctx([{ filename: SUG, content: `Task: ${TASK}` }], `Resolves task: ${TASK.slice(0, 8)}`),
+      ),
+    ).toBeNull();
+  });
+});

--- a/src/__tests__/fixtures/agent-failures/manifest.json
+++ b/src/__tests__/fixtures/agent-failures/manifest.json
@@ -45,7 +45,8 @@
     "dependency_dag_validation",
     "uncommitted_fix_check",
     "verification_owner_assigned",
-    "external_interface_validation"
+    "external_interface_validation",
+    "close_on_ship_link"
   ],
   "coveredRiskFactors": [
     "test_coverage",

--- a/src/gate.ts
+++ b/src/gate.ts
@@ -1799,8 +1799,8 @@ export async function evaluateGate(
           : undefined,
       // close_on_ship_link: the PR body carries the `Closes task: <id>` convention.
       prBody:
-        (github.context.payload?.pull_request as { body?: string } | undefined)
-          ?.body ?? undefined,
+        (github.context.payload?.pull_request as { body?: string } | undefined)?.body ??
+        undefined,
     });
     if (submissionChecks.length > 0) {
       policyFindings.push(`Submission gate: ${submissionChecks.length} finding(s).`);

--- a/src/gate.ts
+++ b/src/gate.ts
@@ -1797,6 +1797,10 @@ export async function evaluateGate(
               headBranch: process.env.GITHUB_HEAD_REF,
             }
           : undefined,
+      // close_on_ship_link: the PR body carries the `Closes task: <id>` convention.
+      prBody:
+        (github.context.payload?.pull_request as { body?: string } | undefined)
+          ?.body ?? undefined,
     });
     if (submissionChecks.length > 0) {
       policyFindings.push(`Submission gate: ${submissionChecks.length} finding(s).`);

--- a/src/submission-checks/phase0-detectors.ts
+++ b/src/submission-checks/phase0-detectors.ts
@@ -405,7 +405,8 @@ export function detectExternalInterfaceValidation(
 // This nudges the producer side so the Spark-side reconcilers have something to act
 // on. Advisory only — never blocks.
 const TASK_PROVENANCE = /\bTask:\s*([0-9a-f]{8}[0-9a-f-]*)/i;
-const CLOSES_TASK = /\b(?:close[sd]?|resolve[sd]?|fix(?:e[sd])?)\s+task\s*[:#]?\s*([0-9a-f]{8}[0-9a-f-]*)/gi;
+const CLOSES_TASK =
+  /\b(?:close[sd]?|resolve[sd]?|fix(?:e[sd])?)\s+task\s*[:#]?\s*([0-9a-f]{8}[0-9a-f-]*)/gi;
 export function detectCloseOnShipLink(
   ctx: SubmissionCheckContext,
 ): SubmissionCheckResult | null {
@@ -426,17 +427,23 @@ export function detectCloseOnShipLink(
     let bm: RegExpExecArray | null;
     while ((bm = re.exec(ctx.prBody)) !== null) linked.add(bm[1].toLowerCase());
     for (const id of taskIds) {
-      const isLinked = [...linked].some((l) => l === id || id.startsWith(l) || l.startsWith(id));
+      const isLinked = [...linked].some(
+        (l) => l === id || id.startsWith(l) || l.startsWith(id),
+      );
       if (!isLinked) unlinked.push(id);
     }
   }
 
   const problems: string[] = [];
   if (missingProvenance.length > 0) {
-    problems.push(`${missingProvenance.length} suggestion(s) missing a 'Task: <id>' provenance line`);
+    problems.push(
+      `${missingProvenance.length} suggestion(s) missing a 'Task: <id>' provenance line`,
+    );
   }
   if (unlinked.length > 0) {
-    problems.push(`PR body has no 'Closes task: <id>' for: ${unlinked.map((i) => i.slice(0, 8)).join(", ")}`);
+    problems.push(
+      `PR body has no 'Closes task: <id>' for: ${unlinked.map((i) => i.slice(0, 8)).join(", ")}`,
+    );
   }
   if (problems.length === 0) return null;
   return advisory({
@@ -444,7 +451,8 @@ export function detectCloseOnShipLink(
     title: "Close-on-ship link missing",
     detail: `${problems.join("; ")}. Add 'Task: <id>' in the suggestion and 'Closes task: <id>' in the PR body so the task auto-closes on merge (docs/plans/close-on-ship-v0.1.md).`,
     files: missingProvenance,
-    suggested_action: "Record the task link so the shipped work closes its task automatically.",
+    suggested_action:
+      "Record the task link so the shipped work closes its task automatically.",
   });
 }
 

--- a/src/submission-checks/phase0-detectors.ts
+++ b/src/submission-checks/phase0-detectors.ts
@@ -399,9 +399,59 @@ export function detectExternalInterfaceValidation(
   });
 }
 
+// close-on-ship producer link (docs/plans/close-on-ship-v0.1.md): a suggestion
+// should carry a `Task: <id>` provenance line, and when shipped its PR body should
+// carry `Closes task: <id>` — that link is what lets the task auto-close on merge.
+// This nudges the producer side so the Spark-side reconcilers have something to act
+// on. Advisory only — never blocks.
+const TASK_PROVENANCE = /\bTask:\s*([0-9a-f]{8}[0-9a-f-]*)/i;
+const CLOSES_TASK = /\b(?:close[sd]?|resolve[sd]?|fix(?:e[sd])?)\s+task\s*[:#]?\s*([0-9a-f]{8}[0-9a-f-]*)/gi;
+export function detectCloseOnShipLink(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const files = suggestionMarkdownFiles(ctx);
+  const missingProvenance: string[] = [];
+  const taskIds = new Set<string>();
+  for (const file of files) {
+    const m = fileContent(file).match(TASK_PROVENANCE);
+    if (m) taskIds.add(m[1].toLowerCase());
+    else missingProvenance.push(file.filename);
+  }
+
+  // PR-body half: only when the gate supplied the body (dormant on local runs).
+  const unlinked: string[] = [];
+  if (ctx.prBody !== undefined && taskIds.size > 0) {
+    const linked = new Set<string>();
+    const re = new RegExp(CLOSES_TASK.source, CLOSES_TASK.flags);
+    let bm: RegExpExecArray | null;
+    while ((bm = re.exec(ctx.prBody)) !== null) linked.add(bm[1].toLowerCase());
+    for (const id of taskIds) {
+      const isLinked = [...linked].some((l) => l === id || id.startsWith(l) || l.startsWith(id));
+      if (!isLinked) unlinked.push(id);
+    }
+  }
+
+  const problems: string[] = [];
+  if (missingProvenance.length > 0) {
+    problems.push(`${missingProvenance.length} suggestion(s) missing a 'Task: <id>' provenance line`);
+  }
+  if (unlinked.length > 0) {
+    problems.push(`PR body has no 'Closes task: <id>' for: ${unlinked.map((i) => i.slice(0, 8)).join(", ")}`);
+  }
+  if (problems.length === 0) return null;
+  return advisory({
+    code: "close_on_ship_link",
+    title: "Close-on-ship link missing",
+    detail: `${problems.join("; ")}. Add 'Task: <id>' in the suggestion and 'Closes task: <id>' in the PR body so the task auto-closes on merge (docs/plans/close-on-ship-v0.1.md).`,
+    files: missingProvenance,
+    suggested_action: "Record the task link so the shipped work closes its task automatically.",
+  });
+}
+
 export function runPhase0Detectors(ctx: SubmissionCheckContext): SubmissionCheckResult[] {
   if (suggestionMarkdownFiles(ctx).length === 0) return [];
   const checks = [
+    detectCloseOnShipLink,
     detectOutputSizeMin,
     detectActionExtractionPresent,
     detectDeltaSectionPresent,

--- a/src/submission-checks/types.ts
+++ b/src/submission-checks/types.ts
@@ -59,4 +59,11 @@ export interface SubmissionCheckContext {
    * layer). Absent for non-PR / local runs, leaving the detector dormant.
    */
   promotion?: { baseBranch?: string; headBranch?: string };
+  /**
+   * The PR description body (from `pull_request.body`, set by the gate I/O layer).
+   * Lets `close_on_ship_link` check for the `Closes task: <id>` convention that
+   * lives in the body, not the diff. Absent for non-PR / local runs, leaving that
+   * half of the detector dormant.
+   */
+  prBody?: string;
 }

--- a/src/submission-engine.ts
+++ b/src/submission-engine.ts
@@ -61,6 +61,8 @@ export interface SubmissionEngineOptions {
   catalogKnownEntities?: string[];
   /** Promotion branch topology (GITHUB_BASE_REF / GITHUB_HEAD_REF), set by the gate. */
   promotion?: { baseBranch?: string; headBranch?: string };
+  /** PR description body (pull_request.body), set by the gate — for close_on_ship_link. */
+  prBody?: string;
 }
 
 function buildContext(options: SubmissionEngineOptions): SubmissionCheckContext {
@@ -98,6 +100,7 @@ function buildContext(options: SubmissionEngineOptions): SubmissionCheckContext 
     catalogKnownEntities:
       catalogKnownEntities.size > 0 ? catalogKnownEntities : undefined,
     promotion: options.promotion,
+    prBody: options.prBody,
   };
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -132,6 +132,7 @@ export const SubmissionCheckCode = z.enum([
   "uncommitted_fix_check",
   "verification_owner_assigned",
   "external_interface_validation",
+  "close_on_ship_link",
 ]);
 export type SubmissionCheckCode = z.infer<typeof SubmissionCheckCode>;
 


### PR DESCRIPTION
## What
A new **advisory** phase-0 submission detector (`close_on_ship_link`) that nudges the *producer* side of close-on-ship. When a PR ships agent suggestion(s), it checks the link that lets the task auto-close on merge:
- each suggestion `.md` should carry a `Task: <id>` provenance line, and
- when the gate has the PR body, it should carry `Closes task: <id>` for those ids.

Missing either → one advisory finding (never blocks) pointing at `docs/plans/close-on-ship-v0.1.md`.

## Why
The close-on-ship *consumers* exist (Spark-side: `reconcile-suggestions` task-close, planner `RECONCILE-SHIPPED`), but the link convention had **~0 adoption**, so nothing fired. Trailhead gates every PR — the right place to make the producer link reliably present so the consumers have something to act on. (Chosen over a CI→Spark close pipeline: reuse the existing closers, fix the root cause.)

## Changes
- `close_on_ship_link` added to `SubmissionCheckCode`.
- New optional `ctx.prBody` threaded from `pull_request.body` (gate.ts → submission-engine → context); dormant on local/non-PR runs.
- `detectCloseOnShipLink` in `phase0-detectors.ts` + registered in `runPhase0Detectors`.
- Tests: `src/__tests__/close-on-ship-link.test.ts` (5 cases, all pass).

## Notes
- **Advisory only** — phase-0 weight, cannot block a merge.
- `dist/` intentionally **not** rebuilt here (it's OS-variable; CI validates the build compiles, maintainer regenerates `dist` + publishes at release per `release.yml`).
- Local full typecheck/build is clean for these files; the only local tsc errors were pre-existing missing devDeps (`js-yaml`/`@swc/core`) in an incomplete local install — CI's `npm ci` resolves them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)