### PR TITLE
chore(release): v4.5.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trailhead",
-  "version": "4.5.4",
+  "version": "4.5.5",
   "private": true,
   "description": "Release readiness gate for GitHub PRs — waits for CI, scores code risk, checks production health, and blocks merges that are not release-ready.",
   "license": "MIT",


### PR DESCRIPTION
Cuts **v4.5.5**, bundling the two commits on `dev` since v4.5.4:
- #302 fix(import_resolution): resolve against repo tree, not just changed files — the sundog #352 false-positive fix
- #298 chore(detectors): genericize internal-repo references (IP hygiene)

On merge I'll tag `v4.5.5` → release.yml builds `dist`, force-moves the `v4` major tag, publishes. Consumers on `@v4` then get the import_resolution fix (Sundog to be repinned `@v3`→`@v4` next).

🤖 Generated with [Claude Code](https://claude.com/claude-code)