### PR TITLE
feat(site): Stripe billing — checkout, webhook, key claim, portal, reconcile

### DIFF
--- a/site/.env.example
+++ b/site/.env.example
@@ -1,0 +1,28 @@
+# ── Trailhead Cloud site (trailhead.komatik.xyz) ──────────────────────────────
+# Copy to .env.local for dev. In production these are set in the Vercel project.
+
+# Stripe — secret key. Use sk_test_* in dev/preview, sk_live_* only in production
+# (assertStripeMode refuses a mismatch).
+STRIPE_SECRET_KEY=
+
+# Stripe — webhook signing secret for the /api/billing/webhook endpoint
+# (Stripe Dashboard → Developers → Webhooks → your endpoint → Signing secret).
+STRIPE_WEBHOOK_SECRET=
+
+# Stripe — recurring Price ids (create the Products/Prices first; see README runbook).
+STRIPE_PRICE_PRO=
+STRIPE_PRICE_TEAM=
+
+# Postgres (dedicated Supabase project, plain Postgres via pg Pool). When unset,
+# the app falls back to the in-memory store (dev only).
+DATABASE_URL=
+
+# AES-256-GCM secret that encrypts the one-time post-checkout key claim
+# (key_claims.key_ciphertext). Generate: `openssl rand -hex 32`.
+TRAILHEAD_CLAIM_SECRET=
+
+# Shared secret for the daily reconcile cron (Bearer). Generate: `openssl rand -hex 32`.
+CRON_SECRET=
+
+# Public site origin (used for Stripe success/cancel + portal return URLs).
+NEXT_PUBLIC_SITE_URL=https://trailhead.komatik.xyz

--- a/site/.gitignore
+++ b/site/.gitignore
@@ -1,0 +1,18 @@
+# Next.js
+.next/
+out/
+next-env.d.ts.timestamp
+
+# deps
+node_modules/
+
+# env
+.env
+.env*.local
+
+# vercel
+.vercel
+
+# test
+coverage/
+*.tsbuildinfo

--- a/site/README.md
+++ b/site/README.md
@@ -1,0 +1,120 @@
+# Trailhead Cloud — `site/`
+
+The Next.js (App Router, TypeScript) app that deploys to **Vercel** at
+**`trailhead.komatik.xyz`**. It serves:
+
+- Stripe **billing** routes (`/api/billing/*`) — checkout, webhook, key claim, portal, reconcile.
+- The **Cloud API** (Hono app from `../cloud`) mounted at **`/api/cloud/[[...route]]`** via the `hono/vercel` adapter.
+- Marketing / pricing / welcome / dashboard pages — **owned by Lane D** (this branch ships only an unopinionated skeleton `app/layout.tsx` + placeholder `app/page.tsx`).
+
+Auth model v1: **possession-of-key = auth**. No login system. The first API key is
+issued on payment and revealed once at `/welcome` (the claim flow); billing is
+self-managed through the Stripe Customer Portal.
+
+---
+
+## Environment matrix
+
+| Var | Required | Where | Purpose |
+|-----|----------|-------|---------|
+| `STRIPE_SECRET_KEY` | yes | Vercel (prod: `sk_live_`, preview/dev: `sk_test_`) | Stripe SDK. `assertStripeMode` refuses a live key outside prod and a test key in prod. |
+| `STRIPE_WEBHOOK_SECRET` | yes | Vercel | Verifies `POST /api/billing/webhook` signatures. |
+| `STRIPE_PRICE_PRO` | yes | Vercel | Recurring Price id for Pro ($39/mo). |
+| `STRIPE_PRICE_TEAM` | yes | Vercel | Recurring Price id for Team ($399/mo). |
+| `DATABASE_URL` | yes (prod) | Vercel | Postgres (dedicated Supabase project). Unset → in-memory store (dev only). Consumed by Lane A's `createPgStore`. |
+| `TRAILHEAD_CLAIM_SECRET` | yes | Vercel | AES-256-GCM key that encrypts the one-time key claim. `openssl rand -hex 32`. |
+| `CRON_SECRET` | yes | Vercel | Bearer secret for the daily reconcile cron. `openssl rand -hex 32`. |
+| `NEXT_PUBLIC_SITE_URL` | yes | Vercel | Public origin for Stripe success/cancel + portal return URLs. Prod = `https://trailhead.komatik.xyz`. |
+
+See `.env.example`. Local dev: `cp .env.example .env.local` and fill in test-mode values.
+
+---
+
+## Route map
+
+| Method | Path | Auth | Notes |
+|--------|------|------|-------|
+| POST | `/api/billing/checkout` | public (IP rate-limited) | `{ plan: 'pro'\|'team', email }` → Stripe Checkout Session (mode=subscription). |
+| POST | `/api/billing/webhook` | Stripe signature | Idempotent via `stripe_webhook_events` (insert-first). Handles `checkout.session.completed`, `customer.subscription.updated`, `customer.subscription.deleted`. |
+| GET | `/api/billing/claim?session_id=` | one-time token (session id) | Atomic one-time API-key reveal. 410 if already claimed/expired. |
+| POST | `/api/billing/portal` | Bearer API key | Stripe Customer Portal session for the key's org. |
+| GET | `/api/billing/reconcile` | Bearer `CRON_SECRET` | Daily Vercel cron. Diffs Stripe ↔ `subscriptions`, repairs drift, purges expired claims. |
+| ANY | `/api/cloud/[[...route]]` | Bearer API key (`/v1/*`) | The mounted Cloud API. e.g. `POST /api/cloud/v1/evaluations`, `GET /api/cloud/health`. |
+
+---
+
+## Store wiring (⚠️ Lane A dependency)
+
+The billing routes and the mounted Cloud API share **one** store, selected in
+`lib/cloudStore.ts`: `createPgStore({ connectionString })` when `DATABASE_URL`
+is set, else `createMemoryStore()` for dev.
+
+`createPgStore` and the async `BillingStore` surface are being built **in parallel
+on Lane A** (`feat/cloud-pg-store`). On this branch they resolve against the
+ambient declaration in **`types/trailhead-cloud.d.ts`** (a typed stub mirroring
+`TRAILHEAD-BILLING-CONTRACT.md`). **On merge**: delete that `.d.ts`, add a real
+`exports` map + built types to `cloud/package.json`, and verify the method
+signatures line up. Runtime wiring: `trailhead-cloud` is a `file:../cloud`
+dependency + `transpilePackages` in `next.config.ts` so Next compiles the cloud
+ESM TypeScript (note: `cloud/` uses `.js`-suffixed ESM imports and copies
+`feedback-core.ts` in at build via `npm run prebuild`).
+
+---
+
+## Vercel project setup
+
+1. **Import the repo** into Vercel; set **Root Directory = `site`**.
+2. Framework preset: **Next.js** (auto). Build command / output default.
+3. **Domain**: add `trailhead.komatik.xyz` to the project.
+4. **Environment variables**: add every row from the matrix above for
+   Production (and test-mode equivalents for Preview).
+5. **Cron**: `vercel.json` already declares the daily reconcile cron
+   (`0 7 * * *` → `/api/billing/reconcile`). Vercel picks it up on deploy; the
+   route authorizes via `Authorization: Bearer $CRON_SECRET`, so set
+   `CRON_SECRET` before the first cron fires.
+6. Deploy. Smoke test: `GET https://trailhead.komatik.xyz/api/cloud/health` →
+   `{"status":"ok"}`.
+
+---
+
+## Stripe setup (operator runbook)
+
+Do this once per mode (test, then live). **Do not commit any ids or keys** —
+they go in Vercel env only.
+
+1. **Products + Prices** (Dashboard → Products, or `stripe` CLI):
+   - Product "Trailhead Pro" → recurring **Price $39.00 / month (USD)** → copy the
+     `price_…` id into `STRIPE_PRICE_PRO`.
+   - Product "Trailhead Team" → recurring **Price $399.00 / month (USD)** → copy into
+     `STRIPE_PRICE_TEAM`.
+   ```bash
+   stripe products create --name "Trailhead Pro"
+   stripe prices create --product <prod_id> --unit-amount 3900 --currency usd \
+     --recurring interval=month
+   stripe products create --name "Trailhead Team"
+   stripe prices create --product <prod_id> --unit-amount 39900 --currency usd \
+     --recurring interval=month
+   ```
+2. **Secret key**: copy `sk_test_…` (test) / `sk_live_…` (prod) into
+   `STRIPE_SECRET_KEY` on the matching Vercel environment.
+3. **Webhook endpoint**: Dashboard → Developers → Webhooks → Add endpoint:
+   - URL: `https://trailhead.komatik.xyz/api/billing/webhook`
+   - Events: `checkout.session.completed`, `customer.subscription.updated`,
+     `customer.subscription.deleted`.
+   - Copy the **Signing secret** into `STRIPE_WEBHOOK_SECRET`.
+4. **Customer Portal**: Dashboard → Settings → Billing → Customer portal → enable
+   (allow plan switch between the Pro/Team prices, cancellation).
+5. **Local webhook testing**: `stripe listen --forward-to localhost:3200/api/billing/webhook`
+   and use the printed `whsec_…` as `STRIPE_WEBHOOK_SECRET` in `.env.local`.
+
+---
+
+## Develop / test
+
+```bash
+cd site
+npm install
+npm run dev        # http://localhost:3200
+npm run typecheck  # tsc --noEmit
+npm run test       # vitest (webhook logic, claim one-time semantics, checkout validation, crypto)
+```

--- a/site/README.md
+++ b/site/README.md
@@ -15,16 +15,16 @@ self-managed through the Stripe Customer Portal.
 
 ## Environment matrix
 
-| Var | Required | Where | Purpose |
-|-----|----------|-------|---------|
-| `STRIPE_SECRET_KEY` | yes | Vercel (prod: `sk_live_`, preview/dev: `sk_test_`) | Stripe SDK. `assertStripeMode` refuses a live key outside prod and a test key in prod. |
-| `STRIPE_WEBHOOK_SECRET` | yes | Vercel | Verifies `POST /api/billing/webhook` signatures. |
-| `STRIPE_PRICE_PRO` | yes | Vercel | Recurring Price id for Pro ($39/mo). |
-| `STRIPE_PRICE_TEAM` | yes | Vercel | Recurring Price id for Team ($399/mo). |
-| `DATABASE_URL` | yes (prod) | Vercel | Postgres (dedicated Supabase project). Unset → in-memory store (dev only). Consumed by Lane A's `createPgStore`. |
-| `TRAILHEAD_CLAIM_SECRET` | yes | Vercel | AES-256-GCM key that encrypts the one-time key claim. `openssl rand -hex 32`. |
-| `CRON_SECRET` | yes | Vercel | Bearer secret for the daily reconcile cron. `openssl rand -hex 32`. |
-| `NEXT_PUBLIC_SITE_URL` | yes | Vercel | Public origin for Stripe success/cancel + portal return URLs. Prod = `https://trailhead.komatik.xyz`. |
+| Var                      | Required   | Where                                              | Purpose                                                                                                          |
+| ------------------------ | ---------- | -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `STRIPE_SECRET_KEY`      | yes        | Vercel (prod: `sk_live_`, preview/dev: `sk_test_`) | Stripe SDK. `assertStripeMode` refuses a live key outside prod and a test key in prod.                           |
+| `STRIPE_WEBHOOK_SECRET`  | yes        | Vercel                                             | Verifies `POST /api/billing/webhook` signatures.                                                                 |
+| `STRIPE_PRICE_PRO`       | yes        | Vercel                                             | Recurring Price id for Pro ($39/mo).                                                                             |
+| `STRIPE_PRICE_TEAM`      | yes        | Vercel                                             | Recurring Price id for Team ($399/mo).                                                                           |
+| `DATABASE_URL`           | yes (prod) | Vercel                                             | Postgres (dedicated Supabase project). Unset → in-memory store (dev only). Consumed by Lane A's `createPgStore`. |
+| `TRAILHEAD_CLAIM_SECRET` | yes        | Vercel                                             | AES-256-GCM key that encrypts the one-time key claim. `openssl rand -hex 32`.                                    |
+| `CRON_SECRET`            | yes        | Vercel                                             | Bearer secret for the daily reconcile cron. `openssl rand -hex 32`.                                              |
+| `NEXT_PUBLIC_SITE_URL`   | yes        | Vercel                                             | Public origin for Stripe success/cancel + portal return URLs. Prod = `https://trailhead.komatik.xyz`.            |
 
 See `.env.example`. Local dev: `cp .env.example .env.local` and fill in test-mode values.
 
@@ -32,14 +32,14 @@ See `.env.example`. Local dev: `cp .env.example .env.local` and fill in test-mod
 
 ## Route map
 
-| Method | Path | Auth | Notes |
-|--------|------|------|-------|
-| POST | `/api/billing/checkout` | public (IP rate-limited) | `{ plan: 'pro'\|'team', email }` → Stripe Checkout Session (mode=subscription). |
-| POST | `/api/billing/webhook` | Stripe signature | Idempotent via `stripe_webhook_events` (insert-first). Handles `checkout.session.completed`, `customer.subscription.updated`, `customer.subscription.deleted`. |
-| GET | `/api/billing/claim?session_id=` | one-time token (session id) | Atomic one-time API-key reveal. 410 if already claimed/expired. |
-| POST | `/api/billing/portal` | Bearer API key | Stripe Customer Portal session for the key's org. |
-| GET | `/api/billing/reconcile` | Bearer `CRON_SECRET` | Daily Vercel cron. Diffs Stripe ↔ `subscriptions`, repairs drift, purges expired claims. |
-| ANY | `/api/cloud/[[...route]]` | Bearer API key (`/v1/*`) | The mounted Cloud API. e.g. `POST /api/cloud/v1/evaluations`, `GET /api/cloud/health`. |
+| Method | Path                             | Auth                        | Notes                                                                                                                                                          |
+| ------ | -------------------------------- | --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| POST   | `/api/billing/checkout`          | public (IP rate-limited)    | `{ plan: 'pro'\|'team', email }` → Stripe Checkout Session (mode=subscription).                                                                                |
+| POST   | `/api/billing/webhook`           | Stripe signature            | Idempotent via `stripe_webhook_events` (insert-first). Handles `checkout.session.completed`, `customer.subscription.updated`, `customer.subscription.deleted`. |
+| GET    | `/api/billing/claim?session_id=` | one-time token (session id) | Atomic one-time API-key reveal. 410 if already claimed/expired.                                                                                                |
+| POST   | `/api/billing/portal`            | Bearer API key              | Stripe Customer Portal session for the key's org.                                                                                                              |
+| GET    | `/api/billing/reconcile`         | Bearer `CRON_SECRET`        | Daily Vercel cron. Diffs Stripe ↔ `subscriptions`, repairs drift, purges expired claims.                                                                       |
+| ANY    | `/api/cloud/[[...route]]`        | Bearer API key (`/v1/*`)    | The mounted Cloud API. e.g. `POST /api/cloud/v1/evaluations`, `GET /api/cloud/health`.                                                                         |
 
 ---
 

--- a/site/__tests__/checkout.test.ts
+++ b/site/__tests__/checkout.test.ts
@@ -67,7 +67,9 @@ describe("POST /api/billing/checkout — happy path", () => {
       id: "cs_new",
     });
 
-    const arg = createSession.mock.calls[0]![0];
+    const [firstCall] = createSession.mock.calls;
+    if (!firstCall) throw new Error("createSession was not called");
+    const arg = firstCall[0];
     expect(arg.mode).toBe("subscription");
     expect(arg.customer_email).toBe("dev@acme.com");
     expect(arg.line_items).toEqual([{ price: "price_team_456", quantity: 1 }]);
@@ -89,7 +91,8 @@ describe("POST /api/billing/checkout — rate limiting", () => {
     for (let i = 0; i < 12; i++) {
       last = await POST(post({ plan: "pro", email: "a@b.com" }, ip));
     }
-    expect(last!.status).toBe(429);
-    expect(last!.headers.get("Retry-After")).toBeTruthy();
+    if (!last) throw new Error("no response captured");
+    expect(last.status).toBe(429);
+    expect(last.headers.get("Retry-After")).toBeTruthy();
   });
 });

--- a/site/__tests__/checkout.test.ts
+++ b/site/__tests__/checkout.test.ts
@@ -72,7 +72,9 @@ describe("POST /api/billing/checkout — happy path", () => {
     expect(arg.customer_email).toBe("dev@acme.com");
     expect(arg.line_items).toEqual([{ price: "price_team_456", quantity: 1 }]);
     expect(arg.metadata).toEqual({ plan: "team", email: "dev@acme.com" });
-    expect(arg.subscription_data).toEqual({ metadata: { plan: "team", email: "dev@acme.com" } });
+    expect(arg.subscription_data).toEqual({
+      metadata: { plan: "team", email: "dev@acme.com" },
+    });
     expect(arg.success_url).toBe(
       "https://trailhead.komatik.xyz/welcome?session_id={CHECKOUT_SESSION_ID}",
     );

--- a/site/__tests__/checkout.test.ts
+++ b/site/__tests__/checkout.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Mock the Stripe client factory so no real Stripe SDK / key is needed.
+const createSession = vi.fn(async (_params: Record<string, unknown>) => ({
+  id: "cs_new",
+  url: "https://checkout.stripe/cs_new",
+}));
+vi.mock("@/lib/stripe", () => ({
+  getStripeClient: vi.fn(() => ({ checkout: { sessions: { create: createSession } } })),
+}));
+
+import { POST } from "@/app/api/billing/checkout/route";
+
+beforeEach(() => {
+  vi.unstubAllEnvs();
+  vi.clearAllMocks();
+  vi.stubEnv("STRIPE_PRICE_PRO", "price_pro_123");
+  vi.stubEnv("STRIPE_PRICE_TEAM", "price_team_456");
+  vi.stubEnv("NEXT_PUBLIC_SITE_URL", "https://trailhead.komatik.xyz");
+});
+
+function post(body: unknown, ip = Math.random().toString(36)): Request {
+  return new Request("http://localhost/api/billing/checkout", {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-forwarded-for": ip },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/billing/checkout — validation", () => {
+  it("rejects an invalid plan", async () => {
+    const res = await POST(post({ plan: "enterprise", email: "a@b.com" }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/plan/);
+    expect(createSession).not.toHaveBeenCalled();
+  });
+
+  it("rejects a malformed email", async () => {
+    const res = await POST(post({ plan: "pro", email: "not-an-email" }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/email/);
+  });
+
+  it("rejects invalid JSON", async () => {
+    const bad = new Request("http://localhost/api/billing/checkout", {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-forwarded-for": "j" },
+      body: "{not json",
+    });
+    const res = await POST(bad);
+    expect(res.status).toBe(400);
+  });
+
+  it("500s when the plan has no configured price", async () => {
+    vi.stubEnv("STRIPE_PRICE_PRO", "");
+    const res = await POST(post({ plan: "pro", email: "a@b.com" }));
+    expect(res.status).toBe(500);
+  });
+});
+
+describe("POST /api/billing/checkout — happy path", () => {
+  it("creates a subscription Checkout Session with plan metadata + contract urls", async () => {
+    const res = await POST(post({ plan: "team", email: "dev@acme.com" }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      url: "https://checkout.stripe/cs_new",
+      id: "cs_new",
+    });
+
+    const arg = createSession.mock.calls[0]![0];
+    expect(arg.mode).toBe("subscription");
+    expect(arg.customer_email).toBe("dev@acme.com");
+    expect(arg.line_items).toEqual([{ price: "price_team_456", quantity: 1 }]);
+    expect(arg.metadata).toEqual({ plan: "team", email: "dev@acme.com" });
+    expect(arg.subscription_data).toEqual({ metadata: { plan: "team", email: "dev@acme.com" } });
+    expect(arg.success_url).toBe(
+      "https://trailhead.komatik.xyz/welcome?session_id={CHECKOUT_SESSION_ID}",
+    );
+    expect(arg.cancel_url).toBe("https://trailhead.komatik.xyz/pricing");
+  });
+});
+
+describe("POST /api/billing/checkout — rate limiting", () => {
+  it("429s after the per-IP limit is exceeded", async () => {
+    const ip = "203.0.113.9";
+    let last: Response | undefined;
+    for (let i = 0; i < 12; i++) {
+      last = await POST(post({ plan: "pro", email: "a@b.com" }, ip));
+    }
+    expect(last!.status).toBe(429);
+    expect(last!.headers.get("Retry-After")).toBeTruthy();
+  });
+});

--- a/site/__tests__/claim.test.ts
+++ b/site/__tests__/claim.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { BillingStore } from "trailhead-cloud";
+import { encryptClaim } from "@/lib/claimCrypto";
+
+// Mock the store accessor so the route never touches the real cloud package.
+vi.mock("@/lib/cloudStore", () => ({
+  getBillingStore: vi.fn(),
+}));
+
+import { getBillingStore } from "@/lib/cloudStore";
+import { GET } from "@/app/api/billing/claim/route";
+
+const SECRET = "claim-route-secret";
+const KEY = "thk_oneTimeRevealKey0001";
+
+beforeEach(() => {
+  vi.unstubAllEnvs();
+  vi.stubEnv("TRAILHEAD_CLAIM_SECRET", SECRET);
+  vi.clearAllMocks();
+});
+
+function req(sessionId?: string, ip = Math.random().toString(36)): Request {
+  const url = sessionId
+    ? `http://localhost/api/billing/claim?session_id=${sessionId}`
+    : `http://localhost/api/billing/claim`;
+  return new Request(url, { headers: { "x-forwarded-for": ip } });
+}
+
+function setStore(store: Partial<BillingStore>) {
+  (getBillingStore as ReturnType<typeof vi.fn>).mockResolvedValue(store as BillingStore);
+}
+
+describe("GET /api/billing/claim — one-time semantics", () => {
+  it("reveals the decrypted key exactly once, then reports already_claimed", async () => {
+    const ciphertext = encryptClaim(KEY, SECRET);
+    let claimed = false;
+    setStore({
+      claimKey: vi.fn(async () => {
+        if (claimed) return null;
+        claimed = true;
+        return { keyCiphertext: ciphertext };
+      }),
+      getKeyClaimStatus: vi.fn(async () => ({
+        exists: true,
+        claimed: true,
+        expired: false,
+      })),
+    });
+
+    const first = await GET(req("cs_1"));
+    expect(first.status).toBe(200);
+    const body = await first.json();
+    expect(body.apiKey).toBe(KEY);
+    expect(body.once).toBe(true);
+
+    const second = await GET(req("cs_1"));
+    expect(second.status).toBe(410);
+    expect((await second.json()).code).toBe("already_claimed");
+  });
+
+  it("404s for an unknown session", async () => {
+    setStore({
+      claimKey: vi.fn(async () => null),
+      getKeyClaimStatus: vi.fn(async () => ({ exists: false, claimed: false, expired: false })),
+    });
+    const res = await GET(req("cs_unknown"));
+    expect(res.status).toBe(404);
+  });
+
+  it("410s (expired) for an unclaimed but expired claim", async () => {
+    setStore({
+      claimKey: vi.fn(async () => null),
+      getKeyClaimStatus: vi.fn(async () => ({ exists: true, claimed: false, expired: true })),
+    });
+    const res = await GET(req("cs_expired"));
+    expect(res.status).toBe(410);
+    expect((await res.json()).code).toBe("expired");
+  });
+
+  it("400s when session_id is missing", async () => {
+    setStore({});
+    const res = await GET(req(undefined));
+    expect(res.status).toBe(400);
+  });
+});

--- a/site/__tests__/claim.test.ts
+++ b/site/__tests__/claim.test.ts
@@ -61,7 +61,11 @@ describe("GET /api/billing/claim — one-time semantics", () => {
   it("404s for an unknown session", async () => {
     setStore({
       claimKey: vi.fn(async () => null),
-      getKeyClaimStatus: vi.fn(async () => ({ exists: false, claimed: false, expired: false })),
+      getKeyClaimStatus: vi.fn(async () => ({
+        exists: false,
+        claimed: false,
+        expired: false,
+      })),
     });
     const res = await GET(req("cs_unknown"));
     expect(res.status).toBe(404);
@@ -70,7 +74,11 @@ describe("GET /api/billing/claim — one-time semantics", () => {
   it("410s (expired) for an unclaimed but expired claim", async () => {
     setStore({
       claimKey: vi.fn(async () => null),
-      getKeyClaimStatus: vi.fn(async () => ({ exists: true, claimed: false, expired: true })),
+      getKeyClaimStatus: vi.fn(async () => ({
+        exists: true,
+        claimed: false,
+        expired: true,
+      })),
     });
     const res = await GET(req("cs_expired"));
     expect(res.status).toBe(410);

--- a/site/__tests__/claimCrypto.test.ts
+++ b/site/__tests__/claimCrypto.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { encryptClaim, decryptClaim } from "@/lib/claimCrypto";
+
+const SECRET = "test-claim-secret-0123456789";
+
+describe("claimCrypto (AES-256-GCM)", () => {
+  it("round-trips a plaintext key", () => {
+    const plain = "thk_deadbeefdeadbeefdeadbeefdeadbeef";
+    const env = encryptClaim(plain, SECRET);
+    expect(env).not.toContain(plain);
+    expect(decryptClaim(env, SECRET)).toBe(plain);
+  });
+
+  it("uses a fresh random IV per encryption (ciphertext differs)", () => {
+    const plain = "thk_same";
+    const a = encryptClaim(plain, SECRET);
+    const b = encryptClaim(plain, SECRET);
+    expect(a).not.toBe(b);
+    expect(decryptClaim(a, SECRET)).toBe(plain);
+    expect(decryptClaim(b, SECRET)).toBe(plain);
+  });
+
+  it("is authenticated — a tampered ciphertext fails to decrypt", () => {
+    const env = encryptClaim("thk_secret", SECRET);
+    const parts = env.split(".");
+    // flip a byte in the ciphertext segment
+    const ct = Buffer.from(parts[3], "base64url");
+    ct[0] ^= 0xff;
+    parts[3] = ct.toString("base64url");
+    expect(() => decryptClaim(parts.join("."), SECRET)).toThrow();
+  });
+
+  it("fails with the wrong secret", () => {
+    const env = encryptClaim("thk_secret", SECRET);
+    expect(() => decryptClaim(env, "wrong-secret")).toThrow();
+  });
+
+  it("throws on a malformed envelope", () => {
+    expect(() => decryptClaim("not-an-envelope", SECRET)).toThrow(/malformed/);
+  });
+
+  it("throws when the secret is missing", () => {
+    expect(() => encryptClaim("x", undefined)).toThrow(/TRAILHEAD_CLAIM_SECRET/);
+  });
+});

--- a/site/__tests__/webhook.test.ts
+++ b/site/__tests__/webhook.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type Stripe from "stripe";
+import type { BillingStore } from "trailhead-cloud";
+import { handleStripeEvent } from "@/lib/webhookHandlers";
+import { decryptClaim } from "@/lib/claimCrypto";
+
+const SECRET = "webhook-test-secret";
+
+beforeEach(() => {
+  vi.unstubAllEnvs();
+  vi.stubEnv("TRAILHEAD_CLAIM_SECRET", SECRET);
+  vi.stubEnv("STRIPE_PRICE_PRO", "price_pro_123");
+  vi.stubEnv("STRIPE_PRICE_TEAM", "price_team_456");
+});
+
+/** A mock BillingStore recording calls; recordStripeEvent is first-seen by default. */
+function mockStore(overrides: Partial<BillingStore> = {}): BillingStore {
+  const seen = new Set<string>();
+  const base: Partial<BillingStore> = {
+    recordStripeEvent: vi.fn(async ({ eventId }) => {
+      const firstSeen = !seen.has(eventId);
+      seen.add(eventId);
+      return { firstSeen };
+    }),
+    createOrgWithSubscription: vi.fn(async () => ({
+      orgId: "org_1",
+      apiKeySecret: "thk_generatedsecretkey",
+      keyPreview: "thk_gen…rkey",
+    })),
+    createKeyClaim: vi.fn(async () => undefined),
+    updateSubscriptionByStripeId: vi.fn(async () => ({ orgId: "org_1" })),
+  };
+  return { ...base, ...overrides } as BillingStore;
+}
+
+function checkoutEvent(overrides: Record<string, unknown> = {}): Stripe.Event {
+  return {
+    id: "evt_checkout_1",
+    type: "checkout.session.completed",
+    data: {
+      object: {
+        id: "cs_test_1",
+        metadata: { plan: "pro", email: "dev@acme.com" },
+        customer: "cus_1",
+        subscription: "sub_1",
+        ...overrides,
+      },
+    },
+  } as unknown as Stripe.Event;
+}
+
+describe("handleStripeEvent — idempotency", () => {
+  it("skips a duplicate event id (insert-first ledger)", async () => {
+    const store = mockStore();
+    const evt = checkoutEvent();
+    const first = await handleStripeEvent(evt, store);
+    const second = await handleStripeEvent(evt, store);
+    expect(first.handled).toBe(true);
+    expect(second).toEqual({ handled: false, reason: "duplicate" });
+    expect(store.createOrgWithSubscription).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("handleStripeEvent — checkout.session.completed", () => {
+  it("creates org+subscription and writes an encrypted, decryptable key claim", async () => {
+    const store = mockStore();
+    const res = await handleStripeEvent(checkoutEvent(), store);
+
+    expect(res).toEqual({ handled: true, orgId: "org_1" });
+    expect(store.createOrgWithSubscription).toHaveBeenCalledWith(
+      expect.objectContaining({
+        plan: "pro",
+        orgName: "acme.com", // email domain per contract
+        stripeCustomerId: "cus_1",
+        stripeSubscriptionId: "sub_1",
+      }),
+    );
+
+    const claimArg = (store.createKeyClaim as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(claimArg.checkoutSessionId).toBe("cs_test_1");
+    expect(claimArg.keyCiphertext).not.toContain("thk_generatedsecretkey");
+    // ciphertext decrypts back to the plaintext key (never stored raw)
+    expect(decryptClaim(claimArg.keyCiphertext, SECRET)).toBe("thk_generatedsecretkey");
+    // ~72h expiry
+    const ttl = new Date(claimArg.expiresAt).getTime() - Date.now();
+    expect(ttl).toBeGreaterThan(71 * 3600 * 1000);
+    expect(ttl).toBeLessThan(73 * 3600 * 1000);
+  });
+
+  it("rejects a session with missing/invalid plan metadata", async () => {
+    const store = mockStore();
+    const evt = checkoutEvent({ metadata: { email: "x@y.com" } });
+    const res = await handleStripeEvent(evt, store);
+    expect(res.handled).toBe(false);
+    expect(res.reason).toBe("missing_or_invalid_plan_metadata");
+    expect(store.createOrgWithSubscription).not.toHaveBeenCalled();
+  });
+
+  it("rejects when customer or subscription id is absent", async () => {
+    const store = mockStore();
+    const evt = checkoutEvent({ subscription: null });
+    const res = await handleStripeEvent(evt, store);
+    expect(res.reason).toBe("missing_customer_or_subscription");
+  });
+});
+
+describe("handleStripeEvent — subscription lifecycle", () => {
+  function subEvent(type: string, status: string, priceId = "price_team_456"): Stripe.Event {
+    return {
+      id: `evt_${type}_${status}`,
+      type,
+      data: {
+        object: {
+          id: "sub_1",
+          status,
+          current_period_end: 1893456000, // 2030-01-01
+          items: { data: [{ price: { id: priceId } }] },
+        },
+      },
+    } as unknown as Stripe.Event;
+  }
+
+  it("syncs plan/status/period on customer.subscription.updated", async () => {
+    const store = mockStore();
+    await handleStripeEvent(subEvent("customer.subscription.updated", "past_due"), store);
+    expect(store.updateSubscriptionByStripeId).toHaveBeenCalledWith("sub_1", {
+      plan: "team",
+      status: "past_due",
+      currentPeriodEnd: new Date(1893456000 * 1000).toISOString(),
+    });
+  });
+
+  it("marks canceled on customer.subscription.deleted", async () => {
+    const store = mockStore();
+    await handleStripeEvent(subEvent("customer.subscription.deleted", "canceled"), store);
+    expect(store.updateSubscriptionByStripeId).toHaveBeenCalledWith(
+      "sub_1",
+      expect.objectContaining({ status: "canceled" }),
+    );
+  });
+
+  it("ignores unrelated event types (but still ledgers them)", async () => {
+    const store = mockStore();
+    const evt = { id: "evt_x", type: "invoice.paid", data: { object: {} } } as unknown as Stripe.Event;
+    const res = await handleStripeEvent(evt, store);
+    expect(res).toEqual({ handled: false, reason: "ignored" });
+    expect(store.recordStripeEvent).toHaveBeenCalledOnce();
+  });
+});

--- a/site/__tests__/webhook.test.ts
+++ b/site/__tests__/webhook.test.ts
@@ -22,6 +22,9 @@ function mockStore(overrides: Partial<BillingStore> = {}): BillingStore {
       seen.add(eventId);
       return { firstSeen };
     }),
+    removeStripeEvent: vi.fn(async (eventId: string) => {
+      seen.delete(eventId);
+    }),
     createOrgWithSubscription: vi.fn(async () => ({
       orgId: "org_1",
       apiKeySecret: "thk_generatedsecretkey",
@@ -58,6 +61,28 @@ describe("handleStripeEvent — idempotency", () => {
     expect(first.handled).toBe(true);
     expect(second).toEqual({ handled: false, reason: "duplicate" });
     expect(store.createOrgWithSubscription).toHaveBeenCalledTimes(1);
+  });
+
+  it("rolls the ledger back on handler failure so Stripe's retry can reprocess", async () => {
+    const store = mockStore({
+      createOrgWithSubscription: vi
+        .fn()
+        .mockRejectedValueOnce(new Error("transient db error"))
+        .mockResolvedValueOnce({
+          orgId: "org_1",
+          apiKeySecret: "thk_generatedsecretkey",
+          keyPreview: "thk_gen…rkey",
+        }),
+    });
+    const evt = checkoutEvent();
+
+    await expect(handleStripeEvent(evt, store)).rejects.toThrow("transient db error");
+    expect(store.removeStripeEvent).toHaveBeenCalledWith(evt.id);
+
+    // Stripe retries the SAME event id — it must NOT short-circuit as duplicate.
+    const retry = await handleStripeEvent(evt, store);
+    expect(retry.handled).toBe(true);
+    expect(store.createOrgWithSubscription).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/site/__tests__/webhook.test.ts
+++ b/site/__tests__/webhook.test.ts
@@ -130,7 +130,11 @@ describe("handleStripeEvent — checkout.session.completed", () => {
 });
 
 describe("handleStripeEvent — subscription lifecycle", () => {
-  function subEvent(type: string, status: string, priceId = "price_team_456"): Stripe.Event {
+  function subEvent(
+    type: string,
+    status: string,
+    priceId = "price_team_456",
+  ): Stripe.Event {
     return {
       id: `evt_${type}_${status}`,
       type,
@@ -166,7 +170,11 @@ describe("handleStripeEvent — subscription lifecycle", () => {
 
   it("ignores unrelated event types (but still ledgers them)", async () => {
     const store = mockStore();
-    const evt = { id: "evt_x", type: "invoice.paid", data: { object: {} } } as unknown as Stripe.Event;
+    const evt = {
+      id: "evt_x",
+      type: "invoice.paid",
+      data: { object: {} },
+    } as unknown as Stripe.Event;
     const res = await handleStripeEvent(evt, store);
     expect(res).toEqual({ handled: false, reason: "ignored" });
     expect(store.recordStripeEvent).toHaveBeenCalledOnce();

--- a/site/app/api/billing/checkout/route.ts
+++ b/site/app/api/billing/checkout/route.ts
@@ -1,0 +1,84 @@
+import { getStripeClient } from "@/lib/stripe";
+import { guardRateLimit } from "@/lib/rateLimit";
+import { isPaidPlan, priceIdForPlan } from "@/lib/plans";
+
+/**
+ * POST /api/billing/checkout  { plan: 'pro'|'team', email }
+ * → Stripe Checkout Session (mode=subscription).
+ *
+ * Mirrors komatik/platform/web/app/api/teams/subscribe/route.ts:32-148
+ * (assertStripeMode→503, rate-limit, price-by-env, metadata on session AND
+ * subscription). No auth: possession-of-key is the v1 auth model, and the key
+ * is issued post-payment — so checkout is public + rate-limited by IP.
+ */
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+function siteUrl(): string {
+  return process.env.NEXT_PUBLIC_SITE_URL ?? "https://trailhead.komatik.xyz";
+}
+
+export async function POST(req: Request): Promise<Response> {
+  // Rate limit first — cheap, and shields the Stripe API from abuse.
+  const denied = guardRateLimit(req, "billing-checkout", 10);
+  if (denied) return denied;
+
+  let stripe: ReturnType<typeof getStripeClient>;
+  try {
+    stripe = getStripeClient();
+  } catch (modeErr) {
+    console.error("[checkout] Stripe mode assertion failed:", modeErr);
+    return Response.json({ error: "Payment system unavailable" }, { status: 503 });
+  }
+
+  let body: { plan?: unknown; email?: unknown };
+  try {
+    body = (await req.json()) as typeof body;
+  } catch {
+    return Response.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const { plan, email } = body;
+  if (!isPaidPlan(plan)) {
+    return Response.json(
+      { error: "plan must be 'pro' or 'team'" },
+      { status: 400 },
+    );
+  }
+  if (typeof email !== "string" || !/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(email)) {
+    return Response.json({ error: "a valid email is required" }, { status: 400 });
+  }
+
+  const priceId = priceIdForPlan(plan);
+  if (!priceId) {
+    console.error(`[checkout] No Stripe Price configured for plan '${plan}'`);
+    return Response.json(
+      { error: `Checkout for '${plan}' is not configured` },
+      { status: 500 },
+    );
+  }
+
+  const origin = siteUrl();
+  const meta = { plan, email };
+
+  try {
+    const session = await stripe.checkout.sessions.create({
+      mode: "subscription",
+      customer_email: email,
+      line_items: [{ price: priceId, quantity: 1 }],
+      metadata: meta,
+      subscription_data: { metadata: meta },
+      allow_promotion_codes: true,
+      success_url: `${origin}/welcome?session_id={CHECKOUT_SESSION_ID}`,
+      cancel_url: `${origin}/pricing`,
+    });
+
+    return Response.json({ url: session.url, id: session.id });
+  } catch (err) {
+    console.error("[checkout] Error:", err);
+    return Response.json(
+      { error: err instanceof Error ? err.message : "Failed to create checkout session" },
+      { status: 500 },
+    );
+  }
+}

--- a/site/app/api/billing/checkout/route.ts
+++ b/site/app/api/billing/checkout/route.ts
@@ -18,6 +18,20 @@ function siteUrl(): string {
   return process.env.NEXT_PUBLIC_SITE_URL ?? "https://trailhead.komatik.xyz";
 }
 
+/**
+ * Structural email plausibility without a backtracking regex (CodeQL
+ * js/polynomial-redos): length-capped, single @, dotted domain, no whitespace.
+ * Stripe Checkout re-validates the address authoritatively.
+ */
+function isPlausibleEmail(email: string): boolean {
+  if (email.length === 0 || email.length > 254 || /\s/.test(email)) return false;
+  const at = email.indexOf("@");
+  if (at <= 0 || at !== email.lastIndexOf("@") || at === email.length - 1) return false;
+  const domain = email.slice(at + 1);
+  const dot = domain.lastIndexOf(".");
+  return dot > 0 && dot < domain.length - 1;
+}
+
 export async function POST(req: Request): Promise<Response> {
   // Rate limit first — cheap, and shields the Stripe API from abuse.
   const denied = guardRateLimit(req, "billing-checkout", 10);
@@ -40,12 +54,9 @@ export async function POST(req: Request): Promise<Response> {
 
   const { plan, email } = body;
   if (!isPaidPlan(plan)) {
-    return Response.json(
-      { error: "plan must be 'pro' or 'team'" },
-      { status: 400 },
-    );
+    return Response.json({ error: "plan must be 'pro' or 'team'" }, { status: 400 });
   }
-  if (typeof email !== "string" || !/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(email)) {
+  if (typeof email !== "string" || !isPlausibleEmail(email)) {
     return Response.json({ error: "a valid email is required" }, { status: 400 });
   }
 

--- a/site/app/api/billing/claim/route.ts
+++ b/site/app/api/billing/claim/route.ts
@@ -1,0 +1,70 @@
+import { getBillingStore } from "@/lib/cloudStore";
+import { decryptClaim } from "@/lib/claimCrypto";
+import { guardRateLimit } from "@/lib/rateLimit";
+
+/**
+ * GET /api/billing/claim?session_id=cs_...  — one-time API key reveal.
+ *
+ * Contract flow 3: if the claim is unclaimed AND unexpired, atomically mark it
+ * claimed and return the key ONCE. Otherwise 410 with guidance to use key
+ * rotation via support. The atomicity lives in store.claimKey (single UPDATE …
+ * WHERE claimed_at IS NULL … RETURNING) so two concurrent reveals can't both win.
+ */
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(req: Request): Promise<Response> {
+  const denied = guardRateLimit(req, "billing-claim", 20);
+  if (denied) return denied;
+
+  const sessionId = new URL(req.url).searchParams.get("session_id");
+  if (!sessionId) {
+    return Response.json({ error: "session_id is required" }, { status: 400 });
+  }
+
+  const store = await getBillingStore();
+
+  const claim = await store.claimKey(sessionId);
+  if (claim) {
+    let apiKey: string;
+    try {
+      apiKey = decryptClaim(claim.keyCiphertext);
+    } catch (err) {
+      console.error(`[claim] Decrypt failed for ${sessionId}:`, err);
+      return Response.json(
+        { error: "Could not decrypt key. Contact support to rotate." },
+        { status: 500 },
+      );
+    }
+    return Response.json({
+      apiKey,
+      once: true,
+      message:
+        "Store this key now — it is shown only once. Add it as TRAILHEAD_API_KEY.",
+    });
+  }
+
+  // Nothing revealed — explain why (unknown / already-claimed / expired).
+  const status = await store.getKeyClaimStatus(sessionId);
+  if (!status.exists) {
+    return Response.json({ error: "No key claim for this session." }, { status: 404 });
+  }
+  if (status.claimed) {
+    return Response.json(
+      {
+        error: "This key was already claimed.",
+        code: "already_claimed",
+        message: "For a new key, rotate via the billing portal or contact support.",
+      },
+      { status: 410 },
+    );
+  }
+  return Response.json(
+    {
+      error: "This claim link has expired.",
+      code: "expired",
+      message: "Contact support to issue a replacement key.",
+    },
+    { status: 410 },
+  );
+}

--- a/site/app/api/billing/claim/route.ts
+++ b/site/app/api/billing/claim/route.ts
@@ -30,7 +30,8 @@ export async function GET(req: Request): Promise<Response> {
     try {
       apiKey = decryptClaim(claim.keyCiphertext);
     } catch (err) {
-      console.error(`[claim] Decrypt failed for ${sessionId}:`, err);
+      // sessionId is user input — keep it out of the format-string position.
+      console.error("[claim] Decrypt failed for session:", sessionId, err);
       return Response.json(
         { error: "Could not decrypt key. Contact support to rotate." },
         { status: 500 },
@@ -39,8 +40,7 @@ export async function GET(req: Request): Promise<Response> {
     return Response.json({
       apiKey,
       once: true,
-      message:
-        "Store this key now — it is shown only once. Add it as TRAILHEAD_API_KEY.",
+      message: "Store this key now — it is shown only once. Add it as TRAILHEAD_API_KEY.",
     });
   }
 

--- a/site/app/api/billing/portal/route.ts
+++ b/site/app/api/billing/portal/route.ts
@@ -23,7 +23,10 @@ export async function POST(req: Request): Promise<Response> {
   const auth = req.headers.get("authorization") ?? "";
   const key = auth.startsWith("Bearer ") ? auth.slice(7).trim() : "";
   if (!key) {
-    return Response.json({ error: "Missing Authorization bearer token" }, { status: 401 });
+    return Response.json(
+      { error: "Missing Authorization bearer token" },
+      { status: 401 },
+    );
   }
 
   let stripe: ReturnType<typeof getStripeClient>;

--- a/site/app/api/billing/portal/route.ts
+++ b/site/app/api/billing/portal/route.ts
@@ -1,0 +1,56 @@
+import { getStripeClient } from "@/lib/stripe";
+import { getBillingStore } from "@/lib/cloudStore";
+import { guardRateLimit } from "@/lib/rateLimit";
+
+/**
+ * POST /api/billing/portal  (Authorization: Bearer <api key>)
+ * → Stripe billing-portal session for the key's org.
+ *
+ * v1 auth is possession-of-key: resolve the Bearer key to its org's Stripe
+ * customer id, then mint a portal session. No login system (contract §Auth v1).
+ */
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+function siteUrl(): string {
+  return process.env.NEXT_PUBLIC_SITE_URL ?? "https://trailhead.komatik.xyz";
+}
+
+export async function POST(req: Request): Promise<Response> {
+  const denied = guardRateLimit(req, "billing-portal", 20);
+  if (denied) return denied;
+
+  const auth = req.headers.get("authorization") ?? "";
+  const key = auth.startsWith("Bearer ") ? auth.slice(7).trim() : "";
+  if (!key) {
+    return Response.json({ error: "Missing Authorization bearer token" }, { status: 401 });
+  }
+
+  let stripe: ReturnType<typeof getStripeClient>;
+  try {
+    stripe = getStripeClient();
+  } catch (modeErr) {
+    console.error("[portal] Stripe mode assertion failed:", modeErr);
+    return Response.json({ error: "Payment system unavailable" }, { status: 503 });
+  }
+
+  const store = await getBillingStore();
+  const resolved = await store.getStripeCustomerIdForKey(key);
+  if (!resolved) {
+    return Response.json({ error: "Invalid API key" }, { status: 401 });
+  }
+
+  try {
+    const session = await stripe.billingPortal.sessions.create({
+      customer: resolved.stripeCustomerId,
+      return_url: `${siteUrl()}/dashboard`,
+    });
+    return Response.json({ url: session.url });
+  } catch (err) {
+    console.error("[portal] Error:", err);
+    return Response.json(
+      { error: err instanceof Error ? err.message : "Failed to create portal session" },
+      { status: 500 },
+    );
+  }
+}

--- a/site/app/api/billing/reconcile/route.ts
+++ b/site/app/api/billing/reconcile/route.ts
@@ -1,0 +1,131 @@
+import type Stripe from "stripe";
+import { getStripeClient } from "@/lib/stripe";
+import { getBillingStore } from "@/lib/cloudStore";
+import { ownedPriceIds, planForPriceId, type PaidPlan } from "@/lib/plans";
+
+/**
+ * GET /api/billing/reconcile  (Authorization: Bearer <CRON_SECRET>)
+ * Daily Vercel cron (vercel.json: "0 7 * * *"). komatik lesson — no
+ * fire-and-forget: Stripe is the source of truth, and drift is repaired here.
+ *
+ * Per contract flow 5:
+ *  - list Stripe subscriptions for OUR products (price ids we own)
+ *  - missing local row      → repair from Stripe truth (upsertSubscriptionFromStripe)
+ *  - status/plan/period drift → resync (updateSubscriptionByStripeId)
+ *  - active sub, zero active keys → needs_attention log line
+ *  - purge expired unclaimed key_claims
+ */
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+function idOf(v: string | { id: string } | null | undefined): string | null {
+  if (!v) return null;
+  return typeof v === "string" ? v : v.id;
+}
+
+function periodEndIso(sub: Stripe.Subscription): string | null {
+  const end = (sub as unknown as { current_period_end?: number }).current_period_end;
+  return typeof end === "number" ? new Date(end * 1000).toISOString() : null;
+}
+
+function planOf(sub: Stripe.Subscription): PaidPlan | null {
+  return planForPriceId(sub.items?.data?.[0]?.price?.id) ?? null;
+}
+
+const ACTIVE_STATUSES = new Set(["active", "trialing"]);
+
+export async function GET(req: Request): Promise<Response> {
+  const auth = req.headers.get("authorization") ?? "";
+  const token = auth.startsWith("Bearer ") ? auth.slice(7).trim() : "";
+  const secret = process.env.CRON_SECRET;
+  if (!secret || token !== secret) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let stripe: Stripe;
+  try {
+    stripe = getStripeClient();
+  } catch (modeErr) {
+    console.error("[reconcile] Stripe mode assertion failed:", modeErr);
+    return Response.json({ error: "Payment system unavailable" }, { status: 503 });
+  }
+
+  const owned = new Set(ownedPriceIds());
+  const store = await getBillingStore();
+
+  const localRows = await store.listSubscriptions();
+  const localByStripeId = new Map(localRows.map((r) => [r.stripeSubscriptionId, r]));
+
+  const summary = { scanned: 0, repaired: 0, resynced: 0, needsAttention: 0, claimsPurged: 0 };
+
+  try {
+    // Walk all Stripe subscriptions; keep only those on a Price we own.
+    for await (const sub of stripe.subscriptions.list({ status: "all", limit: 100 })) {
+      const plan = planOf(sub);
+      const priceId = sub.items?.data?.[0]?.price?.id;
+      if (!plan || !priceId || !owned.has(priceId)) continue;
+
+      summary.scanned += 1;
+      const stripeCustomerId = idOf(sub.customer);
+      if (!stripeCustomerId) continue;
+      const currentPeriodEnd = periodEndIso(sub);
+
+      const local = localByStripeId.get(sub.id);
+      if (!local) {
+        // Missing locally — repair from Stripe truth.
+        const { orgId } = await store.upsertSubscriptionFromStripe({
+          stripeCustomerId,
+          stripeSubscriptionId: sub.id,
+          plan,
+          status: sub.status,
+          currentPeriodEnd,
+        });
+        summary.repaired += 1;
+        console.warn(
+          `[reconcile] repaired missing subscription ${sub.id} → org ${orgId} (${plan}/${sub.status})`,
+        );
+      } else if (
+        local.status !== sub.status ||
+        local.plan !== plan ||
+        local.currentPeriodEnd !== currentPeriodEnd
+      ) {
+        // Drift — resync (this also fixes key suspend/unsuspend inside the store).
+        await store.updateSubscriptionByStripeId(sub.id, {
+          plan,
+          status: sub.status,
+          currentPeriodEnd,
+        });
+        summary.resynced += 1;
+        console.warn(
+          `[reconcile] resynced ${sub.id}: ${local.status}→${sub.status}, ${local.plan}→${plan}`,
+        );
+      }
+
+      // Active sub but no usable key → flag for attention (contract flow 5).
+      if (ACTIVE_STATUSES.has(sub.status)) {
+        const row = local ?? (await store.getSubscriptionByStripeId(sub.id));
+        if (row) {
+          const keys = await store.countActiveKeys(row.orgId);
+          if (keys === 0) {
+            summary.needsAttention += 1;
+            console.warn(
+              `[reconcile] needs_attention: org ${row.orgId} has active sub ${sub.id} but 0 active keys`,
+            );
+          }
+        }
+      }
+    }
+
+    summary.claimsPurged = await store.purgeExpiredClaims();
+  } catch (err) {
+    console.error("[reconcile] Error:", err);
+    return Response.json(
+      { error: err instanceof Error ? err.message : "Reconcile failed", partial: summary },
+      { status: 500 },
+    );
+  }
+
+  console.log("[reconcile] complete", summary);
+  return Response.json({ ok: true, ...summary });
+}

--- a/site/app/api/billing/reconcile/route.ts
+++ b/site/app/api/billing/reconcile/route.ts
@@ -57,7 +57,13 @@ export async function GET(req: Request): Promise<Response> {
   const localRows = await store.listSubscriptions();
   const localByStripeId = new Map(localRows.map((r) => [r.stripeSubscriptionId, r]));
 
-  const summary = { scanned: 0, repaired: 0, resynced: 0, needsAttention: 0, claimsPurged: 0 };
+  const summary = {
+    scanned: 0,
+    repaired: 0,
+    resynced: 0,
+    needsAttention: 0,
+    claimsPurged: 0,
+  };
 
   try {
     // Walk all Stripe subscriptions; keep only those on a Price we own.
@@ -121,7 +127,10 @@ export async function GET(req: Request): Promise<Response> {
   } catch (err) {
     console.error("[reconcile] Error:", err);
     return Response.json(
-      { error: err instanceof Error ? err.message : "Reconcile failed", partial: summary },
+      {
+        error: err instanceof Error ? err.message : "Reconcile failed",
+        partial: summary,
+      },
       { status: 500 },
     );
   }

--- a/site/app/api/billing/webhook/route.ts
+++ b/site/app/api/billing/webhook/route.ts
@@ -1,0 +1,59 @@
+import type Stripe from "stripe";
+import { getStripeClient } from "@/lib/stripe";
+import { getBillingStore } from "@/lib/cloudStore";
+import { handleStripeEvent } from "@/lib/webhookHandlers";
+
+/**
+ * POST /api/billing/webhook — Stripe event sink.
+ *
+ * Mirrors komatik/platform/web/app/api/tier-purchase/webhook/route.ts:11-58
+ * (raw body → signature header → assertStripeMode → constructEvent), then
+ * delegates to handleStripeEvent (idempotent via stripe_webhook_events).
+ *
+ * MUST read the raw body for signature verification — do not parse JSON first.
+ */
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(req: Request): Promise<Response> {
+  const body = await req.text();
+  const sig = req.headers.get("stripe-signature");
+  if (!sig) {
+    return Response.json({ error: "Missing signature" }, { status: 400 });
+  }
+
+  const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
+  if (!webhookSecret) {
+    console.error("[webhook] STRIPE_WEBHOOK_SECRET not configured");
+    return Response.json({ error: "Webhook not configured" }, { status: 503 });
+  }
+
+  let stripe: Stripe;
+  try {
+    stripe = getStripeClient();
+  } catch (modeErr) {
+    console.error("[webhook] Stripe mode assertion failed:", modeErr);
+    return Response.json({ error: "Payment system misconfigured" }, { status: 503 });
+  }
+
+  let event: Stripe.Event;
+  try {
+    event = stripe.webhooks.constructEvent(body, sig, webhookSecret);
+  } catch (err) {
+    console.error("[webhook] Signature verification failed:", err);
+    return Response.json({ error: "Invalid signature" }, { status: 400 });
+  }
+
+  try {
+    const store = await getBillingStore();
+    const result = await handleStripeEvent(event, store);
+    return Response.json({ received: true, ...result });
+  } catch (err) {
+    // Return 500 so Stripe retries — the insert-first ledger makes replay safe.
+    console.error(`[webhook] Handler error for ${event.type} (${event.id}):`, err);
+    return Response.json(
+      { error: err instanceof Error ? err.message : "Handler error" },
+      { status: 500 },
+    );
+  }
+}

--- a/site/app/api/cloud/[[...route]]/route.ts
+++ b/site/app/api/cloud/[[...route]]/route.ts
@@ -1,0 +1,44 @@
+import { Hono } from "hono";
+import { handle } from "hono/vercel";
+import { createCloudApp } from "trailhead-cloud";
+import { getBillingStore } from "@/lib/cloudStore";
+
+/**
+ * Mounts the Trailhead Cloud Hono app (cloud/src/app.ts) at /api/cloud/* via
+ * the hono/vercel adapter. The cloud app declares its routes at the root
+ * (/health, /v1/*, /dashboard) — we re-base them under /api/cloud with a
+ * parent Hono `route()` mount so, e.g., POST /api/cloud/v1/evaluations reaches
+ * the cloud app's /v1/evaluations handler.
+ *
+ * The store is the same Postgres-backed BillingStore the billing routes use
+ * (createPgStore when DATABASE_URL is set), so /v1 ingest and billing share
+ * one source of truth.
+ */
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+let handlerPromise: Promise<(req: Request) => Response | Promise<Response>> | null = null;
+
+function getHandler(): Promise<(req: Request) => Response | Promise<Response>> {
+  if (!handlerPromise) {
+    handlerPromise = (async () => {
+      const store = await getBillingStore();
+      const cloudApp = createCloudApp({ store });
+      const root = new Hono().route("/api/cloud", cloudApp as unknown as Hono);
+      return handle(root) as (req: Request) => Response | Promise<Response>;
+    })();
+  }
+  return handlerPromise;
+}
+
+async function dispatch(req: Request): Promise<Response> {
+  const h = await getHandler();
+  return h(req);
+}
+
+export const GET = dispatch;
+export const POST = dispatch;
+export const PUT = dispatch;
+export const PATCH = dispatch;
+export const DELETE = dispatch;
+export const OPTIONS = dispatch;

--- a/site/app/layout.tsx
+++ b/site/app/layout.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+export const metadata: Metadata = {
+  title: "Trailhead Cloud",
+  description:
+    "Release readiness gate for GitHub PRs — hosted evaluation store, dashboards, and org billing.",
+  metadataBase: new URL(
+    process.env.NEXT_PUBLIC_SITE_URL ?? "https://trailhead.komatik.xyz",
+  ),
+};
+
+// Minimal, unopinionated shell. Lane D owns marketing/pricing/welcome/dashboard.
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/site/app/page.tsx
+++ b/site/app/page.tsx
@@ -2,12 +2,19 @@
 // Kept deliberately minimal so the skeleton stays unopinionated.
 export default function HomePage() {
   return (
-    <main style={{ fontFamily: "system-ui, sans-serif", padding: "4rem 1.5rem", maxWidth: 640, margin: "0 auto" }}>
+    <main
+      style={{
+        fontFamily: "system-ui, sans-serif",
+        padding: "4rem 1.5rem",
+        maxWidth: 640,
+        margin: "0 auto",
+      }}
+    >
       <h1 style={{ fontSize: "1.75rem", fontWeight: 700 }}>Trailhead Cloud</h1>
       <p style={{ color: "#555", lineHeight: 1.6 }}>
-        Placeholder home page. Marketing, pricing, and the post-checkout key claim
-        flow land here (Lane D). The billing API and the Cloud API are already
-        mounted under <code>/api/billing/*</code> and <code>/api/cloud/*</code>.
+        Placeholder home page. Marketing, pricing, and the post-checkout key claim flow
+        land here (Lane D). The billing API and the Cloud API are already mounted under{" "}
+        <code>/api/billing/*</code> and <code>/api/cloud/*</code>.
       </p>
     </main>
   );

--- a/site/app/page.tsx
+++ b/site/app/page.tsx
@@ -1,0 +1,14 @@
+// Placeholder home page — Lane D replaces this with the marketing landing page.
+// Kept deliberately minimal so the skeleton stays unopinionated.
+export default function HomePage() {
+  return (
+    <main style={{ fontFamily: "system-ui, sans-serif", padding: "4rem 1.5rem", maxWidth: 640, margin: "0 auto" }}>
+      <h1 style={{ fontSize: "1.75rem", fontWeight: 700 }}>Trailhead Cloud</h1>
+      <p style={{ color: "#555", lineHeight: 1.6 }}>
+        Placeholder home page. Marketing, pricing, and the post-checkout key claim
+        flow land here (Lane D). The billing API and the Cloud API are already
+        mounted under <code>/api/billing/*</code> and <code>/api/cloud/*</code>.
+      </p>
+    </main>
+  );
+}

--- a/site/lib/assertStripeMode.ts
+++ b/site/lib/assertStripeMode.ts
@@ -22,7 +22,9 @@ export function isProductionEnvironment(opts: AssertStripeModeOptions = {}): boo
   return process.env.NODE_ENV === "production";
 }
 
-export function detectStripeMode(secretKey: string | undefined | null): StripeMode | null {
+export function detectStripeMode(
+  secretKey: string | undefined | null,
+): StripeMode | null {
   if (!secretKey) return null;
   if (secretKey.startsWith("sk_live_") || secretKey.startsWith("rk_live_")) return "live";
   if (secretKey.startsWith("sk_test_") || secretKey.startsWith("rk_test_")) return "test";
@@ -50,7 +52,9 @@ export function assertStripeMode(
       );
     }
     if (mode === null) {
-      throw new Error("STRIPE_SECRET_KEY has unrecognized prefix in production environment");
+      throw new Error(
+        "STRIPE_SECRET_KEY has unrecognized prefix in production environment",
+      );
     }
     return;
   }

--- a/site/lib/assertStripeMode.ts
+++ b/site/lib/assertStripeMode.ts
@@ -1,0 +1,63 @@
+/**
+ * Stripe live/test mode safety guard.
+ *
+ * Mirrors komatik/platform/web/lib/stripe/assertMode.ts (assertStripeMode /
+ * isProductionEnvironment / detectStripeMode). Call inside every Stripe SDK
+ * factory before constructing the client so a misconfigured env cannot process
+ * real payments against test infra (or vice versa).
+ */
+export type StripeMode = "live" | "test";
+
+export interface AssertStripeModeOptions {
+  forceProduction?: boolean;
+}
+
+/** Prefer Vercel's VERCEL_ENV=production; fall back to NODE_ENV. */
+export function isProductionEnvironment(opts: AssertStripeModeOptions = {}): boolean {
+  if (opts.forceProduction) return true;
+  if (process.env.VERCEL_ENV === "production") return true;
+  if (process.env.VERCEL_ENV === "preview" || process.env.VERCEL_ENV === "development") {
+    return false;
+  }
+  return process.env.NODE_ENV === "production";
+}
+
+export function detectStripeMode(secretKey: string | undefined | null): StripeMode | null {
+  if (!secretKey) return null;
+  if (secretKey.startsWith("sk_live_") || secretKey.startsWith("rk_live_")) return "live";
+  if (secretKey.startsWith("sk_test_") || secretKey.startsWith("rk_test_")) return "test";
+  return null;
+}
+
+/**
+ * Assert that the Stripe secret key matches the current environment.
+ * Throws (wrap in a 503) when prod+test, prod+missing/unknown, or non-prod+live.
+ */
+export function assertStripeMode(
+  secretKey: string | undefined | null,
+  opts: AssertStripeModeOptions = {},
+): void {
+  const inProd = isProductionEnvironment(opts);
+  const mode = detectStripeMode(secretKey);
+
+  if (inProd) {
+    if (!secretKey) {
+      throw new Error("STRIPE_SECRET_KEY missing in production environment");
+    }
+    if (mode === "test") {
+      throw new Error(
+        "REFUSING TO RUN: sk_test_ key detected in production. Set sk_live_ in Vercel production env.",
+      );
+    }
+    if (mode === null) {
+      throw new Error("STRIPE_SECRET_KEY has unrecognized prefix in production environment");
+    }
+    return;
+  }
+
+  if (mode === "live") {
+    throw new Error(
+      "REFUSING TO RUN: sk_live_ key detected outside production. Use sk_test_ in dev/preview/staging.",
+    );
+  }
+}

--- a/site/lib/claimCrypto.ts
+++ b/site/lib/claimCrypto.ts
@@ -27,7 +27,10 @@ function fromB64u(s: string): Buffer {
   return Buffer.from(s, "base64url");
 }
 
-export function encryptClaim(plaintext: string, secret = process.env.TRAILHEAD_CLAIM_SECRET): string {
+export function encryptClaim(
+  plaintext: string,
+  secret = process.env.TRAILHEAD_CLAIM_SECRET,
+): string {
   if (!secret) throw new Error("TRAILHEAD_CLAIM_SECRET is not configured");
   const key = deriveKey(secret);
   const iv = randomBytes(IV_BYTES);
@@ -37,7 +40,10 @@ export function encryptClaim(plaintext: string, secret = process.env.TRAILHEAD_C
   return `${VERSION}.${b64u(iv)}.${b64u(tag)}.${b64u(ct)}`;
 }
 
-export function decryptClaim(envelope: string, secret = process.env.TRAILHEAD_CLAIM_SECRET): string {
+export function decryptClaim(
+  envelope: string,
+  secret = process.env.TRAILHEAD_CLAIM_SECRET,
+): string {
   if (!secret) throw new Error("TRAILHEAD_CLAIM_SECRET is not configured");
   const parts = envelope.split(".");
   if (parts.length !== 4 || parts[0] !== VERSION) {
@@ -47,5 +53,7 @@ export function decryptClaim(envelope: string, secret = process.env.TRAILHEAD_CL
   const key = deriveKey(secret);
   const decipher = createDecipheriv("aes-256-gcm", key, fromB64u(ivB64));
   decipher.setAuthTag(fromB64u(tagB64));
-  return Buffer.concat([decipher.update(fromB64u(ctB64)), decipher.final()]).toString("utf8");
+  return Buffer.concat([decipher.update(fromB64u(ctB64)), decipher.final()]).toString(
+    "utf8",
+  );
 }

--- a/site/lib/claimCrypto.ts
+++ b/site/lib/claimCrypto.ts
@@ -1,0 +1,51 @@
+import { createCipheriv, createDecipheriv, createHash, randomBytes } from "node:crypto";
+
+/**
+ * AES-256-GCM authenticated encryption for the one-time post-checkout API key
+ * handoff (key_claims.key_ciphertext). Plaintext keys are NEVER stored — only
+ * this ciphertext, decryptable solely with TRAILHEAD_CLAIM_SECRET.
+ *
+ * Envelope format (compact, self-describing): base64url(iv).base64url(tag).base64url(ct)
+ *   - iv:  12 random bytes (GCM standard nonce; fresh per encryption)
+ *   - tag: 16-byte GCM auth tag (authenticated — tamper ⇒ decrypt throws)
+ *   - ct:  ciphertext
+ */
+const IV_BYTES = 12;
+const VERSION = "v1";
+
+function deriveKey(secret: string): Buffer {
+  // 32-byte key from the operator secret. sha256 gives a stable 256-bit key
+  // regardless of the secret's length/format.
+  return createHash("sha256").update(secret, "utf8").digest();
+}
+
+function b64u(buf: Buffer): string {
+  return buf.toString("base64url");
+}
+
+function fromB64u(s: string): Buffer {
+  return Buffer.from(s, "base64url");
+}
+
+export function encryptClaim(plaintext: string, secret = process.env.TRAILHEAD_CLAIM_SECRET): string {
+  if (!secret) throw new Error("TRAILHEAD_CLAIM_SECRET is not configured");
+  const key = deriveKey(secret);
+  const iv = randomBytes(IV_BYTES);
+  const cipher = createCipheriv("aes-256-gcm", key, iv);
+  const ct = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return `${VERSION}.${b64u(iv)}.${b64u(tag)}.${b64u(ct)}`;
+}
+
+export function decryptClaim(envelope: string, secret = process.env.TRAILHEAD_CLAIM_SECRET): string {
+  if (!secret) throw new Error("TRAILHEAD_CLAIM_SECRET is not configured");
+  const parts = envelope.split(".");
+  if (parts.length !== 4 || parts[0] !== VERSION) {
+    throw new Error("malformed claim envelope");
+  }
+  const [, ivB64, tagB64, ctB64] = parts;
+  const key = deriveKey(secret);
+  const decipher = createDecipheriv("aes-256-gcm", key, fromB64u(ivB64));
+  decipher.setAuthTag(fromB64u(tagB64));
+  return Buffer.concat([decipher.update(fromB64u(ctB64)), decipher.final()]).toString("utf8");
+}

--- a/site/lib/cloudStore.ts
+++ b/site/lib/cloudStore.ts
@@ -1,8 +1,4 @@
-import {
-  createMemoryStore,
-  createPgStore,
-  type BillingStore,
-} from "trailhead-cloud";
+import { createMemoryStore, createPgStore, type BillingStore } from "trailhead-cloud";
 
 /**
  * Billing store accessor for the site routes.

--- a/site/lib/cloudStore.ts
+++ b/site/lib/cloudStore.ts
@@ -1,0 +1,36 @@
+import {
+  createMemoryStore,
+  createPgStore,
+  type BillingStore,
+} from "trailhead-cloud";
+
+/**
+ * Billing store accessor for the site routes.
+ *
+ * ── TODO(merge, Lane A: feat/cloud-pg-store) ──────────────────────────────
+ * `createPgStore` + the async `BillingStore` surface are being built on Lane A
+ * in parallel; on this branch they resolve against the ambient declaration in
+ * `site/types/trailhead-cloud.d.ts`. When Lane A merges, this module should
+ * "just work" against the real cloud exports — delete the ambient .d.ts and
+ * verify the method signatures line up.
+ *
+ * Selection: Postgres store when DATABASE_URL is set (production/preview),
+ * otherwise the in-memory store (local dev / tests inject their own mock).
+ */
+let storePromise: Promise<BillingStore> | null = null;
+
+export function getBillingStore(): Promise<BillingStore> {
+  if (storePromise) return storePromise;
+
+  const connectionString = process.env.DATABASE_URL;
+  storePromise = connectionString
+    ? createPgStore({ connectionString })
+    : Promise.resolve(createMemoryStore());
+
+  return storePromise;
+}
+
+/** Test seam: inject a mock store (and reset between tests). */
+export function __setBillingStoreForTest(store: BillingStore | null): void {
+  storePromise = store ? Promise.resolve(store) : null;
+}

--- a/site/lib/plans.ts
+++ b/site/lib/plans.ts
@@ -1,0 +1,31 @@
+/**
+ * Plan → Stripe Price mapping. Prices live in env (never hardcoded ids), per
+ * the mount contract. Pricing hypotheses: Pro $39/mo, Team $399/mo.
+ */
+export type PaidPlan = "pro" | "team";
+
+export const PAID_PLANS: readonly PaidPlan[] = ["pro", "team"] as const;
+
+export function isPaidPlan(value: unknown): value is PaidPlan {
+  return value === "pro" || value === "team";
+}
+
+/** Resolve the Stripe Price id for a plan from env. Returns undefined if unset. */
+export function priceIdForPlan(plan: PaidPlan): string | undefined {
+  return plan === "pro" ? process.env.STRIPE_PRICE_PRO : process.env.STRIPE_PRICE_TEAM;
+}
+
+/** Reverse map: which of our plans does this Stripe Price id represent? */
+export function planForPriceId(priceId: string | null | undefined): PaidPlan | null {
+  if (!priceId) return null;
+  if (priceId === process.env.STRIPE_PRICE_PRO) return "pro";
+  if (priceId === process.env.STRIPE_PRICE_TEAM) return "team";
+  return null;
+}
+
+/** The Stripe Price ids we own — used by reconcile to scope Stripe listing. */
+export function ownedPriceIds(): string[] {
+  return [process.env.STRIPE_PRICE_PRO, process.env.STRIPE_PRICE_TEAM].filter(
+    (v): v is string => typeof v === "string" && v.length > 0,
+  );
+}

--- a/site/lib/rateLimit.ts
+++ b/site/lib/rateLimit.ts
@@ -38,7 +38,8 @@ export function checkRateLimit(
 /** Best-effort client IP from proxy headers. */
 export function clientIp(req: Request): string {
   const fwd = req.headers.get("x-forwarded-for");
-  if (fwd) return fwd.split(",")[0]!.trim();
+  const first = fwd?.split(",")[0]?.trim();
+  if (first) return first;
   return req.headers.get("x-real-ip") ?? "unknown";
 }
 

--- a/site/lib/rateLimit.ts
+++ b/site/lib/rateLimit.ts
@@ -1,0 +1,76 @@
+/**
+ * Sliding-window in-memory rate limiter — mirrors the discipline of
+ * komatik/platform/web/lib/security/rateLimit.ts (checkRateLimit + a standards
+ * -compliant 429), minus the Upstash Redis backend. On serverless this is
+ * best-effort per-instance; Stripe checkout abuse is additionally bounded by
+ * Stripe's own controls. Swap in Upstash here if cross-instance limits are
+ * needed (set UPSTASH_REDIS_REST_URL/TOKEN and reintroduce the Ratelimit path).
+ */
+const WINDOW_MS = 60_000;
+
+type Store = Map<string, number[]>;
+
+function getStore(): Store {
+  const g = globalThis as unknown as { __thRateStore?: Store };
+  if (!g.__thRateStore) g.__thRateStore = new Map();
+  return g.__thRateStore;
+}
+
+export function checkRateLimit(
+  identifier: string,
+  operation: string,
+  maxPerMinute: number,
+): { allowed: boolean; retryAfterMs: number } {
+  const store = getStore();
+  const key = `${operation}:${identifier}`;
+  const now = Date.now();
+  const timestamps = (store.get(key) ?? []).filter((t) => now - t < WINDOW_MS);
+
+  if (timestamps.length >= maxPerMinute) {
+    const oldest = timestamps[0];
+    return { allowed: false, retryAfterMs: WINDOW_MS - (now - oldest) };
+  }
+  timestamps.push(now);
+  store.set(key, timestamps);
+  return { allowed: true, retryAfterMs: 0 };
+}
+
+/** Best-effort client IP from proxy headers. */
+export function clientIp(req: Request): string {
+  const fwd = req.headers.get("x-forwarded-for");
+  if (fwd) return fwd.split(",")[0]!.trim();
+  return req.headers.get("x-real-ip") ?? "unknown";
+}
+
+/** RFC 9110 compliant 429. */
+export function rateLimitResponse(retryAfterMs: number, maxPerMinute: number): Response {
+  const retryAfterSec = Math.ceil(retryAfterMs / 1000);
+  return new Response(
+    JSON.stringify({
+      error: "Too many requests. Please try again later.",
+      code: "rate_limited",
+      retryAfterSeconds: retryAfterSec,
+    }),
+    {
+      status: 429,
+      headers: {
+        "Content-Type": "application/json",
+        "Retry-After": String(retryAfterSec),
+        "X-RateLimit-Limit": String(maxPerMinute),
+        "X-RateLimit-Remaining": "0",
+        "X-RateLimit-Reset": String(Math.floor((Date.now() + retryAfterMs) / 1000)),
+      },
+    },
+  );
+}
+
+/** One-shot guard: returns a 429 Response if over limit, else null. */
+export function guardRateLimit(
+  req: Request,
+  operation: string,
+  maxPerMinute: number,
+): Response | null {
+  const result = checkRateLimit(clientIp(req), operation, maxPerMinute);
+  if (!result.allowed) return rateLimitResponse(result.retryAfterMs, maxPerMinute);
+  return null;
+}

--- a/site/lib/stripe.ts
+++ b/site/lib/stripe.ts
@@ -1,0 +1,18 @@
+import Stripe from "stripe";
+import { assertStripeMode } from "@/lib/assertStripeMode";
+
+/**
+ * Pinned Stripe API version — matches komatik/platform/web (teams/subscribe).
+ * Bump deliberately, never float, so webhook payload shapes stay stable.
+ */
+export const STRIPE_API_VERSION = "2026-02-25.clover" as Stripe.LatestApiVersion;
+
+/**
+ * Construct a mode-guarded Stripe client. Throws if STRIPE_SECRET_KEY is
+ * missing or mismatched with the environment — callers map that to a 503.
+ */
+export function getStripeClient(): Stripe {
+  const key = process.env.STRIPE_SECRET_KEY;
+  assertStripeMode(key);
+  return new Stripe(key!, { apiVersion: STRIPE_API_VERSION });
+}

--- a/site/lib/stripe.ts
+++ b/site/lib/stripe.ts
@@ -14,5 +14,6 @@ export const STRIPE_API_VERSION = "2026-02-25.clover" as Stripe.LatestApiVersion
 export function getStripeClient(): Stripe {
   const key = process.env.STRIPE_SECRET_KEY;
   assertStripeMode(key);
-  return new Stripe(key!, { apiVersion: STRIPE_API_VERSION });
+  if (!key) throw new Error("STRIPE_SECRET_KEY is not set");
+  return new Stripe(key, { apiVersion: STRIPE_API_VERSION });
 }

--- a/site/lib/webhookHandlers.ts
+++ b/site/lib/webhookHandlers.ts
@@ -1,0 +1,127 @@
+import type Stripe from "stripe";
+import type { BillingStore, PaidPlan } from "trailhead-cloud";
+import { encryptClaim } from "@/lib/claimCrypto";
+import { isPaidPlan, planForPriceId } from "@/lib/plans";
+
+const CLAIM_TTL_MS = 72 * 60 * 60 * 1000; // 72h, per contract key_claims.expires_at
+
+export interface HandleResult {
+  handled: boolean;
+  reason?: string;
+  orgId?: string;
+}
+
+/** `string | {id} | null` → id string. */
+function idOf(v: string | { id: string } | null | undefined): string | null {
+  if (!v) return null;
+  return typeof v === "string" ? v : v.id;
+}
+
+/** Org name from checkout email domain (per contract), falling back to the email. */
+function orgNameFromEmail(email: string | null | undefined): string {
+  if (!email) return "New org";
+  const domain = email.split("@")[1];
+  return domain && domain.length > 0 ? domain : email;
+}
+
+function periodEndIso(sub: Stripe.Subscription): string | null {
+  const end = (sub as unknown as { current_period_end?: number }).current_period_end;
+  return typeof end === "number" ? new Date(end * 1000).toISOString() : null;
+}
+
+function planFromSubscription(sub: Stripe.Subscription): PaidPlan | undefined {
+  const priceId = sub.items?.data?.[0]?.price?.id;
+  return planForPriceId(priceId) ?? undefined;
+}
+
+/**
+ * Core Stripe event handler — pure w.r.t. HTTP: takes a verified event + the
+ * billing store and applies the contract's webhook flows. Kept separate from
+ * the route so it can be unit-tested with a mocked store.
+ *
+ * Idempotency is insert-first: recordStripeEvent inserts into
+ * stripe_webhook_events and a duplicate event id short-circuits (komatik lesson).
+ */
+export async function handleStripeEvent(
+  event: Stripe.Event,
+  store: BillingStore,
+): Promise<HandleResult> {
+  const { firstSeen } = await store.recordStripeEvent({
+    eventId: event.id,
+    eventType: event.type,
+    payload: event,
+  });
+  if (!firstSeen) {
+    return { handled: false, reason: "duplicate" };
+  }
+
+  switch (event.type) {
+    case "checkout.session.completed": {
+      const session = event.data.object as Stripe.Checkout.Session;
+      const plan = session.metadata?.plan;
+      if (!isPaidPlan(plan)) {
+        return { handled: false, reason: "missing_or_invalid_plan_metadata" };
+      }
+      const email =
+        session.metadata?.email ??
+        session.customer_email ??
+        session.customer_details?.email ??
+        null;
+      const stripeCustomerId = idOf(session.customer);
+      const stripeSubscriptionId = idOf(session.subscription);
+      if (!stripeCustomerId || !stripeSubscriptionId) {
+        return { handled: false, reason: "missing_customer_or_subscription" };
+      }
+
+      // Create org + org_settings.plan + subscriptions row + first api_key, all
+      // in one store transaction. Precise status/current_period_end are synced
+      // by the following customer.subscription.updated event (and reconcile).
+      const { orgId, apiKeySecret } = await store.createOrgWithSubscription({
+        orgName: orgNameFromEmail(email),
+        plan,
+        stripeCustomerId,
+        stripeSubscriptionId,
+        status: "active",
+        currentPeriodEnd: null,
+        keyLabel: "Initial key",
+      });
+
+      // Encrypt the plaintext key under TRAILHEAD_CLAIM_SECRET and stash the
+      // one-time claim. Plaintext is never persisted (only key_hash + this
+      // AES-256-GCM ciphertext).
+      const keyCiphertext = encryptClaim(apiKeySecret);
+      await store.createKeyClaim({
+        checkoutSessionId: session.id,
+        orgId,
+        keyCiphertext,
+        expiresAt: new Date(Date.now() + CLAIM_TTL_MS).toISOString(),
+      });
+
+      return { handled: true, orgId };
+    }
+
+    case "customer.subscription.updated": {
+      const sub = event.data.object as Stripe.Subscription;
+      const res = await store.updateSubscriptionByStripeId(sub.id, {
+        plan: planFromSubscription(sub),
+        status: sub.status,
+        currentPeriodEnd: periodEndIso(sub),
+      });
+      // Key suspend/unsuspend by status happens inside the store (single source
+      // of truth), per contract flow 2.
+      return { handled: true, orgId: res?.orgId };
+    }
+
+    case "customer.subscription.deleted": {
+      const sub = event.data.object as Stripe.Subscription;
+      const res = await store.updateSubscriptionByStripeId(sub.id, {
+        status: "canceled",
+        currentPeriodEnd: periodEndIso(sub),
+      });
+      return { handled: true, orgId: res?.orgId };
+    }
+
+    default:
+      return { handled: false, reason: "ignored" };
+  }
+}

--- a/site/lib/webhookHandlers.ts
+++ b/site/lib/webhookHandlers.ts
@@ -55,6 +55,31 @@ export async function handleStripeEvent(
     return { handled: false, reason: "duplicate" };
   }
 
+  try {
+    return await applyStripeEvent(event, store);
+  } catch (err) {
+    // Insert-first alone is a trap: the route 500s so Stripe retries, but the
+    // retry would hit firstSeen=false and short-circuit as a duplicate — a
+    // transient store failure would permanently drop the event (paid customer,
+    // no org/key/claim ever created). Roll the ledger row back so the retry
+    // can actually reprocess. Concurrent duplicate delivery is still deduped
+    // by the insert; rollback only happens on handler failure.
+    try {
+      await store.removeStripeEvent(event.id);
+    } catch (rollbackErr) {
+      console.error(
+        `[webhook] Ledger rollback failed for ${event.id} — event may be dropped until reconcile:`,
+        rollbackErr,
+      );
+    }
+    throw err;
+  }
+}
+
+async function applyStripeEvent(
+  event: Stripe.Event,
+  store: BillingStore,
+): Promise<HandleResult> {
   switch (event.type) {
     case "checkout.session.completed": {
       const session = event.data.object as Stripe.Checkout.Session;

--- a/site/next-env.d.ts
+++ b/site/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/site/next.config.ts
+++ b/site/next.config.ts
@@ -1,0 +1,13 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+  // The Cloud API (Hono app) and its Postgres store live in the sibling
+  // `cloud/` workspace package as ESM TypeScript. Next transpiles it so the
+  // mounted `/api/cloud/*` handler and the billing store share one build.
+  // Lane A owns cloud/ (async CloudStore + createPgStore); see site/README.md.
+  transpilePackages: ["trailhead-cloud"],
+  // `pg` is a native/Node-only driver — never bundle it into the Edge runtime.
+  serverExternalPackages: ["pg"],
+};
+
+export default nextConfig;

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -1,0 +1,2369 @@
+{
+  "name": "trailhead-site",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "trailhead-site",
+      "version": "0.1.0",
+      "dependencies": {
+        "hono": "^4.12.18",
+        "next": "16.2.6",
+        "pg": "^8.21.0",
+        "react": "19.2.6",
+        "react-dom": "19.2.6",
+        "stripe": "^20.4.1",
+        "trailhead-cloud": "file:../cloud"
+      },
+      "devDependencies": {
+        "@types/node": "^25.8.0",
+        "@types/pg": "^8.15.5",
+        "@types/react": "^19.2.15",
+        "@types/react-dom": "^19.2.0",
+        "typescript": "^5.7.0",
+        "vitest": "^4.1.6"
+      }
+    },
+    "../cloud": {
+      "name": "trailhead-cloud",
+      "version": "4.5.2",
+      "dependencies": {
+        "@hono/node-server": "^1.19.13",
+        "hono": "^4.12.18",
+        "zod": "^3.24.0"
+      },
+      "devDependencies": {
+        "@types/node": "^25.8.0",
+        "tsx": "^4.22.1",
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.4"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@next/env": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.6.tgz",
+      "integrity": "sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==",
+      "license": "MIT"
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.6.tgz",
+      "integrity": "sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.6.tgz",
+      "integrity": "sha512-v/YLBHIY132Ced3puBJ7YJKw1lqsCrgcNo2aRJlCEyQrrCeRJlvGlnmxhPxNQI3KE3N1DN5r9TPNPvka3nq5RQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.6.tgz",
+      "integrity": "sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.6.tgz",
+      "integrity": "sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.6.tgz",
+      "integrity": "sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.6.tgz",
+      "integrity": "sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.6.tgz",
+      "integrity": "sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.6.tgz",
+      "integrity": "sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.138.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.138.0.tgz",
+      "integrity": "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.4.tgz",
+      "integrity": "sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.4.tgz",
+      "integrity": "sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.4.tgz",
+      "integrity": "sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.4.tgz",
+      "integrity": "sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.4.tgz",
+      "integrity": "sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.4.tgz",
+      "integrity": "sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.4.tgz",
+      "integrity": "sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.4.tgz",
+      "integrity": "sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.4.tgz",
+      "integrity": "sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.4.tgz",
+      "integrity": "sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.4.tgz",
+      "integrity": "sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.4.tgz",
+      "integrity": "sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.4.tgz",
+      "integrity": "sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.4.tgz",
+      "integrity": "sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.4.tgz",
+      "integrity": "sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.4.tgz",
+      "integrity": "sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.9",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.41",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.41.tgz",
+      "integrity": "sha512-WwS7MHhqGHHlaVsqRZnhvCEMS0owDX+SxRlve7JkuH7My1Ara3ZriTmCQupPfYjxMZ8I/tgxtJYr2t7taHaH4A==",
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001800",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001800.tgz",
+      "integrity": "sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+      "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.27",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
+      "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/next": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.6.tgz",
+      "integrity": "sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@next/env": "16.2.6",
+        "@swc/helpers": "0.5.15",
+        "baseline-browser-mapping": "^2.9.19",
+        "caniuse-lite": "^1.0.30001579",
+        "postcss": "8.4.31",
+        "styled-jsx": "5.1.6"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "16.2.6",
+        "@next/swc-darwin-x64": "16.2.6",
+        "@next/swc-linux-arm64-gnu": "16.2.6",
+        "@next/swc-linux-arm64-musl": "16.2.6",
+        "@next/swc-linux-x64-gnu": "16.2.6",
+        "@next/swc-linux-x64-musl": "16.2.6",
+        "@next/swc-win32-arm64-msvc": "16.2.6",
+        "@next/swc-win32-x64-msvc": "16.2.6",
+        "sharp": "^0.34.5"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "@playwright/test": "^1.51.1",
+        "babel-plugin-react-compiler": "*",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@playwright/test": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pg": {
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.22.0.tgz",
+      "integrity": "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.14.0",
+        "pg-pool": "^3.14.0",
+        "pg-protocol": "^1.15.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.4.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.14.0.tgz",
+      "integrity": "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.15.0.tgz",
+      "integrity": "sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
+      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
+      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.6"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.4.tgz",
+      "integrity": "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.138.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.4",
+        "@rolldown/binding-darwin-arm64": "1.1.4",
+        "@rolldown/binding-darwin-x64": "1.1.4",
+        "@rolldown/binding-freebsd-x64": "1.1.4",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.4",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.4",
+        "@rolldown/binding-linux-arm64-musl": "1.1.4",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.4",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.4",
+        "@rolldown/binding-linux-x64-gnu": "1.1.4",
+        "@rolldown/binding-linux-x64-musl": "1.1.4",
+        "@rolldown/binding-openharmony-arm64": "1.1.4",
+        "@rolldown/binding-wasm32-wasi": "1.1.4",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.4",
+        "@rolldown/binding-win32-x64-msvc": "1.1.4"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stripe": {
+      "version": "20.4.1",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-20.4.1.tgz",
+      "integrity": "sha512-axCguHItc8Sxt0HC6aSkdVRPffjYPV7EQqZRb2GkIa8FzWDycE7nHJM19C6xAIynH1Qp1/BHiopSi96jGBxT0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@types/node": ">=16"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/styled-jsx": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
+      "integrity": "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==",
+      "license": "MIT",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/trailhead-cloud": {
+      "resolved": "../cloud",
+      "link": true
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.3.tgz",
+      "integrity": "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.16",
+        "rolldown": "~1.1.3",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/postcss": {
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    }
+  }
+}

--- a/site/package.json
+++ b/site/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "trailhead-site",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Trailhead Cloud marketing + billing + Cloud API — deploys to Vercel at trailhead.komatik.xyz",
+  "scripts": {
+    "dev": "next dev -p 3200",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "hono": "^4.12.18",
+    "next": "16.2.6",
+    "pg": "^8.21.0",
+    "react": "19.2.6",
+    "react-dom": "19.2.6",
+    "stripe": "^20.4.1",
+    "trailhead-cloud": "file:../cloud"
+  },
+  "devDependencies": {
+    "@types/node": "^25.8.0",
+    "@types/pg": "^8.15.5",
+    "@types/react": "^19.2.15",
+    "@types/react-dom": "^19.2.0",
+    "typescript": "^5.7.0",
+    "vitest": "^4.1.6"
+  }
+}

--- a/site/tsconfig.json
+++ b/site/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "preserve",
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "incremental": true,
+    "allowJs": true,
+    "types": ["node"],
+    "plugins": [{ "name": "next" }],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "types/**/*.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/site/tsconfig.json
+++ b/site/tsconfig.json
@@ -20,6 +20,12 @@
       "@/*": ["./*"]
     }
   },
-  "include": ["next-env.d.ts", "types/**/*.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": [
+    "next-env.d.ts",
+    "types/**/*.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/site/types/trailhead-cloud.d.ts
+++ b/site/types/trailhead-cloud.d.ts
@@ -1,0 +1,167 @@
+/**
+ * Ambient type surface for the sibling `cloud/` workspace package
+ * (imported as `trailhead-cloud`, wired via `file:../cloud` +
+ * `transpilePackages` in next.config.ts).
+ *
+ * ── TODO(merge, Lane A: feat/cloud-pg-store) ──────────────────────────────
+ * Lane A owns cloud/ and is ADDING, in parallel:
+ *   - an async `CloudStore` (methods return Promises)
+ *   - `createPgStore(config)` backed by `pg` Pool + DATABASE_URL
+ *   - the billing store methods declared in `BillingStore` below
+ * Until that branch merges into this one, these declarations are the contract
+ * Lane B codes against. On merge, DELETE this file and rely on the real cloud
+ * exports (add a proper `exports` map + built types to cloud/package.json).
+ * The method shapes here mirror TRAILHEAD-BILLING-CONTRACT.md §"Billing flows"
+ * and the DDL exactly.
+ */
+declare module "trailhead-cloud" {
+  export type PlanTier = "free" | "pro" | "team";
+  export type PaidPlan = "pro" | "team";
+
+  /** Opaque handle for the /v1 Cloud API store surface (see cloud/src/types.ts). */
+  export interface CloudStore {
+    getOrgForKey(apiKey: string): unknown;
+  }
+
+  export interface SubscriptionRow {
+    orgId: string;
+    stripeCustomerId: string;
+    stripeSubscriptionId: string;
+    plan: PaidPlan;
+    status: string;
+    currentPeriodEnd: string | null;
+  }
+
+  export interface CreateOrgWithSubscriptionInput {
+    /** Org display name — derived from checkout email domain or a custom field. */
+    orgName: string;
+    plan: PaidPlan;
+    stripeCustomerId: string;
+    stripeSubscriptionId: string;
+    status: string;
+    currentPeriodEnd: string | null;
+    keyLabel?: string;
+  }
+
+  export interface CreateOrgResult {
+    orgId: string;
+    /** Plaintext api key — returned ONCE; caller encrypts into a key_claim. */
+    apiKeySecret: string;
+    keyPreview: string;
+  }
+
+  /**
+   * Stripe-truth shape for reconcile repair. No orgId — the store resolves the
+   * org by stripe_customer_id (creating a minimal org if the webhook was lost).
+   */
+  export interface UpsertSubscriptionInput {
+    stripeCustomerId: string;
+    stripeSubscriptionId: string;
+    plan: PaidPlan;
+    status: string;
+    currentPeriodEnd: string | null;
+    orgName?: string;
+  }
+
+  /**
+   * The billing-facing store surface. Lane A implements this on both the
+   * Postgres store (createPgStore) and the in-memory store (tests/dev).
+   * All methods are async to match Lane A's async CloudStore conversion.
+   */
+  export interface BillingStore extends CloudStore {
+    /**
+     * Webhook idempotency ledger — insert-first into stripe_webhook_events.
+     * Returns `{ firstSeen: true }` only for a never-before-seen event id;
+     * a duplicate event returns `{ firstSeen: false }` and MUST be skipped.
+     */
+    recordStripeEvent(input: {
+      eventId: string;
+      eventType: string;
+      payload: unknown;
+    }): Promise<{ firstSeen: boolean }>;
+
+    /**
+     * checkout.session.completed handler — in ONE transaction: create org,
+     * org_settings.plan, subscriptions row, and issue the first api_key
+     * (key_hash + key_preview stored; plaintext returned once to the caller).
+     */
+    createOrgWithSubscription(
+      input: CreateOrgWithSubscriptionInput,
+    ): Promise<CreateOrgResult>;
+
+    /** Persist the one-time key handoff row (AES-256-GCM ciphertext, +72h expiry). */
+    createKeyClaim(input: {
+      checkoutSessionId: string;
+      orgId: string;
+      keyCiphertext: string;
+      expiresAt: string;
+    }): Promise<void>;
+
+    /**
+     * Atomic one-time reveal: if the claim is unclaimed AND unexpired, stamp
+     * claimed_at and return the ciphertext; otherwise return null. Must be a
+     * single UPDATE ... WHERE claimed_at IS NULL ... RETURNING (no read-modify-write).
+     */
+    claimKey(checkoutSessionId: string): Promise<{ keyCiphertext: string } | null>;
+
+    /** Non-mutating status for a claim (for friendly UI messaging). */
+    getKeyClaimStatus(
+      checkoutSessionId: string,
+    ): Promise<{ exists: boolean; claimed: boolean; expired: boolean }>;
+
+    /**
+     * customer.subscription.updated/deleted — sync plan/status/current_period_end
+     * on the subscriptions row keyed by stripe_subscription_id, AND suspend the
+     * org's api_keys when status ∈ {past_due,unpaid,canceled,incomplete_expired},
+     * or unsuspend when back to active/trialing. Returns the affected orgId.
+     */
+    updateSubscriptionByStripeId(
+      stripeSubscriptionId: string,
+      patch: {
+        plan?: PaidPlan;
+        status: string;
+        currentPeriodEnd?: string | null;
+      },
+    ): Promise<{ orgId: string } | null>;
+
+    /** Portal: resolve a Bearer api key to its org + Stripe customer id. */
+    getStripeCustomerIdForKey(
+      apiKey: string,
+    ): Promise<{ orgId: string; stripeCustomerId: string } | null>;
+
+    /** Reconcile: all subscription rows we believe we have. */
+    listSubscriptions(): Promise<SubscriptionRow[]>;
+
+    getSubscriptionByStripeId(
+      stripeSubscriptionId: string,
+    ): Promise<SubscriptionRow | null>;
+
+    /** Reconcile repair: create/refresh a subscription row from Stripe truth. */
+    upsertSubscriptionFromStripe(input: UpsertSubscriptionInput): Promise<{ orgId: string }>;
+
+    /** Reconcile: unrevoked, unsuspended key count for an org. */
+    countActiveKeys(orgId: string): Promise<number>;
+
+    /** Reconcile: delete expired unclaimed key_claims. Returns rows purged. */
+    purgeExpiredClaims(): Promise<number>;
+  }
+
+  export interface CloudAppOptions {
+    store?: CloudStore | BillingStore;
+    seedKeys?: unknown[];
+  }
+
+  export interface HonoLike {
+    fetch(request: Request, ...rest: unknown[]): Response | Promise<Response>;
+  }
+
+  export function createCloudApp(options?: CloudAppOptions): HonoLike;
+  export function createMemoryStore(seedKeys?: unknown[]): BillingStore;
+  export function parseSeedKeys(raw: string | undefined): unknown[];
+
+  /** Lane A (feat/cloud-pg-store): Postgres-backed async store over DATABASE_URL. */
+  export function createPgStore(config: {
+    connectionString: string;
+    seedKeys?: unknown[];
+  }): Promise<BillingStore>;
+}

--- a/site/types/trailhead-cloud.d.ts
+++ b/site/types/trailhead-cloud.d.ts
@@ -145,7 +145,9 @@ declare module "trailhead-cloud" {
     ): Promise<SubscriptionRow | null>;
 
     /** Reconcile repair: create/refresh a subscription row from Stripe truth. */
-    upsertSubscriptionFromStripe(input: UpsertSubscriptionInput): Promise<{ orgId: string }>;
+    upsertSubscriptionFromStripe(
+      input: UpsertSubscriptionInput,
+    ): Promise<{ orgId: string }>;
 
     /** Reconcile: unrevoked, unsuspended key count for an org. */
     countActiveKeys(orgId: string): Promise<number>;

--- a/site/types/trailhead-cloud.d.ts
+++ b/site/types/trailhead-cloud.d.ts
@@ -81,6 +81,14 @@ declare module "trailhead-cloud" {
     }): Promise<{ firstSeen: boolean }>;
 
     /**
+     * Rollback for the idempotency ledger: called when the handler THROWS
+     * after insert-first, so Stripe's retry of the same event id is not
+     * short-circuited as a duplicate and can actually reprocess. Without
+     * this, a transient store failure permanently drops the event.
+     */
+    removeStripeEvent(eventId: string): Promise<void>;
+
+    /**
      * checkout.session.completed handler — in ONE transaction: create org,
      * org_settings.plan, subscriptions row, and issue the first api_key
      * (key_hash + key_preview stored; plaintext returned once to the caller).

--- a/site/vercel.json
+++ b/site/vercel.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "crons": [
+    {
+      "path": "/api/billing/reconcile",
+      "schedule": "0 7 * * *"
+    }
+  ]
+}

--- a/site/vitest.config.ts
+++ b/site/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "vitest/config";
+import path from "node:path";
+
+// Self-contained: the repo root has its own vitest config that scans src/**.
+// This config keeps site/ tests isolated to site/__tests__ and wires the `@/`
+// path alias used by the app (matches tsconfig paths).
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "."),
+    },
+  },
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["__tests__/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## What
Billing-sprint Lane B — the commercial plumbing (brief §5.1–5.3): new `site/` Next.js app deploying to Vercel at trailhead.komatik.xyz.

Routes: `POST /api/billing/checkout` (rate-limited, price-by-env) · `POST /api/billing/webhook` (signature-verified, idempotent) · `GET /api/billing/claim` (one-time key reveal, AES-256-GCM envelope, atomic claim-once) · `POST /api/billing/portal` (Bearer key → Stripe portal) · `GET /api/billing/reconcile` (CRON_SECRET, daily Vercel cron — Stripe↔store diff repair, purges expired claims) · `/api/cloud/[[...route]]` mounts the Cloud Hono app via hono/vercel.

Mirrors the komatik monorepo's Stripe discipline (tier-purchase webhook + teams/subscribe patterns; assertStripeMode, raw-body signature, RFC 9110 rate limits, API version pinned).

**Review hardening (coordinator):** the insert-first idempotency ledger now rolls back on handler failure — without it, a transient store error during `checkout.session.completed` permanently dropped the event (paid customer, no org/key/claim, Stripe retries short-circuited as duplicates). Regression-tested.

## Dependencies
- ⚠️ `next build` needs Lane A (`feat/cloud-pg-store`, in flight) to give `cloud/` a package exports entry + the async store (`createPgStore`, `removeStripeEvent`, `upsertSubscriptionFromStripe`). tsc + 24/24 tests green now; production build goes green on A's merge. **Merge order: A → this → feat/site-pages.**
- Infra already provisioned: Supabase `trailhead-cloud` (mehoxxjfntubqwbqybht), live Stripe prices ($39/$399), secrets in Stash — env matrix + runbook in `site/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)