### PR TITLE
release: v4.6.0 — close_on_ship_link detector + evaluate-pr backfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 All notable changes to Trailhead will be documented in this file.
 
-## [Unreleased]
+## [4.6.0] - 2026-07-18
 
 ### Added
 
+- **Phase-0 `close_on_ship_link` detector** ([#301](https://github.com/KomatikAI/trailhead/pull/301)) — producer side of the close-on-ship loop: submission checks now surface agent PRs that lack an explicit `Closes task: <id>` / `Resolves task: <id>` link, so merged work can be reconciled back to fleet tasks instead of dying unlinked (the planner's RECONCILE-SHIPPED pass consumes these links).
 - **On-demand / backfill evaluation (`evaluate-pr`)** — new Action input to evaluate a specific PR by number instead of the triggering event's PR. Resolves the PR head commit via the API and scores the diff with the current engine, so historical PRs (open, closed, or merged) can be re-evaluated or backfilled with the latest version. Diff/author/age/provenance are fetched by PR number (no checkout required). In this mode the gate only scores and persists the evaluation — PR comments, labels, reviewer requests, self-heal, and autofix are skipped. Drivable from `workflow_dispatch` or a direct `node dist/index.js` run. See `examples/github-actions/trailhead-backfill.yml`.
 
 ## [4.5.7] - 2026-07-01

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@komatikai/trailhead",
-  "version": "4.5.7",
+  "version": "4.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@komatikai/trailhead",
-      "version": "4.5.7",
+      "version": "4.6.0",
       "license": "MIT",
       "dependencies": {
         "@swc/core": "^1.15.40"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@komatikai/trailhead",
-  "version": "4.5.7",
+  "version": "4.6.0",
   "description": "Trailhead CLI — setup wizard and utilities for the Trailhead deployment gate",
   "bin": {
     "trailhead": "dist/index.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trailhead",
-  "version": "4.5.7",
+  "version": "4.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "trailhead",
-      "version": "4.5.7",
+      "version": "4.6.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trailhead",
-  "version": "4.5.7",
+  "version": "4.6.0",
   "private": true,
   "description": "Release readiness gate for GitHub PRs — waits for CI, scores code risk, checks production health, and blocks merges that are not release-ready.",
   "license": "MIT",


### PR DESCRIPTION
Version bump (root + cli) and CHANGELOG for the two features merged today (#301, #279). #301 had no changelog entry — added here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VyuPuP4q3jjn5Ysj4XBfTm