### PR TITLE
ci(release): make CI-built dist canonical instead of failing on env-noise diff

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,17 +29,25 @@ jobs:
       - name: Build (ncc)
         run: npm run build
 
-      # The action serves the COMMITTED dist/ at the tag (main: dist/index.js);
-      # this workflow's build output is discarded. If the committed bundle does
-      # not match a fresh build of the tagged source, the "release" ships stale
-      # code — this happened silently on v4.5.5/v4.5.6 (dist last committed
-      # 2026-06-07; the v4.5.5 import_resolution fix never reached consumers).
-      - name: Verify committed dist matches this source
+      # The action serves the COMMITTED dist/ at the tag (main: dist/index.js).
+      # v4.5.5/v4.5.6 silently shipped stale dist (last committed 2026-06-07;
+      # the v4.5.5 import_resolution fix never reached consumers). ncc output
+      # is NOT byte-reproducible across environments, so instead of failing on
+      # any diff, make the CI build canonical: commit it and move the version
+      # tag to that commit. The shipped bundle then always matches the tagged
+      # source by construction. (GITHUB_TOKEN pushes don't re-trigger this
+      # workflow, so the run continues to the major-tag + release steps below.)
+      - name: Make CI-built dist canonical (commit + retag if it differs)
         run: |
           if ! git diff --quiet -- dist; then
-            echo "::error::dist/ is stale — run 'npm run build' and commit dist before tagging"
+            echo "dist differs from the CI build — committing the CI-built bundle and moving ${GITHUB_REF_NAME}"
             git diff --stat -- dist
-            exit 1
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add dist
+            git commit -m "build(release): CI-built dist for ${GITHUB_REF_NAME}"
+            git tag -f "${GITHUB_REF_NAME}" HEAD
+            git push origin "${GITHUB_REF_NAME}" --force
           fi
 
       - name: Update major version tag


### PR DESCRIPTION
Follow-up to #309: the new dist guard failed the v4.5.7 release on a 40-line environment-noise diff — ncc output is not byte-reproducible across machines, so strict equality can never pass for locally-built dist. This flips the guard from fail to self-heal: the release workflow commits its own CI-built bundle and force-moves the version tag to that commit. Shipped dist == tagged source by construction; a v4.5.5-style stale-dist tag now ships CORRECT code instead of failing. GITHUB_TOKEN pushes don't re-trigger the workflow, so the same run continues to the major-tag move + GitHub release.

After merge: re-point the v4.5.7 tag at the new dev HEAD to rerun the release with the fixed workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)