### PR TITLE
fix(cloud+site): dashboard XSS escaping, 429 rate-limit vs hard-cap disambiguation, quota increment race

### DIFF
--- a/cloud/dist/app.js
+++ b/cloud/dist/app.js
@@ -67,7 +67,7 @@ export function createCloudApp(options = {}) {
             c.header(header, value);
         }
         if (rate.remaining < 0) {
-            return c.json({ error: "rate limit exceeded" }, 429);
+            return c.json({ error: "rate limit exceeded", code: "rate_limited" }, 429);
         }
         await applyQuotaHeaders(c, store, keyRecord.orgId);
         await next();
@@ -92,6 +92,7 @@ export function createCloudApp(options = {}) {
             const quota = await store.getQuota(orgId);
             return c.json({
                 error: "evaluation hard limit reached — usage is far above your plan's monthly quota. Upgrade to keep ingesting.",
+                code: "hard_cap_exceeded",
                 plan: quota.plan,
                 limit: quota.limit,
                 used: quota.used,

--- a/cloud/dist/pg-store.js
+++ b/cloud/dist/pg-store.js
@@ -153,7 +153,17 @@ export function createPgStore(pool) {
                 }
                 const settingsRes = await client.query(`SELECT plan FROM org_settings WHERE org_id = $1`, [orgId]);
                 const plan = settingsRes.rows[0]?.plan ?? "free";
-                const usageRes = await client.query(`SELECT evals FROM usage_counters WHERE org_id = $1 AND month_key = $2`, [orgId, monthKey()]);
+                // Quota check-then-act race fix: two concurrent ingests both reading
+                // `used` before either increments can both pass the hardLimited check
+                // at the boundary. Ensure a row exists (INSERT ... ON CONFLICT DO
+                // NOTHING) then take SELECT ... FOR UPDATE to lock it for the rest of
+                // this transaction — any concurrent ingest for the same org+month
+                // blocks here until we commit/rollback, serializing the
+                // read-decide-increment sequence.
+                await client.query(`INSERT INTO usage_counters (org_id, month_key, evals)
+             VALUES ($1, $2, 0)
+           ON CONFLICT (org_id, month_key) DO NOTHING`, [orgId, monthKey()]);
+                const usageRes = await client.query(`SELECT evals FROM usage_counters WHERE org_id = $1 AND month_key = $2 FOR UPDATE`, [orgId, monthKey()]);
                 const used = usageRes.rows[0] ? Number(usageRes.rows[0].evals) : 0;
                 const quota = evaluateQuota(plan, used);
                 if (!quota.store) {

--- a/cloud/dist/store.js
+++ b/cloud/dist/store.js
@@ -142,6 +142,12 @@ export function createMemoryStore(seedKeys = []) {
                     return { created: false, evaluation: existing };
                 }
             }
+            // NOTE on the pg-store check-then-act race (SELECT ... FOR UPDATE fix
+            // there): this in-memory store does not need an equivalent lock. There
+            // is no `await` between reading `used` here and calling
+            // incrementUsage() below, and this store runs entirely on the single
+            // JS event loop (no separate DB round-trip to interleave with), so the
+            // read-decide-increment sequence is already atomic.
             const used = getUsage(orgId);
             const quota = evaluateQuota(settings.plan, used);
             if (!quota.store) {

--- a/cloud/src/app-billing.test.ts
+++ b/cloud/src/app-billing.test.ts
@@ -87,8 +87,25 @@ describe("app billing responses", () => {
     });
     const res = await post(app);
     expect(res.status).toBe(429);
-    const body = (await res.json()) as { error: string };
+    const body = (await res.json()) as { error: string; code: string };
     expect(body.error).toMatch(/hard limit/i);
+    // Distinguishes this from the rate-limiter's 429 so notify.ts (Action side)
+    // never mistakes a transient rate-limit burst for a permanent hard cap.
+    expect(body.code).toBe("hard_cap_exceeded");
+  });
+
+  it("per-org rate limit → 429 with code=rate_limited (distinct from the hard-cap 429)", async () => {
+    const app = createCloudApp({ store: stubStore({}) });
+    // RATE_LIMIT is 120 requests per org per window — burst past it on a
+    // fresh app (fresh rateBuckets) so this is independent of quota/hard-cap.
+    let last: Awaited<ReturnType<typeof post>> | undefined;
+    for (let i = 0; i < 122; i += 1) {
+      last = await post(app);
+    }
+    expect(last!.status).toBe(429);
+    const body = (await last!.json()) as { error: string; code: string };
+    expect(body.error).toMatch(/rate limit/i);
+    expect(body.code).toBe("rate_limited");
   });
 
   it("soft over-quota ingest → 200 + X-Trailhead-Quota-Exceeded header + body flag", async () => {

--- a/cloud/src/app.ts
+++ b/cloud/src/app.ts
@@ -110,7 +110,7 @@ export function createCloudApp(options: CloudAppOptions = {}): Hono {
       c.header(header, value);
     }
     if (rate.remaining < 0) {
-      return c.json({ error: "rate limit exceeded" }, 429);
+      return c.json({ error: "rate limit exceeded", code: "rate_limited" }, 429);
     }
 
     await applyQuotaHeaders(c, store, keyRecord.orgId);
@@ -144,6 +144,7 @@ export function createCloudApp(options: CloudAppOptions = {}): Hono {
         {
           error:
             "evaluation hard limit reached — usage is far above your plan's monthly quota. Upgrade to keep ingesting.",
+          code: "hard_cap_exceeded",
           plan: quota.plan,
           limit: quota.limit,
           used: quota.used,

--- a/cloud/src/pg-store.ts
+++ b/cloud/src/pg-store.ts
@@ -222,8 +222,22 @@ export function createPgStore(pool: Pool): CloudStore {
           [orgId],
         );
         const plan: PlanTier = (settingsRes.rows[0]?.plan as PlanTier) ?? "free";
+
+        // Quota check-then-act race fix: two concurrent ingests both reading
+        // `used` before either increments can both pass the hardLimited check
+        // at the boundary. Ensure a row exists (INSERT ... ON CONFLICT DO
+        // NOTHING) then take SELECT ... FOR UPDATE to lock it for the rest of
+        // this transaction — any concurrent ingest for the same org+month
+        // blocks here until we commit/rollback, serializing the
+        // read-decide-increment sequence.
+        await client.query(
+          `INSERT INTO usage_counters (org_id, month_key, evals)
+             VALUES ($1, $2, 0)
+           ON CONFLICT (org_id, month_key) DO NOTHING`,
+          [orgId, monthKey()],
+        );
         const usageRes = await client.query(
-          `SELECT evals FROM usage_counters WHERE org_id = $1 AND month_key = $2`,
+          `SELECT evals FROM usage_counters WHERE org_id = $1 AND month_key = $2 FOR UPDATE`,
           [orgId, monthKey()],
         );
         const used = usageRes.rows[0] ? Number(usageRes.rows[0].evals) : 0;

--- a/cloud/src/store-contract.test.ts
+++ b/cloud/src/store-contract.test.ts
@@ -296,4 +296,38 @@ describe.each(backends)("CloudStore contract [$name]", (backend) => {
     expect(hard.hardLimited).toBe(true);
     expect(await store.getEvaluation(org.id, "hard-1")).toBeNull();
   });
+
+  it("concurrent ingests at the hard-cap boundary never overshoot the cap (quota race fix)", async () => {
+    const { org } = await newProOrg();
+    const limit = PLANS.pro.evaluationsPerMonth;
+    const hardCap = limit * 3; // HARD_LIMIT_MULTIPLIER
+
+    // evaluateQuota: store === !hardLimited, and hardLimited === used >= hardCap
+    // (usage measured BEFORE this insert). So exactly `margin` more ingests can
+    // still be stored (usage climbs hardCap-margin, ..., hardCap-1) before the
+    // used-count reaches hardCap and every subsequent ingest is rejected —
+    // regardless of how many arrive concurrently at that boundary.
+    const margin = 5;
+    const burst = 20;
+    await seedUsage(org.id, hardCap - margin);
+
+    const results = await Promise.all(
+      Array.from({ length: burst }, (_, i) =>
+        store.ingestEvaluation(org.id, evalPayload(`race-${org.id}-${i}`)),
+      ),
+    );
+
+    const storedCount = results.filter((r) => r.created).length;
+    const hardLimitedCount = results.filter((r) => r.hardLimited).length;
+
+    // The race (unlocked read-then-increment) would let more than `margin`
+    // concurrent requests all observe used < hardCap and all get stored,
+    // pushing usage past hardCap. The fix (row lock / atomic JS execution)
+    // must cap stored count at exactly `margin`.
+    expect(storedCount).toBe(margin);
+    expect(hardLimitedCount).toBe(burst - margin);
+
+    const finalUsed = (await store.getQuota(org.id)).used;
+    expect(finalUsed).toBe(hardCap);
+  });
 });

--- a/cloud/src/store.ts
+++ b/cloud/src/store.ts
@@ -202,6 +202,12 @@ export function createMemoryStore(seedKeys: ApiKeyRecord[] = []): CloudStore {
         }
       }
 
+      // NOTE on the pg-store check-then-act race (SELECT ... FOR UPDATE fix
+      // there): this in-memory store does not need an equivalent lock. There
+      // is no `await` between reading `used` here and calling
+      // incrementUsage() below, and this store runs entirely on the single
+      // JS event loop (no separate DB round-trip to interleave with), so the
+      // read-decide-increment sequence is already atomic.
       const used = getUsage(orgId);
       const quota = evaluateQuota(settings.plan, used);
       if (!quota.store) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -53491,16 +53491,60 @@ async function storeViaApiOnce(url, evaluation) {
         signal: AbortSignal.timeout(STORE_TIMEOUT_MS),
     });
     const contentType = response.headers.get("content-type") ?? "";
-    if (response.ok && contentType.includes("application/json")) {
+    const isJson = contentType.includes("application/json");
+    if (response.ok && isJson) {
         info(`Evaluation stored successfully at ${url}`);
-        return { ok: true, retryable: false };
+        const quotaExceeded = response.headers.get("x-trailhead-quota-exceeded") === "true";
+        if (quotaExceeded) {
+            core_warning("Trailhead Cloud: this evaluation is over your plan's monthly quota. " +
+                "It was still stored — upgrade at https://trailhead.komatik.xyz/pricing");
+        }
+        return { ok: true, retryable: false, quotaExceeded };
+    }
+    // 402 = org suspended (payment failure). Availability of the paid store must
+    // never block a merge — this is informational only, never a gate failure.
+    if (response.status === 402) {
+        core_warning("Trailhead Cloud: your plan is suspended — this evaluation was NOT stored. " +
+            "Reactivate at https://trailhead.komatik.xyz/pricing");
+        return { ok: false, retryable: false, suspended: true };
+    }
+    // A 429 with a structured JSON body can be EITHER the per-org rate limiter
+    // (transient — a CI burst on one key — retryable) OR the monthly hard usage
+    // cap backstop (permanent for the billing period — not retryable). The
+    // Cloud API distinguishes the two via a machine-readable `code` field. A
+    // 429 with a non-JSON (HTML) body is most likely Vercel bot protection,
+    // which IS worth retrying — handled by the generic path below.
+    if (response.status === 429 && isJson) {
+        let code;
+        try {
+            const parsed = (await response.clone().json());
+            code = parsed?.code;
+        }
+        catch {
+            code = undefined;
+        }
+        if (code === "hard_cap_exceeded") {
+            core_warning("Trailhead Cloud: you're over this month's hard usage cap — this evaluation was NOT " +
+                "stored. Upgrade at https://trailhead.komatik.xyz/pricing");
+            return { ok: false, retryable: false, hardCapped: true };
+        }
+        if (code === "rate_limited") {
+            core_warning(`Trailhead Cloud: rate limit exceeded on attempt — this evaluation will be retried`);
+            return { ok: false, retryable: true, hardCapped: false };
+        }
+        // Unknown/missing code (e.g. an older Cloud API deployment that hasn't
+        // rolled out the `code` field yet) — fail open and treat as retryable
+        // rather than risk showing a false "hard cap" message to paying orgs.
+        core_warning("Trailhead Cloud: received HTTP 429 without a recognized `code` field — " +
+            "treating as retryable");
+        return { ok: false, retryable: true, hardCapped: false };
     }
     const nonRetryableClientErrors = new Set([400, 401, 403]);
     if (nonRetryableClientErrors.has(response.status)) {
         core_warning(`Evaluation store returned HTTP ${response.status} — not retrying`);
         return { ok: false, retryable: false };
     }
-    if (!contentType.includes("application/json")) {
+    if (!isJson) {
         core_warning(`Evaluation store at ${url} returned HTML instead of JSON (HTTP ${response.status}). ` +
             `Vercel bot protection is likely blocking the request.`);
     }
@@ -53514,13 +53558,32 @@ async function storeViaApiOnce(url, evaluation) {
 }
 async function storeViaApi(url, evaluation, maxRetries = 3) {
     const maxAttempts = maxRetries + 1;
+    const notStored = {
+        stored: false,
+        quotaExceeded: false,
+        suspended: false,
+        hardCapped: false,
+    };
     for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
         try {
             const result = await storeViaApiOnce(url, evaluation);
-            if (result.ok)
-                return true;
+            if (result.ok) {
+                return {
+                    stored: true,
+                    quotaExceeded: result.quotaExceeded ?? false,
+                    suspended: false,
+                    hardCapped: false,
+                };
+            }
+            if (result.suspended || result.hardCapped) {
+                return {
+                    ...notStored,
+                    suspended: result.suspended ?? false,
+                    hardCapped: result.hardCapped ?? false,
+                };
+            }
             if (!result.retryable || attempt >= maxAttempts - 1)
-                return false;
+                return notStored;
             const delayMs = STORE_RETRY_BACKOFF_MS[attempt] ?? 16_000;
             core_warning(`Evaluation store attempt ${attempt + 1}/${maxAttempts} failed — retrying in ${delayMs}ms`);
             await sleep(delayMs);
@@ -53534,7 +53597,7 @@ async function storeViaApi(url, evaluation, maxRetries = 3) {
             await sleep(delayMs);
         }
     }
-    return false;
+    return notStored;
 }
 async function storeViaSupabase(evaluation) {
     const supabaseUrl = process.env.SUPABASE_URL;
@@ -53602,12 +53665,35 @@ function buildEvaluationStoreRow(evaluation) {
         agent_provenance_id: agentId,
     };
 }
-async function storeEvaluation(url, evaluation, options = {}) {
+const NOT_STORED = {
+    stored: false,
+    quotaExceeded: false,
+    suspended: false,
+    hardCapped: false,
+};
+/**
+ * Store an evaluation and report the Cloud API's billing/quota state so
+ * callers can surface it in the check summary. Availability of the paid
+ * store — including suspension or a hard usage cap — must never throw or
+ * otherwise block the gate; every path here is fail-open.
+ */
+async function storeEvaluationDetailed(url, evaluation, options = {}) {
     const maxRetries = options.maxRetries ?? 3;
     try {
-        const stored = await storeViaApi(url, evaluation, maxRetries);
-        if (stored)
-            return true;
+        const result = await storeViaApi(url, evaluation, maxRetries);
+        if (result.stored) {
+            return { ...NOT_STORED, stored: true, quotaExceeded: result.quotaExceeded };
+        }
+        // Suspended/hard-capped are deliberate billing-gate outcomes from the
+        // Cloud API, not transient failures — don't fall back to the legacy
+        // Supabase direct-insert path, just report the state honestly.
+        if (result.suspended || result.hardCapped) {
+            return {
+                ...NOT_STORED,
+                suspended: result.suspended,
+                hardCapped: result.hardCapped,
+            };
+        }
     }
     catch (error) {
         core_warning(`Evaluation store API failed: ${error}`);
@@ -53615,14 +53701,69 @@ async function storeEvaluation(url, evaluation, options = {}) {
     try {
         const fallback = await storeViaSupabase(evaluation);
         if (fallback)
-            return true;
+            return { ...NOT_STORED, stored: true };
     }
     catch (error) {
         core_warning(`Supabase direct fallback also failed: ${error}`);
     }
     core_warning("Evaluation could not be stored. To fix: either set VERCEL_AUTOMATION_BYPASS_SECRET " +
         "or set SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY in your workflow env.");
-    return false;
+    return NOT_STORED;
+}
+async function storeEvaluation(url, evaluation, options = {}) {
+    const outcome = await storeEvaluationDetailed(url, evaluation, options);
+    return outcome.stored;
+}
+
+;// CONCATENATED MODULE: ./src/cloud-upsell.ts
+/**
+ * Trailhead Cloud upsell + quota/billing surfacing for the check summary footer.
+ *
+ * One line, always at the end of the summary, never affects the gate decision.
+ * Suppressible via the `disable-cloud-upsell` action input.
+ */
+const CLOUD_MARKETING_URL = "https://trailhead.komatik.xyz";
+const CLOUD_PRICING_URL = "https://trailhead.komatik.xyz/pricing";
+function withUtm(url, campaign) {
+    const u = new URL(url);
+    u.searchParams.set("utm_source", "action");
+    u.searchParams.set("utm_medium", "check-summary");
+    u.searchParams.set("utm_campaign", campaign);
+    return u.toString();
+}
+/**
+ * Build the single footer line to append to the check summary, or null if
+ * nothing should be shown (has a key, under quota, no billing issue, or
+ * the user opted out).
+ *
+ * Precedence: suspended > hard-capped > quota-exceeded > no-key upsell.
+ * These are mutually exclusive in practice (all require a configured key
+ * except the no-key case), but the order guards against ambiguous input.
+ */
+function buildCloudFooterLine(options) {
+    if (options.disableUpsell)
+        return null;
+    if (options.suspended) {
+        const link = withUtm(CLOUD_PRICING_URL, "suspended-upsell");
+        return (`> 🚫 **Evaluation not stored — your Trailhead Cloud plan is suspended.** ` +
+            `Reactivate to resume history & trends → ${link}`);
+    }
+    if (options.hardCapped) {
+        const link = withUtm(CLOUD_PRICING_URL, "quota-upsell");
+        return (`> 🚫 **Evaluation not stored — you're over this month's hard usage cap.** ` +
+            `Upgrade your plan to keep full history → ${link}`);
+    }
+    if (options.quotaExceeded) {
+        const link = withUtm(CLOUD_PRICING_URL, "quota-upsell");
+        return (`> ⚠️ Over your plan's monthly evaluations — history still stored this quarter; ` +
+            `upgrade at ${link}`);
+    }
+    if (!options.hasCloudKey) {
+        const link = withUtm(CLOUD_MARKETING_URL, "cloud-upsell");
+        return (`📊 This evaluation wasn't persisted — track trends, DORA metrics & agent-governance ` +
+            `across your org with Trailhead Cloud → ${link}`);
+    }
+    return null;
 }
 
 ;// CONCATENATED MODULE: ./src/credit-meter.ts
@@ -56018,6 +56159,7 @@ async function runCrossRepoOpener(opts) {
 
 
 
+
 class PolicyOverrideError extends Error {
     constructor(message) {
         super(message);
@@ -56240,6 +56382,7 @@ async function run() {
             ciManifestPath: ciManifestPath || undefined,
             agentBrief,
             submissionGate: getInput("submission-gate") === "true",
+            disableCloudUpsell: getInput("disable-cloud-upsell") === "true",
         };
         if (policyOverride?.changes.riskThreshold !== undefined) {
             config.riskThreshold = policyOverride.changes.riskThreshold;
@@ -56480,6 +56623,9 @@ async function run() {
             reportParts.push(wrapCollapsibleSection("DORA-5 Metrics", doraReport));
         }
         let fullReport = reportParts.join("\n---\n\n");
+        let cloudQuotaExceeded = false;
+        let cloudSuspended = false;
+        let cloudHardCapped = false;
         if (config.evaluationStoreUrl) {
             const storeSecretInput = getInput("evaluation-store-secret");
             if (storeSecretInput && !process.env.EVALUATION_STORE_SECRET) {
@@ -56489,14 +56635,30 @@ async function run() {
                 process.env.EVALUATION_STORE_SECRET = config.trailheadApiKey;
             }
             const storeRetries = parseEvaluationStoreRetries(getInput("evaluation-store-retries") || "");
-            const stored = await storeEvaluation(config.evaluationStoreUrl, evaluation, {
-                maxRetries: storeRetries,
-            });
-            evaluation.storePersisted = stored;
-            if (!stored) {
+            const storeOutcome = await storeEvaluationDetailed(config.evaluationStoreUrl, evaluation, { maxRetries: storeRetries });
+            evaluation.storePersisted = storeOutcome.stored;
+            cloudQuotaExceeded = storeOutcome.quotaExceeded;
+            cloudSuspended = storeOutcome.suspended;
+            cloudHardCapped = storeOutcome.hardCapped;
+            // The cloud-upsell footer below already explains suspended/hard-capped
+            // state plainly with a link — don't also prepend the generic warning.
+            if (!storeOutcome.stored && !cloudSuspended && !cloudHardCapped) {
                 const persistWarning = "> ⚠️ **Evaluation not persisted — dashboard incomplete.**";
                 fullReport = `${persistWarning}\n\n${fullReport}`;
             }
+        }
+        const cloudFooterLine = buildCloudFooterLine({
+            // BYOS self-hosters (evaluation-store-url without a cloud key) DO
+            // persist evaluations — the "wasn't persisted" upsell must only fire
+            // in truly local-only mode.
+            hasCloudKey: Boolean(config.trailheadApiKey || config.evaluationStoreUrl),
+            disableUpsell: config.disableCloudUpsell ?? false,
+            quotaExceeded: cloudQuotaExceeded,
+            suspended: cloudSuspended,
+            hardCapped: cloudHardCapped,
+        });
+        if (cloudFooterLine) {
+            fullReport = `${fullReport}\n\n${cloudFooterLine}`;
         }
         await summary.addRaw(fullReport).write();
         const checkName = resolveCheckName(evaluation.gateMode ?? "risk-only", config.checkName);

--- a/site/public/dashboard-embed.html
+++ b/site/public/dashboard-embed.html
@@ -530,8 +530,26 @@
         return "var(--green)";
       }
 
+      // Every dynamic value interpolated into innerHTML/insertAdjacentHTML in
+      // this file MUST be routed through escapeHtml() — including values used
+      // inside HTML attributes (quotes are escaped too). Values sourced from
+      // untrusted/attacker-influenced input (API key labels, CI check/context
+      // names, free-text reasons, etc.) are especially important here: a
+      // stored XSS in this file executes for every viewer of the dashboard.
+      function escapeHtml(value) {
+        return String(value)
+          .replace(/&/g, "&amp;")
+          .replace(/</g, "&lt;")
+          .replace(/>/g, "&gt;")
+          .replace(/"/g, "&quot;")
+          .replace(/'/g, "&#39;");
+      }
+
       function badge(text, kind) {
-        return '<span class="badge badge-' + kind + '">' + text + "</span>";
+        // `kind` is always one of our own hardcoded literals ("pass"/"fail"/"warn"),
+        // never attacker-controlled, so it is safe to place directly in the class
+        // attribute. `text` may be a dynamic label in the future, so escape it.
+        return '<span class="badge badge-' + kind + '">' + escapeHtml(text) + "</span>";
       }
 
       function relativeTime(dateStr) {
@@ -568,13 +586,13 @@
           .map(function (point) {
             return (
               '<div class="bar" style="height:' +
-              point.avgRisk +
+              escapeHtml(point.avgRisk) +
               "%;background:" +
               scoreColor(point.avgRisk) +
               '" title="' +
-              point.date +
+              escapeHtml(point.date) +
               ": " +
-              point.avgRisk +
+              escapeHtml(point.avgRisk) +
               '"></div>'
             );
           })
@@ -584,14 +602,14 @@
       function renderReleaseReady(rr) {
         document.getElementById("releaseReadyPanel").innerHTML =
           '<div class="stat-value" style="color:var(--green)">' +
-          rr.passRate +
+          escapeHtml(rr.passRate) +
           "%</div>" +
           '<div class="stat-sub">' +
-          rr.pass +
+          escapeHtml(rr.pass) +
           " pass / " +
-          rr.fail +
+          escapeHtml(rr.fail) +
           " fail" +
-          (rr.unknown ? " / " + rr.unknown + " unknown" : "") +
+          (rr.unknown ? " / " + escapeHtml(rr.unknown) + " unknown" : "") +
           "</div>" +
           Object.entries(rr.byContext || {})
             .map(function (entry) {
@@ -600,7 +618,13 @@
               const total = stats.pass + stats.fail;
               const rate = total ? Math.round((stats.pass / total) * 100) : 0;
               return (
-                "<div class='stat-sub'>" + name + ": " + rate + "% (" + total + ")</div>"
+                "<div class='stat-sub'>" +
+                escapeHtml(name) +
+                ": " +
+                rate +
+                "% (" +
+                total +
+                ")</div>"
               );
             })
             .join("");
@@ -609,32 +633,32 @@
       function renderCi(ci) {
         document.getElementById("ciPanel").innerHTML =
           "<div class='stat-sub'>CI failed: <strong>" +
-          ci.ciFailed +
+          escapeHtml(ci.ciFailed) +
           "</strong></div>" +
           "<div class='stat-sub'>Release Ready failed: <strong>" +
-          ci.releaseReadyFailed +
+          escapeHtml(ci.releaseReadyFailed) +
           "</strong></div>" +
           "<div class='stat-sub'>Both: <strong>" +
-          ci.both +
+          escapeHtml(ci.both) +
           "</strong></div>" +
           "<div class='stat-sub'>RR failed without CI fail: <strong>" +
-          ci.releaseReadyFailedOnly +
+          escapeHtml(ci.releaseReadyFailedOnly) +
           "</strong></div>";
       }
 
       function renderDora(dora) {
         document.getElementById("doraPanel").innerHTML =
           "<div class='stat-value'>" +
-          dora.rating +
+          escapeHtml(dora.rating) +
           "</div>" +
           "<div class='stat-sub'>Deploy freq: " +
-          dora.deploymentFrequencyPerWeek +
+          escapeHtml(dora.deploymentFrequencyPerWeek) +
           "/wk</div>" +
           "<div class='stat-sub'>CFR: " +
-          dora.changeFailureRate +
+          escapeHtml(dora.changeFailureRate) +
           "%</div>" +
           "<div class='stat-sub'>Avg risk: " +
-          dora.avgRiskScore +
+          escapeHtml(dora.avgRiskScore) +
           "</div>";
       }
 
@@ -643,12 +667,12 @@
           "<div class='stat-value' style='color:" +
           (cfr.cfr > 15 ? "var(--red)" : cfr.cfr > 5 ? "var(--yellow)" : "var(--green)") +
           "'>" +
-          cfr.cfr +
+          escapeHtml(cfr.cfr) +
           "%</div>" +
           "<div class='stat-sub'>" +
-          cfr.failures +
+          escapeHtml(cfr.failures) +
           " failures / " +
-          (cfr.successes + cfr.failures) +
+          escapeHtml(cfr.successes + cfr.failures) +
           " deploys</div>";
       }
 
@@ -664,23 +688,23 @@
             : 0;
         document.getElementById("stats").innerHTML =
           "<div class='stat-card'><div class='stat-label'>Evaluations</div><div class='stat-value'>" +
-          data.recentEvaluations.length +
+          escapeHtml(data.recentEvaluations.length) +
           "+</div><div class='stat-sub'>" +
-          data.windowDays +
+          escapeHtml(data.windowDays) +
           "d window</div></div>" +
           "<div class='stat-card'><div class='stat-label'>Avg Risk</div><div class='stat-value' style='color:" +
           scoreColor(avgRisk) +
           "'>" +
-          avgRisk +
+          escapeHtml(avgRisk) +
           "</div></div>" +
           "<div class='stat-card'><div class='stat-label'>Release Ready</div><div class='stat-value allow'>" +
-          rr.passRate +
+          escapeHtml(rr.passRate) +
           "%</div></div>" +
           "<div class='stat-card'><div class='stat-label'>CFR</div><div class='stat-value'>" +
-          data.cfr.cfr +
+          escapeHtml(data.cfr.cfr) +
           "%</div></div>" +
           "<div class='stat-card'><div class='stat-label'>DORA Rating</div><div class='stat-value'>" +
-          data.dora.rating +
+          escapeHtml(data.dora.rating) +
           "</div></div>";
       }
 
@@ -695,13 +719,13 @@
           .map(function (d) {
             return (
               "<div class='stat-sub'>" +
-              d.detector +
+              escapeHtml(d.detector) +
               ": " +
-              d.falsePositiveRate +
+              escapeHtml(d.falsePositiveRate) +
               "% FP (" +
-              d.falsePositive +
+              escapeHtml(d.falsePositive) +
               "/" +
-              d.total +
+              escapeHtml(d.total) +
               ")" +
               (d.noisy ? " " + badge("NOISY", "fail") : "") +
               "</div>"
@@ -726,30 +750,32 @@
         const q = data.quota;
         document.getElementById("planPanel").innerHTML =
           "<div class='stat-value'>" +
-          (data.settings.plan || "pro").toUpperCase() +
+          escapeHtml((data.settings.plan || "pro").toUpperCase()) +
           "</div>" +
           "<div class='stat-sub'>Quota: " +
-          q.used +
+          escapeHtml(q.used) +
           " / " +
-          q.limit +
+          escapeHtml(q.limit) +
           " evaluations this month</div>" +
           "<div class='stat-sub'>Seats: " +
-          data.settings.seatsUsed +
+          escapeHtml(data.settings.seatsUsed) +
           " / " +
-          data.settings.seats +
+          escapeHtml(data.settings.seats) +
           "</div>";
 
         const keys = await apiFetch("/v1/api-keys");
         document.getElementById("keysPanel").innerHTML = (keys.keys || [])
           .map(function (k) {
+            // k.label is attacker-controlled free text (set via POST /v1/api-keys)
+            // and rendered for every viewer of this org's dashboard — must be escaped.
             return (
               "<div class='stat-sub'>" +
-              k.label +
+              escapeHtml(k.label) +
               " — <code>" +
-              k.keyPreview +
+              escapeHtml(k.keyPreview) +
               "</code> " +
               "<button type='button' data-revoke='" +
-              k.id +
+              escapeHtml(k.id) +
               "' class='danger-btn' style='margin-left:8px;padding:2px 8px;font-size:0.75rem'>Revoke</button></div>"
             );
           })
@@ -799,7 +825,10 @@
       function renderTable(rows) {
         document.getElementById("evalBody").innerHTML = rows
           .map(function (row) {
-            const ctx = row.context && row.context.name ? row.context.name : "—";
+            // row.context.name is a CI-derived, effectively attacker-influenced
+            // string (workflow/job name) — escape along with every other field.
+            const ctx =
+              row.context && row.context.name ? escapeHtml(row.context.name) : "—";
             const rr =
               row.releaseReady === true
                 ? badge("PASS", "pass")
@@ -808,21 +837,21 @@
                   : "—";
             return (
               '<tr class="clickable" data-id="' +
-              row.id +
+              escapeHtml(row.id) +
               '"><td title="' +
-              row.receivedAt +
+              escapeHtml(row.receivedAt) +
               '">' +
-              relativeTime(row.receivedAt) +
+              escapeHtml(relativeTime(row.receivedAt)) +
               "</td><td>" +
-              row.repoId +
+              escapeHtml(row.repoId) +
               "</td><td>" +
-              (row.prNumber ? "#" + row.prNumber : "—") +
+              (row.prNumber ? "#" + escapeHtml(row.prNumber) : "—") +
               "</td><td style='color:" +
               scoreColor(row.riskScore) +
               "'>" +
-              row.riskScore +
+              escapeHtml(row.riskScore) +
               "</td><td>" +
-              row.gateDecision +
+              escapeHtml(row.gateDecision) +
               "</td><td>" +
               rr +
               "</td><td>" +
@@ -843,23 +872,33 @@
         const data = await apiFetch("/v1/evaluations/" + encodeURIComponent(id));
         const e = data.evaluation;
         currentEval = e;
+        // CI check names, release-ready reasons, and risk-factor types/scores
+        // are all derived from CI/webhook payloads and are effectively
+        // attacker-influenced (an attacker who controls a repo's CI config or
+        // PR content can set them) — every field here must be escaped.
         const ciChecks =
           e.ci && e.ci.checks
             ? e.ci.checks
                 .map(function (c) {
-                  return c.name + ": " + c.status + (c.required ? " (required)" : "");
+                  return (
+                    escapeHtml(c.name) +
+                    ": " +
+                    escapeHtml(c.status) +
+                    (c.required ? " (required)" : "")
+                  );
                 })
                 .join("\n")
             : "—";
-        const reasons = (e.releaseReadyReasons || []).join("\n") || "—";
+        const reasons =
+          (e.releaseReadyReasons || []).map(escapeHtml).join("\n") || "—";
         const factors = (e.riskFactors || [])
           .map(function (f) {
             return (
-              f.type +
+              escapeHtml(f.type) +
               ": " +
-              f.score +
+              escapeHtml(f.score) +
               ' <button type="button" data-detector="' +
-              f.type +
+              escapeHtml(f.type) +
               '" class="dismiss-factor-btn" style="margin-left:6px;font-size:0.7rem">Dismiss</button>'
             );
           })
@@ -868,18 +907,18 @@
         document.getElementById("modalBody").innerHTML =
           "<dl class='detail-grid'>" +
           "<dt>Commit</dt><dd><code>" +
-          e.commitSha.substring(0, 7) +
+          escapeHtml(e.commitSha.substring(0, 7)) +
           "</code></dd>" +
           "<dt>PR</dt><dd>" +
-          (e.prNumber ? "#" + e.prNumber : "—") +
+          (e.prNumber ? "#" + escapeHtml(e.prNumber) : "—") +
           "</dd>" +
           "<dt>Risk / Health</dt><dd>" +
-          e.riskScore +
+          escapeHtml(e.riskScore) +
           " / " +
-          e.healthScore +
+          escapeHtml(e.healthScore) +
           "</dd>" +
           "<dt>Gate mode</dt><dd>" +
-          (e.gateMode || "—") +
+          escapeHtml(e.gateMode || "—") +
           "</dd></dl>" +
           "<h3>CI checks</h3><pre>" +
           ciChecks +

--- a/src/__tests__/notify.test.ts
+++ b/src/__tests__/notify.test.ts
@@ -477,8 +477,10 @@ describe("storeEvaluationDetailed — quota/billing surfacing", () => {
     expect(fetch).toHaveBeenCalledTimes(1);
   });
 
-  it("reports hardCapped=true, stored=false, and does not throw on JSON HTTP 429", async () => {
-    vi.mocked(fetch).mockResolvedValueOnce(jsonResponse('{"error":"hard_cap"}', 429));
+  it("reports hardCapped=true, stored=false, and does not throw on a JSON HTTP 429 with code=hard_cap_exceeded", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      jsonResponse('{"error":"hard_cap","code":"hard_cap_exceeded"}', 429),
+    );
 
     const outcome = await storeEvaluationDetailed(
       "https://example.com/api/trailhead/store",
@@ -490,8 +492,52 @@ describe("storeEvaluationDetailed — quota/billing surfacing", () => {
       suspended: false,
       hardCapped: true,
     });
-    // Not retried — a JSON 429 is a permanent-for-the-period hard cap, not transient.
+    // Not retried — code:hard_cap_exceeded is permanent for the billing period.
     expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries a JSON HTTP 429 with code=rate_limited instead of reporting hardCapped", async () => {
+    vi.useFakeTimers();
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(
+        jsonResponse('{"error":"rate limit exceeded","code":"rate_limited"}', 429),
+      )
+      .mockResolvedValueOnce(jsonResponse('{"stored":true}'));
+
+    const promise = storeEvaluationDetailed(
+      "https://example.com/api/trailhead/store",
+      makeEvaluation(),
+    );
+    await vi.advanceTimersByTimeAsync(1_000);
+    await expect(promise).resolves.toEqual({
+      stored: true,
+      quotaExceeded: false,
+      suspended: false,
+      hardCapped: false,
+    });
+    expect(fetch).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
+  });
+
+  it("defaults an unrecognized/missing 429 `code` to retryable (fail-open) rather than hard-capped", async () => {
+    vi.useFakeTimers();
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(jsonResponse('{"error":"too many requests"}', 429))
+      .mockResolvedValueOnce(jsonResponse('{"stored":true}'));
+
+    const promise = storeEvaluationDetailed(
+      "https://example.com/api/trailhead/store",
+      makeEvaluation(),
+    );
+    await vi.advanceTimersByTimeAsync(1_000);
+    await expect(promise).resolves.toEqual({
+      stored: true,
+      quotaExceeded: false,
+      suspended: false,
+      hardCapped: false,
+    });
+    expect(fetch).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
   });
 
   it("still retries a non-JSON (HTML) 429 — likely bot protection, not a hard cap", async () => {

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -240,16 +240,44 @@ async function storeViaApiOnce(
     return { ok: false, retryable: false, suspended: true };
   }
 
-  // 429 with a structured JSON body is the Cloud API's hard usage cap
-  // (3x plan limit, abuse backstop) — permanent for the billing period, so
-  // retrying is pointless. A 429 with a non-JSON (HTML) body is most likely
-  // Vercel bot protection, which IS worth retrying — handled below.
+  // A 429 with a structured JSON body can be EITHER the per-org rate limiter
+  // (transient — a CI burst on one key — retryable) OR the monthly hard usage
+  // cap backstop (permanent for the billing period — not retryable). The
+  // Cloud API distinguishes the two via a machine-readable `code` field. A
+  // 429 with a non-JSON (HTML) body is most likely Vercel bot protection,
+  // which IS worth retrying — handled by the generic path below.
   if (response.status === 429 && isJson) {
+    let code: unknown;
+    try {
+      const parsed = (await response.clone().json()) as { code?: unknown };
+      code = parsed?.code;
+    } catch {
+      code = undefined;
+    }
+
+    if (code === "hard_cap_exceeded") {
+      core.warning(
+        "Trailhead Cloud: you're over this month's hard usage cap — this evaluation was NOT " +
+          "stored. Upgrade at https://trailhead.komatik.xyz/pricing",
+      );
+      return { ok: false, retryable: false, hardCapped: true };
+    }
+
+    if (code === "rate_limited") {
+      core.warning(
+        `Trailhead Cloud: rate limit exceeded on attempt — this evaluation will be retried`,
+      );
+      return { ok: false, retryable: true, hardCapped: false };
+    }
+
+    // Unknown/missing code (e.g. an older Cloud API deployment that hasn't
+    // rolled out the `code` field yet) — fail open and treat as retryable
+    // rather than risk showing a false "hard cap" message to paying orgs.
     core.warning(
-      "Trailhead Cloud: you're over this month's hard usage cap — this evaluation was NOT " +
-        "stored. Upgrade at https://trailhead.komatik.xyz/pricing",
+      "Trailhead Cloud: received HTTP 429 without a recognized `code` field — " +
+        "treating as retryable",
     );
-    return { ok: false, retryable: false, hardCapped: true };
+    return { ok: false, retryable: true, hardCapped: false };
   }
 
   const nonRetryableClientErrors = new Set([400, 401, 403]);


### PR DESCRIPTION
## Summary

Three reviewed-and-confirmed P1 defects, fixed independently of the concurrent site↔store contract P0 work on `claude/site-store-contract-fix` (this PR does not touch `site/lib/webhookHandlers.ts`, `site/app/api/billing/*`, or `site/types/`).

### Fix 1 — Stored XSS in `site/public/dashboard-embed.html`

Every render function (`renderTable`, `openDrillDown`, `renderSettings`, `renderNoise`, `renderStats`, `renderCi`, `renderDora`, `renderCfr`, `renderReleaseReady`, `renderRiskChart`) built markup via string concatenation into `innerHTML` with zero escaping. Attacker-controlled fields — most notably the free-text API key `label` (`POST /v1/api-keys`), which is rendered to every viewer of the org's dashboard — could inject a script that exfiltrates the sessionStorage-held API key (`th_cloud_key`). CI-derived fields (check names, context names, `releaseReadyReasons`, risk-factor types) are similarly attacker-influenced via repo/CI config.

Fix: added a single `escapeHtml()` helper and routed every interpolated dynamic value through it, including attribute positions (`data-id`, `data-revoke`, `data-detector`, `title`, inline `style`). File stays self-contained, no new dependencies.

### Fix 2 — 429 rate-limit vs hard-cap disambiguation

`cloud/src/app.ts` returned an identically-shaped 429+JSON for both the per-org rate limiter and the monthly hard-usage-cap backstop. `src/notify.ts`'s `storeViaApiOnce` treated *any* 429+JSON as permanent (`hardCapped: true`, non-retryable), so a CI burst on one key showed paying customers a false "over your hard usage cap" message and skipped a retry that would have succeeded.

Fix: added a machine-readable `code` field to both 429 bodies (`rate_limited` / `hard_cap_exceeded`). `notify.ts` now branches on it — `rate_limited` retries with backoff, `hard_cap_exceeded` stays permanent, and an unknown/missing `code` (e.g. an older Cloud API deployment) defaults to retryable (fail-open) rather than risking a false hard-cap message.

### Fix 3 — Quota check-then-act race

`cloud/src/pg-store.ts`'s `ingestEvaluation` read `usage_counters` without a row lock, decided quota, then incremented — two concurrent ingests at the hard-cap boundary could both pass and both get stored, overshooting the cap.

Fix: inside the existing transaction, `INSERT ... ON CONFLICT DO NOTHING` guarantees the org+month row exists, then `SELECT ... FOR UPDATE` locks it before reading `used`, serializing concurrent ingests for the same org+month. The in-memory store needed no equivalent lock (documented why: no `await` between read and increment, single JS event loop).

## Dist discipline

- `cloud/dist` is committed/canonical (PR #310 self-heal) — rebuilt via `cd cloud && npm run build` (`app.js`, `pg-store.js`, `store.js` regenerated) and committed alongside each source change.
- The Action also has a committed root `dist/index.js` (action.yml → `runs.main: dist/index.js`, built via ncc). Rebuilt via `npm run build` at repo root (same command CI/release workflows use) and committed.

## Test plan

- [x] `cloud && npm test` — 48/48 passing (includes new rate-limit-code test, hard-cap-code assertion, and the quota-race concurrency test)
- [x] Root `npx vitest run` — 839/839 passing (includes updated `notify.test.ts`: rate_limited retries, hard_cap_exceeded permanent, unknown-code fail-open-retryable)
- [x] `store-contract.test.ts` concurrency test verified against a **real local Postgres instance** (throwaway db/role created and dropped afterward) as well as the in-memory store — confirms the `SELECT ... FOR UPDATE` fix actually serializes concurrent transactions and caps stored count at exactly the expected margin
- [x] `tsc --noEmit` clean at both repo root and `cloud/`
- [x] `dashboard-embed.html`: extracted `<script>` body and ran `node --check` (syntax valid); unit-verified `escapeHtml()` neutralizes both tag-injection (`<img onerror=...>`) and attribute-breakout (`"><script>`) payloads (repo has no jsdom, so this was the available smoke path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017BdALWWeU1KUxUWRCEZHk8