### PR TITLE
feat(action): Trailhead Cloud upsell + quota/billing surfacing in check summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,24 @@ See [docs/evaluation-storage.md](docs/evaluation-storage.md) and [docs/marketpla
 
 Bring-your-own-store (`evaluation-store-url` + secret) remains supported for self-hosted deployments.
 
+#### Check-summary footer
+
+When no `trailhead-api-key` is configured, the check summary ends with one footer line pointing at Trailhead Cloud — it never affects the gate decision and is purely informational:
+
+> 📊 This evaluation wasn't persisted — track trends, DORA metrics & agent-governance across your org with Trailhead Cloud → https://trailhead.komatik.xyz
+
+Set `disable-cloud-upsell: true` to suppress it.
+
+When a `trailhead-api-key` **is** configured, the same footer slot instead surfaces plan/billing state reported by the Cloud API — the gate always evaluates normally; store availability never blocks a merge:
+
+| Cloud API response                              | Footer                                                             | Evaluation stored? |
+| ------------------------------------------------ | -------------------------------------------------------------------- | ------------------- |
+| `200` + `X-Trailhead-Quota-Exceeded: true`        | Soft over-quota warning with an upgrade link                         | Yes                 |
+| `402` (plan suspended)                            | Plain "not stored — plan suspended" notice with a reactivation link | No                  |
+| `429` (hard usage cap, 3× plan limit)             | Plain "not stored — over hard usage cap" notice with an upgrade link | No                  |
+
+All links carry `utm_source=action&utm_medium=check-summary&utm_campaign=<cloud-upsell|quota-upsell|suspended-upsell>` for clickthrough measurement.
+
 ### Gate modes
 
 | Mode            | Behavior                                                                                                                 |
@@ -187,6 +205,7 @@ For **AI-authored PRs**, enable the submission gate and remediation loop — see
 | `trailhead-api-key`               | —          | Trailhead Cloud API key (auto-configures store)       |
 | `evaluation-store-url`            | —          | BYOS evaluation trend store URL                       |
 | `evaluation-store-secret`         | —          | Bearer token for evaluation store                     |
+| `disable-cloud-upsell`            | `false`    | Suppress the Cloud upsell/quota footer line            |
 | `dora-metrics`                    | `false`    | Compute DORA-5 metrics alongside gate                 |
 | `dora-environment`                | —          | Filter DORA metrics to one environment                |
 | `environment`                     | —          | Target deployment environment for threshold overrides |
@@ -237,6 +256,7 @@ Full input list and outputs below. Legacy table retained for reference:
 | `evaluation-store-url`      | No       | —                     | URL to POST evaluations for trend dashboards (BYOS; omit if using `trailhead-api-key`)       |
 | `evaluation-store-secret`   | No       | —                     | Bearer token for `evaluation-store-url`                                                      |
 | `evaluation-store-retries`  | No       | `3`                   | Retry attempts for transient evaluation store failures                                       |
+| `disable-cloud-upsell`      | No       | `false`               | Suppress the Trailhead Cloud upsell/quota footer line in the check summary                   |
 | `dora-metrics`              | No       | `false`               | Compute DORA-5 metrics alongside the gate evaluation                                         |
 | `dora-environment`          | No       | —                     | Filter DORA metrics to a specific deployment environment                                     |
 | `environment`               | No       | —                     | Target deployment environment (for per-env threshold overrides)                              |

--- a/README.md
+++ b/README.md
@@ -110,11 +110,11 @@ Set `disable-cloud-upsell: true` to suppress it.
 
 When a `trailhead-api-key` **is** configured, the same footer slot instead surfaces plan/billing state reported by the Cloud API — the gate always evaluates normally; store availability never blocks a merge:
 
-| Cloud API response                              | Footer                                                             | Evaluation stored? |
-| ------------------------------------------------ | -------------------------------------------------------------------- | ------------------- |
-| `200` + `X-Trailhead-Quota-Exceeded: true`        | Soft over-quota warning with an upgrade link                         | Yes                 |
-| `402` (plan suspended)                            | Plain "not stored — plan suspended" notice with a reactivation link | No                  |
-| `429` (hard usage cap, 3× plan limit)             | Plain "not stored — over hard usage cap" notice with an upgrade link | No                  |
+| Cloud API response                         | Footer                                                               | Evaluation stored? |
+| ------------------------------------------ | -------------------------------------------------------------------- | ------------------ |
+| `200` + `X-Trailhead-Quota-Exceeded: true` | Soft over-quota warning with an upgrade link                         | Yes                |
+| `402` (plan suspended)                     | Plain "not stored — plan suspended" notice with a reactivation link  | No                 |
+| `429` (hard usage cap, 3× plan limit)      | Plain "not stored — over hard usage cap" notice with an upgrade link | No                 |
 
 All links carry `utm_source=action&utm_medium=check-summary&utm_campaign=<cloud-upsell|quota-upsell|suspended-upsell>` for clickthrough measurement.
 
@@ -205,7 +205,7 @@ For **AI-authored PRs**, enable the submission gate and remediation loop — see
 | `trailhead-api-key`               | —          | Trailhead Cloud API key (auto-configures store)       |
 | `evaluation-store-url`            | —          | BYOS evaluation trend store URL                       |
 | `evaluation-store-secret`         | —          | Bearer token for evaluation store                     |
-| `disable-cloud-upsell`            | `false`    | Suppress the Cloud upsell/quota footer line            |
+| `disable-cloud-upsell`            | `false`    | Suppress the Cloud upsell/quota footer line           |
 | `dora-metrics`                    | `false`    | Compute DORA-5 metrics alongside gate                 |
 | `dora-environment`                | —          | Filter DORA metrics to one environment                |
 | `environment`                     | —          | Target deployment environment for threshold overrides |

--- a/action.yml
+++ b/action.yml
@@ -91,6 +91,10 @@ inputs:
     description: "Number of retry attempts when POST to evaluation-store-url fails with transient errors (default 3)."
     required: false
     default: "3"
+  disable-cloud-upsell:
+    description: "Suppress the Trailhead Cloud upsell/quota footer line in the check summary (shown by default when no trailhead-api-key is set, or when the Cloud API reports quota/billing state)."
+    required: false
+    default: "false"
   dora-metrics:
     description: "Compute DORA-5 metrics (deployment frequency, change failure rate, lead time, FDRT, rework rate) alongside the gate evaluation."
     required: false

--- a/src/__tests__/cloud-upsell.test.ts
+++ b/src/__tests__/cloud-upsell.test.ts
@@ -71,7 +71,11 @@ describe("buildCloudFooterLine", () => {
       buildCloudFooterLine({ hasCloudKey: true, disableUpsell: true, hardCapped: true }),
     ).toBeNull();
     expect(
-      buildCloudFooterLine({ hasCloudKey: true, disableUpsell: true, quotaExceeded: true }),
+      buildCloudFooterLine({
+        hasCloudKey: true,
+        disableUpsell: true,
+        quotaExceeded: true,
+      }),
     ).toBeNull();
   });
 

--- a/src/__tests__/cloud-upsell.test.ts
+++ b/src/__tests__/cloud-upsell.test.ts
@@ -1,0 +1,88 @@
+import { buildCloudFooterLine } from "../cloud-upsell.js";
+
+describe("buildCloudFooterLine", () => {
+  it("shows the no-key upsell line when no cloud key is configured", () => {
+    const line = buildCloudFooterLine({ hasCloudKey: false, disableUpsell: false });
+    expect(line).not.toBeNull();
+    expect(line).toContain("wasn't persisted");
+    expect(line).toContain("Trailhead Cloud");
+    expect(line).toContain("https://trailhead.komatik.xyz/");
+    expect(line).toContain("utm_source=action");
+    expect(line).toContain("utm_medium=check-summary");
+    expect(line).toContain("utm_campaign=cloud-upsell");
+    // Exactly one line.
+    expect(line?.includes("\n")).toBe(false);
+  });
+
+  it("suppresses the no-key upsell line when disable-cloud-upsell is set", () => {
+    const line = buildCloudFooterLine({ hasCloudKey: false, disableUpsell: true });
+    expect(line).toBeNull();
+  });
+
+  it("says nothing when a cloud key is configured and nothing is exceptional", () => {
+    const line = buildCloudFooterLine({ hasCloudKey: true, disableUpsell: false });
+    expect(line).toBeNull();
+  });
+
+  it("shows the soft quota-exceeded line when the org has a key but is over quota", () => {
+    const line = buildCloudFooterLine({
+      hasCloudKey: true,
+      disableUpsell: false,
+      quotaExceeded: true,
+    });
+    expect(line).not.toBeNull();
+    expect(line).toContain("Over your plan's monthly evaluations");
+    expect(line).toContain("history still stored");
+    expect(line).toContain("utm_campaign=quota-upsell");
+    expect(line?.includes("\n")).toBe(false);
+  });
+
+  it("shows a plain not-stored message and link when suspended (402)", () => {
+    const line = buildCloudFooterLine({
+      hasCloudKey: true,
+      disableUpsell: false,
+      suspended: true,
+    });
+    expect(line).not.toBeNull();
+    expect(line).toContain("not stored");
+    expect(line).toContain("suspended");
+    expect(line).toContain("utm_campaign=suspended-upsell");
+    expect(line?.includes("\n")).toBe(false);
+  });
+
+  it("shows a plain not-stored message and link when hard-capped (429)", () => {
+    const line = buildCloudFooterLine({
+      hasCloudKey: true,
+      disableUpsell: false,
+      hardCapped: true,
+    });
+    expect(line).not.toBeNull();
+    expect(line).toContain("not stored");
+    expect(line).toContain("hard usage cap");
+    expect(line).toContain("utm_campaign=quota-upsell");
+    expect(line?.includes("\n")).toBe(false);
+  });
+
+  it("suppresses suspended/hard-capped/quota lines too when disable-cloud-upsell is set", () => {
+    expect(
+      buildCloudFooterLine({ hasCloudKey: true, disableUpsell: true, suspended: true }),
+    ).toBeNull();
+    expect(
+      buildCloudFooterLine({ hasCloudKey: true, disableUpsell: true, hardCapped: true }),
+    ).toBeNull();
+    expect(
+      buildCloudFooterLine({ hasCloudKey: true, disableUpsell: true, quotaExceeded: true }),
+    ).toBeNull();
+  });
+
+  it("prioritizes suspended over hard-capped and quota-exceeded", () => {
+    const line = buildCloudFooterLine({
+      hasCloudKey: true,
+      disableUpsell: false,
+      suspended: true,
+      hardCapped: true,
+      quotaExceeded: true,
+    });
+    expect(line).toContain("suspended");
+  });
+});

--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -243,6 +243,21 @@ describe("run — cloud-upsell footer in the check summary", () => {
     expect(summaryText).not.toContain("utm_campaign=cloud-upsell");
   });
 
+  it("does not show the no-key upsell to BYOS self-hosters (evaluation-store-url without a cloud key)", async () => {
+    const { summaryText } = await runMain({
+      inputs: { "api-key": "test-key", "evaluation-store-url": "https://store.example.com" },
+      storeOutcome: {
+        stored: true,
+        quotaExceeded: false,
+        suspended: false,
+        hardCapped: false,
+      },
+    });
+
+    expect(summaryText).not.toContain("wasn't persisted");
+    expect(summaryText).not.toContain("utm_campaign=cloud-upsell");
+  });
+
   it("appends the soft quota-exceeded footer when the cloud store reports quotaExceeded", async () => {
     const { summaryText } = await runMain({
       inputs: { "api-key": "test-key", "trailhead-api-key": "th_live_abc" },

--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -245,7 +245,10 @@ describe("run — cloud-upsell footer in the check summary", () => {
 
   it("does not show the no-key upsell to BYOS self-hosters (evaluation-store-url without a cloud key)", async () => {
     const { summaryText } = await runMain({
-      inputs: { "api-key": "test-key", "evaluation-store-url": "https://store.example.com" },
+      inputs: {
+        "api-key": "test-key",
+        "evaluation-store-url": "https://store.example.com",
+      },
       storeOutcome: {
         stored: true,
         quotaExceeded: false,

--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -78,13 +78,19 @@ describe("run (main entrypoint)", () => {
     const commentSpy = vi.spyOn(gate, "postPrComment").mockResolvedValue();
     const checkSpy = vi.spyOn(gate, "createCheckRun").mockResolvedValue();
     const webhookSpy = vi.spyOn(notify, "deliverWebhooks").mockResolvedValue();
-    const storeSpy = vi.spyOn(notify, "storeEvaluation").mockResolvedValue(true);
+    const storeSpy = vi.spyOn(notify, "storeEvaluationDetailed").mockResolvedValue({
+      stored: true,
+      quotaExceeded: false,
+      suspended: false,
+      hardCapped: false,
+    });
     setupInputs({
       "api-key": "test-key",
       "github-token": "ghp_test",
       "webhook-url": "https://hooks.slack.com/test",
       "webhook-events": "warn,block",
       "evaluation-store-url": "https://example.com/api/trailhead/store",
+      "disable-cloud-upsell": "true",
     });
 
     await import("../main.js");
@@ -120,5 +126,167 @@ describe("run (main entrypoint)", () => {
       { maxRetries: 3 },
     );
     expect(core.setFailed).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * Cloud-upsell footer, exercised end-to-end through `run()`. Each `run()`
+ * import has module-level side effects that only fire once per module
+ * instance, so these tests reset the module registry and re-import every
+ * dependency (including the @actions/* mocks) fresh per scenario.
+ */
+describe("run — cloud-upsell footer in the check summary", () => {
+  async function runMain(options: {
+    inputs: Record<string, string>;
+    storeOutcome?: {
+      stored: boolean;
+      quotaExceeded: boolean;
+      suspended: boolean;
+      hardCapped: boolean;
+    };
+  }): Promise<{
+    freshCore: typeof import("@actions/core");
+    summaryText: string;
+  }> {
+    vi.resetModules();
+
+    const freshCore = await import("@actions/core");
+    const freshGithub = await import("@actions/github");
+    const freshGate = await import("../gate.js");
+    const freshNotify = await import("../notify.js");
+    const freshHealers = await import("../healers/index.js");
+
+    vi.mocked(freshCore.getInput).mockImplementation(
+      (name: string) => options.inputs[name] ?? "",
+    );
+    (freshGithub.context as { payload: { pull_request?: { number: number } } }).payload =
+      {
+        pull_request: { number: 42 },
+      };
+    vi.mocked(freshGithub.getOctokit).mockReturnValue({
+      rest: {
+        issues: {
+          createComment: vi.fn().mockResolvedValue({}),
+          listComments: vi.fn().mockResolvedValue({ data: [] }),
+          updateComment: vi.fn().mockResolvedValue({}),
+          listLabelsOnIssue: vi.fn().mockResolvedValue({ data: [] }),
+          createLabel: vi.fn().mockResolvedValue({}),
+          removeLabel: vi.fn().mockResolvedValue({}),
+          addLabels: vi.fn().mockResolvedValue({}),
+        },
+        checks: { create: vi.fn().mockResolvedValue({}) },
+        pulls: {
+          requestReviewers: vi.fn().mockResolvedValue({}),
+          listFiles: vi.fn().mockResolvedValue({ data: [] }),
+          get: vi.fn().mockResolvedValue({ data: {} }),
+          listCommits: vi.fn().mockResolvedValue({ data: [] }),
+          listReviews: vi.fn().mockResolvedValue({ data: [] }),
+        },
+        repos: {
+          getContent: vi.fn().mockRejectedValue(new Error("not found")),
+          listCommits: vi.fn().mockResolvedValue({ data: [] }),
+        },
+      },
+      request: vi.fn().mockResolvedValue({ data: [] }),
+    } as never);
+
+    vi.spyOn(freshHealers, "registerHealer").mockImplementation(() => undefined);
+    vi.spyOn(freshGate, "evaluateGate").mockResolvedValue(makeEvaluation());
+    vi.spyOn(freshGate, "formatGateReport").mockReturnValue("## Report");
+    vi.spyOn(freshGate, "postPrComment").mockResolvedValue();
+    vi.spyOn(freshGate, "createCheckRun").mockResolvedValue();
+    if (options.storeOutcome) {
+      vi.spyOn(freshNotify, "storeEvaluationDetailed").mockResolvedValue(
+        options.storeOutcome,
+      );
+    }
+
+    await import("../main.js");
+    await new Promise((r) => setTimeout(r, 0));
+
+    const summaryText = vi
+      .mocked(freshCore.summary.addRaw)
+      .mock.calls.map((call) => call[0])
+      .join("\n");
+
+    return { freshCore, summaryText };
+  }
+
+  it("appends the no-key upsell footer when no trailhead-api-key is set", async () => {
+    const { summaryText } = await runMain({ inputs: { "api-key": "test-key" } });
+
+    expect(summaryText).toContain("wasn't persisted");
+    expect(summaryText).toContain("Trailhead Cloud");
+    expect(summaryText).toContain("utm_campaign=cloud-upsell");
+  });
+
+  it("suppresses the footer when disable-cloud-upsell is true", async () => {
+    const { summaryText } = await runMain({
+      inputs: { "api-key": "test-key", "disable-cloud-upsell": "true" },
+    });
+
+    expect(summaryText).not.toContain("Trailhead Cloud");
+    expect(summaryText).not.toContain("utm_campaign");
+  });
+
+  it("does not append the no-key footer when a trailhead-api-key is configured", async () => {
+    const { summaryText } = await runMain({
+      inputs: { "api-key": "test-key", "trailhead-api-key": "th_live_abc" },
+      storeOutcome: {
+        stored: true,
+        quotaExceeded: false,
+        suspended: false,
+        hardCapped: false,
+      },
+    });
+
+    expect(summaryText).not.toContain("utm_campaign=cloud-upsell");
+  });
+
+  it("appends the soft quota-exceeded footer when the cloud store reports quotaExceeded", async () => {
+    const { summaryText } = await runMain({
+      inputs: { "api-key": "test-key", "trailhead-api-key": "th_live_abc" },
+      storeOutcome: {
+        stored: true,
+        quotaExceeded: true,
+        suspended: false,
+        hardCapped: false,
+      },
+    });
+
+    expect(summaryText).toContain("Over your plan's monthly evaluations");
+    expect(summaryText).toContain("utm_campaign=quota-upsell");
+  });
+
+  it("appends the suspended footer and does not fail the gate on 402", async () => {
+    const { freshCore, summaryText } = await runMain({
+      inputs: { "api-key": "test-key", "trailhead-api-key": "th_live_abc" },
+      storeOutcome: {
+        stored: false,
+        quotaExceeded: false,
+        suspended: true,
+        hardCapped: false,
+      },
+    });
+
+    expect(summaryText).toContain("suspended");
+    expect(summaryText).toContain("utm_campaign=suspended-upsell");
+    expect(freshCore.setFailed).not.toHaveBeenCalled();
+  });
+
+  it("appends the hard-cap footer and does not fail the gate on 429", async () => {
+    const { freshCore, summaryText } = await runMain({
+      inputs: { "api-key": "test-key", "trailhead-api-key": "th_live_abc" },
+      storeOutcome: {
+        stored: false,
+        quotaExceeded: false,
+        suspended: false,
+        hardCapped: true,
+      },
+    });
+
+    expect(summaryText).toContain("hard usage cap");
+    expect(summaryText).toContain("utm_campaign=quota-upsell");
+    expect(freshCore.setFailed).not.toHaveBeenCalled();
   });
 });

--- a/src/__tests__/notify.test.ts
+++ b/src/__tests__/notify.test.ts
@@ -6,6 +6,7 @@ import {
   deliverWebhookEvent,
   sendWebhook,
   storeEvaluation,
+  storeEvaluationDetailed,
 } from "../notify.js";
 import { buildRemediation } from "../remediation.js";
 import type { GateEvaluation } from "../types.js";
@@ -406,5 +407,123 @@ describe("storeEvaluation", () => {
     await expect(promise).resolves.toBe(true);
     expect(fetch).toHaveBeenCalledTimes(2);
     vi.useRealTimers();
+  });
+});
+
+describe("storeEvaluationDetailed — quota/billing surfacing", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+    delete process.env.EVALUATION_STORE_SECRET;
+    delete process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+    delete process.env.SUPABASE_URL;
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete process.env.EVALUATION_STORE_SECRET;
+    delete process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+    delete process.env.SUPABASE_URL;
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+  });
+
+  it("reports quotaExceeded=true on 200 + X-Trailhead-Quota-Exceeded header, and stays stored", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response('{"stored":true}', {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+          "X-Trailhead-Quota-Exceeded": "true",
+        },
+      }),
+    );
+
+    const outcome = await storeEvaluationDetailed(
+      "https://example.com/api/trailhead/store",
+      makeEvaluation(),
+    );
+    expect(outcome).toEqual({
+      stored: true,
+      quotaExceeded: true,
+      suspended: false,
+      hardCapped: false,
+    });
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not set quotaExceeded when the header is absent", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(jsonResponse('{"stored":true}'));
+    const outcome = await storeEvaluationDetailed(
+      "https://example.com/api/trailhead/store",
+      makeEvaluation(),
+    );
+    expect(outcome.quotaExceeded).toBe(false);
+  });
+
+  it("reports suspended=true, stored=false, and does not throw on HTTP 402", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(jsonResponse('{"error":"suspended"}', 402));
+
+    const outcome = await storeEvaluationDetailed(
+      "https://example.com/api/trailhead/store",
+      makeEvaluation(),
+    );
+    expect(outcome).toEqual({
+      stored: false,
+      quotaExceeded: false,
+      suspended: true,
+      hardCapped: false,
+    });
+    // Not retried, and no Supabase-fallback fetch either (deliberate billing gate).
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports hardCapped=true, stored=false, and does not throw on JSON HTTP 429", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(jsonResponse('{"error":"hard_cap"}', 429));
+
+    const outcome = await storeEvaluationDetailed(
+      "https://example.com/api/trailhead/store",
+      makeEvaluation(),
+    );
+    expect(outcome).toEqual({
+      stored: false,
+      quotaExceeded: false,
+      suspended: false,
+      hardCapped: true,
+    });
+    // Not retried — a JSON 429 is a permanent-for-the-period hard cap, not transient.
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("still retries a non-JSON (HTML) 429 — likely bot protection, not a hard cap", async () => {
+    vi.useFakeTimers();
+    const html429 = () =>
+      new Response("<html>checkpoint</html>", {
+        status: 429,
+        headers: { "Content-Type": "text/html" },
+      });
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(html429())
+      .mockResolvedValueOnce(jsonResponse('{"stored":true}'));
+
+    const promise = storeEvaluationDetailed(
+      "https://example.com/api/trailhead/store",
+      makeEvaluation(),
+    );
+    await vi.advanceTimersByTimeAsync(1_000);
+    await expect(promise).resolves.toEqual({
+      stored: true,
+      quotaExceeded: false,
+      suspended: false,
+      hardCapped: false,
+    });
+    expect(fetch).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
+  });
+
+  it("storeEvaluation boolean wrapper still resolves false on suspended/hard-capped without throwing", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(jsonResponse('{"error":"suspended"}', 402));
+    await expect(
+      storeEvaluation("https://example.com/api/trailhead/store", makeEvaluation()),
+    ).resolves.toBe(false);
   });
 });

--- a/src/cloud-upsell.ts
+++ b/src/cloud-upsell.ts
@@ -1,0 +1,79 @@
+/**
+ * Trailhead Cloud upsell + quota/billing surfacing for the check summary footer.
+ *
+ * One line, always at the end of the summary, never affects the gate decision.
+ * Suppressible via the `disable-cloud-upsell` action input.
+ */
+
+export const CLOUD_MARKETING_URL = "https://trailhead.komatik.xyz";
+export const CLOUD_PRICING_URL = "https://trailhead.komatik.xyz/pricing";
+
+export type CloudUpsellCampaign = "cloud-upsell" | "quota-upsell" | "suspended-upsell";
+
+function withUtm(url: string, campaign: CloudUpsellCampaign): string {
+  const u = new URL(url);
+  u.searchParams.set("utm_source", "action");
+  u.searchParams.set("utm_medium", "check-summary");
+  u.searchParams.set("utm_campaign", campaign);
+  return u.toString();
+}
+
+export interface CloudFooterOptions {
+  /** Whether a trailhead-api-key was configured for this run (cloud mode). */
+  hasCloudKey: boolean;
+  /** `disable-cloud-upsell: true` input. */
+  disableUpsell: boolean;
+  /** Cloud API responded 200 with `X-Trailhead-Quota-Exceeded: true` (still stored). */
+  quotaExceeded?: boolean;
+  /** Cloud API responded 402 — org suspended, evaluation NOT stored. */
+  suspended?: boolean;
+  /** Cloud API responded 429 — hard usage cap, evaluation NOT stored. */
+  hardCapped?: boolean;
+}
+
+/**
+ * Build the single footer line to append to the check summary, or null if
+ * nothing should be shown (has a key, under quota, no billing issue, or
+ * the user opted out).
+ *
+ * Precedence: suspended > hard-capped > quota-exceeded > no-key upsell.
+ * These are mutually exclusive in practice (all require a configured key
+ * except the no-key case), but the order guards against ambiguous input.
+ */
+export function buildCloudFooterLine(options: CloudFooterOptions): string | null {
+  if (options.disableUpsell) return null;
+
+  if (options.suspended) {
+    const link = withUtm(CLOUD_PRICING_URL, "suspended-upsell");
+    return (
+      `> 🚫 **Evaluation not stored — your Trailhead Cloud plan is suspended.** ` +
+      `Reactivate to resume history & trends → ${link}`
+    );
+  }
+
+  if (options.hardCapped) {
+    const link = withUtm(CLOUD_PRICING_URL, "quota-upsell");
+    return (
+      `> 🚫 **Evaluation not stored — you're over this month's hard usage cap.** ` +
+      `Upgrade your plan to keep full history → ${link}`
+    );
+  }
+
+  if (options.quotaExceeded) {
+    const link = withUtm(CLOUD_PRICING_URL, "quota-upsell");
+    return (
+      `> ⚠️ Over your plan's monthly evaluations — history still stored this quarter; ` +
+      `upgrade at ${link}`
+    );
+  }
+
+  if (!options.hasCloudKey) {
+    const link = withUtm(CLOUD_MARKETING_URL, "cloud-upsell");
+    return (
+      `📊 This evaluation wasn't persisted — track trends, DORA metrics & agent-governance ` +
+      `across your org with Trailhead Cloud → ${link}`
+    );
+  }
+
+  return null;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,15 @@ export {
   deliverWebhooks,
   deliverWebhookEvent,
   storeEvaluation,
+  storeEvaluationDetailed,
 } from "./notify.js";
+export type { CloudStoreOutcome } from "./notify.js";
+export {
+  buildCloudFooterLine,
+  CLOUD_MARKETING_URL,
+  CLOUD_PRICING_URL,
+} from "./cloud-upsell.js";
+export type { CloudFooterOptions, CloudUpsellCampaign } from "./cloud-upsell.js";
 export {
   meterDeployCheck,
   resolveCreditMeterConfig,

--- a/src/main.ts
+++ b/src/main.ts
@@ -635,7 +635,10 @@ async function run(): Promise<void> {
     }
 
     const cloudFooterLine = buildCloudFooterLine({
-      hasCloudKey: Boolean(config.trailheadApiKey),
+      // BYOS self-hosters (evaluation-store-url without a cloud key) DO
+      // persist evaluations — the "wasn't persisted" upsell must only fire
+      // in truly local-only mode.
+      hasCloudKey: Boolean(config.trailheadApiKey || config.evaluationStoreUrl),
       disableUpsell: config.disableCloudUpsell ?? false,
       quotaExceeded: cloudQuotaExceeded,
       suspended: cloudSuspended,

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,7 +11,8 @@ import {
   resolveCheckName,
   wrapCollapsibleSection,
 } from "./gate.js";
-import { deliverWebhooks, storeEvaluation } from "./notify.js";
+import { deliverWebhooks, storeEvaluationDetailed } from "./notify.js";
+import { buildCloudFooterLine } from "./cloud-upsell.js";
 import {
   meterDeployCheck,
   resolveCreditMeterConfig,
@@ -298,6 +299,7 @@ async function run(): Promise<void> {
       ciManifestPath: ciManifestPath || undefined,
       agentBrief,
       submissionGate: core.getInput("submission-gate") === "true",
+      disableCloudUpsell: core.getInput("disable-cloud-upsell") === "true",
     };
 
     if (policyOverride?.changes.riskThreshold !== undefined) {
@@ -599,6 +601,10 @@ async function run(): Promise<void> {
     }
     let fullReport = reportParts.join("\n---\n\n");
 
+    let cloudQuotaExceeded = false;
+    let cloudSuspended = false;
+    let cloudHardCapped = false;
+
     if (config.evaluationStoreUrl) {
       const storeSecretInput = core.getInput("evaluation-store-secret");
       if (storeSecretInput && !process.env.EVALUATION_STORE_SECRET) {
@@ -610,15 +616,33 @@ async function run(): Promise<void> {
       const storeRetries = parseEvaluationStoreRetries(
         core.getInput("evaluation-store-retries") || "",
       );
-      const stored = await storeEvaluation(config.evaluationStoreUrl, evaluation, {
-        maxRetries: storeRetries,
-      });
-      evaluation.storePersisted = stored;
-      if (!stored) {
+      const storeOutcome = await storeEvaluationDetailed(
+        config.evaluationStoreUrl,
+        evaluation,
+        { maxRetries: storeRetries },
+      );
+      evaluation.storePersisted = storeOutcome.stored;
+      cloudQuotaExceeded = storeOutcome.quotaExceeded;
+      cloudSuspended = storeOutcome.suspended;
+      cloudHardCapped = storeOutcome.hardCapped;
+      // The cloud-upsell footer below already explains suspended/hard-capped
+      // state plainly with a link — don't also prepend the generic warning.
+      if (!storeOutcome.stored && !cloudSuspended && !cloudHardCapped) {
         const persistWarning =
           "> ⚠️ **Evaluation not persisted — dashboard incomplete.**";
         fullReport = `${persistWarning}\n\n${fullReport}`;
       }
+    }
+
+    const cloudFooterLine = buildCloudFooterLine({
+      hasCloudKey: Boolean(config.trailheadApiKey),
+      disableUpsell: config.disableCloudUpsell ?? false,
+      quotaExceeded: cloudQuotaExceeded,
+      suspended: cloudSuspended,
+      hardCapped: cloudHardCapped,
+    });
+    if (cloudFooterLine) {
+      fullReport = `${fullReport}\n\n${cloudFooterLine}`;
     }
 
     await core.summary.addRaw(fullReport).write();

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -448,7 +448,11 @@ export async function storeEvaluationDetailed(
     // Cloud API, not transient failures — don't fall back to the legacy
     // Supabase direct-insert path, just report the state honestly.
     if (result.suspended || result.hardCapped) {
-      return { ...NOT_STORED, suspended: result.suspended, hardCapped: result.hardCapped };
+      return {
+        ...NOT_STORED,
+        suspended: result.suspended,
+        hardCapped: result.hardCapped,
+      };
     }
   } catch (error) {
     core.warning(`Evaluation store API failed: ${error}`);

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -178,13 +178,21 @@ export async function deliverWebhooks(
   }
 }
 
+interface StoreAttemptResult {
+  ok: boolean;
+  retryable: boolean;
+  /** 200 + X-Trailhead-Quota-Exceeded: true — stored, but over plan quota. */
+  quotaExceeded?: boolean;
+  /** 402 — org suspended (payment failure); evaluation NOT stored. */
+  suspended?: boolean;
+  /** 429 with a structured JSON body — hard usage cap; evaluation NOT stored. */
+  hardCapped?: boolean;
+}
+
 async function storeViaApiOnce(
   url: string,
   evaluation: GateEvaluation,
-): Promise<{
-  ok: boolean;
-  retryable: boolean;
-}> {
+): Promise<StoreAttemptResult> {
   const storeSecret = process.env.EVALUATION_STORE_SECRET;
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
@@ -208,10 +216,40 @@ async function storeViaApiOnce(
   });
 
   const contentType = response.headers.get("content-type") ?? "";
+  const isJson = contentType.includes("application/json");
 
-  if (response.ok && contentType.includes("application/json")) {
+  if (response.ok && isJson) {
     core.info(`Evaluation stored successfully at ${url}`);
-    return { ok: true, retryable: false };
+    const quotaExceeded = response.headers.get("x-trailhead-quota-exceeded") === "true";
+    if (quotaExceeded) {
+      core.warning(
+        "Trailhead Cloud: this evaluation is over your plan's monthly quota. " +
+          "It was still stored — upgrade at https://trailhead.komatik.xyz/pricing",
+      );
+    }
+    return { ok: true, retryable: false, quotaExceeded };
+  }
+
+  // 402 = org suspended (payment failure). Availability of the paid store must
+  // never block a merge — this is informational only, never a gate failure.
+  if (response.status === 402) {
+    core.warning(
+      "Trailhead Cloud: your plan is suspended — this evaluation was NOT stored. " +
+        "Reactivate at https://trailhead.komatik.xyz/pricing",
+    );
+    return { ok: false, retryable: false, suspended: true };
+  }
+
+  // 429 with a structured JSON body is the Cloud API's hard usage cap
+  // (3x plan limit, abuse backstop) — permanent for the billing period, so
+  // retrying is pointless. A 429 with a non-JSON (HTML) body is most likely
+  // Vercel bot protection, which IS worth retrying — handled below.
+  if (response.status === 429 && isJson) {
+    core.warning(
+      "Trailhead Cloud: you're over this month's hard usage cap — this evaluation was NOT " +
+        "stored. Upgrade at https://trailhead.komatik.xyz/pricing",
+    );
+    return { ok: false, retryable: false, hardCapped: true };
   }
 
   const nonRetryableClientErrors = new Set([400, 401, 403]);
@@ -220,7 +258,7 @@ async function storeViaApiOnce(
     return { ok: false, retryable: false };
   }
 
-  if (!contentType.includes("application/json")) {
+  if (!isJson) {
     core.warning(
       `Evaluation store at ${url} returned HTML instead of JSON (HTTP ${response.status}). ` +
         `Vercel bot protection is likely blocking the request.`,
@@ -237,18 +275,45 @@ async function storeViaApiOnce(
   };
 }
 
+interface StoreViaApiResult {
+  stored: boolean;
+  quotaExceeded: boolean;
+  suspended: boolean;
+  hardCapped: boolean;
+}
+
 async function storeViaApi(
   url: string,
   evaluation: GateEvaluation,
   maxRetries = 3,
-): Promise<boolean> {
+): Promise<StoreViaApiResult> {
   const maxAttempts = maxRetries + 1;
+  const notStored: StoreViaApiResult = {
+    stored: false,
+    quotaExceeded: false,
+    suspended: false,
+    hardCapped: false,
+  };
 
   for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
     try {
       const result = await storeViaApiOnce(url, evaluation);
-      if (result.ok) return true;
-      if (!result.retryable || attempt >= maxAttempts - 1) return false;
+      if (result.ok) {
+        return {
+          stored: true,
+          quotaExceeded: result.quotaExceeded ?? false,
+          suspended: false,
+          hardCapped: false,
+        };
+      }
+      if (result.suspended || result.hardCapped) {
+        return {
+          ...notStored,
+          suspended: result.suspended ?? false,
+          hardCapped: result.hardCapped ?? false,
+        };
+      }
+      if (!result.retryable || attempt >= maxAttempts - 1) return notStored;
 
       const delayMs = STORE_RETRY_BACKOFF_MS[attempt] ?? 16_000;
       core.warning(
@@ -267,7 +332,7 @@ async function storeViaApi(
     }
   }
 
-  return false;
+  return notStored;
 }
 
 async function storeViaSupabase(evaluation: GateEvaluation): Promise<boolean> {
@@ -345,22 +410,53 @@ export function buildEvaluationStoreRow(
   };
 }
 
-export async function storeEvaluation(
+export interface CloudStoreOutcome {
+  stored: boolean;
+  /** 200 + X-Trailhead-Quota-Exceeded: true — stored, but over plan quota. */
+  quotaExceeded: boolean;
+  /** 402 — org suspended (payment failure); evaluation NOT stored. */
+  suspended: boolean;
+  /** 429 hard usage cap (3x plan limit, abuse backstop); evaluation NOT stored. */
+  hardCapped: boolean;
+}
+
+const NOT_STORED: CloudStoreOutcome = {
+  stored: false,
+  quotaExceeded: false,
+  suspended: false,
+  hardCapped: false,
+};
+
+/**
+ * Store an evaluation and report the Cloud API's billing/quota state so
+ * callers can surface it in the check summary. Availability of the paid
+ * store — including suspension or a hard usage cap — must never throw or
+ * otherwise block the gate; every path here is fail-open.
+ */
+export async function storeEvaluationDetailed(
   url: string,
   evaluation: GateEvaluation,
   options: { maxRetries?: number } = {},
-): Promise<boolean> {
+): Promise<CloudStoreOutcome> {
   const maxRetries = options.maxRetries ?? 3;
   try {
-    const stored = await storeViaApi(url, evaluation, maxRetries);
-    if (stored) return true;
+    const result = await storeViaApi(url, evaluation, maxRetries);
+    if (result.stored) {
+      return { ...NOT_STORED, stored: true, quotaExceeded: result.quotaExceeded };
+    }
+    // Suspended/hard-capped are deliberate billing-gate outcomes from the
+    // Cloud API, not transient failures — don't fall back to the legacy
+    // Supabase direct-insert path, just report the state honestly.
+    if (result.suspended || result.hardCapped) {
+      return { ...NOT_STORED, suspended: result.suspended, hardCapped: result.hardCapped };
+    }
   } catch (error) {
     core.warning(`Evaluation store API failed: ${error}`);
   }
 
   try {
     const fallback = await storeViaSupabase(evaluation);
-    if (fallback) return true;
+    if (fallback) return { ...NOT_STORED, stored: true };
   } catch (error) {
     core.warning(`Supabase direct fallback also failed: ${error}`);
   }
@@ -369,5 +465,14 @@ export async function storeEvaluation(
     "Evaluation could not be stored. To fix: either set VERCEL_AUTOMATION_BYPASS_SECRET " +
       "or set SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY in your workflow env.",
   );
-  return false;
+  return NOT_STORED;
+}
+
+export async function storeEvaluation(
+  url: string,
+  evaluation: GateEvaluation,
+  options: { maxRetries?: number } = {},
+): Promise<boolean> {
+  const outcome = await storeEvaluationDetailed(url, evaluation, options);
+  return outcome.stored;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -690,6 +690,7 @@ export interface TrailheadConfig {
   ciManifestPath?: string;
   agentBrief?: AgentBriefMode;
   submissionGate?: boolean;
+  disableCloudUpsell?: boolean;
 }
 
 export interface TestRepairResult {


### PR DESCRIPTION
## What
Billing-sprint Lane C — the in-product conversion channel from the monetization brief (§5.5/§6): every free run advertises Cloud, and paid runs surface quota/billing state honestly.

- **New module `src/cloud-upsell.ts`** — single source of truth for the footer line; precedence suspended > hard-capped > soft-quota > no-key upsell. One line, footer only, never affects the gate decision.
- **No-key (local-only) runs**: `📊 This evaluation wasn't persisted — track trends, DORA metrics & agent-governance … → trailhead.komatik.xyz`. Fires **only** in truly local-only mode — BYOS self-hosters (`evaluation-store-url`, no cloud key) persist to their own store and are exempt (caught in review; regression-tested).
- **Cloud responses surfaced**: 200+`X-Trailhead-Quota-Exceeded` → soft upgrade nudge (still stored); 402 suspended / 429 hard cap → plain "not stored" + link, gate never fails on billing state (`core.setFailed` asserted uncalled in tests).
- **`storeEvaluationDetailed()`** returns `{stored, quotaExceeded, suspended, hardCapped}`; old `storeEvaluation()` kept as boolean wrapper. 402/JSON-429 short-circuit as non-retryable with warn annotations; HTML-429 (Vercel bot-check) retry behavior preserved.
- **Instrumented** per brief §7: UTM campaign per state (`cloud-upsell`/`quota-upsell`/`suspended-upsell`) to measure upgrade-prompt clickthrough.
- New input `disable-cloud-upsell` (default false), documented in action.yml + README.

## Tests
837 passing (baseline 816; +21 incl. footer branches, suppression, BYOS exemption, 402/429 tolerance, e2e summary scenarios). `tsc` + eslint clean. `dist/` untouched (CI-built dist is canonical per release workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)