### PR TITLE
fix(import_resolution): resolve against repo tree, not just changed files

### DIFF
--- a/src/__tests__/import-resolution.test.ts
+++ b/src/__tests__/import-resolution.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { detectImportResolution } from "../submission-checks/detectors.js";
+import type { SubmissionCheckContext } from "../submission-checks/types.js";
+import { prPathSet } from "../submission-checks/helpers.js";
+import {
+  buildRenamePatterns,
+  buildSlugOnlyPatterns,
+} from "../submission-checks/detector-policy.js";
+
+function ctx(
+  files: Array<{ filename: string; content: string }>,
+  repoPaths?: string[],
+): SubmissionCheckContext {
+  const normalized = files.map((f) => ({ filename: f.filename, content: f.content }));
+  return {
+    files: normalized,
+    prPaths: prPathSet(normalized),
+    komatikInstance: true,
+    staleTerms: [],
+    authRouteAllowlist: [],
+    maxFileLines: 1000,
+    declaredPackages: new Set(),
+    namingAllowlist: {},
+    pathIgnorePatterns: [],
+    renamePatterns: buildRenamePatterns(undefined, { includeKomatikDefaults: true }),
+    slugOnlyPatterns: buildSlugOnlyPatterns(undefined),
+    detectorPolicy: {},
+    repoPaths: repoPaths ? new Set(repoPaths) : undefined,
+  };
+}
+
+const HARNESS = {
+  filename: "src/arena/harness.ts",
+  content: `import { Mode } from "./types";\nexport const x = 1;\n`,
+};
+
+describe("detectImportResolution", () => {
+  it("does NOT false-block an import to an existing, unchanged sibling (the bug)", () => {
+    // ./types resolves to src/arena/types.ts which exists in the repo but is not
+    // part of this PR's changed files.
+    const r = detectImportResolution(
+      ctx([HARNESS], ["src/arena/types.ts", "src/arena/harness.ts"]),
+    );
+    expect(r).toBeNull();
+  });
+
+  it("stays dormant when repo ground truth is unavailable", () => {
+    expect(detectImportResolution(ctx([HARNESS]))).toBeNull();
+  });
+
+  it("still blocks a genuinely unresolvable import (not in PR or repo)", () => {
+    const r = detectImportResolution(ctx([HARNESS], ["src/arena/harness.ts"]));
+    expect(r?.code).toBe("import_resolution");
+    expect(r?.severity).toBe("blocking");
+    expect(r?.files).toContain("src/arena/harness.ts");
+  });
+
+  it("resolves an import to another file changed in the same PR", () => {
+    const r = detectImportResolution(
+      ctx(
+        [
+          HARNESS,
+          { filename: "src/arena/types.ts", content: "export type Mode = string;" },
+        ],
+        ["src/arena/harness.ts", "src/arena/types.ts"],
+      ),
+    );
+    expect(r).toBeNull();
+  });
+});

--- a/src/gate.ts
+++ b/src/gate.ts
@@ -256,6 +256,46 @@ async function fetchPrFiles(prNumber: number, token?: string): Promise<PrFileInf
   }
 }
 
+/**
+ * Full file list of the PR head tree (git ls-files equivalent, via the API) so
+ * import_resolution can resolve relative imports to existing, UNCHANGED siblings
+ * — not just files in the PR diff. Returns undefined on any failure or a truncated
+ * tree, which leaves import_resolution dormant rather than risking false positives.
+ */
+async function fetchRepoPaths(
+  prNumber: number,
+  token?: string,
+): Promise<string[] | undefined> {
+  if (!token) return undefined;
+  try {
+    const octokit = github.getOctokit(token);
+    const { owner, repo } = github.context.repo;
+    const headSha =
+      (github.context.payload?.pull_request as { head?: { sha?: string } } | undefined)
+        ?.head?.sha ??
+      (await octokit.rest.pulls.get({ owner, repo, pull_number: prNumber })).data.head
+        .sha;
+    const { data } = await octokit.rest.git.getTree({
+      owner,
+      repo,
+      tree_sha: headSha,
+      recursive: "true",
+    });
+    if (data.truncated) {
+      core.debug(
+        "Repo tree truncated; skipping repoPaths (import_resolution stays dormant).",
+      );
+      return undefined;
+    }
+    return data.tree
+      .filter((e) => e.type === "blob" && typeof e.path === "string")
+      .map((e) => e.path as string);
+  } catch (error) {
+    core.debug(`Failed to fetch repo tree for repoPaths: ${error}`);
+    return undefined;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Risk scoring — delegates to shared engine
 // ---------------------------------------------------------------------------
@@ -1777,6 +1817,12 @@ export async function evaluateGate(
         );
       }
     }
+    // import_resolution ground truth: the full repo file list lets relative
+    // imports resolve to existing, unchanged siblings (not just changed files),
+    // killing the false-positive block. Undefined → that detector stays dormant.
+    const repoPaths = prNumber
+      ? await fetchRepoPaths(prNumber, config.githubToken)
+      : undefined;
     submissionChecks = runSubmissionGate({
       files: files.map((f) => ({
         filename: f.filename,
@@ -1789,6 +1835,7 @@ export async function evaluateGate(
       mode: submissionMode,
       declaredPackages: parseDeclaredPackages(process.env.TRAILHEAD_DECLARED_PACKAGES),
       catalogKnownEntities,
+      repoPaths,
       // promotion_coherence (ADR-010): branch topology from the Actions env.
       promotion:
         process.env.GITHUB_BASE_REF || process.env.GITHUB_HEAD_REF

--- a/src/submission-checks/detectors.ts
+++ b/src/submission-checks/detectors.ts
@@ -432,14 +432,21 @@ function resolveRelativeImport(
 export function detectImportResolution(
   ctx: SubmissionCheckContext,
 ): SubmissionCheckResult | null {
+  // Resolving relative imports needs repo ground truth: an import to an existing,
+  // UNCHANGED sibling (not in this PR's diff) is valid but looks "unresolved" if we
+  // only check changed files — a blocking false positive. Without repoPaths we can't
+  // tell that from a fabricated path, so stay dormant (the repoPaths convention used
+  // by the other existence-dependent detectors).
+  if (!ctx.repoPaths) return null;
   const codeExts = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"]);
+  const known = new Set<string>([...ctx.prPaths, ...ctx.repoPaths]);
   const hits: string[] = [];
 
   for (const file of ctx.files) {
     if (!codeExts.has(extensionOf(file.filename))) continue;
     const content = fileContent(file);
     for (const specifier of extractRelativeImports(content)) {
-      if (!resolveRelativeImport(file.filename, specifier, ctx.prPaths)) {
+      if (!resolveRelativeImport(file.filename, specifier, known)) {
         hits.push(file.filename);
         break;
       }


### PR DESCRIPTION
## The bug (hit on sundog #352)
`import_resolution` resolved relative imports **only against the PR's changed files** (`ctx.prPaths`) and blocked when unresolved. An import to an existing, **unchanged** sibling not in the diff (e.g. `arena/types.ts`, `harness.ts`) therefore became a **blocking false positive** — even though typecheck proves the import is valid.

Root cause: the framework already has `ctx.repoPaths` for exactly this ("tell a fabricated reference from a reference to an existing, unchanged file"), but **`gate.ts` never populated it**, and the detector only ever consulted `prPaths`.

## Fix
- **gate.ts** fetches the PR head tree via the GitHub API (`git.getTree` recursive) and passes `repoPaths`. Truncated tree / no token → `undefined` (safe).
- **detectImportResolution** resolves against `prPaths ∪ repoPaths`, and **stays dormant when `repoPaths` is unavailable** rather than false-blocking — the same convention the other existence-dependent detectors use.
- Genuinely unresolvable imports (in neither the PR nor the repo) still **block** (true positives preserved).

## Tests
`src/__tests__/import-resolution.test.ts` — 4 cases: unchanged-sibling no longer blocks; dormant without ground truth; genuinely-missing still blocks; same-PR sibling resolves.

## Blast radius
Small — only `detectReferencedFilesExist` (advisory phase-0) also reads `repoPaths` and already guards on its absence. `dist/` not rebuilt here (OS-variable; CI validates build, maintainer regenerates at release).

Fixes the Trailhead block on sundog #352 without admin-merge / workflow disable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)