### PR TITLE
chore(release): v4.5.6 — bump root + cli in lockstep

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@komatikai/trailhead",
-  "version": "4.5.4",
+  "version": "4.5.6",
   "description": "Trailhead CLI — setup wizard and utilities for the Trailhead deployment gate",
   "bin": {
     "trailhead": "dist/index.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trailhead",
-  "version": "4.5.5",
+  "version": "4.5.6",
   "private": true,
   "description": "Release readiness gate for GitHub PRs — waits for CI, scores code risk, checks production health, and blocks merges that are not release-ready.",
   "license": "MIT",


### PR DESCRIPTION
v4.5.5 shipped the **Action/gate** (v4 moved, import_resolution fix live) but the **CLI npm publish failed**: `cli/package.json` was left at 4.5.4 (I'd bumped only the root). This bumps **both** root and `cli` to 4.5.6 so `@komatikai/trailhead` publishes with the fix. On merge I'll tag `v4.5.6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)