### PR TITLE
release: v4.5.7 — Deno test-pattern fix ships, GATE-3 goes opt-in, dist staleness guard

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,18 @@ jobs:
       - name: Build (ncc)
         run: npm run build
 
-      # Release tags are cut from ubuntu-latest; dist/ in the tag reflects this build.
+      # The action serves the COMMITTED dist/ at the tag (main: dist/index.js);
+      # this workflow's build output is discarded. If the committed bundle does
+      # not match a fresh build of the tagged source, the "release" ships stale
+      # code — this happened silently on v4.5.5/v4.5.6 (dist last committed
+      # 2026-06-07; the v4.5.5 import_resolution fix never reached consumers).
+      - name: Verify committed dist matches this source
+        run: |
+          if ! git diff --quiet -- dist; then
+            echo "::error::dist/ is stale — run 'npm run build' and commit dist before tagging"
+            git diff --stat -- dist
+            exit 1
+          fi
 
       - name: Update major version tag
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to Trailhead will be documented in this file.
 
+## [4.5.7] - 2026-07-01
+
+### Fixed
+
+- **`TEST_FILE_PATTERN` recognizes Deno `_test.ts` + multi-language test conventions** ([#307](https://github.com/KomatikAI/trailhead/issues/307), [#308](https://github.com/KomatikAI/trailhead/pull/308)) — repos using Deno-style `*_test.ts` (e.g. komatik's Edge Function suite) scored zero test files, driving `test_coverage` to 100 and false-BLOCKing every EF PR. Dominant false-block class on komatik (test_coverage ≥60 on 70% of evals over 60d).
+
+### Added
+
+- **GATE-3: severity-based risk-factor penalties** ([#305](https://github.com/KomatikAI/trailhead/pull/305)) — per-severity penalty points (critical 10 / high 5 / medium 2 / low 1) added on top of the weighted risk score. **Opt-in**: applies only with `policies.risk_factor_severity.enabled: true` (changed from always-on before release so the fleet's block-rate calibration isn't shifted by release drift).
+
 ## [4.5.2] - 2026-06-06
 
 ### Fixed

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@komatikai/trailhead",
-  "version": "4.5.4",
+  "version": "4.5.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@komatikai/trailhead",
-      "version": "4.5.4",
+      "version": "4.5.7",
       "license": "MIT",
       "dependencies": {
         "@swc/core": "^1.15.40"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@komatikai/trailhead",
-  "version": "4.5.6",
+  "version": "4.5.7",
   "description": "Trailhead CLI — setup wizard and utilities for the Trailhead deployment gate",
   "bin": {
     "trailhead": "dist/index.js"

--- a/dist/index.js
+++ b/dist/index.js
@@ -42339,6 +42339,15 @@ const RepoConfig = objectType({
             max_changes: numberType().int().min(1).default(2000),
             mode: enumType(["warn", "block"]).default("warn"),
             require_plan_for_agent_prs: booleanType().default(false),
+            // Branch pairs exempt from scope limits (glob patterns; empty list
+            // matches any branch, same semantics as contexts[].match). Meant for
+            // promotion PRs (dev→staging, staging→master), which aggregate many
+            // already-gated merges and structurally exceed any sane max_files.
+            exempt: arrayType(objectType({
+                head_branch: arrayType(stringType()).default([]),
+                base_branch: arrayType(stringType()).default([]),
+            }))
+                .default([]),
         })
             .default({}),
         duplicate_logic: objectType({
@@ -51371,6 +51380,17 @@ async function detectPrScopeRisk(params) {
     const cfg = params.repoConfig?.policies?.pr_scope;
     if (!cfg?.enabled)
         return { factor: null, findings: [], forceBlock: false };
+    const exempt = (cfg.exempt ?? []).some((rule) => {
+        const headOk = rule.head_branch.length === 0 ||
+            (params.headRef !== undefined && matchesGlobs(params.headRef, rule.head_branch));
+        const baseOk = rule.base_branch.length === 0 ||
+            (params.baseRef !== undefined && matchesGlobs(params.baseRef, rule.base_branch));
+        return headOk && baseOk;
+    });
+    if (exempt) {
+        info(`pr_scope: branch pair ${params.headRef ?? "?"} -> ${params.baseRef ?? "?"} matches an exempt rule — scope limits skipped`);
+        return { factor: null, findings: [], forceBlock: false };
+    }
     const fileCount = params.files.length;
     const totalChanges = params.files.reduce((sum, f) => sum + f.changes, 0);
     const findings = [];
@@ -52034,6 +52054,8 @@ async function evaluateGate(config, commitSha, prNumber) {
         prNumber,
         token: config.githubToken,
         provenance,
+        headRef: prMatchCtx.headRef,
+        baseRef: prMatchCtx.baseRef,
     });
     if (prScope.factor) {
         riskFactors.push(prScope.factor);

--- a/dist/index.js
+++ b/dist/index.js
@@ -42360,6 +42360,18 @@ const RepoConfig = objectType({
             threshold: numberType().min(0).max(100).default(100),
         })
             .default({}),
+        // GATE-3: per-severity penalty points added to the weighted risk score
+        // for each risk factor at that severity (applyRiskFactorSeverityPenalties).
+        // Opt-in: penalties apply only when enabled=true, so shipping the feature
+        // doesn't shift every repo's scores mid-calibration.
+        risk_factor_severity: objectType({
+            enabled: booleanType().default(false),
+            critical: numberType().min(0).optional(),
+            high: numberType().min(0).optional(),
+            medium: numberType().min(0).optional(),
+            low: numberType().min(0).optional(),
+        })
+            .optional(),
     })
         .default({}),
 });
@@ -42503,7 +42515,13 @@ function parseRepoConfigContent(content) {
 // ---------------------------------------------------------------------------
 // Pattern constants
 // ---------------------------------------------------------------------------
-const TEST_FILE_PATTERN = /\.(test|spec)\.(ts|tsx|js|jsx)$|__tests__\/|\.cy\.(ts|js)$/;
+// Recognizes test files across language conventions, not just JS `.test.`/`.spec.`.
+// The `_test.<ext>` arm covers the Deno convention (`foo_test.ts`) — komatik's
+// entire Edge-Function suite uses it, so without this every EF PR scored as
+// zero-coverage and got over-penalized at the agent risk threshold (#307). Also
+// covers Go (`_test.go`), Python (`test_*.py` / `*_test.py` / `conftest.py`),
+// Ruby (`*_spec.rb` / `spec/`), and Java (`*Test.java`/`*Tests.java`).
+const TEST_FILE_PATTERN = /\.(test|spec)\.(ts|tsx|js|jsx|mjs|cjs)$|_test\.(ts|tsx|js|jsx|mjs|cjs|go)$|(^|\/)test_[^/]+\.py$|_test\.py$|(^|\/)conftest\.py$|_spec\.rb$|(^|\/)spec\/|(Test|Tests)\.java$|__tests__\/|\.cy\.(ts|js)$/;
 const NON_SOURCE_PATTERN = /\.(sql|ya?ml|json|md|css|svg|lock|txt|env|png|jpg|gif)$/i;
 const SENSITIVE_PATTERNS = [
     /(?:^|\/)migrations\//i,
@@ -49333,14 +49351,22 @@ function resolveRelativeImport(fromFile, specifier, prPaths) {
     return candidates.some((c) => prPaths.has(c));
 }
 function detectImportResolution(ctx) {
+    // Resolving relative imports needs repo ground truth: an import to an existing,
+    // UNCHANGED sibling (not in this PR's diff) is valid but looks "unresolved" if we
+    // only check changed files — a blocking false positive. Without repoPaths we can't
+    // tell that from a fabricated path, so stay dormant (the repoPaths convention used
+    // by the other existence-dependent detectors).
+    if (!ctx.repoPaths)
+        return null;
     const codeExts = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"]);
+    const known = new Set([...ctx.prPaths, ...ctx.repoPaths]);
     const hits = [];
     for (const file of ctx.files) {
         if (!codeExts.has(extensionOf(file.filename)))
             continue;
         const content = fileContent(file);
         for (const specifier of extractRelativeImports(content)) {
-            if (!resolveRelativeImport(file.filename, specifier, ctx.prPaths)) {
+            if (!resolveRelativeImport(file.filename, specifier, known)) {
                 hits.push(file.filename);
                 break;
             }
@@ -50882,6 +50908,41 @@ async function fetchPrFiles(prNumber, token) {
         return [];
     }
 }
+/**
+ * Full file list of the PR head tree (git ls-files equivalent, via the API) so
+ * import_resolution can resolve relative imports to existing, UNCHANGED siblings
+ * — not just files in the PR diff. Returns undefined on any failure or a truncated
+ * tree, which leaves import_resolution dormant rather than risking false positives.
+ */
+async function fetchRepoPaths(prNumber, token) {
+    if (!token)
+        return undefined;
+    try {
+        const octokit = getOctokit(token);
+        const { owner, repo } = github_context.repo;
+        const headSha = github_context.payload?.pull_request
+            ?.head?.sha ??
+            (await octokit.rest.pulls.get({ owner, repo, pull_number: prNumber })).data.head
+                .sha;
+        const { data } = await octokit.rest.git.getTree({
+            owner,
+            repo,
+            tree_sha: headSha,
+            recursive: "true",
+        });
+        if (data.truncated) {
+            core_debug("Repo tree truncated; skipping repoPaths (import_resolution stays dormant).");
+            return undefined;
+        }
+        return data.tree
+            .filter((e) => e.type === "blob" && typeof e.path === "string")
+            .map((e) => e.path);
+    }
+    catch (error) {
+        core_debug(`Failed to fetch repo tree for repoPaths: ${error}`);
+        return undefined;
+    }
+}
 // ---------------------------------------------------------------------------
 // Risk scoring — delegates to shared engine
 // ---------------------------------------------------------------------------
@@ -51995,6 +52056,24 @@ async function evaluateGate(config, commitSha, prNumber) {
     const riskScore = riskFactors.length > 0
         ? weightedAverageScores(riskFactors, customWeights)
         : localRiskScore;
+    // GATE-3: Apply severity-based penalties to risk factors. Opt-in via
+    // policies.risk_factor_severity.enabled — an always-on penalty would shift
+    // every repo's scores mid-calibration, making block-rate movement
+    // unattributable to config vs release drift.
+    const severityPenaltiesCfg = repoConfig?.policies?.risk_factor_severity;
+    const severityPenaltiesEnabled = severityPenaltiesCfg?.enabled === true;
+    const severityPenalties = {
+        critical: severityPenaltiesCfg?.critical ?? 10,
+        high: severityPenaltiesCfg?.high ?? 5,
+        medium: severityPenaltiesCfg?.medium ?? 2,
+        low: severityPenaltiesCfg?.low ?? 1,
+    };
+    const { adjustedScore: riskScoreWithPenalties, appliedPenalties } = severityPenaltiesEnabled
+        ? applyRiskFactorSeverityPenalties(riskScore, riskFactors, severityPenalties)
+        : { adjustedScore: riskScore, appliedPenalties: 0 };
+    if (appliedPenalties > 0) {
+        info(`GATE-3: Applied ${appliedPenalties} points of severity penalties to risk score (${riskScore} -> ${riskScoreWithPenalties})`);
+    }
     const agentPolicy = await enforceAgentPrPolicies({
         prNumber,
         token: config.githubToken,
@@ -52028,6 +52107,12 @@ async function evaluateGate(config, commitSha, prNumber) {
                 core_warning(`contract_integrity: could not load catalog index "${catalogIndexPath}": ${err.message}`);
             }
         }
+        // import_resolution ground truth: the full repo file list lets relative
+        // imports resolve to existing, unchanged siblings (not just changed files),
+        // killing the false-positive block. Undefined → that detector stays dormant.
+        const repoPaths = prNumber
+            ? await fetchRepoPaths(prNumber, config.githubToken)
+            : undefined;
         submissionChecks = runSubmissionGate({
             files: files.map((f) => ({
                 filename: f.filename,
@@ -52040,6 +52125,7 @@ async function evaluateGate(config, commitSha, prNumber) {
             mode: submissionMode,
             declaredPackages: parseDeclaredPackages(process.env.TRAILHEAD_DECLARED_PACKAGES),
             catalogKnownEntities,
+            repoPaths,
             // promotion_coherence (ADR-010): branch topology from the Actions env.
             promotion: process.env.GITHUB_BASE_REF || process.env.GITHUB_HEAD_REF
                 ? {
@@ -52076,9 +52162,10 @@ async function evaluateGate(config, commitSha, prNumber) {
     if (mcpCheck)
         healthChecks.push(mcpCheck);
     const healthScore = aggregateHealthScore(healthChecks);
+    // GATE-3: Use riskScoreWithPenalties for gate decision
     const baselineDecision = freezeCheck.frozen
         ? "block"
-        : decideGate(riskScore, healthScore, adjustedRiskThreshold, effectiveWarnThreshold);
+        : decideGate(riskScoreWithPenalties, healthScore, adjustedRiskThreshold, effectiveWarnThreshold);
     // GATE-3 (2b): critical sensitive_files change escalates out of the risk average.
     const sensitiveEscalation = decideSensitiveFilesEscalation(riskFactors, repoConfig?.policies?.sensitive_files);
     if (sensitiveEscalation.reason)
@@ -52172,7 +52259,7 @@ async function evaluateGate(config, commitSha, prNumber) {
                     info("[agent-trust] metrics present but trust=null (cold start — insufficient evidence or flat signals)");
                 }
             }
-            return strictnessFromTrust(trust, riskScore);
+            return strictnessFromTrust(trust, riskScoreWithPenalties);
         })()
         : {
             strictness: "baseline",
@@ -52184,7 +52271,7 @@ async function evaluateGate(config, commitSha, prNumber) {
         commitSha,
         prNumber,
         healthScore,
-        riskScore,
+        riskScore: riskScoreWithPenalties, // GATE-3: Use adjusted score with severity penalties
         gateDecision,
         healthChecks,
         riskFactors,
@@ -52280,7 +52367,7 @@ async function evaluateGate(config, commitSha, prNumber) {
     const releaseResult = computeReleaseReady({
         gateMode,
         gateDecision,
-        riskScore,
+        riskScore: riskScoreWithPenalties, // GATE-3: Use adjusted score
         riskThreshold: adjustedRiskThreshold,
         healthScore,
         healthChecksConfigured: healthChecks.length > 0,
@@ -52471,6 +52558,37 @@ async function createCheckRun(evaluation, report, token, checkName) {
     catch (error) {
         core_debug(`Failed to create check run: ${error}`);
     }
+}
+// ---------------------------------------------------------------------------
+// Risk factor severity penalty application (GATE-3)
+// ---------------------------------------------------------------------------
+/**
+ * Apply severity-based penalties to risk factors.
+ * Adds penalty points for high/critical severity factors to increase overall risk score.
+ */
+function applyRiskFactorSeverityPenalties(baseRiskScore, riskFactors, severityPenalties) {
+    const penalties = severityPenalties ?? { critical: 10, high: 5, medium: 2, low: 1 };
+    let totalPenalty = 0;
+    for (const factor of riskFactors) {
+        const detail = factor.detail;
+        const severity = detail?.["severity"];
+        if (severity) {
+            const penaltyValue = severity === "critical"
+                ? (penalties.critical ?? 10)
+                : severity === "high"
+                    ? (penalties.high ?? 5)
+                    : severity === "medium"
+                        ? (penalties.medium ?? 2)
+                        : severity === "low"
+                            ? (penalties.low ?? 1)
+                            : 0;
+            if (penaltyValue > 0) {
+                totalPenalty += penaltyValue;
+            }
+        }
+    }
+    const adjustedScore = Math.min(100, baseRiskScore + totalPenalty);
+    return { adjustedScore, appliedPenalties: totalPenalty };
 }
 
 // ---------------------------------------------------------------------------

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trailhead",
-  "version": "4.5.4",
+  "version": "4.5.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "trailhead",
-      "version": "4.5.4",
+      "version": "4.5.7",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trailhead",
-  "version": "4.5.6",
+  "version": "4.5.7",
   "private": true,
   "description": "Release readiness gate for GitHub PRs — waits for CI, scores code risk, checks production health, and blocks merges that are not release-ready.",
   "license": "MIT",

--- a/src/__tests__/cross-repo-impact.test.ts
+++ b/src/__tests__/cross-repo-impact.test.ts
@@ -74,6 +74,7 @@ const baseConfig = {
       max_changes: 2000,
       mode: "warn",
       require_plan_for_agent_prs: false,
+      exempt: [],
     },
     duplicate_logic: { enabled: true, mode: "warn" },
     cross_repo_impact: { enabled: true, mode: "warn" as const },

--- a/src/__tests__/pr-scope-exempt.test.ts
+++ b/src/__tests__/pr-scope-exempt.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { detectPrScopeRisk } from "../gate.js";
+import type { RepoConfig } from "../types.js";
+
+// 89 files / ~4262 changes — the shape of a real promotion PR (komatik #2743)
+// that structurally exceeds any sane max_files/max_changes.
+const bigPr = Array.from({ length: 89 }, (_, i) => ({
+  filename: `src/file-${i}.ts`,
+  changes: 48,
+  additions: 24,
+  deletions: 24,
+  status: "modified",
+}));
+
+function repoConfig(exempt: Array<{ head_branch?: string[]; base_branch?: string[] }>) {
+  return {
+    policies: {
+      pr_scope: {
+        enabled: true,
+        max_files: 50,
+        max_changes: 2000,
+        mode: "block",
+        require_plan_for_agent_prs: false,
+        exempt: exempt.map((e) => ({
+          head_branch: e.head_branch ?? [],
+          base_branch: e.base_branch ?? [],
+        })),
+      },
+    },
+  } as unknown as RepoConfig;
+}
+
+describe("pr_scope branch exemptions", () => {
+  it("blocks an oversized PR with no exempt rules", async () => {
+    const result = await detectPrScopeRisk({
+      files: bigPr as never,
+      repoConfig: repoConfig([]),
+      provenance: null,
+      headRef: "feature/huge",
+      baseRef: "dev",
+    });
+    expect(result.findings.length).toBeGreaterThan(0);
+    expect(result.factor?.type).toBe("pr_scope");
+  });
+
+  it("exempts a promotion PR matching a head/base pair", async () => {
+    const result = await detectPrScopeRisk({
+      files: bigPr as never,
+      repoConfig: repoConfig([{ head_branch: ["dev"], base_branch: ["staging"] }]),
+      provenance: null,
+      headRef: "dev",
+      baseRef: "staging",
+    });
+    expect(result.findings).toEqual([]);
+    expect(result.factor).toBeNull();
+    expect(result.forceBlock).toBe(false);
+  });
+
+  it("does not exempt when only one side of the pair matches", async () => {
+    const result = await detectPrScopeRisk({
+      files: bigPr as never,
+      repoConfig: repoConfig([{ head_branch: ["dev"], base_branch: ["staging"] }]),
+      provenance: null,
+      headRef: "dev",
+      baseRef: "master",
+    });
+    expect(result.findings.length).toBeGreaterThan(0);
+  });
+
+  it("treats an empty pattern list as wildcard (contexts[].match semantics)", async () => {
+    const result = await detectPrScopeRisk({
+      files: bigPr as never,
+      repoConfig: repoConfig([{ base_branch: ["master"] }]),
+      provenance: null,
+      headRef: "staging",
+      baseRef: "master",
+    });
+    expect(result.findings).toEqual([]);
+  });
+
+  it("does not exempt when branch refs are unavailable", async () => {
+    const result = await detectPrScopeRisk({
+      files: bigPr as never,
+      repoConfig: repoConfig([{ head_branch: ["dev"], base_branch: ["staging"] }]),
+      provenance: null,
+    });
+    expect(result.findings.length).toBeGreaterThan(0);
+  });
+});

--- a/src/__tests__/risk-engine.test.ts
+++ b/src/__tests__/risk-engine.test.ts
@@ -78,7 +78,9 @@ describe("risk-engine", () => {
 
     it("identifies test files across language conventions (#307)", () => {
       // Deno underscore convention — komatik's entire EF suite uses it
-      expect(isTestFile("supabase/functions/_shared/shadcn-substrate_test.ts")).toBe(true);
+      expect(isTestFile("supabase/functions/_shared/shadcn-substrate_test.ts")).toBe(
+        true,
+      );
       expect(isTestFile("pkg/server_test.go")).toBe(true);
       expect(isTestFile("tests/test_models.py")).toBe(true);
       expect(isTestFile("app/user_test.py")).toBe(true);

--- a/src/gate.ts
+++ b/src/gate.ts
@@ -1778,19 +1778,22 @@ export async function evaluateGate(
       ? weightedAverageScores(riskFactors as RiskFactorResult[], customWeights)
       : localRiskScore;
 
-  // GATE-3: Apply severity-based penalties to risk factors
+  // GATE-3: Apply severity-based penalties to risk factors. Opt-in via
+  // policies.risk_factor_severity.enabled — an always-on penalty would shift
+  // every repo's scores mid-calibration, making block-rate movement
+  // unattributable to config vs release drift.
   const severityPenaltiesCfg = repoConfig?.policies?.risk_factor_severity;
-  const severityPenalties = severityPenaltiesCfg
-    ? {
-        critical: severityPenaltiesCfg.critical ?? 10,
-        high: severityPenaltiesCfg.high ?? 5,
-        medium: severityPenaltiesCfg.medium ?? 2,
-        low: severityPenaltiesCfg.low ?? 1,
-      }
-    : { critical: 10, high: 5, medium: 2, low: 1 }; // Default penalties
+  const severityPenaltiesEnabled = severityPenaltiesCfg?.enabled === true;
+  const severityPenalties = {
+    critical: severityPenaltiesCfg?.critical ?? 10,
+    high: severityPenaltiesCfg?.high ?? 5,
+    medium: severityPenaltiesCfg?.medium ?? 2,
+    low: severityPenaltiesCfg?.low ?? 1,
+  };
 
-  const { adjustedScore: riskScoreWithPenalties, appliedPenalties } =
-    applyRiskFactorSeverityPenalties(riskScore, riskFactors, severityPenalties);
+  const { adjustedScore: riskScoreWithPenalties, appliedPenalties } = severityPenaltiesEnabled
+    ? applyRiskFactorSeverityPenalties(riskScore, riskFactors, severityPenalties)
+    : { adjustedScore: riskScore, appliedPenalties: 0 };
 
   if (appliedPenalties > 0) {
     core.info(

--- a/src/gate.ts
+++ b/src/gate.ts
@@ -1811,9 +1811,10 @@ export async function evaluateGate(
     low: severityPenaltiesCfg?.low ?? 1,
   };
 
-  const { adjustedScore: riskScoreWithPenalties, appliedPenalties } = severityPenaltiesEnabled
-    ? applyRiskFactorSeverityPenalties(riskScore, riskFactors, severityPenalties)
-    : { adjustedScore: riskScore, appliedPenalties: 0 };
+  const { adjustedScore: riskScoreWithPenalties, appliedPenalties } =
+    severityPenaltiesEnabled
+      ? applyRiskFactorSeverityPenalties(riskScore, riskFactors, severityPenalties)
+      : { adjustedScore: riskScore, appliedPenalties: 0 };
 
   if (appliedPenalties > 0) {
     core.info(

--- a/src/gate.ts
+++ b/src/gate.ts
@@ -871,15 +871,33 @@ interface PrScopeDetection {
   forceBlock: boolean;
 }
 
-async function detectPrScopeRisk(params: {
+export async function detectPrScopeRisk(params: {
   files: PrFileInfo[];
   repoConfig: RepoConfig | null;
   prNumber?: number;
   token?: string;
   provenance: PrProvenance | null;
+  headRef?: string;
+  baseRef?: string;
 }): Promise<PrScopeDetection> {
   const cfg = params.repoConfig?.policies?.pr_scope;
   if (!cfg?.enabled) return { factor: null, findings: [], forceBlock: false };
+
+  const exempt = (cfg.exempt ?? []).some((rule) => {
+    const headOk =
+      rule.head_branch.length === 0 ||
+      (params.headRef !== undefined && matchesGlobs(params.headRef, rule.head_branch));
+    const baseOk =
+      rule.base_branch.length === 0 ||
+      (params.baseRef !== undefined && matchesGlobs(params.baseRef, rule.base_branch));
+    return headOk && baseOk;
+  });
+  if (exempt) {
+    core.info(
+      `pr_scope: branch pair ${params.headRef ?? "?"} -> ${params.baseRef ?? "?"} matches an exempt rule — scope limits skipped`,
+    );
+    return { factor: null, findings: [], forceBlock: false };
+  }
 
   const fileCount = params.files.length;
   const totalChanges = params.files.reduce((sum, f) => sum + f.changes, 0);
@@ -1748,6 +1766,8 @@ export async function evaluateGate(
     prNumber,
     token: config.githubToken,
     provenance,
+    headRef: prMatchCtx.headRef,
+    baseRef: prMatchCtx.baseRef,
   });
   if (prScope.factor) {
     riskFactors.push(prScope.factor);

--- a/src/types.ts
+++ b/src/types.ts
@@ -611,6 +611,18 @@ export const RepoConfig = z.object({
           max_changes: z.number().int().min(1).default(2000),
           mode: z.enum(["warn", "block"]).default("warn"),
           require_plan_for_agent_prs: z.boolean().default(false),
+          // Branch pairs exempt from scope limits (glob patterns; empty list
+          // matches any branch, same semantics as contexts[].match). Meant for
+          // promotion PRs (dev→staging, staging→master), which aggregate many
+          // already-gated merges and structurally exceed any sane max_files.
+          exempt: z
+            .array(
+              z.object({
+                head_branch: z.array(z.string()).default([]),
+                base_branch: z.array(z.string()).default([]),
+              }),
+            )
+            .default([]),
         })
         .default({}),
       duplicate_logic: z

--- a/src/types.ts
+++ b/src/types.ts
@@ -637,8 +637,11 @@ export const RepoConfig = z.object({
         .default({}),
       // GATE-3: per-severity penalty points added to the weighted risk score
       // for each risk factor at that severity (applyRiskFactorSeverityPenalties).
+      // Opt-in: penalties apply only when enabled=true, so shipping the feature
+      // doesn't shift every repo's scores mid-calibration.
       risk_factor_severity: z
         .object({
+          enabled: z.boolean().default(false),
           critical: z.number().min(0).optional(),
           high: z.number().min(0).optional(),
           medium: z.number().min(0).optional(),


### PR DESCRIPTION
Phase 0 of the gate-tuning campaign (see `komatik-agents/intel/TRAILHEAD-GATE-REVIEW-2026-07-01.md`): get the unreleased strictness-relevant changes out the door in a calibration-safe way — plus a release-integrity fix found on the way.

**1. Ships the `TEST_FILE_PATTERN` Deno fix (#307/#308)** — the dominant false-block class on komatik (Deno `_test.ts` scored as zero test files → `test_coverage`=100 → block; test_coverage ≥60 on 70% of komatik evals over 60d).

**2. GATE-3 severity penalties (#305) become opt-in** — `policies.risk_factor_severity.enabled: true` required; defaults (10/5/2/1) unchanged when enabled. As merged, penalties applied unconditionally, which would shift every repo's scores in the same release that's supposed to *reduce* false blocks — making Phase-0 block-rate movement unattributable.

**3. NEW — `pr_scope.exempt`: branch-pair exemptions from scope limits.** Promotion PRs (dev→staging, staging→master) aggregate many already-individually-gated merges and structurally exceed any sane max_files/max_changes — komatik #2743 (89 files, 4262 changes) was force-blocked purely on scope. `policies.pr_scope.exempt` takes head_branch/base_branch glob pairs (empty list = wildcard, `contexts[].match` semantics); matching PRs skip scope limits entirely; refs unavailable = no exemption (fail strict). +5 tests (816 total pass). Hand-rolled YAML parser verified to round-trip the nested exempt shape.

**4. Release-integrity fix: v4.5.5 and v4.5.6 shipped stale `dist/`.** The action serves the *committed* `dist/index.js`; the release workflow builds but discards its output. `dist` was last committed June 7 — the v4.5.5 `import_resolution` fix (c3473d7) **never actually reached consumers**, and tagging v4.5.7 without this would have silently dropped the Deno fix too. This PR commits a fresh bundle and adds a release-workflow step failing the release when committed dist ≠ fresh build of the tagged source.

**Verification:** 816/816 tests; tsc clean; ncc build clean; dist grep-confirmed to contain both the GATE-3 opt-in gate and the exempt logic.

**After merge:** tag the merge commit `v4.5.7` (release workflow: tests, build, dist guard, `v4` major-tag move, GitHub release) → then KomatikAI/komatik#2750 (pin bump + promote-exemption config) and fleet-wide pin bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)