### PR TITLE
fix(seo): add og:image, canonical, and JSON-LD to cloud dashboard

### DIFF
--- a/cloud/public/dashboard.html
+++ b/cloud/public/dashboard.html
@@ -4,6 +4,27 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Trailhead Cloud Dashboard</title>
+    <!-- SEO meta -->
+    <meta name="description" content="Trailhead Cloud: release readiness analytics, risk scoring, and CI feedback for engineering teams. Powered by Komatik." />
+    <link rel="canonical" href="https://trailhead.komatik.xyz/dashboard" />
+    <!-- Open Graph -->
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Trailhead" />
+    <meta property="og:url" content="https://trailhead.komatik.xyz/dashboard" />
+    <meta property="og:title" content="Trailhead Cloud — Release Readiness Analytics" />
+    <meta property="og:description" content="Track risk scores, DORA metrics, CI feedback, and release readiness for every PR. Built for teams shipping fast." />
+    <meta property="og:image" content="https://trailhead.komatik.xyz/og-image.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Trailhead Cloud — Release Readiness Analytics" />
+    <meta name="twitter:description" content="Track risk scores, DORA metrics, CI feedback, and release readiness for every PR." />
+    <meta name="twitter:image" content="https://trailhead.komatik.xyz/og-image.png" />
+    <!-- JSON-LD -->
+    <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"WebApplication","name":"Trailhead Cloud","url":"https://trailhead.komatik.xyz","description":"Release readiness analytics, risk scoring, and CI feedback for engineering teams.","applicationCategory":"DeveloperApplication","operatingSystem":"Web","creator":{"@type":"Organization","name":"Komatik","url":"https://komatik.ai"}}
+    </script>
     <style>
       *,
       *::before,

--- a/cloud/public/dashboard.html
+++ b/cloud/public/dashboard.html
@@ -5,25 +5,47 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Trailhead Cloud Dashboard</title>
     <!-- SEO meta -->
-    <meta name="description" content="Trailhead Cloud: release readiness analytics, risk scoring, and CI feedback for engineering teams. Powered by Komatik." />
+    <meta
+      name="description"
+      content="Trailhead Cloud: release readiness analytics, risk scoring, and CI feedback for engineering teams. Powered by Komatik."
+    />
     <link rel="canonical" href="https://trailhead.komatik.xyz/dashboard" />
     <!-- Open Graph -->
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="Trailhead" />
     <meta property="og:url" content="https://trailhead.komatik.xyz/dashboard" />
     <meta property="og:title" content="Trailhead Cloud — Release Readiness Analytics" />
-    <meta property="og:description" content="Track risk scores, DORA metrics, CI feedback, and release readiness for every PR. Built for teams shipping fast." />
+    <meta
+      property="og:description"
+      content="Track risk scores, DORA metrics, CI feedback, and release readiness for every PR. Built for teams shipping fast."
+    />
     <meta property="og:image" content="https://trailhead.komatik.xyz/og-image.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Trailhead Cloud — Release Readiness Analytics" />
-    <meta name="twitter:description" content="Track risk scores, DORA metrics, CI feedback, and release readiness for every PR." />
+    <meta
+      name="twitter:description"
+      content="Track risk scores, DORA metrics, CI feedback, and release readiness for every PR."
+    />
     <meta name="twitter:image" content="https://trailhead.komatik.xyz/og-image.png" />
     <!-- JSON-LD -->
     <script type="application/ld+json">
-    {"@context":"https://schema.org","@type":"WebApplication","name":"Trailhead Cloud","url":"https://trailhead.komatik.xyz","description":"Release readiness analytics, risk scoring, and CI feedback for engineering teams.","applicationCategory":"DeveloperApplication","operatingSystem":"Web","creator":{"@type":"Organization","name":"Komatik","url":"https://komatik.ai"}}
+      {
+        "@context": "https://schema.org",
+        "@type": "WebApplication",
+        "name": "Trailhead Cloud",
+        "url": "https://trailhead.komatik.xyz",
+        "description": "Release readiness analytics, risk scoring, and CI feedback for engineering teams.",
+        "applicationCategory": "DeveloperApplication",
+        "operatingSystem": "Web",
+        "creator": {
+          "@type": "Organization",
+          "name": "Komatik",
+          "url": "https://komatik.ai"
+        }
+      }
     </script>
     <style>
       *,


### PR DESCRIPTION
## What changed

Adds the three SEO signals flagged as persistently failing on `trailhead.komatik.xyz` (SEO report `intel/SEO-REPORT.md` §2, 2026-07-13):

- `og:image` + Twitter card image (pointing at `/og-image.png`)
- `<link rel="canonical">` pointing at `/dashboard`
- `WebApplication` JSON-LD structured data

Also included as low-cost bonus fixes: full Open Graph block (`og:type`, `og:url`, `og:title`, `og:description`, `og:site_name`) and a meta description.

## Why

These signals were missing from `cloud/public/dashboard.html`, hurting link previews and search indexing for the dashboard page.

## Notes

- Bundle reference: `agents/frontend-dev/suggestions/trailhead/fix-seo-og-canonical-jsonld` (the bundle's `.patch` file had a corrupt hunk header — line counts didn't match its own diff body — so the same content was applied as a manual, minimal edit instead of `git apply`).
- **Follow-up required, not in this PR**: `/og-image.png` (1200x630) must be created at `cloud/public/og-image.png`, or the `og:image`/`twitter:image` tags will 404.
- If this app is ever deployed at a different domain, update the canonical href, all `og:url`/`og:image`/twitter image absolute URLs, and the JSON-LD `url` field.
- [UNVERIFIED] full build left to CI — only did a syntax/structure sanity check locally (balanced tags, valid JSON-LD) per task rules; no `npm install`/build was run.

Closes task: 42f5b6c0-b180-4ad3-a2c4-d68b62c6677d

🤖 Generated with [Claude Code](https://claude.com/claude-code)