### PR TITLE
style(site): retheme to canonical Trailhead brand — Trail Green on GitHub-dark

### DIFF
--- a/site/app/globals.css
+++ b/site/app/globals.css
@@ -1,15 +1,16 @@
 :root {
-  color-scheme: light dark;
-  --bg: #ffffff;
-  --bg-raised: #f6f8fa;
-  --border: #d0d7de;
-  --text: #1f2328;
-  --text-muted: #57606a;
-  --accent: #0969da;
-  --accent-contrast: #ffffff;
-  --green: #1a7f37;
-  --yellow: #9a6700;
-  --red: #cf222e;
+  color-scheme: dark light;
+  /* Trail Green on GitHub-dark — canonical Trailhead brand (dark-first). */
+  --bg: #0d1117;
+  --bg-raised: #161b22;
+  --border: #30363d;
+  --text: #e6edf3;
+  --text-muted: #8b949e;
+  --accent: #22c55e;
+  --accent-contrast: #0d1117;
+  --green: #22c55e;
+  --yellow: #d29922;
+  --red: #ef4444;
   --radius: 10px;
   --font-sans:
     -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif,
@@ -18,18 +19,19 @@
     ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
 }
 
-@media (prefers-color-scheme: dark) {
+@media (prefers-color-scheme: light) {
   :root {
-    --bg: #0d1117;
-    --bg-raised: #161b22;
-    --border: #30363d;
-    --text: #c9d1d9;
-    --text-muted: #8b949e;
-    --accent: #58a6ff;
-    --accent-contrast: #0d1117;
-    --green: #3fb950;
-    --yellow: #d29922;
-    --red: #f85149;
+    --bg: #ffffff;
+    --bg-raised: #f6f8fa;
+    --border: #d0d7de;
+    --text: #1f2328;
+    --text-muted: #57606a;
+    /* Darker green for AA contrast on white. */
+    --accent: #1a7f37;
+    --accent-contrast: #ffffff;
+    --green: #1a7f37;
+    --yellow: #9a6700;
+    --red: #cf222e;
   }
 }
 

--- a/site/app/icon.svg
+++ b/site/app/icon.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
   <rect width="24" height="24" rx="5" fill="#0d1117"/>
-  <path d="M3 20L9.5 6L13 13.5L15.5 9L21 20" stroke="#58a6ff" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
-  <circle cx="9.5" cy="6" r="1.7" fill="#58a6ff"/>
+  <path d="M3 20L9.5 6L13 13.5L15.5 9L21 20" stroke="#22c55e" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <circle cx="9.5" cy="6" r="1.7" fill="#22c55e"/>
 </svg>

--- a/site/app/layout.tsx
+++ b/site/app/layout.tsx
@@ -31,6 +31,9 @@ export const metadata: Metadata = {
   icons: {
     icon: "/icon.svg",
   },
+  other: {
+    "theme-color": "#0D1117",
+  },
 };
 
 // Shared shell: nav + footer + design tokens. Individual pages (Lane D) stay

--- a/site/public/dashboard-embed.html
+++ b/site/public/dashboard-embed.html
@@ -18,10 +18,11 @@
         --border: #30363d;
         --text: #c9d1d9;
         --text-muted: #8b949e;
-        --accent: #58a6ff;
-        --green: #3fb950;
+        --accent: #22c55e;
+        --accent-contrast: #0d1117;
+        --green: #22c55e;
         --yellow: #d29922;
-        --red: #f85149;
+        --red: #ef4444;
         --radius: 8px;
       }
       body {
@@ -69,7 +70,7 @@
       }
       .config-bar button {
         background: var(--accent);
-        color: #fff;
+        color: var(--accent-contrast);
         border: none;
         border-radius: var(--radius);
         padding: 8px 16px;


### PR DESCRIPTION
Fixes the brand collision David flagged: the site shipped GitHub-blue accents (#0969da/#58a6ff), which is the Trace product's color family. Per packages/design-tokens/tokens.json in the komatik monorepo, Trailhead = Trail Green #22C55E; the (portfolio)/apps/trailhead page is the reference implementation.

- globals.css inverted to dark-first (bg #0D1117 / raised #161B22 / border #30363D) with accent #22C55E; light variant keeps green at #1a7f37 for AA on white.
- Green fills get dark text (#22C55E fails AA with white), mirroring the reference page.
- Favicon mark blue→green; theme-color #0D1117; dashboard embed inline palette rethemed.
- All pages already consumed the CSS vars — zero component edits needed.

39/39 tests, tsc + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)