### PR TITLE
feat(site): landing, pricing, welcome key-claim, dashboard pages

### DIFF
--- a/site/__tests__/checkoutForm.test.ts
+++ b/site/__tests__/checkoutForm.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { submitCheckout } from "@/lib/checkoutClient";
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("submitCheckout — pricing page checkout form handler", () => {
+  it("returns a redirect result on 200 with a Stripe url", async () => {
+    const result = await submitCheckout("pro", "dev@acme.com", async (url, init) => {
+      expect(url).toBe("/api/billing/checkout");
+      expect(init.method).toBe("POST");
+      expect(JSON.parse(init.body as string)).toEqual({ plan: "pro", email: "dev@acme.com" });
+      return jsonResponse(200, { url: "https://checkout.stripe/cs_new", id: "cs_new" });
+    });
+    expect(result).toEqual({ status: "redirect", url: "https://checkout.stripe/cs_new" });
+  });
+
+  it("returns rate_limited with retryAfterSeconds on 429", async () => {
+    const result = await submitCheckout("team", "a@b.com", async () =>
+      jsonResponse(429, {
+        error: "Too many requests. Please try again later.",
+        code: "rate_limited",
+        retryAfterSeconds: 42,
+      }),
+    );
+    expect(result).toEqual({ status: "rate_limited", retryAfterSeconds: 42 });
+  });
+
+  it("returns rate_limited with null retryAfterSeconds when the body omits it", async () => {
+    const result = await submitCheckout("pro", "a@b.com", async () => jsonResponse(429, {}));
+    expect(result).toEqual({ status: "rate_limited", retryAfterSeconds: null });
+  });
+
+  it("returns error with the server message on a validation failure", async () => {
+    const result = await submitCheckout("pro", "not-an-email", async () =>
+      jsonResponse(400, { error: "a valid email is required" }),
+    );
+    expect(result).toEqual({ status: "error", message: "a valid email is required" });
+  });
+
+  it("returns error when Stripe is unavailable (503)", async () => {
+    const result = await submitCheckout("team", "a@b.com", async () =>
+      jsonResponse(503, { error: "Payment system unavailable" }),
+    );
+    expect(result).toEqual({ status: "error", message: "Payment system unavailable" });
+  });
+
+  it("returns error when the response has no url", async () => {
+    const result = await submitCheckout("pro", "a@b.com", async () => jsonResponse(200, {}));
+    expect(result).toEqual({
+      status: "error",
+      message: "Checkout session did not return a redirect URL.",
+    });
+  });
+
+  it("returns error on a network failure", async () => {
+    const result = await submitCheckout("pro", "a@b.com", async () => {
+      throw new Error("network down");
+    });
+    expect(result).toEqual({
+      status: "error",
+      message: "Network error — check your connection and try again.",
+    });
+  });
+});

--- a/site/__tests__/claimState.test.ts
+++ b/site/__tests__/claimState.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import { resolveClaimState } from "@/lib/claimClient";
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("resolveClaimState — /welcome state machine", () => {
+  it("returns missing when there is no session_id (no fetch performed)", async () => {
+    let called = false;
+    const state = await resolveClaimState(null, async () => {
+      called = true;
+      throw new Error("should not be called");
+    });
+    expect(state).toEqual({ status: "missing" });
+    expect(called).toBe(false);
+  });
+
+  it("returns revealed on 200 with the decrypted key", async () => {
+    const state = await resolveClaimState("cs_1", async () =>
+      jsonResponse(200, { apiKey: "thk_abc123", once: true, message: "Store this now." }),
+    );
+    expect(state).toEqual({
+      status: "revealed",
+      apiKey: "thk_abc123",
+      message: "Store this now.",
+    });
+  });
+
+  it("returns already_claimed on 410 with code already_claimed", async () => {
+    const state = await resolveClaimState("cs_2", async () =>
+      jsonResponse(410, {
+        error: "This key was already claimed.",
+        code: "already_claimed",
+        message: "For a new key, rotate via the billing portal or contact support.",
+      }),
+    );
+    expect(state).toEqual({
+      status: "already_claimed",
+      message: "For a new key, rotate via the billing portal or contact support.",
+    });
+  });
+
+  it("returns expired on 410 with code expired", async () => {
+    const state = await resolveClaimState("cs_3", async () =>
+      jsonResponse(410, {
+        error: "This claim link has expired.",
+        code: "expired",
+        message: "Contact support to issue a replacement key.",
+      }),
+    );
+    expect(state).toEqual({
+      status: "expired",
+      message: "Contact support to issue a replacement key.",
+    });
+  });
+
+  it("returns not_found on 404", async () => {
+    const state = await resolveClaimState("cs_unknown", async () =>
+      jsonResponse(404, { error: "No key claim for this session." }),
+    );
+    expect(state).toEqual({ status: "not_found" });
+  });
+
+  it("returns rate_limited on 429", async () => {
+    const state = await resolveClaimState("cs_4", async () => jsonResponse(429, {}));
+    expect(state).toEqual({ status: "rate_limited" });
+  });
+
+  it("returns error on network failure", async () => {
+    const state = await resolveClaimState("cs_5", async () => {
+      throw new Error("network down");
+    });
+    expect(state.status).toBe("error");
+  });
+
+  it("returns error on an unexpected status", async () => {
+    const state = await resolveClaimState("cs_6", async () =>
+      jsonResponse(500, { error: "Could not decrypt key. Contact support to rotate." }),
+    );
+    expect(state).toEqual({
+      status: "error",
+      message: "Could not decrypt key. Contact support to rotate.",
+    });
+  });
+});

--- a/site/app/dashboard/page.tsx
+++ b/site/app/dashboard/page.tsx
@@ -1,0 +1,31 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Dashboard",
+  robots: { index: false, follow: false },
+};
+
+/**
+ * Serves the existing Cloud dashboard (cloud/public/dashboard.html) via a
+ * same-origin static route (site/public/dashboard-embed.html) in an iframe.
+ * The embedded page is a key-entry shell itself (API Base + API Key inputs,
+ * "Load" button) — porting is large (1000+ lines of self-contained vanilla
+ * JS driving many /v1 endpoints) so this route serves it directly rather
+ * than rewriting it as React. The embedded copy was edited to use
+ * sessionStorage instead of localStorage so the key never persists past the
+ * tab, and to default its API base to the same-origin /api/cloud mount
+ * (Lane B's Hono adapter) instead of a standalone host. Team-gated features
+ * (org rollup) render whatever /api/cloud/v1/* returns for the key's plan —
+ * there is no client-side plan gating here.
+ */
+export default function DashboardPage() {
+  return (
+    <main style={{ height: "calc(100vh - 64px)" }}>
+      <iframe
+        src="/dashboard-embed.html"
+        title="Trailhead Cloud Dashboard"
+        style={{ width: "100%", height: "100%", border: "none", display: "block" }}
+      />
+    </main>
+  );
+}

--- a/site/app/globals.css
+++ b/site/app/globals.css
@@ -1,0 +1,130 @@
+:root {
+  color-scheme: light dark;
+  --bg: #ffffff;
+  --bg-raised: #f6f8fa;
+  --border: #d0d7de;
+  --text: #1f2328;
+  --text-muted: #57606a;
+  --accent: #0969da;
+  --accent-contrast: #ffffff;
+  --green: #1a7f37;
+  --yellow: #9a6700;
+  --red: #cf222e;
+  --radius: 10px;
+  --font-sans:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif,
+    "Apple Color Emoji", "Segoe UI Emoji";
+  --font-mono:
+    ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0d1117;
+    --bg-raised: #161b22;
+    --border: #30363d;
+    --text: #c9d1d9;
+    --text-muted: #8b949e;
+    --accent: #58a6ff;
+    --accent-contrast: #0d1117;
+    --green: #3fb950;
+    --yellow: #d29922;
+    --red: #f85149;
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  padding: 0;
+  margin: 0;
+}
+
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font-sans);
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+}
+
+a {
+  color: inherit;
+}
+
+code,
+pre {
+  font-family: var(--font-mono);
+}
+
+.wrap {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  border-radius: var(--radius);
+  padding: 10px 18px;
+  font-size: 0.9375rem;
+  font-weight: 600;
+  text-decoration: none;
+  cursor: pointer;
+  border: 1px solid transparent;
+  font-family: inherit;
+  transition: opacity 0.15s ease;
+}
+
+.btn:hover {
+  opacity: 0.85;
+}
+
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.btn-primary {
+  background: var(--accent);
+  color: var(--accent-contrast);
+}
+
+.btn-secondary {
+  background: transparent;
+  color: var(--text);
+  border-color: var(--border);
+}
+
+.card {
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 24px;
+}
+
+.muted {
+  color: var(--text-muted);
+}
+
+.mono {
+  font-family: var(--font-mono);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 2px 10px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+}

--- a/site/app/icon.svg
+++ b/site/app/icon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+  <rect width="24" height="24" rx="5" fill="#0d1117"/>
+  <path d="M3 20L9.5 6L13 13.5L15.5 9L21 20" stroke="#58a6ff" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <circle cx="9.5" cy="6" r="1.7" fill="#58a6ff"/>
+</svg>

--- a/site/app/layout.tsx
+++ b/site/app/layout.tsx
@@ -1,20 +1,48 @@
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
+import SiteNav from "@/components/SiteNav";
+import SiteFooter from "@/components/SiteFooter";
+import "./globals.css";
+
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://trailhead.komatik.xyz";
 
 export const metadata: Metadata = {
-  title: "Trailhead Cloud",
+  title: {
+    default: "Trailhead — The release gate for the AI-agent era",
+    template: "%s · Trailhead",
+  },
   description:
-    "Release readiness gate for GitHub PRs — hosted evaluation store, dashboards, and org billing.",
-  metadataBase: new URL(
-    process.env.NEXT_PUBLIC_SITE_URL ?? "https://trailhead.komatik.xyz",
-  ),
+    "Trailhead is a release-readiness gate for GitHub PRs: CI-aware risk scoring, production health checks, and agent-governance policies for Claude, Copilot, and Codex PRs — one Release Ready check to merge on.",
+  metadataBase: new URL(siteUrl),
+  openGraph: {
+    title: "Trailhead — The release gate for the AI-agent era",
+    description:
+      "Risk scoring, CI orchestration, and agent-governance policies for GitHub PRs — free as a GitHub Action, hosted analytics on Trailhead Cloud.",
+    url: siteUrl,
+    siteName: "Trailhead",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Trailhead — The release gate for the AI-agent era",
+    description:
+      "CI-aware risk scoring and agent-governance policies for GitHub PRs. One Release Ready check to merge on.",
+  },
+  icons: {
+    icon: "/icon.svg",
+  },
 };
 
-// Minimal, unopinionated shell. Lane D owns marketing/pricing/welcome/dashboard.
+// Shared shell: nav + footer + design tokens. Individual pages (Lane D) stay
+// server components where possible so the marketing surface remains static.
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <SiteNav />
+        {children}
+        <SiteFooter />
+      </body>
     </html>
   );
 }

--- a/site/app/page.tsx
+++ b/site/app/page.tsx
@@ -1,14 +1,343 @@
-// Placeholder home page — Lane D replaces this with the marketing landing page.
-// Kept deliberately minimal so the skeleton stays unopinionated.
+import Link from "next/link";
+import { TrailheadMark } from "@/components/SiteNav";
+
+const MARKETPLACE_URL = "https://github.com/marketplace/actions/trailhead";
+const REPO_URL = "https://github.com/KomatikAI/trailhead";
+
+// Fully static server component — no client JS on the landing page.
 export default function HomePage() {
   return (
-    <main style={{ fontFamily: "system-ui, sans-serif", padding: "4rem 1.5rem", maxWidth: 640, margin: "0 auto" }}>
-      <h1 style={{ fontSize: "1.75rem", fontWeight: 700 }}>Trailhead Cloud</h1>
-      <p style={{ color: "#555", lineHeight: 1.6 }}>
-        Placeholder home page. Marketing, pricing, and the post-checkout key claim
-        flow land here (Lane D). The billing API and the Cloud API are already
-        mounted under <code>/api/billing/*</code> and <code>/api/cloud/*</code>.
-      </p>
+    <main>
+      <Hero />
+      <Proof />
+      <HowItWorks />
+      <AgentGovernance />
+      <Dogfood />
+      <PlanTeaser />
+      <FinalCta />
     </main>
+  );
+}
+
+function Hero() {
+  return (
+    <section className="wrap" style={{ padding: "88px 24px 64px", textAlign: "center" }}>
+      <div
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          gap: 6,
+          fontSize: "0.8125rem",
+          fontWeight: 600,
+          color: "var(--accent)",
+          background: "var(--bg-raised)",
+          border: "1px solid var(--border)",
+          borderRadius: 999,
+          padding: "5px 14px",
+          marginBottom: 24,
+        }}
+      >
+        <TrailheadMark size={14} /> v4 &middot; 17-factor risk engine &middot; CI-aware
+      </div>
+      <h1
+        style={{
+          fontSize: "clamp(2.25rem, 5vw, 3.5rem)",
+          lineHeight: 1.08,
+          fontWeight: 800,
+          letterSpacing: "-0.02em",
+          margin: "0 0 20px",
+        }}
+      >
+        The release gate for the
+        <br />
+        AI-agent era.
+      </h1>
+      <p
+        className="muted"
+        style={{ fontSize: "1.1875rem", maxWidth: 640, margin: "0 auto 36px", lineHeight: 1.6 }}
+      >
+        Trailhead waits for your CI, scores every pull request across 17 weighted risk factors,
+        checks production health, and gates AI-authored PRs before they hit main — one{" "}
+        <strong>Release&nbsp;Ready</strong> check, one merge rule.
+      </p>
+      <div
+        style={{ display: "flex", gap: 12, justifyContent: "center", flexWrap: "wrap", marginBottom: 16 }}
+      >
+        <Link href={MARKETPLACE_URL} className="btn btn-primary" style={{ padding: "12px 22px" }}>
+          Install from GitHub Marketplace
+        </Link>
+        <Link href="/pricing" className="btn btn-secondary" style={{ padding: "12px 22px" }}>
+          View Trailhead Cloud pricing
+        </Link>
+      </div>
+      <p className="muted" style={{ fontSize: "0.8125rem" }}>
+        Free as a GitHub Action &middot; no API key required to start
+      </p>
+      <CodeBlock />
+    </section>
+  );
+}
+
+function CodeBlock() {
+  const snippet = `- uses: KomatikAI/trailhead@v4
+  with:
+    gate-mode: release-ready
+    wait-for-checks: "true"
+    risk-threshold: "70"`;
+  return (
+    <div
+      className="card mono"
+      style={{
+        textAlign: "left",
+        maxWidth: 560,
+        margin: "40px auto 0",
+        fontSize: "0.8125rem",
+        overflowX: "auto",
+      }}
+    >
+      <pre style={{ margin: 0, whiteSpace: "pre" }}>{snippet}</pre>
+    </div>
+  );
+}
+
+function Proof() {
+  const stats: [string, string][] = [
+    ["17", "weighted risk factors"],
+    ["1", "merge check — Release Ready"],
+    ["3", "gate modes: release-ready, advisory, risk-only"],
+    ["0", "secrets required for the free Action"],
+  ];
+  return (
+    <section style={{ borderTop: "1px solid var(--border)", borderBottom: "1px solid var(--border)" }}>
+      <div
+        className="wrap"
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))",
+          gap: 24,
+          padding: "36px 24px",
+        }}
+      >
+        {stats.map(([value, label]) => (
+          <div key={label} style={{ textAlign: "center" }}>
+            <div style={{ fontSize: "1.875rem", fontWeight: 800 }}>{value}</div>
+            <div className="muted" style={{ fontSize: "0.875rem" }}>
+              {label}
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function HowItWorks() {
+  const steps: [string, string][] = [
+    [
+      "Install the Action",
+      "Add one workflow step. Trailhead reads .trailhead.yml, waits for your required CI checks, and posts a single composite check on every pull request.",
+    ],
+    [
+      "Score risk, CI, and health",
+      "17 weighted factors — code churn, security alerts, supply-chain changes, sensitive files, CI integrity, deploy history — roll up into a 0-100 risk score, plus a production health probe.",
+    ],
+    [
+      "Get one merge decision",
+      "allow, warn, or block. \"Trailhead — Release Ready\" is the one check your branch protection rule requires, so there's nothing else to reconcile across CI and risk.",
+    ],
+  ];
+  return (
+    <section className="wrap" style={{ padding: "72px 24px" }}>
+      <SectionHeading eyebrow="How it works" title="Three steps from PR open to merge decision" />
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fit, minmax(260px, 1fr))",
+          gap: 20,
+          marginTop: 40,
+        }}
+      >
+        {steps.map(([title, body], i) => (
+          <div key={title} className="card">
+            <div
+              className="mono"
+              style={{ color: "var(--accent)", fontWeight: 700, marginBottom: 12, fontSize: "0.875rem" }}
+            >
+              STEP {i + 1}
+            </div>
+            <h3 style={{ margin: "0 0 8px", fontSize: "1.0625rem" }}>{title}</h3>
+            <p className="muted" style={{ margin: 0, fontSize: "0.9375rem" }}>
+              {body}
+            </p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function AgentGovernance() {
+  const findings: [string, string][] = [
+    ["Provenance classification", "Every PR is labeled human, dependabot, copilot, codex, claude, custom-bot, or unknown."],
+    ["Agent-policy findings", "Sensitive-path gates, required-approval counts, and code-owner review for agent-authored PRs."],
+    ["Session-burst detection", "Flags correlated bursts of agent commits inside a time window — a signature of runaway automation."],
+    ["Trust profiles & SLAs", "Per-repo strictness (baseline, elevated, strict) plus escalation status and acknowledge/resolve SLAs."],
+  ];
+  return (
+    <section style={{ background: "var(--bg-raised)", borderTop: "1px solid var(--border)", borderBottom: "1px solid var(--border)" }}>
+      <div className="wrap" style={{ padding: "72px 24px" }}>
+        <SectionHeading
+          eyebrow="Agent governance"
+          title="Gate the PRs your agents open, not just the ones your team writes"
+          body="Copilot, Codex, and Claude now open pull requests directly. Trailhead treats agent-authored code as a distinct risk class instead of scoring it the same as a human diff — the gap most CI tooling still ignores in 2026."
+        />
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))",
+            gap: 20,
+            marginTop: 40,
+          }}
+        >
+          {findings.map(([title, body]) => (
+            <div key={title} className="card" style={{ background: "var(--bg)" }}>
+              <h3 style={{ margin: "0 0 8px", fontSize: "1rem" }}>{title}</h3>
+              <p className="muted" style={{ margin: 0, fontSize: "0.9375rem" }}>
+                {body}
+              </p>
+            </div>
+          ))}
+        </div>
+        <p className="muted" style={{ marginTop: 28, fontSize: "0.875rem" }}>
+          Governance policies (approval requirements, sensitive-path gates, strict unknown-provenance
+          handling) are configured per-repo in <code>.trailhead.yml</code> — see the{" "}
+          <Link href={`${REPO_URL}#agent-governance-optional`}>agent governance docs</Link>.
+        </p>
+      </div>
+    </section>
+  );
+}
+
+function Dogfood() {
+  return (
+    <section className="wrap" style={{ padding: "72px 24px" }}>
+      <div
+        className="card"
+        style={{
+          display: "flex",
+          gap: 28,
+          alignItems: "center",
+          flexWrap: "wrap",
+          padding: 36,
+        }}
+      >
+        <div style={{ flex: "1 1 320px" }}>
+          <div className="badge" style={{ marginBottom: 14 }}>
+            Dogfooded internally
+          </div>
+          <h2 style={{ fontSize: "1.5rem", margin: "0 0 12px" }}>
+            We run Trailhead on our own agent fleet
+          </h2>
+          <p className="muted" style={{ margin: 0, fontSize: "0.9375rem", maxWidth: 560 }}>
+            Komatik gates every pull request its own AI agents open against{" "}
+            <code>KomatikAI/agents</code> with the same submission engine, trust scoring, and risk
+            factors shipped here — provenance classification, sensitive-path policies, and Gate 1
+            submission checks, running on real, autonomous, multi-agent PR traffic every day.
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function PlanTeaser() {
+  return (
+    <section style={{ borderTop: "1px solid var(--border)" }}>
+      <div className="wrap" style={{ padding: "72px 24px", textAlign: "center" }}>
+        <SectionHeading eyebrow="Pricing" title="Free to gate. Paid to remember." center />
+        <p className="muted" style={{ maxWidth: 560, margin: "16px auto 32px" }}>
+          The Action is free forever — no API key, no store. Trailhead Cloud adds hosted evaluation
+          history, dashboards, and org-wide agent-governance policy for teams that need the record.
+        </p>
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
+            gap: 16,
+            maxWidth: 760,
+            margin: "0 auto 32px",
+          }}
+        >
+          {[
+            ["Free", "Risk-only gate, local", "$0"],
+            ["Pro", "5,000 evals/mo + dashboard", "$39/mo"],
+            ["Team", "50,000 evals/mo + org rollup + SSO", "$399/mo"],
+          ].map(([name, desc, price]) => (
+            <div key={name} className="card" style={{ textAlign: "left" }}>
+              <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline" }}>
+                <strong>{name}</strong>
+                <span className="mono muted">{price}</span>
+              </div>
+              <p className="muted" style={{ fontSize: "0.875rem", margin: "8px 0 0" }}>
+                {desc}
+              </p>
+            </div>
+          ))}
+        </div>
+        <Link href="/pricing" className="btn btn-primary" style={{ padding: "12px 22px" }}>
+          See full plan details
+        </Link>
+      </div>
+    </section>
+  );
+}
+
+function FinalCta() {
+  return (
+    <section style={{ background: "var(--bg-raised)", borderTop: "1px solid var(--border)" }}>
+      <div className="wrap" style={{ padding: "72px 24px", textAlign: "center" }}>
+        <h2 style={{ fontSize: "1.875rem", margin: "0 0 12px" }}>Ship your next PR through a real gate</h2>
+        <p className="muted" style={{ margin: "0 0 28px" }}>
+          Add the Action in a few minutes. Add Cloud when you need the history.
+        </p>
+        <div style={{ display: "flex", gap: 12, justifyContent: "center", flexWrap: "wrap" }}>
+          <Link href={MARKETPLACE_URL} className="btn btn-primary" style={{ padding: "12px 22px" }}>
+            Install from GitHub Marketplace
+          </Link>
+          <Link href={REPO_URL} className="btn btn-secondary" style={{ padding: "12px 22px" }}>
+            View source on GitHub
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function SectionHeading({
+  eyebrow,
+  title,
+  body,
+  center,
+}: {
+  eyebrow: string;
+  title: string;
+  body?: string;
+  center?: boolean;
+}) {
+  return (
+    <div style={{ textAlign: center ? "center" : "left", maxWidth: 720, margin: center ? "0 auto" : 0 }}>
+      <div
+        className="mono muted"
+        style={{ fontSize: "0.8125rem", fontWeight: 700, letterSpacing: "0.04em", textTransform: "uppercase" }}
+      >
+        {eyebrow}
+      </div>
+      <h2 style={{ fontSize: "1.75rem", margin: "8px 0 0", letterSpacing: "-0.01em" }}>{title}</h2>
+      {body ? (
+        <p className="muted" style={{ marginTop: 12, fontSize: "0.9375rem" }}>
+          {body}
+        </p>
+      ) : null}
+    </div>
   );
 }

--- a/site/app/pricing/CheckoutForm.tsx
+++ b/site/app/pricing/CheckoutForm.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+import type { PaidPlan } from "@/lib/plans";
+import { submitCheckout } from "@/lib/checkoutClient";
+
+type Status = "idle" | "loading" | "error" | "rate_limited";
+
+/**
+ * Client-side checkout form for a paid plan column. Submit logic (POST to
+ * /api/billing/checkout, status mapping) lives in lib/checkoutClient.ts —
+ * pure and unit-testable with a mocked fetch, see
+ * __tests__/checkoutForm.test.ts. This component owns form state + the
+ * browser redirect.
+ */
+export default function CheckoutForm({ plan, label }: { plan: PaidPlan; label: string }) {
+  const [email, setEmail] = useState("");
+  const [status, setStatus] = useState<Status>("idle");
+  const [error, setError] = useState<string | null>(null);
+  const [retryAfter, setRetryAfter] = useState<number | null>(null);
+
+  async function onSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setStatus("loading");
+    setError(null);
+    setRetryAfter(null);
+
+    const result = await submitCheckout(plan, email);
+    switch (result.status) {
+      case "redirect":
+        window.location.href = result.url;
+        return;
+      case "rate_limited":
+        setStatus("rate_limited");
+        setRetryAfter(result.retryAfterSeconds);
+        return;
+      case "error":
+        setStatus("error");
+        setError(result.message);
+        return;
+    }
+  }
+
+  const busy = status === "loading";
+
+  return (
+    <form onSubmit={onSubmit} style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+      <label htmlFor={`email-${plan}`} className="muted" style={{ fontSize: "0.8125rem" }}>
+        Work email
+      </label>
+      <input
+        id={`email-${plan}`}
+        type="email"
+        required
+        placeholder="you@company.com"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        disabled={busy}
+        style={{
+          padding: "9px 12px",
+          borderRadius: "var(--radius)",
+          border: "1px solid var(--border)",
+          background: "var(--bg)",
+          color: "var(--text)",
+          fontSize: "0.9375rem",
+        }}
+      />
+      <button type="submit" className="btn btn-primary" disabled={busy} style={{ marginTop: 4 }}>
+        {busy ? "Redirecting to Stripe…" : label}
+      </button>
+      {status === "rate_limited" ? (
+        <p role="alert" style={{ color: "var(--red)", fontSize: "0.8125rem", margin: 0 }}>
+          Too many checkout attempts. Try again{" "}
+          {retryAfter ? `in about ${retryAfter}s` : "in a minute"}.
+        </p>
+      ) : null}
+      {status === "error" && error ? (
+        <p role="alert" style={{ color: "var(--red)", fontSize: "0.8125rem", margin: 0 }}>
+          {error}
+        </p>
+      ) : null}
+    </form>
+  );
+}

--- a/site/app/pricing/page.tsx
+++ b/site/app/pricing/page.tsx
@@ -1,0 +1,200 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { PLAN_CATALOG as PLANS } from "@/lib/planCatalog";
+import CheckoutForm from "./CheckoutForm";
+
+export const metadata: Metadata = {
+  title: "Pricing",
+  description:
+    "Trailhead is free as a GitHub Action. Trailhead Cloud adds hosted evaluation storage, dashboards, and agent-governance policy: Pro $39/mo, Team $399/mo.",
+};
+
+const MARKETPLACE_URL = "https://github.com/marketplace/actions/trailhead";
+
+export default function PricingPage() {
+  return (
+    <main className="wrap" style={{ padding: "64px 24px 96px" }}>
+      <div style={{ textAlign: "center", maxWidth: 640, margin: "0 auto 48px" }}>
+        <h1 style={{ fontSize: "2.25rem", margin: "0 0 12px", letterSpacing: "-0.01em" }}>Pricing</h1>
+        <p className="muted" style={{ fontSize: "1.0625rem" }}>
+          The gate is free. Cloud is for teams that need the history, the dashboard, and org-wide
+          agent-governance policy.
+        </p>
+      </div>
+
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fit, minmax(280px, 1fr))",
+          gap: 20,
+          alignItems: "stretch",
+        }}
+      >
+        <PlanCard
+          name="Free"
+          price="$0"
+          tagline="Risk-only gate, runs entirely in your CI"
+          features={[
+            "17-factor risk score, unlimited PRs",
+            "CI-aware release-ready gate mode",
+            "Security & supply-chain risk factors",
+            "No API key, no account, no store",
+          ]}
+          cta={
+            <Link href={MARKETPLACE_URL} className="btn btn-secondary" style={{ width: "100%" }}>
+              Install from Marketplace
+            </Link>
+          }
+        />
+        <PlanCard
+          name="Pro"
+          price="$39"
+          priceSuffix="/mo"
+          tagline={`${PLANS.pro.evaluationsPerMonth.toLocaleString()} evals/mo, hosted history`}
+          highlight
+          features={[
+            "Everything in Free",
+            `${PLANS.pro.evaluationsPerMonth.toLocaleString()} stored evaluations / month`,
+            "Hosted trend dashboard",
+            `Up to ${PLANS.pro.seatsIncluded} seats included`,
+            "API keys for CI ingest",
+          ]}
+          cta={<CheckoutForm plan="pro" label="Start Pro" />}
+        />
+        <PlanCard
+          name="Team"
+          price="$399"
+          priceSuffix="/mo"
+          tagline="Agent governance for orgs shipping AI-authored PRs"
+          features={[
+            "Everything in Pro",
+            `${PLANS.team.evaluationsPerMonth.toLocaleString()} stored evaluations / month`,
+            "Org-wide rollup dashboard across repos",
+            "SSO",
+            "Agent-governance policies: provenance classification, sensitive-path gates, session-burst detection, trust profiles, escalation SLAs",
+            `Up to ${PLANS.team.seatsIncluded} seats included`,
+          ]}
+          cta={<CheckoutForm plan="team" label="Start Team" />}
+        />
+      </div>
+
+      <QuotaNote />
+      <Faq />
+    </main>
+  );
+}
+
+function PlanCard({
+  name,
+  price,
+  priceSuffix,
+  tagline,
+  features,
+  cta,
+  highlight,
+}: {
+  name: string;
+  price: string;
+  priceSuffix?: string;
+  tagline: string;
+  features: string[];
+  cta: React.ReactNode;
+  highlight?: boolean;
+}) {
+  return (
+    <div
+      className="card"
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 16,
+        borderColor: highlight ? "var(--accent)" : "var(--border)",
+        borderWidth: highlight ? 2 : 1,
+      }}
+    >
+      <div>
+        <div style={{ display: "flex", alignItems: "baseline", justifyContent: "space-between" }}>
+          <h2 style={{ margin: 0, fontSize: "1.25rem" }}>{name}</h2>
+          {highlight ? <span className="badge">Most popular</span> : null}
+        </div>
+        <div style={{ margin: "10px 0 4px" }}>
+          <span style={{ fontSize: "2rem", fontWeight: 800 }}>{price}</span>
+          {priceSuffix ? <span className="muted">{priceSuffix}</span> : null}
+        </div>
+        <p className="muted" style={{ margin: 0, fontSize: "0.875rem" }}>
+          {tagline}
+        </p>
+      </div>
+      <ul style={{ listStyle: "none", padding: 0, margin: 0, display: "flex", flexDirection: "column", gap: 8, flex: 1 }}>
+        {features.map((f) => (
+          <li key={f} style={{ display: "flex", gap: 8, fontSize: "0.875rem" }}>
+            <span aria-hidden="true" style={{ color: "var(--green)" }}>
+              ✓
+            </span>
+            <span>{f}</span>
+          </li>
+        ))}
+      </ul>
+      <div>{cta}</div>
+    </div>
+  );
+}
+
+function QuotaNote() {
+  return (
+    <div className="card" style={{ marginTop: 40 }}>
+      <h2 style={{ fontSize: "1.0625rem", margin: "0 0 8px" }}>How quota works</h2>
+      <p className="muted" style={{ margin: 0, fontSize: "0.9375rem" }}>
+        Going over your monthly evaluation limit does not stop your gate. Evaluations keep being
+        stored and the response carries an upsell header until usage reaches <strong>3&times;</strong>{" "}
+        your plan limit — at that point ingest is hard-capped (402/429) as an abuse backstop until
+        the next billing cycle or an upgrade. You will see the quota warning in your CI logs well
+        before that happens.
+      </p>
+    </div>
+  );
+}
+
+function Faq() {
+  const items: [string, string][] = [
+    [
+      "What counts as an eval?",
+      "One stored evaluation per PR check run that Trailhead's gate posts to your Cloud store — i.e. one per pull request update that runs the gate, not per risk factor or per API call.",
+    ],
+    [
+      "What happens if I go over my quota?",
+      "Nothing breaks. Over-quota evaluations are still stored and your CI run still gets a decision; the response includes an upsell header and message until you hit 3x your plan limit, which is a hard cap.",
+    ],
+    [
+      "Can I self-host the evaluation store instead of using Cloud?",
+      "Yes. Bring-your-own-store is supported via the evaluation-store-url and evaluation-store-secret inputs on the Action — Cloud is optional hosted storage, not a requirement to use Trailhead.",
+    ],
+    [
+      "How do API keys work?",
+      "A Cloud subscription issues one API key at checkout, shown once on the /welcome page. Add it as the TRAILHEAD_API_KEY secret in your repo or org and pass it to the Action via the trailhead-api-key input — it auto-configures the store URL and auth.",
+    ],
+    [
+      "How do I cancel or change plans?",
+      "Billing is managed entirely through the Stripe customer portal — open it from your dashboard. There's no separate account system to manage; possession of your API key is what authenticates billing-portal access.",
+    ],
+    [
+      "Do I need Trailhead Cloud to use the risk gate?",
+      "No. The GitHub Action's risk-only and release-ready gate modes run entirely in your CI with no API key. Cloud only adds hosted history, dashboards, org rollup, and SSO.",
+    ],
+  ];
+  return (
+    <div style={{ marginTop: 56 }}>
+      <h2 style={{ fontSize: "1.5rem", marginBottom: 20 }}>Frequently asked questions</h2>
+      <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+        {items.map(([q, a]) => (
+          <details key={q} className="card">
+            <summary style={{ cursor: "pointer", fontWeight: 600 }}>{q}</summary>
+            <p className="muted" style={{ margin: "10px 0 0", fontSize: "0.9375rem" }}>
+              {a}
+            </p>
+          </details>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/site/app/robots.ts
+++ b/site/app/robots.ts
@@ -1,0 +1,16 @@
+import type { MetadataRoute } from "next";
+
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://trailhead.komatik.xyz";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: ["/api/", "/welcome", "/dashboard", "/dashboard-embed.html"],
+      },
+    ],
+    sitemap: `${siteUrl}/sitemap.xml`,
+  };
+}

--- a/site/app/sitemap.ts
+++ b/site/app/sitemap.ts
@@ -1,0 +1,11 @@
+import type { MetadataRoute } from "next";
+
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://trailhead.komatik.xyz";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const now = new Date();
+  return [
+    { url: `${siteUrl}/`, lastModified: now, changeFrequency: "weekly", priority: 1 },
+    { url: `${siteUrl}/pricing`, lastModified: now, changeFrequency: "weekly", priority: 0.9 },
+  ];
+}

--- a/site/app/welcome/ClaimClient.tsx
+++ b/site/app/welcome/ClaimClient.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { resolveClaimState, type ClaimState } from "@/lib/claimClient";
+
+// State-transition logic lives in lib/claimClient.ts (pure, unit-testable
+// with a mocked fetch — see __tests__/claimState.test.ts). This component is
+// just the wiring + presentation.
+const WORKFLOW_SNIPPET = `- uses: KomatikAI/trailhead@v4
+  with:
+    gate-mode: release-ready
+    trailhead-api-key: \${{ secrets.TRAILHEAD_API_KEY }}`;
+
+export default function ClaimClient() {
+  const searchParams = useSearchParams();
+  const sessionId = searchParams.get("session_id");
+  const [state, setState] = useState<ClaimState>({ status: "loading" });
+
+  useEffect(() => {
+    let cancelled = false;
+    resolveClaimState(sessionId).then((next) => {
+      if (!cancelled) setState(next);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId]);
+
+  return <div className="wrap" style={{ padding: "64px 24px 96px", maxWidth: 640 }}>{render(state)}</div>;
+}
+
+function render(state: ClaimState) {
+  switch (state.status) {
+    case "loading":
+      return <p className="muted">Loading your API key…</p>;
+
+    case "missing":
+      return (
+        <ErrorPanel title="No checkout session found">
+          This page expects a <code>?session_id=</code> query parameter from a Stripe Checkout
+          redirect. If you just paid, check your email receipt for the correct link, or{" "}
+          <a href="mailto:support@komatik.ai">contact support</a>.
+        </ErrorPanel>
+      );
+
+    case "not_found":
+      return (
+        <ErrorPanel title="We couldn't find that checkout session">
+          Double-check the link, or <a href="mailto:support@komatik.ai">contact support</a> with
+          your receipt email.
+        </ErrorPanel>
+      );
+
+    case "already_claimed":
+      return (
+        <ErrorPanel title="This key was already claimed">
+          {state.message} Lost the key?{" "}
+          <a href="mailto:support@komatik.ai">Contact support</a> to rotate it, or open the billing
+          portal from your <a href="/dashboard">dashboard</a>.
+        </ErrorPanel>
+      );
+
+    case "expired":
+      return (
+        <ErrorPanel title="This claim link has expired">
+          {state.message} Claim links are valid for 72 hours after checkout.{" "}
+          <a href="mailto:support@komatik.ai">Contact support</a> to issue a replacement key.
+        </ErrorPanel>
+      );
+
+    case "rate_limited":
+      return (
+        <ErrorPanel title="Too many attempts">
+          Please wait a minute and reload this page.
+        </ErrorPanel>
+      );
+
+    case "error":
+      return (
+        <ErrorPanel title="Something went wrong">
+          {state.message} <a href="mailto:support@komatik.ai">Contact support</a> if this persists.
+        </ErrorPanel>
+      );
+
+    case "revealed":
+      return <RevealPanel apiKey={state.apiKey} message={state.message} />;
+  }
+}
+
+function ErrorPanel({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="card">
+      <h1 style={{ fontSize: "1.375rem", margin: "0 0 12px" }}>{title}</h1>
+      <p className="muted" style={{ margin: 0, fontSize: "0.9375rem" }}>
+        {children}
+      </p>
+    </div>
+  );
+}
+
+function RevealPanel({ apiKey, message }: { apiKey: string; message: string }) {
+  const [copied, setCopied] = useState(false);
+
+  async function copy() {
+    try {
+      await navigator.clipboard.writeText(apiKey);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard API can fail in insecure contexts — the key is still selectable text.
+    }
+  }
+
+  return (
+    <div>
+      <h1 style={{ fontSize: "1.75rem", margin: "0 0 8px" }}>You&rsquo;re in 🎉</h1>
+      <p className="muted" style={{ marginTop: 0 }}>{message}</p>
+
+      <div
+        role="alert"
+        style={{
+          border: "1px solid var(--red)",
+          borderRadius: "var(--radius)",
+          padding: "12px 16px",
+          background: "color-mix(in srgb, var(--red) 10%, transparent)",
+          fontSize: "0.875rem",
+          fontWeight: 600,
+          margin: "20px 0",
+        }}
+      >
+        This key is shown once. It will not be shown again — copy it now and store it as a secret.
+      </div>
+
+      <div
+        className="card mono"
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 12,
+          fontSize: "0.9375rem",
+          wordBreak: "break-all",
+        }}
+      >
+        <span>{apiKey}</span>
+        <button type="button" className="btn btn-primary" onClick={copy} style={{ flexShrink: 0 }}>
+          {copied ? "Copied" : "Copy"}
+        </button>
+      </div>
+
+      <h2 style={{ fontSize: "1.125rem", marginTop: 36 }}>Next steps</h2>
+      <ol style={{ paddingLeft: 20, fontSize: "0.9375rem" }}>
+        <li style={{ marginBottom: 12 }}>
+          Add it as a repo or org secret named <code>TRAILHEAD_API_KEY</code> — GitHub &rarr;
+          Settings &rarr; Secrets and variables &rarr; Actions.
+        </li>
+        <li style={{ marginBottom: 12 }}>
+          Reference it in your workflow so Trailhead auto-configures the Cloud store:
+          <div className="card mono" style={{ marginTop: 8, fontSize: "0.8125rem", overflowX: "auto" }}>
+            <pre style={{ margin: 0, whiteSpace: "pre" }}>{WORKFLOW_SNIPPET}</pre>
+          </div>
+        </li>
+        <li>
+          Open your <a href="/dashboard">dashboard</a> to watch evaluations land after the next PR.
+        </li>
+      </ol>
+    </div>
+  );
+}

--- a/site/app/welcome/page.tsx
+++ b/site/app/welcome/page.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from "next";
+import { Suspense } from "react";
+import ClaimClient from "./ClaimClient";
+
+export const metadata: Metadata = {
+  title: "Claim your API key",
+  robots: { index: false, follow: false },
+};
+
+// Server wrapper only — the state machine needs useSearchParams, so the
+// actual UI is a client component wrapped in Suspense (Next.js requirement
+// for useSearchParams in an App Router page).
+export default function WelcomePage() {
+  return (
+    <Suspense fallback={<div className="wrap" style={{ padding: "64px 24px" }}>Loading…</div>}>
+      <ClaimClient />
+    </Suspense>
+  );
+}

--- a/site/components/SiteFooter.tsx
+++ b/site/components/SiteFooter.tsx
@@ -1,0 +1,44 @@
+import Link from "next/link";
+
+export default function SiteFooter() {
+  return (
+    <footer style={{ borderTop: "1px solid var(--border)", marginTop: 96 }}>
+      <div
+        className="wrap muted"
+        style={{
+          display: "flex",
+          flexWrap: "wrap",
+          gap: 16,
+          justifyContent: "space-between",
+          padding: "28px 24px",
+          fontSize: "0.875rem",
+        }}
+      >
+        <span>&copy; {new Date().getFullYear()} Komatik. Trailhead is MIT-licensed.</span>
+        <div style={{ display: "flex", gap: 20 }}>
+          <Link href="https://github.com/KomatikAI/trailhead" style={{ textDecoration: "none" }}>
+            GitHub
+          </Link>
+          <Link
+            href="https://github.com/KomatikAI/trailhead#documentation"
+            style={{ textDecoration: "none" }}
+          >
+            Docs
+          </Link>
+          <Link href="/pricing" style={{ textDecoration: "none" }}>
+            Pricing
+          </Link>
+          <Link href="/dashboard" style={{ textDecoration: "none" }}>
+            Dashboard
+          </Link>
+          <Link
+            href="https://github.com/KomatikAI/trailhead/actions/workflows/ci.yml"
+            style={{ textDecoration: "none" }}
+          >
+            Status
+          </Link>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/site/components/SiteNav.tsx
+++ b/site/components/SiteNav.tsx
@@ -1,0 +1,89 @@
+import Link from "next/link";
+
+const REPO_URL = "https://github.com/KomatikAI/trailhead";
+
+/**
+ * Server-rendered nav — no client JS. Links to docs (GitHub), pricing, the
+ * dashboard, and status. Kept intentionally small; the landing page stays
+ * static.
+ */
+export default function SiteNav() {
+  return (
+    <header
+      style={{
+        borderBottom: "1px solid var(--border)",
+        position: "sticky",
+        top: 0,
+        background: "var(--bg)",
+        zIndex: 10,
+      }}
+    >
+      <nav
+        className="wrap"
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          height: 64,
+        }}
+      >
+        <Link
+          href="/"
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+            fontWeight: 700,
+            fontSize: "1.0625rem",
+            textDecoration: "none",
+          }}
+        >
+          <TrailheadMark size={22} />
+          Trailhead
+        </Link>
+        <div style={{ display: "flex", alignItems: "center", gap: 20, fontSize: "0.9375rem" }}>
+          <Link href={`${REPO_URL}#documentation`} style={{ textDecoration: "none" }}>
+            Docs
+          </Link>
+          <Link href="/pricing" style={{ textDecoration: "none" }}>
+            Pricing
+          </Link>
+          <Link href="/dashboard" style={{ textDecoration: "none" }}>
+            Dashboard
+          </Link>
+          <Link
+            href="https://github.com/KomatikAI/trailhead/actions/workflows/ci.yml"
+            style={{ textDecoration: "none" }}
+          >
+            Status
+          </Link>
+          <Link href="https://github.com/marketplace/actions/trailhead" className="btn btn-primary">
+            Install
+          </Link>
+        </div>
+      </nav>
+    </header>
+  );
+}
+
+export function TrailheadMark({ size = 20 }: { size?: number }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      <path
+        d="M3 20L9.5 6L13 13.5L15.5 9L21 20"
+        stroke="var(--accent)"
+        strokeWidth="2.25"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <circle cx="9.5" cy="6" r="1.6" fill="var(--accent)" />
+    </svg>
+  );
+}

--- a/site/lib/checkoutClient.ts
+++ b/site/lib/checkoutClient.ts
@@ -1,0 +1,56 @@
+import type { PaidPlan } from "@/lib/plans";
+
+/**
+ * Pure submit logic for the pricing page's checkout form, split out of
+ * CheckoutForm.tsx so it's testable with a mocked `fetch` in Node (matching
+ * site/__tests__/checkout.test.ts, which tests the route the same way)
+ * without needing a DOM/React renderer.
+ *
+ * Mirrors POST /api/billing/checkout (site/app/api/billing/checkout/route.ts):
+ *   200 { url, id }                                → redirect
+ *   400/500/503 { error }                          → error
+ *   429 { error, code, retryAfterSeconds } + header → rate_limited
+ *   network / other                                 → error
+ */
+export type CheckoutResult =
+  | { status: "redirect"; url: string }
+  | { status: "rate_limited"; retryAfterSeconds: number | null }
+  | { status: "error"; message: string };
+
+export type FetchLike = (input: string, init: RequestInit) => Promise<Response>;
+
+export async function submitCheckout(
+  plan: PaidPlan,
+  email: string,
+  fetchImpl: FetchLike = fetch,
+): Promise<CheckoutResult> {
+  let res: Response;
+  try {
+    res = await fetchImpl("/api/billing/checkout", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ plan, email }),
+    });
+  } catch {
+    return { status: "error", message: "Network error — check your connection and try again." };
+  }
+
+  if (res.status === 429) {
+    const body = (await res.json().catch(() => ({}))) as { retryAfterSeconds?: number };
+    return {
+      status: "rate_limited",
+      retryAfterSeconds: typeof body.retryAfterSeconds === "number" ? body.retryAfterSeconds : null,
+    };
+  }
+
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as { error?: string };
+    return { status: "error", message: body.error ?? "Something went wrong. Try again." };
+  }
+
+  const body = (await res.json()) as { url?: string };
+  if (!body.url) {
+    return { status: "error", message: "Checkout session did not return a redirect URL." };
+  }
+  return { status: "redirect", url: body.url };
+}

--- a/site/lib/claimClient.ts
+++ b/site/lib/claimClient.ts
@@ -1,0 +1,64 @@
+/**
+ * Pure state-resolution logic for the /welcome claim page, split out of
+ * ClaimClient.tsx so it's testable with a mocked `fetch` in Node (matching
+ * the pattern in site/__tests__/claim.test.ts, which tests the route the
+ * same way) without needing a DOM/React renderer.
+ *
+ * Mirrors the contract of GET /api/billing/claim
+ * (site/app/api/billing/claim/route.ts):
+ *   200 { apiKey, once, message }                           → revealed
+ *   400 (no session_id — never reached here; guarded first)  → missing
+ *   404 { error }                                            → not_found
+ *   410 { error, code: "already_claimed", message }          → already_claimed
+ *   410 { error, code: "expired", message }                  → expired
+ *   429                                                       → rate_limited
+ *   network / other                                           → error
+ */
+export type ClaimState =
+  | { status: "loading" }
+  | { status: "missing" }
+  | { status: "revealed"; apiKey: string; message: string }
+  | { status: "already_claimed"; message: string }
+  | { status: "expired"; message: string }
+  | { status: "not_found" }
+  | { status: "rate_limited" }
+  | { status: "error"; message: string };
+
+export type FetchLike = (input: string) => Promise<Response>;
+
+export async function resolveClaimState(
+  sessionId: string | null,
+  fetchImpl: FetchLike = fetch,
+): Promise<ClaimState> {
+  if (!sessionId) {
+    return { status: "missing" };
+  }
+
+  let res: Response;
+  try {
+    res = await fetchImpl(`/api/billing/claim?session_id=${encodeURIComponent(sessionId)}`);
+  } catch {
+    return { status: "error", message: "Network error — check your connection and reload." };
+  }
+
+  if (res.status === 200) {
+    const body = (await res.json()) as { apiKey: string; message: string };
+    return { status: "revealed", apiKey: body.apiKey, message: body.message };
+  }
+  if (res.status === 429) {
+    return { status: "rate_limited" };
+  }
+  if (res.status === 404) {
+    return { status: "not_found" };
+  }
+  if (res.status === 410) {
+    const body = (await res.json().catch(() => ({}))) as { code?: string; message?: string };
+    if (body.code === "already_claimed") {
+      return { status: "already_claimed", message: body.message ?? "This key was already claimed." };
+    }
+    return { status: "expired", message: body.message ?? "This claim link has expired." };
+  }
+
+  const body = (await res.json().catch(() => ({}))) as { error?: string };
+  return { status: "error", message: body.error ?? "Could not load your key." };
+}

--- a/site/lib/planCatalog.ts
+++ b/site/lib/planCatalog.ts
@@ -1,0 +1,46 @@
+/**
+ * Marketing-facing plan catalog for the pricing page.
+ *
+ * Mirrors `cloud/src/billing.ts` PLANS exactly (Lane A, `feat/cloud-pg-store`,
+ * not yet merged into this branch). We don't import PLANS from the
+ * `trailhead-cloud` package here because the ambient module declaration in
+ * `site/types/trailhead-cloud.d.ts` (Lane B's pre-merge compatibility shim)
+ * doesn't export it yet — importing it would pass at runtime post-merge but
+ * fail `tsc` today. Once Lane A merges and the package exposes real types,
+ * swap this for `import { PLANS } from "trailhead-cloud"` and delete this file.
+ */
+export interface PlanCatalogEntry {
+  id: "free" | "pro" | "team";
+  name: string;
+  evaluationsPerMonth: number;
+  orgRollup: boolean;
+  sso: boolean;
+  seatsIncluded: number;
+}
+
+export const PLAN_CATALOG: Record<"free" | "pro" | "team", PlanCatalogEntry> = {
+  free: {
+    id: "free",
+    name: "Free",
+    evaluationsPerMonth: 0,
+    orgRollup: false,
+    sso: false,
+    seatsIncluded: 1,
+  },
+  pro: {
+    id: "pro",
+    name: "Pro",
+    evaluationsPerMonth: 5_000,
+    orgRollup: false,
+    sso: false,
+    seatsIncluded: 3,
+  },
+  team: {
+    id: "team",
+    name: "Team",
+    evaluationsPerMonth: 50_000,
+    orgRollup: true,
+    sso: true,
+    seatsIncluded: 10,
+  },
+};

--- a/site/public/dashboard-embed.html
+++ b/site/public/dashboard-embed.html
@@ -1,0 +1,1013 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Trailhead Cloud Dashboard</title>
+    <style>
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+      :root {
+        --bg: #0d1117;
+        --surface: #161b22;
+        --border: #30363d;
+        --text: #c9d1d9;
+        --text-muted: #8b949e;
+        --accent: #58a6ff;
+        --green: #3fb950;
+        --yellow: #d29922;
+        --red: #f85149;
+        --radius: 8px;
+      }
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+        background: var(--bg);
+        color: var(--text);
+        line-height: 1.5;
+        padding: 24px;
+        max-width: 1280px;
+        margin: 0 auto;
+      }
+      h1 {
+        font-size: 1.5rem;
+        font-weight: 600;
+      }
+      .subtitle {
+        color: var(--text-muted);
+        font-size: 0.875rem;
+        margin: 4px 0 24px;
+      }
+      .config-bar {
+        display: flex;
+        gap: 12px;
+        margin-bottom: 24px;
+        flex-wrap: wrap;
+        align-items: end;
+      }
+      .config-bar label {
+        display: flex;
+        flex-direction: column;
+        font-size: 0.75rem;
+        color: var(--text-muted);
+        gap: 4px;
+      }
+      .config-bar input,
+      .config-bar select {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        color: var(--text);
+        border-radius: var(--radius);
+        padding: 6px 10px;
+        font-size: 0.875rem;
+        min-width: 180px;
+      }
+      .config-bar button {
+        background: var(--accent);
+        color: #fff;
+        border: none;
+        border-radius: var(--radius);
+        padding: 8px 16px;
+        font-size: 0.875rem;
+        cursor: pointer;
+        font-weight: 500;
+      }
+      .stats {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        gap: 16px;
+        margin-bottom: 24px;
+      }
+      .stat-card,
+      .panel {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--radius);
+        padding: 16px;
+      }
+      .stat-label {
+        font-size: 0.75rem;
+        color: var(--text-muted);
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+      }
+      .stat-value {
+        font-size: 1.75rem;
+        font-weight: 700;
+        margin-top: 4px;
+      }
+      .stat-sub {
+        font-size: 0.75rem;
+        color: var(--text-muted);
+        margin-top: 2px;
+      }
+      .grid-2 {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 16px;
+        margin-bottom: 24px;
+      }
+      .grid-3 {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 16px;
+        margin-bottom: 24px;
+      }
+      .panel h3 {
+        font-size: 0.875rem;
+        color: var(--text-muted);
+        margin-bottom: 12px;
+      }
+      .bar-chart {
+        display: flex;
+        align-items: end;
+        gap: 4px;
+        height: 100px;
+      }
+      .bar {
+        flex: 1;
+        border-radius: 2px 2px 0 0;
+        min-width: 8px;
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--radius);
+        overflow: hidden;
+        font-size: 0.875rem;
+      }
+      th,
+      td {
+        padding: 10px 14px;
+        border-top: 1px solid var(--border);
+        text-align: left;
+      }
+      thead th {
+        border-top: none;
+        background: rgba(255, 255, 255, 0.04);
+        color: var(--text-muted);
+        font-size: 0.75rem;
+        text-transform: uppercase;
+      }
+      tr.clickable {
+        cursor: pointer;
+      }
+      tr.clickable:hover td {
+        background: rgba(255, 255, 255, 0.03);
+      }
+      .badge {
+        display: inline-block;
+        padding: 2px 8px;
+        border-radius: 12px;
+        font-size: 0.75rem;
+        font-weight: 500;
+      }
+      .badge-pass {
+        background: rgba(63, 185, 80, 0.15);
+        color: var(--green);
+      }
+      .badge-fail {
+        background: rgba(248, 81, 73, 0.15);
+        color: var(--red);
+      }
+      .badge-warn {
+        background: rgba(210, 153, 34, 0.15);
+        color: var(--yellow);
+      }
+      .empty-state {
+        text-align: center;
+        padding: 48px 24px;
+        color: var(--text-muted);
+      }
+      .modal-backdrop {
+        display: none;
+        position: fixed;
+        inset: 0;
+        background: rgba(0, 0, 0, 0.6);
+        z-index: 100;
+        align-items: center;
+        justify-content: center;
+        padding: 24px;
+      }
+      .modal-backdrop.open {
+        display: flex;
+      }
+      .modal {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--radius);
+        max-width: 720px;
+        width: 100%;
+        max-height: 85vh;
+        overflow: auto;
+        padding: 20px;
+      }
+      .modal h2 {
+        font-size: 1.125rem;
+        margin-bottom: 12px;
+      }
+      .detail-grid {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 12px;
+        margin-bottom: 16px;
+      }
+      .detail-grid dt {
+        color: var(--text-muted);
+        font-size: 0.75rem;
+      }
+      .detail-grid dd {
+        margin: 0 0 8px;
+      }
+      pre {
+        background: var(--bg);
+        border: 1px solid var(--border);
+        border-radius: var(--radius);
+        padding: 12px;
+        overflow: auto;
+        font-size: 0.75rem;
+      }
+      .allow {
+        color: var(--green);
+      }
+      .warn {
+        color: var(--yellow);
+      }
+      .block {
+        color: var(--red);
+      }
+      .tabs {
+        display: flex;
+        gap: 8px;
+        margin-bottom: 16px;
+      }
+      .tabs button {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        color: var(--text-muted);
+        border-radius: var(--radius);
+        padding: 8px 14px;
+        cursor: pointer;
+      }
+      .tabs button.active {
+        color: var(--text);
+        border-color: var(--accent);
+      }
+      .tab-panel {
+        display: none;
+      }
+      .tab-panel.active {
+        display: block;
+      }
+      .danger-btn {
+        background: var(--red);
+      }
+      textarea,
+      .config-bar textarea {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        color: var(--text);
+        border-radius: var(--radius);
+        padding: 8px;
+        min-height: 80px;
+        width: 100%;
+      }
+      @media (max-width: 900px) {
+        .grid-2,
+        .grid-3,
+        .detail-grid {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Trailhead Cloud</h1>
+    <p class="subtitle" id="orgLabel">Release readiness analytics</p>
+
+    <div class="config-bar">
+      <label>
+        API Base
+        <input type="text" id="apiBase" placeholder="https://api.trailhead.dev" />
+      </label>
+      <label>
+        API Key
+        <input type="password" id="apiKey" placeholder="thk_..." />
+      </label>
+      <label>
+        Repository
+        <select id="repoSelect">
+          <option value="">All repos</option>
+        </select>
+      </label>
+      <label>
+        Window
+        <select id="window">
+          <option value="30" selected>30 days</option>
+          <option value="90">90 days</option>
+        </select>
+      </label>
+      <button type="button" id="loadBtn">Load</button>
+    </div>
+
+    <div class="tabs" id="tabs" style="display: none">
+      <button type="button" class="active" data-tab="analytics">Analytics</button>
+      <button type="button" data-tab="feedback">Feedback</button>
+      <button type="button" data-tab="settings">Settings</button>
+    </div>
+
+    <div id="content" style="display: none">
+      <div class="tab-panel active" id="tab-analytics">
+        <div class="stats" id="stats"></div>
+        <div class="grid-2">
+          <div class="panel">
+            <h3>Risk trend (daily avg)</h3>
+            <div class="bar-chart" id="riskChart"></div>
+          </div>
+          <div class="panel">
+            <h3>Release Ready pass rate</h3>
+            <div id="releaseReadyPanel"></div>
+          </div>
+        </div>
+        <div class="grid-3">
+          <div class="panel">
+            <h3>CI failure correlation</h3>
+            <div id="ciPanel"></div>
+          </div>
+          <div class="panel">
+            <h3>DORA proxy</h3>
+            <div id="doraPanel"></div>
+          </div>
+          <div class="panel">
+            <h3>Deploy outcomes (CFR)</h3>
+            <div id="cfrPanel"></div>
+          </div>
+        </div>
+        <table>
+          <thead>
+            <tr>
+              <th>Time</th>
+              <th>Repo</th>
+              <th>PR</th>
+              <th>Risk</th>
+              <th>Decision</th>
+              <th>Release Ready</th>
+              <th>Context</th>
+            </tr>
+          </thead>
+          <tbody id="evalBody"></tbody>
+        </table>
+      </div>
+
+      <div class="tab-panel" id="tab-feedback">
+        <div class="grid-2">
+          <div class="panel">
+            <h3>Detector noise (&gt;15% FP flagged)</h3>
+            <div id="noisePanel"></div>
+          </div>
+          <div class="panel">
+            <h3>Policy tuning proposal</h3>
+            <pre id="tuningYaml"></pre>
+            <button type="button" id="copyYamlBtn">Copy YAML</button>
+          </div>
+        </div>
+        <div class="panel" style="margin-top: 16px">
+          <h3>Digest preview (weekly noisy detectors)</h3>
+          <pre id="digestPreview"></pre>
+        </div>
+      </div>
+
+      <div class="tab-panel" id="tab-settings">
+        <div class="grid-2">
+          <div class="panel">
+            <h3>Plan &amp; quota</h3>
+            <div id="planPanel"></div>
+          </div>
+          <div class="panel">
+            <h3>API keys</h3>
+            <div id="keysPanel"></div>
+            <button type="button" id="createKeyBtn" style="margin-top: 12px">
+              Create key
+            </button>
+          </div>
+        </div>
+        <div class="grid-2" style="margin-top: 16px">
+          <div class="panel">
+            <h3>SSO (Team plan)</h3>
+            <label
+              >Provider
+              <select id="ssoProvider">
+                <option value="oidc">OIDC</option>
+                <option value="saml">SAML</option>
+              </select>
+            </label>
+            <label style="margin-top: 8px; display: block"
+              >Issuer URL
+              <input type="url" id="ssoIssuer" placeholder="https://idp.example.com" />
+            </label>
+            <label style="margin-top: 8px; display: block"
+              >Client ID
+              <input type="text" id="ssoClientId" />
+            </label>
+            <button type="button" id="saveSsoBtn" style="margin-top: 12px">
+              Save SSO config
+            </button>
+          </div>
+          <div class="panel">
+            <h3>Digest subscription</h3>
+            <label
+              ><input type="checkbox" id="digestEnabled" /> Enable weekly digest</label
+            >
+            <label style="margin-top: 8px; display: block"
+              >Channel
+              <select id="digestChannel">
+                <option value="slack">Slack</option>
+                <option value="email">Email</option>
+              </select>
+            </label>
+            <label style="margin-top: 8px; display: block"
+              >Destination
+              <input
+                type="text"
+                id="digestDestination"
+                placeholder="#channel or email@org.com"
+              />
+            </label>
+            <button type="button" id="saveDigestBtn" style="margin-top: 12px">
+              Save digest settings
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="empty-state" id="emptyState">
+      Enter your Trailhead Cloud API key and click <strong>Load</strong>.
+    </div>
+
+    <div class="modal-backdrop" id="modal">
+      <div class="modal">
+        <h2>Evaluation drill-down</h2>
+        <div id="modalBody"></div>
+        <div id="dismissPanel" style="margin-top: 16px; display: none">
+          <h3>Dismiss finding</h3>
+          <label>Detector <input type="text" id="dismissDetector" /></label>
+          <label style="display: block; margin-top: 8px"
+            >Reason
+            <textarea
+              id="dismissReason"
+              placeholder="Why is this a false positive?"
+            ></textarea>
+          </label>
+          <button type="button" id="submitDismissBtn" style="margin-top: 8px">
+            Submit feedback
+          </button>
+        </div>
+        <button type="button" id="closeModal" style="margin-top: 16px">Close</button>
+      </div>
+    </div>
+
+    <script>
+      // Embedded copy of cloud/public/dashboard.html, served same-origin under
+      // site/ and pointed at the Hono-mounted Cloud API (/api/cloud/v1/*)
+      // instead of a standalone api.trailhead.dev host. Key storage uses
+      // sessionStorage (never localStorage/cookies) so the API key does not
+      // outlive the browser tab.
+      const DEFAULT_BASE = window.location.origin + "/api/cloud";
+
+      function authHeaders() {
+        return {
+          Authorization: "Bearer " + document.getElementById("apiKey").value.trim(),
+          Accept: "application/json",
+        };
+      }
+
+      function apiBase() {
+        return document.getElementById("apiBase").value.trim().replace(/\/$/, "");
+      }
+
+      async function apiFetch(path, options) {
+        const res = await fetch(apiBase() + path, {
+          headers: {
+            ...authHeaders(),
+            ...(options && options.body ? { "Content-Type": "application/json" } : {}),
+          },
+          ...options,
+        });
+        if (!res.ok) {
+          const err = await res.text();
+          throw new Error("HTTP " + res.status + ": " + err);
+        }
+        return res.json();
+      }
+
+      function apiPost(path, body) {
+        return apiFetch(path, { method: "POST", body: JSON.stringify(body) });
+      }
+
+      function apiPut(path, body) {
+        return apiFetch(path, { method: "PUT", body: JSON.stringify(body) });
+      }
+
+      function apiDelete(path) {
+        return apiFetch(path, { method: "DELETE" });
+      }
+
+      let currentEval = null;
+      let latestTuningYaml = "";
+
+      function scoreColor(score) {
+        if (score > 70) return "var(--red)";
+        if (score > 55) return "var(--yellow)";
+        return "var(--green)";
+      }
+
+      function badge(text, kind) {
+        return '<span class="badge badge-' + kind + '">' + text + "</span>";
+      }
+
+      function relativeTime(dateStr) {
+        const diff = Date.now() - new Date(dateStr).getTime();
+        const mins = Math.floor(diff / 60000);
+        if (mins < 60) return mins + "m ago";
+        const hours = Math.floor(mins / 60);
+        if (hours < 24) return hours + "h ago";
+        return Math.floor(hours / 24) + "d ago";
+      }
+
+      async function loadRepos() {
+        const data = await apiFetch("/v1/repos");
+        const select = document.getElementById("repoSelect");
+        const current = select.value;
+        select.innerHTML = '<option value="">All repos</option>';
+        for (const repo of data.repos || []) {
+          const opt = document.createElement("option");
+          opt.value = repo.fullName;
+          opt.textContent = repo.fullName + " (" + repo.evaluationCount + ")";
+          select.appendChild(opt);
+        }
+        if (current) select.value = current;
+      }
+
+      function renderRiskChart(trend) {
+        const el = document.getElementById("riskChart");
+        if (!trend.length) {
+          el.innerHTML = '<p class="stat-sub">No data in window</p>';
+          return;
+        }
+        el.innerHTML = trend
+          .slice(-14)
+          .map(function (point) {
+            return (
+              '<div class="bar" style="height:' +
+              point.avgRisk +
+              "%;background:" +
+              scoreColor(point.avgRisk) +
+              '" title="' +
+              point.date +
+              ": " +
+              point.avgRisk +
+              '"></div>'
+            );
+          })
+          .join("");
+      }
+
+      function renderReleaseReady(rr) {
+        document.getElementById("releaseReadyPanel").innerHTML =
+          '<div class="stat-value" style="color:var(--green)">' +
+          rr.passRate +
+          "%</div>" +
+          '<div class="stat-sub">' +
+          rr.pass +
+          " pass / " +
+          rr.fail +
+          " fail" +
+          (rr.unknown ? " / " + rr.unknown + " unknown" : "") +
+          "</div>" +
+          Object.entries(rr.byContext || {})
+            .map(function (entry) {
+              const name = entry[0];
+              const stats = entry[1];
+              const total = stats.pass + stats.fail;
+              const rate = total ? Math.round((stats.pass / total) * 100) : 0;
+              return (
+                "<div class='stat-sub'>" + name + ": " + rate + "% (" + total + ")</div>"
+              );
+            })
+            .join("");
+      }
+
+      function renderCi(ci) {
+        document.getElementById("ciPanel").innerHTML =
+          "<div class='stat-sub'>CI failed: <strong>" +
+          ci.ciFailed +
+          "</strong></div>" +
+          "<div class='stat-sub'>Release Ready failed: <strong>" +
+          ci.releaseReadyFailed +
+          "</strong></div>" +
+          "<div class='stat-sub'>Both: <strong>" +
+          ci.both +
+          "</strong></div>" +
+          "<div class='stat-sub'>RR failed without CI fail: <strong>" +
+          ci.releaseReadyFailedOnly +
+          "</strong></div>";
+      }
+
+      function renderDora(dora) {
+        document.getElementById("doraPanel").innerHTML =
+          "<div class='stat-value'>" +
+          dora.rating +
+          "</div>" +
+          "<div class='stat-sub'>Deploy freq: " +
+          dora.deploymentFrequencyPerWeek +
+          "/wk</div>" +
+          "<div class='stat-sub'>CFR: " +
+          dora.changeFailureRate +
+          "%</div>" +
+          "<div class='stat-sub'>Avg risk: " +
+          dora.avgRiskScore +
+          "</div>";
+      }
+
+      function renderCfr(cfr) {
+        document.getElementById("cfrPanel").innerHTML =
+          "<div class='stat-value' style='color:" +
+          (cfr.cfr > 15 ? "var(--red)" : cfr.cfr > 5 ? "var(--yellow)" : "var(--green)") +
+          "'>" +
+          cfr.cfr +
+          "%</div>" +
+          "<div class='stat-sub'>" +
+          cfr.failures +
+          " failures / " +
+          (cfr.successes + cfr.failures) +
+          " deploys</div>";
+      }
+
+      function renderStats(data) {
+        const rr = data.releaseReady;
+        const avgRisk =
+          data.riskTrend.length > 0
+            ? Math.round(
+                data.riskTrend.reduce(function (s, p) {
+                  return s + p.avgRisk;
+                }, 0) / data.riskTrend.length,
+              )
+            : 0;
+        document.getElementById("stats").innerHTML =
+          "<div class='stat-card'><div class='stat-label'>Evaluations</div><div class='stat-value'>" +
+          data.recentEvaluations.length +
+          "+</div><div class='stat-sub'>" +
+          data.windowDays +
+          "d window</div></div>" +
+          "<div class='stat-card'><div class='stat-label'>Avg Risk</div><div class='stat-value' style='color:" +
+          scoreColor(avgRisk) +
+          "'>" +
+          avgRisk +
+          "</div></div>" +
+          "<div class='stat-card'><div class='stat-label'>Release Ready</div><div class='stat-value allow'>" +
+          rr.passRate +
+          "%</div></div>" +
+          "<div class='stat-card'><div class='stat-label'>CFR</div><div class='stat-value'>" +
+          data.cfr.cfr +
+          "%</div></div>" +
+          "<div class='stat-card'><div class='stat-label'>DORA Rating</div><div class='stat-value'>" +
+          data.dora.rating +
+          "</div></div>";
+      }
+
+      function renderNoise(noise) {
+        const rows = (noise && noise.detectors) || [];
+        if (!rows.length) {
+          document.getElementById("noisePanel").innerHTML =
+            "<p class='stat-sub'>No feedback yet</p>";
+          return;
+        }
+        document.getElementById("noisePanel").innerHTML = rows
+          .map(function (d) {
+            return (
+              "<div class='stat-sub'>" +
+              d.detector +
+              ": " +
+              d.falsePositiveRate +
+              "% FP (" +
+              d.falsePositive +
+              "/" +
+              d.total +
+              ")" +
+              (d.noisy ? " " + badge("NOISY", "fail") : "") +
+              "</div>"
+            );
+          })
+          .join("");
+      }
+
+      function renderTuning(tuning) {
+        latestTuningYaml = (tuning && tuning.yamlSnippet) || "# No tuning proposals";
+        document.getElementById("tuningYaml").textContent = latestTuningYaml;
+      }
+
+      async function renderDigestPreview() {
+        const digest = await apiFetch("/v1/digest/preview");
+        document.getElementById("digestPreview").textContent =
+          digest.subject + "\n\n" + digest.body;
+      }
+
+      async function renderSettings() {
+        const data = await apiFetch("/v1/org/settings");
+        const q = data.quota;
+        document.getElementById("planPanel").innerHTML =
+          "<div class='stat-value'>" +
+          (data.settings.plan || "pro").toUpperCase() +
+          "</div>" +
+          "<div class='stat-sub'>Quota: " +
+          q.used +
+          " / " +
+          q.limit +
+          " evaluations this month</div>" +
+          "<div class='stat-sub'>Seats: " +
+          data.settings.seatsUsed +
+          " / " +
+          data.settings.seats +
+          "</div>";
+
+        const keys = await apiFetch("/v1/api-keys");
+        document.getElementById("keysPanel").innerHTML = (keys.keys || [])
+          .map(function (k) {
+            return (
+              "<div class='stat-sub'>" +
+              k.label +
+              " — <code>" +
+              k.keyPreview +
+              "</code> " +
+              "<button type='button' data-revoke='" +
+              k.id +
+              "' class='danger-btn' style='margin-left:8px;padding:2px 8px;font-size:0.75rem'>Revoke</button></div>"
+            );
+          })
+          .join("");
+
+        document.querySelectorAll("[data-revoke]").forEach(function (btn) {
+          btn.addEventListener("click", async function () {
+            await apiDelete("/v1/api-keys/" + btn.getAttribute("data-revoke"));
+            await renderSettings();
+          });
+        });
+
+        if (data.settings.sso) {
+          document.getElementById("ssoProvider").value =
+            data.settings.sso.provider || "oidc";
+          document.getElementById("ssoIssuer").value = data.settings.sso.issuerUrl || "";
+          document.getElementById("ssoClientId").value = data.settings.sso.clientId || "";
+        }
+        if (data.settings.digest) {
+          document.getElementById("digestEnabled").checked =
+            !!data.settings.digest.enabled;
+          document.getElementById("digestChannel").value =
+            data.settings.digest.channel || "slack";
+          document.getElementById("digestDestination").value =
+            data.settings.digest.destination || "";
+        }
+      }
+
+      function setupTabs() {
+        document.getElementById("tabs").style.display = "flex";
+        document.querySelectorAll(".tabs button").forEach(function (btn) {
+          btn.addEventListener("click", function () {
+            document.querySelectorAll(".tabs button").forEach(function (b) {
+              b.classList.remove("active");
+            });
+            document.querySelectorAll(".tab-panel").forEach(function (p) {
+              p.classList.remove("active");
+            });
+            btn.classList.add("active");
+            document
+              .getElementById("tab-" + btn.getAttribute("data-tab"))
+              .classList.add("active");
+          });
+        });
+      }
+
+      function renderTable(rows) {
+        document.getElementById("evalBody").innerHTML = rows
+          .map(function (row) {
+            const ctx = row.context && row.context.name ? row.context.name : "—";
+            const rr =
+              row.releaseReady === true
+                ? badge("PASS", "pass")
+                : row.releaseReady === false
+                  ? badge("FAIL", "fail")
+                  : "—";
+            return (
+              '<tr class="clickable" data-id="' +
+              row.id +
+              '"><td title="' +
+              row.receivedAt +
+              '">' +
+              relativeTime(row.receivedAt) +
+              "</td><td>" +
+              row.repoId +
+              "</td><td>" +
+              (row.prNumber ? "#" + row.prNumber : "—") +
+              "</td><td style='color:" +
+              scoreColor(row.riskScore) +
+              "'>" +
+              row.riskScore +
+              "</td><td>" +
+              row.gateDecision +
+              "</td><td>" +
+              rr +
+              "</td><td>" +
+              ctx +
+              "</td></tr>"
+            );
+          })
+          .join("");
+
+        document.querySelectorAll("tr.clickable").forEach(function (tr) {
+          tr.addEventListener("click", function () {
+            openDrillDown(tr.getAttribute("data-id"));
+          });
+        });
+      }
+
+      async function openDrillDown(id) {
+        const data = await apiFetch("/v1/evaluations/" + encodeURIComponent(id));
+        const e = data.evaluation;
+        currentEval = e;
+        const ciChecks =
+          e.ci && e.ci.checks
+            ? e.ci.checks
+                .map(function (c) {
+                  return c.name + ": " + c.status + (c.required ? " (required)" : "");
+                })
+                .join("\n")
+            : "—";
+        const reasons = (e.releaseReadyReasons || []).join("\n") || "—";
+        const factors = (e.riskFactors || [])
+          .map(function (f) {
+            return (
+              f.type +
+              ": " +
+              f.score +
+              ' <button type="button" data-detector="' +
+              f.type +
+              '" class="dismiss-factor-btn" style="margin-left:6px;font-size:0.7rem">Dismiss</button>'
+            );
+          })
+          .join("\n");
+
+        document.getElementById("modalBody").innerHTML =
+          "<dl class='detail-grid'>" +
+          "<dt>Commit</dt><dd><code>" +
+          e.commitSha.substring(0, 7) +
+          "</code></dd>" +
+          "<dt>PR</dt><dd>" +
+          (e.prNumber ? "#" + e.prNumber : "—") +
+          "</dd>" +
+          "<dt>Risk / Health</dt><dd>" +
+          e.riskScore +
+          " / " +
+          e.healthScore +
+          "</dd>" +
+          "<dt>Gate mode</dt><dd>" +
+          (e.gateMode || "—") +
+          "</dd></dl>" +
+          "<h3>CI checks</h3><pre>" +
+          ciChecks +
+          "</pre>" +
+          "<h3>Release Ready reasons</h3><pre>" +
+          reasons +
+          "</pre>" +
+          "<h3>Risk factors</h3><pre id='factorList'>" +
+          (factors || "—") +
+          "</pre>";
+        document.getElementById("dismissPanel").style.display = "block";
+        document.getElementById("dismissDetector").value = "";
+        document.getElementById("dismissReason").value = "";
+        document.querySelectorAll(".dismiss-factor-btn").forEach(function (btn) {
+          btn.addEventListener("click", function () {
+            document.getElementById("dismissDetector").value =
+              btn.getAttribute("data-detector");
+          });
+        });
+        document.getElementById("modal").classList.add("open");
+      }
+
+      async function loadData() {
+        const key = document.getElementById("apiKey").value.trim();
+        if (!key) {
+          alert("Please enter your Trailhead API key");
+          return;
+        }
+
+        sessionStorage.setItem("th_cloud_base", apiBase());
+        sessionStorage.setItem("th_cloud_key", key);
+
+        try {
+          const orgs = await apiFetch("/v1/orgs");
+          if (orgs.orgs && orgs.orgs[0]) {
+            document.getElementById("orgLabel").textContent = "Org: " + orgs.orgs[0].name;
+          }
+
+          await loadRepos();
+
+          const repo = document.getElementById("repoSelect").value;
+          const days = document.getElementById("window").value;
+          const qs =
+            "?days=" + days + (repo ? "&repo_id=" + encodeURIComponent(repo) : "");
+          const data = await apiFetch("/v1/analytics/dashboard" + qs);
+
+          document.getElementById("emptyState").style.display = "none";
+          document.getElementById("content").style.display = "block";
+          setupTabs();
+
+          renderStats(data);
+          renderRiskChart(data.riskTrend);
+          renderReleaseReady(data.releaseReady);
+          renderCi(data.ciCorrelation);
+          renderDora(data.dora);
+          renderCfr(data.cfr);
+          renderTable(data.recentEvaluations);
+          renderNoise(data.detectorNoise);
+          renderTuning(data.tuningProposal);
+          await renderDigestPreview();
+          await renderSettings();
+        } catch (err) {
+          alert("Load failed: " + err.message);
+        }
+      }
+
+      document.getElementById("loadBtn").addEventListener("click", loadData);
+      document.getElementById("copyYamlBtn").addEventListener("click", function () {
+        navigator.clipboard.writeText(latestTuningYaml);
+      });
+      document
+        .getElementById("createKeyBtn")
+        .addEventListener("click", async function () {
+          const label = prompt("Key label", "CI rotation key");
+          const created = await apiPost("/v1/api-keys", { label: label || "API key" });
+          alert("Copy this key now — it won't be shown again:\n\n" + created.secret);
+          await renderSettings();
+        });
+      document.getElementById("saveSsoBtn").addEventListener("click", async function () {
+        await apiPut("/v1/org/settings", {
+          sso: {
+            enabled: true,
+            provider: document.getElementById("ssoProvider").value,
+            issuerUrl: document.getElementById("ssoIssuer").value || undefined,
+            clientId: document.getElementById("ssoClientId").value || undefined,
+          },
+        });
+        alert("SSO configuration saved");
+      });
+      document
+        .getElementById("saveDigestBtn")
+        .addEventListener("click", async function () {
+          await apiPut("/v1/digest/subscribe", {
+            enabled: document.getElementById("digestEnabled").checked,
+            channel: document.getElementById("digestChannel").value,
+            destination: document.getElementById("digestDestination").value,
+            fpThreshold: 15,
+          });
+          await renderDigestPreview();
+          alert("Digest settings saved");
+        });
+      document
+        .getElementById("submitDismissBtn")
+        .addEventListener("click", async function () {
+          if (!currentEval) return;
+          await apiPost("/v1/feedback", {
+            detector: document.getElementById("dismissDetector").value,
+            disposition: "false_positive",
+            repo: currentEval.repoId,
+            reason: document.getElementById("dismissReason").value,
+            evaluationId: currentEval.id,
+          });
+          alert("Feedback recorded");
+          document.getElementById("modal").classList.remove("open");
+          await loadData();
+        });
+      document.getElementById("closeModal").addEventListener("click", function () {
+        document.getElementById("modal").classList.remove("open");
+      });
+      document.getElementById("modal").addEventListener("click", function (e) {
+        if (e.target.id === "modal")
+          document.getElementById("modal").classList.remove("open");
+      });
+
+      const savedBase = sessionStorage.getItem("th_cloud_base");
+      const savedKey = sessionStorage.getItem("th_cloud_key");
+      document.getElementById("apiBase").value = savedBase || DEFAULT_BASE;
+      if (savedKey) document.getElementById("apiKey").value = savedKey;
+      if (savedKey) loadData();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## What
Billing-sprint Lane D, **stacked on #⬆ feat/site-billing** (retarget to dev after it merges).

- **/** — static landing, "The release gate for the AI-agent era": 17-factor engine, agent-governance section (claims sourced from README's Agent Governance Signals), Komatik-fleet dogfood proof, Marketplace CTA (slug verified: `marketplace/actions/trailhead`). Zero client JS.
- **/pricing** — Free / Pro $39 / Team $399 from a plan catalog mirroring `cloud/src/billing.ts` PLANS (documented temp duplicate; swaps to a real import post-Lane-A), checkout form with 429/error handling, 6-question FAQ with honest quota copy (soft overage, 3× hard cap).
- **/welcome** — one-time key claim: state machine extracted to `lib/claimClient.ts` mapped 1:1 to the claim route's actual responses (revealed/404/410-claimed/410-expired/429/network), copy-to-clipboard, exact secret + workflow snippet.
- **/dashboard** — existing cloud dashboard ported as a self-contained embed pointed at same-origin `/api/cloud`; API key kept in **sessionStorage only**.
- Shared nav/footer, OG meta, inline SVG favicon, robots (disallows /api, /welcome, /dashboard), sitemap.

## Tests
38/38 in site/ (claim state machine ×8, checkout form ×7, + Lane B's suites), tsc clean. `next build` blocked only by the known Lane A package boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)