### PR TITLE
release: v4.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,14 @@
 
 All notable changes to Trailhead will be documented in this file.
 
-## [Unreleased]
+## [4.6.1] - 2026-07-21
 
 ### Fixed
 
 - **Pull-request release gates target the PR head SHA** ([#327](https://github.com/KomatikAI/trailhead/issues/327)) — normal `pull_request` workflows now fetch native and external CI results from `pull_request.head.sha` instead of GitHub's synthetic merge commit, preventing `missing_required: skip` from incorrectly marking a PR release-ready when a required check failed. Push and merge-queue events continue to use the event SHA.
 - **Windows action builds tolerate an already-current SWC binding** — the bundle copy step now skips an identical native binary instead of attempting to overwrite a file that may still be locked by the compiler.
 - **GitHub App and MCP shared submission sources are synchronized** — restores the generated `close_on_ship_link` detector copies omitted from the v4.6.0 feature merge, including the MCP runtime output.
+- **Cross-platform release version sync** — the root `npm version` lifecycle now updates the CLI package through a Node helper instead of relying on POSIX shell variable expansion under Windows `cmd.exe`.
 
 ## [4.6.0] - 2026-07-18
 

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@komatikai/trailhead",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@komatikai/trailhead",
-      "version": "4.6.0",
+      "version": "4.6.1",
       "license": "MIT",
       "dependencies": {
         "@swc/core": "^1.15.40"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@komatikai/trailhead",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "description": "Trailhead CLI — setup wizard and utilities for the Trailhead deployment gate",
   "bin": {
     "trailhead": "dist/index.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trailhead",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "trailhead",
-      "version": "4.6.0",
+      "version": "4.6.1",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trailhead",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "private": true,
   "description": "Release readiness gate for GitHub PRs — waits for CI, scores code risk, checks production health, and blocks merges that are not release-ready.",
   "license": "MIT",
@@ -16,7 +16,7 @@
   "scripts": {
     "build": "ncc build src/main.ts -o dist --source-map --license licenses.txt && node scripts/copy-swc-bindings.mjs",
     "build:cli": "node scripts/build-cli-bundle.mjs",
-    "version": "npm --prefix cli version \"$npm_package_version\" --no-git-tag-version --allow-same-version && git add cli/package.json cli/package-lock.json",
+    "version": "node scripts/sync-cli-version.mjs",
     "typecheck": "tsc --noEmit",
     "lint": "eslint . && tsc --noEmit",
     "format": "prettier --write .",

--- a/scripts/sync-cli-version.mjs
+++ b/scripts/sync-cli-version.mjs
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+
+const version = process.env.npm_package_version;
+if (!version) {
+  console.error("sync-cli-version: npm_package_version is not set");
+  process.exit(1);
+}
+
+const npmCli = process.env.npm_execpath;
+if (!npmCli) {
+  console.error("sync-cli-version: npm_execpath is not set");
+  process.exit(1);
+}
+
+execFileSync(
+  process.execPath,
+  [
+    npmCli,
+    "--prefix",
+    "cli",
+    "version",
+    version,
+    "--no-git-tag-version",
+    "--allow-same-version",
+  ],
+  { stdio: "inherit" },
+);
+execFileSync("git", ["add", "cli/package.json", "cli/package-lock.json"], {
+  stdio: "inherit",
+});


### PR DESCRIPTION
## Summary
- release the PR-head SHA correctness fix from #328 as v4.6.1
- synchronize root and CLI package versions
- make the root `npm version` lifecycle cross-platform after the Windows release attempt exposed literal `$npm_package_version` handling

## Validation
- cross-platform version hook exercised successfully via `npm version 4.6.1 --no-git-tag-version --allow-same-version`
- `npm run format:check`
- `npm run lint`
- 852 root tests passed
- CLI bundle and offline doctor passed

Release notes are in `CHANGELOG.md`.