### PR TITLE
feat(gate-3): severity-based risk-factor penalties

### DIFF
--- a/src/gate.ts
+++ b/src/gate.ts
@@ -1778,6 +1778,26 @@ export async function evaluateGate(
       ? weightedAverageScores(riskFactors as RiskFactorResult[], customWeights)
       : localRiskScore;
 
+  // GATE-3: Apply severity-based penalties to risk factors
+  const severityPenaltiesCfg = repoConfig?.policies?.risk_factor_severity;
+  const severityPenalties = severityPenaltiesCfg
+    ? {
+        critical: severityPenaltiesCfg.critical ?? 10,
+        high: severityPenaltiesCfg.high ?? 5,
+        medium: severityPenaltiesCfg.medium ?? 2,
+        low: severityPenaltiesCfg.low ?? 1,
+      }
+    : { critical: 10, high: 5, medium: 2, low: 1 }; // Default penalties
+  
+  const { adjustedScore: riskScoreWithPenalties, appliedPenalties } =
+    applyRiskFactorSeverityPenalties(riskScore, riskFactors, severityPenalties);
+  
+  if (appliedPenalties > 0) {
+    core.info(
+      `GATE-3: Applied ${appliedPenalties} points of severity penalties to risk score (${riskScore} -> ${riskScoreWithPenalties})`,
+    );
+  }
+
   const agentPolicy = await enforceAgentPrPolicies({
     prNumber,
     token: config.githubToken,
@@ -1875,10 +1895,11 @@ export async function evaluateGate(
   if (mcpCheck) healthChecks.push(mcpCheck);
 
   const healthScore = aggregateHealthScore(healthChecks);
+  // GATE-3: Use riskScoreWithPenalties for gate decision
   const baselineDecision = freezeCheck.frozen
     ? ("block" as GateDecision)
     : (decideGate(
-        riskScore,
+        riskScoreWithPenalties,
         healthScore,
         adjustedRiskThreshold,
         effectiveWarnThreshold,
@@ -2012,7 +2033,7 @@ export async function evaluateGate(
             }
           }
 
-          return strictnessFromTrust(trust, riskScore);
+          return strictnessFromTrust(trust, riskScoreWithPenalties);
         })()
       : {
           strictness: "baseline" as const,
@@ -2025,7 +2046,7 @@ export async function evaluateGate(
     commitSha,
     prNumber,
     healthScore,
-    riskScore,
+    riskScore: riskScoreWithPenalties,  // GATE-3: Use adjusted score with severity penalties
     gateDecision,
     healthChecks,
     riskFactors,
@@ -2126,7 +2147,7 @@ export async function evaluateGate(
   const releaseResult = computeReleaseReady({
     gateMode,
     gateDecision,
-    riskScore,
+    riskScore: riskScoreWithPenalties,  // GATE-3: Use adjusted score
     riskThreshold: adjustedRiskThreshold,
     healthScore,
     healthChecksConfigured: healthChecks.length > 0,
@@ -2354,6 +2375,53 @@ export async function createCheckRun(
   } catch (error) {
     core.debug(`Failed to create check run: ${error}`);
   }
+}
+
+// ---------------------------------------------------------------------------
+// Risk factor severity penalty application (GATE-3)
+// ---------------------------------------------------------------------------
+
+/**
+ * Apply severity-based penalties to risk factors.
+ * Adds penalty points for high/critical severity factors to increase overall risk score.
+ */
+export function applyRiskFactorSeverityPenalties(
+  baseRiskScore: number,
+  riskFactors: RiskFactor[],
+  severityPenalties?: {
+    critical?: number;
+    high?: number;
+    medium?: number;
+    low?: number;
+  },
+): { adjustedScore: number; appliedPenalties: number } {
+  const penalties = severityPenalties ?? { critical: 10, high: 5, medium: 2, low: 1 };
+  let totalPenalty = 0;
+
+  for (const factor of riskFactors) {
+    const detail = factor.detail as Record<string, unknown> | undefined;
+    const severity = detail?.["severity"] as string | undefined;
+
+    if (severity) {
+      const penaltyValue =
+        severity === "critical"
+          ? penalties.critical ?? 10
+          : severity === "high"
+            ? penalties.high ?? 5
+            : severity === "medium"
+              ? penalties.medium ?? 2
+              : severity === "low"
+                ? penalties.low ?? 1
+                : 0;
+
+      if (penaltyValue > 0) {
+        totalPenalty += penaltyValue;
+      }
+    }
+  }
+
+  const adjustedScore = Math.min(100, baseRiskScore + totalPenalty);
+  return { adjustedScore, appliedPenalties: totalPenalty };
 }
 
 export { shouldBlockMerge, resolveCheckName, checkConclusionForEvaluation };

--- a/src/gate.ts
+++ b/src/gate.ts
@@ -1788,10 +1788,10 @@ export async function evaluateGate(
         low: severityPenaltiesCfg.low ?? 1,
       }
     : { critical: 10, high: 5, medium: 2, low: 1 }; // Default penalties
-  
+
   const { adjustedScore: riskScoreWithPenalties, appliedPenalties } =
     applyRiskFactorSeverityPenalties(riskScore, riskFactors, severityPenalties);
-  
+
   if (appliedPenalties > 0) {
     core.info(
       `GATE-3: Applied ${appliedPenalties} points of severity penalties to risk score (${riskScore} -> ${riskScoreWithPenalties})`,
@@ -2046,7 +2046,7 @@ export async function evaluateGate(
     commitSha,
     prNumber,
     healthScore,
-    riskScore: riskScoreWithPenalties,  // GATE-3: Use adjusted score with severity penalties
+    riskScore: riskScoreWithPenalties, // GATE-3: Use adjusted score with severity penalties
     gateDecision,
     healthChecks,
     riskFactors,
@@ -2147,7 +2147,7 @@ export async function evaluateGate(
   const releaseResult = computeReleaseReady({
     gateMode,
     gateDecision,
-    riskScore: riskScoreWithPenalties,  // GATE-3: Use adjusted score
+    riskScore: riskScoreWithPenalties, // GATE-3: Use adjusted score
     riskThreshold: adjustedRiskThreshold,
     healthScore,
     healthChecksConfigured: healthChecks.length > 0,
@@ -2405,13 +2405,13 @@ export function applyRiskFactorSeverityPenalties(
     if (severity) {
       const penaltyValue =
         severity === "critical"
-          ? penalties.critical ?? 10
+          ? (penalties.critical ?? 10)
           : severity === "high"
-            ? penalties.high ?? 5
+            ? (penalties.high ?? 5)
             : severity === "medium"
-              ? penalties.medium ?? 2
+              ? (penalties.medium ?? 2)
               : severity === "low"
-                ? penalties.low ?? 1
+                ? (penalties.low ?? 1)
                 : 0;
 
       if (penaltyValue > 0) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -635,6 +635,16 @@ export const RepoConfig = z.object({
           threshold: z.number().min(0).max(100).default(100),
         })
         .default({}),
+      // GATE-3: per-severity penalty points added to the weighted risk score
+      // for each risk factor at that severity (applyRiskFactorSeverityPenalties).
+      risk_factor_severity: z
+        .object({
+          critical: z.number().min(0).optional(),
+          high: z.number().min(0).optional(),
+          medium: z.number().min(0).optional(),
+          low: z.number().min(0).optional(),
+        })
+        .optional(),
     })
     .default({}),
 });


### PR DESCRIPTION
Salvages the stranded GATE-3 WIP from the Spark working tree, rebased onto current dev (v4.5.6).

**Kept:** `applyRiskFactorSeverityPenalties` — per-severity penalty points (critical=10/high=5/medium=2/low=1 defaults) added to the weighted risk score, configurable via the new `policies.risk_factor_severity` schema field, wired into `evaluateGate` with logging. This is the missing piece that lets real factor severity move the score — relevant to the threshold-recalibration problem (real scores ≤8 vs threshold 40).

**Dropped from the WIP, deliberately:**
- hono `^4.12.23` bump — dev already has `^4.12.18`, which clears all 5 GHSAs
- `decideGate` healthScore-warn removal — dev's `release-ready.ts` (landed after the WIP was written) documents health_score as WARN-ONLY *via that exact decideGate path*; deleting it would silence the genuine-outage signal. The WIP predated that design decision; dev's version wins.

**Added beyond the WIP:** the `risk_factor_severity` zod schema field (the WIP read the config key but never declared it — `tsc` failed without it).

857/857 tests, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)