### PR TITLE
promote: staging → main (v4.6.0, 2026-07-18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Trailhead will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- **On-demand / backfill evaluation (`evaluate-pr`)** — new Action input to evaluate a specific PR by number instead of the triggering event's PR. Resolves the PR head commit via the API and scores the diff with the current engine, so historical PRs (open, closed, or merged) can be re-evaluated or backfilled with the latest version. Diff/author/age/provenance are fetched by PR number (no checkout required). In this mode the gate only scores and persists the evaluation — PR comments, labels, reviewer requests, self-heal, and autofix are skipped. Drivable from `workflow_dispatch` or a direct `node dist/index.js` run. See `examples/github-actions/trailhead-backfill.yml`.
+
 ## [4.5.7] - 2026-07-01
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 All notable changes to Trailhead will be documented in this file.
 
-## [Unreleased]
+## [4.6.0] - 2026-07-18
 
 ### Added
 
+- **Phase-0 `close_on_ship_link` detector** ([#301](https://github.com/KomatikAI/trailhead/pull/301)) — producer side of the close-on-ship loop: submission checks now surface agent PRs that lack an explicit `Closes task: <id>` / `Resolves task: <id>` link, so merged work can be reconciled back to fleet tasks instead of dying unlinked (the planner's RECONCILE-SHIPPED pass consumes these links).
 - **On-demand / backfill evaluation (`evaluate-pr`)** — new Action input to evaluate a specific PR by number instead of the triggering event's PR. Resolves the PR head commit via the API and scores the diff with the current engine, so historical PRs (open, closed, or merged) can be re-evaluated or backfilled with the latest version. Diff/author/age/provenance are fetched by PR number (no checkout required). In this mode the gate only scores and persists the evaluation — PR comments, labels, reviewer requests, self-heal, and autofix are skipped. Drivable from `workflow_dispatch` or a direct `node dist/index.js` run. See `examples/github-actions/trailhead-backfill.yml`.
 
 ## [4.5.7] - 2026-07-01

--- a/action.yml
+++ b/action.yml
@@ -211,6 +211,10 @@ inputs:
     description: "Set to 'false' to disable the cross-repo PR opener even when configured. Default enabled (the opener still requires submission.contract_integrity.cross_repo_opener.enabled, an api_owners map, and a cross-repo-token to actually open PRs)."
     required: false
     default: "true"
+  evaluate-pr:
+    description: "Evaluate a specific PR by number instead of the triggering event's PR. Enables backfill / on-demand re-evaluation of historical PRs (open, closed, or merged) with the current engine version — driven from workflow_dispatch or a direct `node dist/index.js` run. The diff, author history, age, and provenance are fetched from the GitHub API by PR number, so no checkout of the PR is required. In this mode the gate only scores and persists the evaluation; PR comments, labels, reviewer requests, self-heal, and autofix are skipped. Requires github-token."
+    required: false
+    default: ""
 
 outputs:
   health-score:

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@komatikai/trailhead",
-  "version": "4.5.7",
+  "version": "4.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@komatikai/trailhead",
-      "version": "4.5.7",
+      "version": "4.6.0",
       "license": "MIT",
       "dependencies": {
         "@swc/core": "^1.15.40"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@komatikai/trailhead",
-  "version": "4.5.7",
+  "version": "4.6.0",
   "description": "Trailhead CLI — setup wizard and utilities for the Trailhead deployment gate",
   "bin": {
     "trailhead": "dist/index.js"

--- a/dist/index.js
+++ b/dist/index.js
@@ -56484,8 +56484,35 @@ async function run() {
         if (policyOverride) {
             core_warning(`Governed override active (${policyOverride.linkedTicket}) by ${policyOverride.owner}; expires ${policyOverride.expiresAt}.`);
         }
-        const commitSha = context.sha;
-        const prNumber = context.payload.pull_request?.number;
+        // On-demand evaluation: when `evaluate-pr` is set, score that PR by number
+        // instead of the triggering event's PR. Enables backfill / re-evaluation of
+        // historical PRs (open, closed, or merged) with the current engine version,
+        // driven from a workflow_dispatch or a direct `node dist/index.js` run.
+        // The diff/author/age/provenance are all fetched from the GitHub API by PR
+        // number (see evaluateGate), so no checkout of the PR is required.
+        let commitSha = context.sha;
+        let prNumber = context.payload.pull_request?.number;
+        const evaluatePrInput = getInput("evaluate-pr").trim();
+        const backfillMode = Boolean(evaluatePrInput);
+        if (evaluatePrInput) {
+            const parsedPr = parseInt(evaluatePrInput, 10);
+            if (Number.isNaN(parsedPr) || parsedPr <= 0) {
+                throw new Error(`evaluate-pr must be a positive PR number; got "${evaluatePrInput}".`);
+            }
+            if (!config.githubToken) {
+                throw new Error("evaluate-pr requires a github-token to resolve the PR head commit.");
+            }
+            const octokit = getOctokit(config.githubToken);
+            const { data: targetPr } = await octokit.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: parsedPr,
+            });
+            prNumber = parsedPr;
+            commitSha = targetPr.head.sha;
+            info(`evaluate-pr mode: PR #${parsedPr} (${targetPr.state}) @ ${commitSha.substring(0, 7)} ` +
+                `base=${targetPr.base.ref} — backfill/re-evaluation; PR comments, labels and autofix are skipped.`);
+        }
         info(`Evaluating deployment gate for ${commitSha.substring(0, 7)}`);
         const evaluation = await evaluateGate(config, commitSha, prNumber);
         if (policyOverride && !evaluation.policyOverride) {
@@ -56524,7 +56551,7 @@ async function run() {
         }
         // Autofix self-heal (ADR-010) — opt-in; dry-run (plan only) unless enabled.
         const autofixFixes = evaluation.remediation?.fixes ?? [];
-        if (config.githubToken && prNumber && autofixFixes.some((f) => f.autofix_eligible)) {
+        if (config.githubToken && prNumber && !backfillMode && autofixFixes.some((f) => f.autofix_eligible)) {
             try {
                 const autofixEnabled = getInput("autofix") === "true" || readEnv("TRAILHEAD_AUTOFIX") === "true";
                 const prPayload = context.payload.pull_request;
@@ -56750,7 +56777,7 @@ async function run() {
         }
         await summary.addRaw(fullReport).write();
         const checkName = resolveCheckName(evaluation.gateMode ?? "risk-only", config.checkName);
-        if (config.githubToken) {
+        if (config.githubToken && !backfillMode) {
             if (prNumber) {
                 await postPrComment(fullReport, prNumber, config.githubToken);
             }
@@ -56769,10 +56796,10 @@ async function run() {
         if (!blockMerge) {
             if (evaluation.gateDecision === "warn") {
                 core_warning(fullReport);
-                if (config.githubToken && prNumber && config.reviewersOnRisk.length > 0) {
+                if (config.githubToken && prNumber && !backfillMode && config.reviewersOnRisk.length > 0) {
                     await requestHighRiskReviewers(prNumber, config.reviewersOnRisk, config.githubToken);
                 }
-                if (config.selfHeal && prNumber) {
+                if (config.selfHeal && prNumber && !backfillMode) {
                     const repairs = await runSelfHeal(config, prNumber);
                     if (repairs.length > 0) {
                         info(`Self-heal attempted ${repairs.length} repair(s): ` +
@@ -56785,10 +56812,10 @@ async function run() {
             }
             return;
         }
-        if (config.githubToken && prNumber && config.reviewersOnRisk.length > 0) {
+        if (config.githubToken && prNumber && !backfillMode && config.reviewersOnRisk.length > 0) {
             await requestHighRiskReviewers(prNumber, config.reviewersOnRisk, config.githubToken);
         }
-        if (config.selfHeal && prNumber) {
+        if (config.selfHeal && prNumber && !backfillMode) {
             const repairs = await runSelfHeal(config, prNumber);
             const successes = repairs.filter((r) => r.success);
             if (successes.length > 0) {

--- a/examples/github-actions/trailhead-backfill.yml
+++ b/examples/github-actions/trailhead-backfill.yml
@@ -1,0 +1,36 @@
+# Backfill / re-evaluate a specific PR with the current Trailhead engine.
+#
+# Use this to populate the evaluation store for historical PRs (e.g. after a
+# version upgrade) or to re-score a single PR on demand. The gate fetches the
+# PR diff by number from the API — it works for open, closed, and merged PRs,
+# and requires no checkout of the PR. Only the evaluation is scored and
+# persisted; PR comments, labels, reviewers, self-heal, and autofix are skipped.
+#
+# Drive it across many PRs with:
+#   for pr in 2100 2101 2102; do
+#     gh workflow run trailhead-backfill.yml -f pr="$pr"
+#   done
+name: Trailhead Backfill
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "PR number to evaluate"
+        required: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  backfill:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: KomatikAI/trailhead@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          evaluate-pr: ${{ inputs.pr }}
+          evaluation-store-url: "https://komatik.ai/api/trailhead/store"
+          evaluation-store-secret: ${{ secrets.INTERNAL_API_SECRET }}
+          dora-metrics: "true"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trailhead",
-  "version": "4.5.7",
+  "version": "4.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "trailhead",
-      "version": "4.5.7",
+      "version": "4.6.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trailhead",
-  "version": "4.5.7",
+  "version": "4.6.0",
   "private": true,
   "description": "Release readiness gate for GitHub PRs — waits for CI, scores code risk, checks production health, and blocks merges that are not release-ready.",
   "license": "MIT",

--- a/src/__tests__/close-on-ship-link.test.ts
+++ b/src/__tests__/close-on-ship-link.test.ts
@@ -34,18 +34,24 @@ const SUG = "agents/backend-dev/suggestions/komatik/fix/idea.md";
 
 describe("detectCloseOnShipLink", () => {
   it("returns null when the PR has no suggestion files", () => {
-    expect(detectCloseOnShipLink(ctx([{ filename: "src/app.ts", content: "x" }]))).toBeNull();
+    expect(
+      detectCloseOnShipLink(ctx([{ filename: "src/app.ts", content: "x" }])),
+    ).toBeNull();
   });
 
   it("flags a suggestion missing a 'Task: <id>' provenance line", () => {
-    const r = detectCloseOnShipLink(ctx([{ filename: SUG, content: "# Proposal\nno task line here" }]));
+    const r = detectCloseOnShipLink(
+      ctx([{ filename: SUG, content: "# Proposal\nno task line here" }]),
+    );
     expect(r?.code).toBe("close_on_ship_link");
     expect(r?.severity).toBe("advisory");
     expect(r?.files).toContain(SUG);
   });
 
   it("is dormant on the body half when prBody is absent (provenance present)", () => {
-    const r = detectCloseOnShipLink(ctx([{ filename: SUG, content: `# Proposal\nTask: ${TASK}\n` }]));
+    const r = detectCloseOnShipLink(
+      ctx([{ filename: SUG, content: `# Proposal\nTask: ${TASK}\n` }]),
+    );
     expect(r).toBeNull();
   });
 
@@ -59,11 +65,16 @@ describe("detectCloseOnShipLink", () => {
 
   it("passes when the PR body carries 'Closes task: <id>' (full or short id)", () => {
     expect(
-      detectCloseOnShipLink(ctx([{ filename: SUG, content: `Task: ${TASK}` }], `Closes task: ${TASK}`)),
+      detectCloseOnShipLink(
+        ctx([{ filename: SUG, content: `Task: ${TASK}` }], `Closes task: ${TASK}`),
+      ),
     ).toBeNull();
     expect(
       detectCloseOnShipLink(
-        ctx([{ filename: SUG, content: `Task: ${TASK}` }], `Resolves task: ${TASK.slice(0, 8)}`),
+        ctx(
+          [{ filename: SUG, content: `Task: ${TASK}` }],
+          `Resolves task: ${TASK.slice(0, 8)}`,
+        ),
       ),
     ).toBeNull();
   });

--- a/src/__tests__/close-on-ship-link.test.ts
+++ b/src/__tests__/close-on-ship-link.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { detectCloseOnShipLink } from "../submission-checks/phase0-detectors.js";
+import type { SubmissionCheckContext } from "../submission-checks/types.js";
+import { prPathSet } from "../submission-checks/helpers.js";
+import {
+  buildRenamePatterns,
+  buildSlugOnlyPatterns,
+} from "../submission-checks/detector-policy.js";
+
+function ctx(
+  files: Array<{ filename: string; content?: string }>,
+  prBody?: string,
+): SubmissionCheckContext {
+  const normalized = files.map((f) => ({ filename: f.filename, content: f.content }));
+  return {
+    files: normalized,
+    prPaths: prPathSet(normalized),
+    komatikInstance: true,
+    staleTerms: [],
+    authRouteAllowlist: [],
+    maxFileLines: 1000,
+    declaredPackages: new Set(),
+    namingAllowlist: {},
+    pathIgnorePatterns: [],
+    renamePatterns: buildRenamePatterns(undefined, { includeKomatikDefaults: true }),
+    slugOnlyPatterns: buildSlugOnlyPatterns(undefined),
+    detectorPolicy: {},
+    prBody,
+  };
+}
+
+const TASK = "4139db4b-3993-4e1a-9b2c-aaaaaaaaaaaa";
+const SUG = "agents/backend-dev/suggestions/komatik/fix/idea.md";
+
+describe("detectCloseOnShipLink", () => {
+  it("returns null when the PR has no suggestion files", () => {
+    expect(detectCloseOnShipLink(ctx([{ filename: "src/app.ts", content: "x" }]))).toBeNull();
+  });
+
+  it("flags a suggestion missing a 'Task: <id>' provenance line", () => {
+    const r = detectCloseOnShipLink(ctx([{ filename: SUG, content: "# Proposal\nno task line here" }]));
+    expect(r?.code).toBe("close_on_ship_link");
+    expect(r?.severity).toBe("advisory");
+    expect(r?.files).toContain(SUG);
+  });
+
+  it("is dormant on the body half when prBody is absent (provenance present)", () => {
+    const r = detectCloseOnShipLink(ctx([{ filename: SUG, content: `# Proposal\nTask: ${TASK}\n` }]));
+    expect(r).toBeNull();
+  });
+
+  it("flags when the PR body lacks a 'Closes task: <id>' for a task-linked suggestion", () => {
+    const r = detectCloseOnShipLink(
+      ctx([{ filename: SUG, content: `Task: ${TASK}` }], "Ships the fix. No close link."),
+    );
+    expect(r?.code).toBe("close_on_ship_link");
+    expect(r?.detail).toMatch(/Closes task/i);
+  });
+
+  it("passes when the PR body carries 'Closes task: <id>' (full or short id)", () => {
+    expect(
+      detectCloseOnShipLink(ctx([{ filename: SUG, content: `Task: ${TASK}` }], `Closes task: ${TASK}`)),
+    ).toBeNull();
+    expect(
+      detectCloseOnShipLink(
+        ctx([{ filename: SUG, content: `Task: ${TASK}` }], `Resolves task: ${TASK.slice(0, 8)}`),
+      ),
+    ).toBeNull();
+  });
+});

--- a/src/__tests__/fixtures/agent-failures/manifest.json
+++ b/src/__tests__/fixtures/agent-failures/manifest.json
@@ -45,7 +45,8 @@
     "dependency_dag_validation",
     "uncommitted_fix_check",
     "verification_owner_assigned",
-    "external_interface_validation"
+    "external_interface_validation",
+    "close_on_ship_link"
   ],
   "coveredRiskFactors": [
     "test_coverage",

--- a/src/gate.ts
+++ b/src/gate.ts
@@ -1799,8 +1799,8 @@ export async function evaluateGate(
           : undefined,
       // close_on_ship_link: the PR body carries the `Closes task: <id>` convention.
       prBody:
-        (github.context.payload?.pull_request as { body?: string } | undefined)
-          ?.body ?? undefined,
+        (github.context.payload?.pull_request as { body?: string } | undefined)?.body ??
+        undefined,
     });
     if (submissionChecks.length > 0) {
       policyFindings.push(`Submission gate: ${submissionChecks.length} finding(s).`);

--- a/src/gate.ts
+++ b/src/gate.ts
@@ -1797,6 +1797,10 @@ export async function evaluateGate(
               headBranch: process.env.GITHUB_HEAD_REF,
             }
           : undefined,
+      // close_on_ship_link: the PR body carries the `Closes task: <id>` convention.
+      prBody:
+        (github.context.payload?.pull_request as { body?: string } | undefined)
+          ?.body ?? undefined,
     });
     if (submissionChecks.length > 0) {
       policyFindings.push(`Submission gate: ${submissionChecks.length} finding(s).`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -318,8 +318,42 @@ async function run(): Promise<void> {
       );
     }
 
-    const commitSha = context.sha;
-    const prNumber = context.payload.pull_request?.number;
+    // On-demand evaluation: when `evaluate-pr` is set, score that PR by number
+    // instead of the triggering event's PR. Enables backfill / re-evaluation of
+    // historical PRs (open, closed, or merged) with the current engine version,
+    // driven from a workflow_dispatch or a direct `node dist/index.js` run.
+    // The diff/author/age/provenance are all fetched from the GitHub API by PR
+    // number (see evaluateGate), so no checkout of the PR is required.
+    let commitSha = context.sha;
+    let prNumber = context.payload.pull_request?.number;
+
+    const evaluatePrInput = core.getInput("evaluate-pr").trim();
+    const backfillMode = Boolean(evaluatePrInput);
+    if (evaluatePrInput) {
+      const parsedPr = parseInt(evaluatePrInput, 10);
+      if (Number.isNaN(parsedPr) || parsedPr <= 0) {
+        throw new Error(
+          `evaluate-pr must be a positive PR number; got "${evaluatePrInput}".`,
+        );
+      }
+      if (!config.githubToken) {
+        throw new Error(
+          "evaluate-pr requires a github-token to resolve the PR head commit.",
+        );
+      }
+      const octokit = github.getOctokit(config.githubToken);
+      const { data: targetPr } = await octokit.rest.pulls.get({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        pull_number: parsedPr,
+      });
+      prNumber = parsedPr;
+      commitSha = targetPr.head.sha;
+      core.info(
+        `evaluate-pr mode: PR #${parsedPr} (${targetPr.state}) @ ${commitSha.substring(0, 7)} ` +
+          `base=${targetPr.base.ref} — backfill/re-evaluation; PR comments, labels and autofix are skipped.`,
+      );
+    }
 
     core.info(`Evaluating deployment gate for ${commitSha.substring(0, 7)}`);
 
@@ -374,7 +408,7 @@ async function run(): Promise<void> {
 
     // Autofix self-heal (ADR-010) — opt-in; dry-run (plan only) unless enabled.
     const autofixFixes = evaluation.remediation?.fixes ?? [];
-    if (config.githubToken && prNumber && autofixFixes.some((f) => f.autofix_eligible)) {
+    if (config.githubToken && prNumber && !backfillMode && autofixFixes.some((f) => f.autofix_eligible)) {
       try {
         const autofixEnabled =
           core.getInput("autofix") === "true" || readEnv("TRAILHEAD_AUTOFIX") === "true";
@@ -655,7 +689,7 @@ async function run(): Promise<void> {
       config.checkName,
     );
 
-    if (config.githubToken) {
+    if (config.githubToken && !backfillMode) {
       if (prNumber) {
         await postPrComment(fullReport, prNumber, config.githubToken);
       }
@@ -677,14 +711,14 @@ async function run(): Promise<void> {
     if (!blockMerge) {
       if (evaluation.gateDecision === "warn") {
         core.warning(fullReport);
-        if (config.githubToken && prNumber && config.reviewersOnRisk.length > 0) {
+        if (config.githubToken && prNumber && !backfillMode && config.reviewersOnRisk.length > 0) {
           await requestHighRiskReviewers(
             prNumber,
             config.reviewersOnRisk,
             config.githubToken,
           );
         }
-        if (config.selfHeal && prNumber) {
+        if (config.selfHeal && prNumber && !backfillMode) {
           const repairs = await runSelfHeal(config, prNumber);
           if (repairs.length > 0) {
             core.info(
@@ -699,14 +733,14 @@ async function run(): Promise<void> {
       return;
     }
 
-    if (config.githubToken && prNumber && config.reviewersOnRisk.length > 0) {
+    if (config.githubToken && prNumber && !backfillMode && config.reviewersOnRisk.length > 0) {
       await requestHighRiskReviewers(
         prNumber,
         config.reviewersOnRisk,
         config.githubToken,
       );
     }
-    if (config.selfHeal && prNumber) {
+    if (config.selfHeal && prNumber && !backfillMode) {
       const repairs = await runSelfHeal(config, prNumber);
       const successes = repairs.filter((r) => r.success);
       if (successes.length > 0) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -408,7 +408,12 @@ async function run(): Promise<void> {
 
     // Autofix self-heal (ADR-010) — opt-in; dry-run (plan only) unless enabled.
     const autofixFixes = evaluation.remediation?.fixes ?? [];
-    if (config.githubToken && prNumber && !backfillMode && autofixFixes.some((f) => f.autofix_eligible)) {
+    if (
+      config.githubToken &&
+      prNumber &&
+      !backfillMode &&
+      autofixFixes.some((f) => f.autofix_eligible)
+    ) {
       try {
         const autofixEnabled =
           core.getInput("autofix") === "true" || readEnv("TRAILHEAD_AUTOFIX") === "true";
@@ -711,7 +716,12 @@ async function run(): Promise<void> {
     if (!blockMerge) {
       if (evaluation.gateDecision === "warn") {
         core.warning(fullReport);
-        if (config.githubToken && prNumber && !backfillMode && config.reviewersOnRisk.length > 0) {
+        if (
+          config.githubToken &&
+          prNumber &&
+          !backfillMode &&
+          config.reviewersOnRisk.length > 0
+        ) {
           await requestHighRiskReviewers(
             prNumber,
             config.reviewersOnRisk,
@@ -733,7 +743,12 @@ async function run(): Promise<void> {
       return;
     }
 
-    if (config.githubToken && prNumber && !backfillMode && config.reviewersOnRisk.length > 0) {
+    if (
+      config.githubToken &&
+      prNumber &&
+      !backfillMode &&
+      config.reviewersOnRisk.length > 0
+    ) {
       await requestHighRiskReviewers(
         prNumber,
         config.reviewersOnRisk,

--- a/src/submission-checks/phase0-detectors.ts
+++ b/src/submission-checks/phase0-detectors.ts
@@ -405,7 +405,8 @@ export function detectExternalInterfaceValidation(
 // This nudges the producer side so the Spark-side reconcilers have something to act
 // on. Advisory only — never blocks.
 const TASK_PROVENANCE = /\bTask:\s*([0-9a-f]{8}[0-9a-f-]*)/i;
-const CLOSES_TASK = /\b(?:close[sd]?|resolve[sd]?|fix(?:e[sd])?)\s+task\s*[:#]?\s*([0-9a-f]{8}[0-9a-f-]*)/gi;
+const CLOSES_TASK =
+  /\b(?:close[sd]?|resolve[sd]?|fix(?:e[sd])?)\s+task\s*[:#]?\s*([0-9a-f]{8}[0-9a-f-]*)/gi;
 export function detectCloseOnShipLink(
   ctx: SubmissionCheckContext,
 ): SubmissionCheckResult | null {
@@ -426,17 +427,23 @@ export function detectCloseOnShipLink(
     let bm: RegExpExecArray | null;
     while ((bm = re.exec(ctx.prBody)) !== null) linked.add(bm[1].toLowerCase());
     for (const id of taskIds) {
-      const isLinked = [...linked].some((l) => l === id || id.startsWith(l) || l.startsWith(id));
+      const isLinked = [...linked].some(
+        (l) => l === id || id.startsWith(l) || l.startsWith(id),
+      );
       if (!isLinked) unlinked.push(id);
     }
   }
 
   const problems: string[] = [];
   if (missingProvenance.length > 0) {
-    problems.push(`${missingProvenance.length} suggestion(s) missing a 'Task: <id>' provenance line`);
+    problems.push(
+      `${missingProvenance.length} suggestion(s) missing a 'Task: <id>' provenance line`,
+    );
   }
   if (unlinked.length > 0) {
-    problems.push(`PR body has no 'Closes task: <id>' for: ${unlinked.map((i) => i.slice(0, 8)).join(", ")}`);
+    problems.push(
+      `PR body has no 'Closes task: <id>' for: ${unlinked.map((i) => i.slice(0, 8)).join(", ")}`,
+    );
   }
   if (problems.length === 0) return null;
   return advisory({
@@ -444,7 +451,8 @@ export function detectCloseOnShipLink(
     title: "Close-on-ship link missing",
     detail: `${problems.join("; ")}. Add 'Task: <id>' in the suggestion and 'Closes task: <id>' in the PR body so the task auto-closes on merge (docs/plans/close-on-ship-v0.1.md).`,
     files: missingProvenance,
-    suggested_action: "Record the task link so the shipped work closes its task automatically.",
+    suggested_action:
+      "Record the task link so the shipped work closes its task automatically.",
   });
 }
 

--- a/src/submission-checks/phase0-detectors.ts
+++ b/src/submission-checks/phase0-detectors.ts
@@ -399,9 +399,59 @@ export function detectExternalInterfaceValidation(
   });
 }
 
+// close-on-ship producer link (docs/plans/close-on-ship-v0.1.md): a suggestion
+// should carry a `Task: <id>` provenance line, and when shipped its PR body should
+// carry `Closes task: <id>` — that link is what lets the task auto-close on merge.
+// This nudges the producer side so the Spark-side reconcilers have something to act
+// on. Advisory only — never blocks.
+const TASK_PROVENANCE = /\bTask:\s*([0-9a-f]{8}[0-9a-f-]*)/i;
+const CLOSES_TASK = /\b(?:close[sd]?|resolve[sd]?|fix(?:e[sd])?)\s+task\s*[:#]?\s*([0-9a-f]{8}[0-9a-f-]*)/gi;
+export function detectCloseOnShipLink(
+  ctx: SubmissionCheckContext,
+): SubmissionCheckResult | null {
+  const files = suggestionMarkdownFiles(ctx);
+  const missingProvenance: string[] = [];
+  const taskIds = new Set<string>();
+  for (const file of files) {
+    const m = fileContent(file).match(TASK_PROVENANCE);
+    if (m) taskIds.add(m[1].toLowerCase());
+    else missingProvenance.push(file.filename);
+  }
+
+  // PR-body half: only when the gate supplied the body (dormant on local runs).
+  const unlinked: string[] = [];
+  if (ctx.prBody !== undefined && taskIds.size > 0) {
+    const linked = new Set<string>();
+    const re = new RegExp(CLOSES_TASK.source, CLOSES_TASK.flags);
+    let bm: RegExpExecArray | null;
+    while ((bm = re.exec(ctx.prBody)) !== null) linked.add(bm[1].toLowerCase());
+    for (const id of taskIds) {
+      const isLinked = [...linked].some((l) => l === id || id.startsWith(l) || l.startsWith(id));
+      if (!isLinked) unlinked.push(id);
+    }
+  }
+
+  const problems: string[] = [];
+  if (missingProvenance.length > 0) {
+    problems.push(`${missingProvenance.length} suggestion(s) missing a 'Task: <id>' provenance line`);
+  }
+  if (unlinked.length > 0) {
+    problems.push(`PR body has no 'Closes task: <id>' for: ${unlinked.map((i) => i.slice(0, 8)).join(", ")}`);
+  }
+  if (problems.length === 0) return null;
+  return advisory({
+    code: "close_on_ship_link",
+    title: "Close-on-ship link missing",
+    detail: `${problems.join("; ")}. Add 'Task: <id>' in the suggestion and 'Closes task: <id>' in the PR body so the task auto-closes on merge (docs/plans/close-on-ship-v0.1.md).`,
+    files: missingProvenance,
+    suggested_action: "Record the task link so the shipped work closes its task automatically.",
+  });
+}
+
 export function runPhase0Detectors(ctx: SubmissionCheckContext): SubmissionCheckResult[] {
   if (suggestionMarkdownFiles(ctx).length === 0) return [];
   const checks = [
+    detectCloseOnShipLink,
     detectOutputSizeMin,
     detectActionExtractionPresent,
     detectDeltaSectionPresent,

--- a/src/submission-checks/types.ts
+++ b/src/submission-checks/types.ts
@@ -59,4 +59,11 @@ export interface SubmissionCheckContext {
    * layer). Absent for non-PR / local runs, leaving the detector dormant.
    */
   promotion?: { baseBranch?: string; headBranch?: string };
+  /**
+   * The PR description body (from `pull_request.body`, set by the gate I/O layer).
+   * Lets `close_on_ship_link` check for the `Closes task: <id>` convention that
+   * lives in the body, not the diff. Absent for non-PR / local runs, leaving that
+   * half of the detector dormant.
+   */
+  prBody?: string;
 }

--- a/src/submission-engine.ts
+++ b/src/submission-engine.ts
@@ -61,6 +61,8 @@ export interface SubmissionEngineOptions {
   catalogKnownEntities?: string[];
   /** Promotion branch topology (GITHUB_BASE_REF / GITHUB_HEAD_REF), set by the gate. */
   promotion?: { baseBranch?: string; headBranch?: string };
+  /** PR description body (pull_request.body), set by the gate — for close_on_ship_link. */
+  prBody?: string;
 }
 
 function buildContext(options: SubmissionEngineOptions): SubmissionCheckContext {
@@ -98,6 +100,7 @@ function buildContext(options: SubmissionEngineOptions): SubmissionCheckContext 
     catalogKnownEntities:
       catalogKnownEntities.size > 0 ? catalogKnownEntities : undefined,
     promotion: options.promotion,
+    prBody: options.prBody,
   };
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -132,6 +132,7 @@ export const SubmissionCheckCode = z.enum([
   "uncommitted_fix_check",
   "verification_owner_assigned",
   "external_interface_validation",
+  "close_on_ship_link",
 ]);
 export type SubmissionCheckCode = z.infer<typeof SubmissionCheckCode>;
 


### PR DESCRIPTION
Promotes v4.6.0 to main: close_on_ship_link detector (#301), evaluate-pr backfill (#279), release prep (#323). Tag v4.6.0 follows on the merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VyuPuP4q3jjn5Ysj4XBfTm