### PR TITLE
fix(security): clear legacy CodeQL high alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Trailhead will be documented in this file.
 
+## [Unreleased]
+
+### Security
+
+- **Legacy CodeQL high-severity backlog cleared** — replaces potentially super-linear diagnostic and package-diff regexes with bounded or string-based parsing, removes clear-text dashboard API-key persistence, and avoids incomplete dynamic-regex escaping in the v4.3 rollout helper.
+
 ## [4.6.1] - 2026-07-21
 
 ### Fixed

--- a/cloud/public/dashboard.html
+++ b/cloud/public/dashboard.html
@@ -949,7 +949,6 @@
         }
 
         localStorage.setItem("th_cloud_base", apiBase());
-        localStorage.setItem("th_cloud_key", key);
 
         try {
           const orgs = await apiFetch("/v1/orgs");
@@ -1044,10 +1043,7 @@
       });
 
       const savedBase = localStorage.getItem("th_cloud_base");
-      const savedKey = localStorage.getItem("th_cloud_key");
       document.getElementById("apiBase").value = savedBase || DEFAULT_BASE;
-      if (savedKey) document.getElementById("apiKey").value = savedKey;
-      if (savedKey) loadData();
     </script>
   </body>
 </html>

--- a/dist/index.js
+++ b/dist/index.js
@@ -42850,6 +42850,21 @@ function detectDependencyChanges(files) {
             return true;
         let activeSection = null;
         let sectionDepth = 0;
+        const isStringProperty = (line) => {
+            let candidate = line.trim();
+            if (candidate.endsWith(","))
+                candidate = candidate.slice(0, -1).trimEnd();
+            if (!candidate.startsWith('"'))
+                return false;
+            const keyEnd = candidate.indexOf('"', 1);
+            if (keyEnd < 2)
+                return false;
+            const afterKey = candidate.slice(keyEnd + 1).trimStart();
+            if (!afterKey.startsWith(":"))
+                return false;
+            const value = afterKey.slice(1).trim();
+            return value.length >= 2 && value.startsWith('"') && value.endsWith('"');
+        };
         for (const rawLine of patch.split("\n")) {
             if (rawLine.startsWith("@@"))
                 continue;
@@ -42873,7 +42888,7 @@ function detectDependencyChanges(files) {
             const openCount = (line.match(/\{/g) ?? []).length;
             const closeCount = (line.match(/\}/g) ?? []).length;
             sectionDepth += openCount - closeCount;
-            if (prefix !== " " && /^\s*"[^"\r\n]+"\s*:\s*"[^"\r\n]*"\s*,?\s*$/.test(line)) {
+            if (prefix !== " " && isStringProperty(line)) {
                 return true;
             }
             if (sectionDepth <= 0) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -42837,7 +42837,11 @@ function computeRiskScore(files, config) {
 // Dependency change detection
 // ---------------------------------------------------------------------------
 function detectDependencyChanges(files) {
-    const depFiles = files.filter((f) => DEPENDENCY_FILES.some((p) => p.test(f.filename.replace(/.*\//, ""))));
+    const dependencyBasename = (filename) => {
+        const separator = Math.max(filename.lastIndexOf("/"), filename.lastIndexOf("\\"));
+        return separator >= 0 ? filename.slice(separator + 1) : filename;
+    };
+    const depFiles = files.filter((f) => DEPENDENCY_FILES.some((p) => p.test(dependencyBasename(f.filename))));
     if (depFiles.length === 0)
         return null;
     const isLockfile = (filename) => /\.(lock|sum)$|lock\.(json|yaml)$/.test(filename);
@@ -42869,7 +42873,7 @@ function detectDependencyChanges(files) {
             const openCount = (line.match(/\{/g) ?? []).length;
             const closeCount = (line.match(/\}/g) ?? []).length;
             sectionDepth += openCount - closeCount;
-            if (prefix !== " " && /^\s*"[^"]+"\s*:\s*".*"\s*,?\s*$/.test(line)) {
+            if (prefix !== " " && /^\s*"[^"\r\n]+"\s*:\s*"[^"\r\n]*"\s*,?\s*$/.test(line)) {
                 return true;
             }
             if (sectionDepth <= 0) {
@@ -42880,7 +42884,7 @@ function detectDependencyChanges(files) {
         return false;
     };
     const relevantDepFiles = depFiles.filter((f) => {
-        const base = f.filename.replace(/.*\//, "");
+        const base = dependencyBasename(f.filename);
         if (base === "package.json") {
             return packageJsonTouchesDependencies(f.patch);
         }
@@ -54816,16 +54820,18 @@ async function attemptRepair(testFile, errorOutput) {
 }
 
 ;// CONCATENATED MODULE: ./src/healers/jest.ts
-const SNAPSHOT_PATTERN = /Snapshot .* mismatched|›.*Snapshot/i;
 const IMPORT_PATTERN = /Cannot find module ['"]([^'"]+)['"]/i;
-const MOCK_DRIFT_PATTERN = /TypeError:.*is not a function/i;
 function detectFailureType(errorOutput) {
-    if (SNAPSHOT_PATTERN.test(errorOutput))
+    const normalized = errorOutput.toLowerCase();
+    if ((normalized.includes("snapshot") && normalized.includes("mismatched")) ||
+        (errorOutput.includes("›") && normalized.includes("snapshot"))) {
         return "snapshot-mismatch";
+    }
     if (IMPORT_PATTERN.test(errorOutput))
         return "import-resolution";
-    if (MOCK_DRIFT_PATTERN.test(errorOutput))
+    if (normalized.includes("typeerror:") && normalized.includes("is not a function")) {
         return "mock-drift";
+    }
     return "unknown";
 }
 function repairSnapshot(testFile) {
@@ -54910,20 +54916,28 @@ const jestHealer = {
 };
 
 ;// CONCATENATED MODULE: ./src/healers/playwright.ts
-const TIMEOUT_PATTERN = /Timeout (\d+)ms exceeded|Test timeout of (\d+)ms exceeded/i;
-const NAVIGATION_PATTERN = /page\.goto.*net::|ERR_CONNECTION_REFUSED|Navigation failed/i;
-const SELECTOR_PATTERN = /locator\..*resolved to (\d+) element|waiting for (locator|selector)|element not found/i;
 function playwright_detectFailureType(errorOutput) {
-    if (TIMEOUT_PATTERN.test(errorOutput))
+    const normalized = errorOutput.toLowerCase();
+    if (normalized.includes("timeout") && normalized.includes("ms exceeded")) {
         return "timeout";
-    if (NAVIGATION_PATTERN.test(errorOutput))
+    }
+    if ((normalized.includes("page.goto") && normalized.includes("net::")) ||
+        normalized.includes("err_connection_refused") ||
+        normalized.includes("navigation failed")) {
         return "navigation-failure";
-    if (SELECTOR_PATTERN.test(errorOutput))
+    }
+    if ((normalized.includes("locator.") &&
+        normalized.includes("resolved to") &&
+        normalized.includes("element")) ||
+        normalized.includes("waiting for locator") ||
+        normalized.includes("waiting for selector") ||
+        normalized.includes("element not found")) {
         return "selector-drift";
+    }
     return "unknown";
 }
 function repairSelector(testFile, errorOutput) {
-    const selectorMatch = errorOutput.match(/(?:locator|getBy\w+)\(['"]([^'"]+)['"]\)/);
+    const selectorMatch = errorOutput.match(/(?:locator|getBy[A-Za-z]{1,32})\(['"]([^'"\r\n]{1,500})['"]\)/);
     const selector = selectorMatch?.[1] ?? "(unknown selector)";
     return {
         success: true,
@@ -55012,16 +55026,23 @@ const playwrightHealer = {
 };
 
 ;// CONCATENATED MODULE: ./src/healers/cypress.ts
-const cypress_SELECTOR_PATTERN = /Timed out retrying.*cy\.(get|find|contains)|Expected to find element|querying for.*element/i;
-const INTERCEPT_PATTERN = /cy\.intercept|cy\.wait.*alias|No request ever occurred/i;
-const cypress_TIMEOUT_PATTERN = /Timed out retrying after (\d+)ms|CypressError.*timeout/i;
 function cypress_detectFailureType(errorOutput) {
-    if (INTERCEPT_PATTERN.test(errorOutput))
+    const normalized = errorOutput.toLowerCase();
+    if (normalized.includes("cy.intercept") ||
+        (normalized.includes("cy.wait") && normalized.includes("alias")) ||
+        normalized.includes("no request ever occurred")) {
         return "intercept-drift";
-    if (cypress_SELECTOR_PATTERN.test(errorOutput))
+    }
+    if ((normalized.includes("timed out retrying") &&
+        ["cy.get", "cy.find", "cy.contains"].some((token) => normalized.includes(token))) ||
+        normalized.includes("expected to find element") ||
+        (normalized.includes("querying for") && normalized.includes("element"))) {
         return "selector-drift";
-    if (cypress_TIMEOUT_PATTERN.test(errorOutput))
+    }
+    if (normalized.includes("timed out retrying after ") ||
+        (normalized.includes("cypresserror") && normalized.includes("timeout"))) {
         return "timeout";
+    }
     return "unknown";
 }
 function cypress_repairSelector(testFile, errorOutput) {
@@ -55044,7 +55065,7 @@ function cypress_repairSelector(testFile, errorOutput) {
     };
 }
 function repairIntercept(testFile, errorOutput) {
-    const aliasMatch = errorOutput.match(/cy\.wait\(['"]@([^'"]+)['"]\)|alias.*['"]@([^'"]+)['"]/);
+    const aliasMatch = errorOutput.match(/cy\.wait\(['"]@([^'"\r\n]{1,200})['"]\)|alias[^'"\r\n]{0,200}['"]@([^'"\r\n]{1,200})['"]/);
     const alias = aliasMatch?.[1] ?? aliasMatch?.[2] ?? "(unknown)";
     return {
         success: true,

--- a/mcp/dist/risk-engine.js
+++ b/mcp/dist/risk-engine.js
@@ -302,7 +302,11 @@ export function computeRiskScore(files, config) {
 // Dependency change detection
 // ---------------------------------------------------------------------------
 export function detectDependencyChanges(files) {
-    const depFiles = files.filter((f) => DEPENDENCY_FILES.some((p) => p.test(f.filename.replace(/.*\//, ""))));
+    const dependencyBasename = (filename) => {
+        const separator = Math.max(filename.lastIndexOf("/"), filename.lastIndexOf("\\"));
+        return separator >= 0 ? filename.slice(separator + 1) : filename;
+    };
+    const depFiles = files.filter((f) => DEPENDENCY_FILES.some((p) => p.test(dependencyBasename(f.filename))));
     if (depFiles.length === 0)
         return null;
     const isLockfile = (filename) => /\.(lock|sum)$|lock\.(json|yaml)$/.test(filename);
@@ -334,7 +338,7 @@ export function detectDependencyChanges(files) {
             const openCount = (line.match(/\{/g) ?? []).length;
             const closeCount = (line.match(/\}/g) ?? []).length;
             sectionDepth += openCount - closeCount;
-            if (prefix !== " " && /^\s*"[^"]+"\s*:\s*".*"\s*,?\s*$/.test(line)) {
+            if (prefix !== " " && /^\s*"[^"\r\n]+"\s*:\s*"[^"\r\n]*"\s*,?\s*$/.test(line)) {
                 return true;
             }
             if (sectionDepth <= 0) {
@@ -345,7 +349,7 @@ export function detectDependencyChanges(files) {
         return false;
     };
     const relevantDepFiles = depFiles.filter((f) => {
-        const base = f.filename.replace(/.*\//, "");
+        const base = dependencyBasename(f.filename);
         if (base === "package.json") {
             return packageJsonTouchesDependencies(f.patch);
         }

--- a/mcp/dist/risk-engine.js
+++ b/mcp/dist/risk-engine.js
@@ -315,6 +315,21 @@ export function detectDependencyChanges(files) {
             return true;
         let activeSection = null;
         let sectionDepth = 0;
+        const isStringProperty = (line) => {
+            let candidate = line.trim();
+            if (candidate.endsWith(","))
+                candidate = candidate.slice(0, -1).trimEnd();
+            if (!candidate.startsWith('"'))
+                return false;
+            const keyEnd = candidate.indexOf('"', 1);
+            if (keyEnd < 2)
+                return false;
+            const afterKey = candidate.slice(keyEnd + 1).trimStart();
+            if (!afterKey.startsWith(":"))
+                return false;
+            const value = afterKey.slice(1).trim();
+            return value.length >= 2 && value.startsWith('"') && value.endsWith('"');
+        };
         for (const rawLine of patch.split("\n")) {
             if (rawLine.startsWith("@@"))
                 continue;
@@ -338,7 +353,7 @@ export function detectDependencyChanges(files) {
             const openCount = (line.match(/\{/g) ?? []).length;
             const closeCount = (line.match(/\}/g) ?? []).length;
             sectionDepth += openCount - closeCount;
-            if (prefix !== " " && /^\s*"[^"\r\n]+"\s*:\s*"[^"\r\n]*"\s*,?\s*$/.test(line)) {
+            if (prefix !== " " && isStringProperty(line)) {
                 return true;
             }
             if (sectionDepth <= 0) {

--- a/scripts/batch-v4.3-rollout-prs.mjs
+++ b/scripts/batch-v4.3-rollout-prs.mjs
@@ -120,15 +120,18 @@ function patchWorkflow(content) {
     return `${prefix}${ACTION_REPO}${TARGET_REF}`;
   });
 
-  const storeRegex = new RegExp(LEGACY_STORE.replace(/\//g, "\\/"), "g");
-  const nextStore = nextAction.replace(storeRegex, () => {
+  const nextStore = nextAction.replaceAll(LEGACY_STORE, () => {
     storeChanged = true;
     return CANONICAL_STORE;
   });
 
-  const alreadyPinned = new RegExp(
-    `${ACTION_REPO.replace("/", "\\/")}${TARGET_REF.replace(".", "\\.")}(?:\\s|$)`,
-  ).test(content);
+  const targetPin = `${ACTION_REPO}${TARGET_REF}`;
+  const alreadyPinned = content.split(/\r?\n/).some((line) => {
+    const pinIndex = line.indexOf(targetPin);
+    if (pinIndex < 0) return false;
+    const following = line[pinIndex + targetPin.length];
+    return following === undefined || following === "#" || /\s/.test(following);
+  });
   const alreadyStore = !content.includes(LEGACY_STORE);
 
   return {

--- a/site/public/dashboard-embed.html
+++ b/site/public/dashboard-embed.html
@@ -948,7 +948,6 @@
         }
 
         sessionStorage.setItem("th_cloud_base", apiBase());
-        sessionStorage.setItem("th_cloud_key", key);
 
         try {
           const orgs = await apiFetch("/v1/orgs");
@@ -1043,10 +1042,7 @@
       });
 
       const savedBase = sessionStorage.getItem("th_cloud_base");
-      const savedKey = sessionStorage.getItem("th_cloud_key");
       document.getElementById("apiBase").value = savedBase || DEFAULT_BASE;
-      if (savedKey) document.getElementById("apiKey").value = savedKey;
-      if (savedKey) loadData();
     </script>
   </body>
 </html>

--- a/src/__tests__/dashboard-security.test.ts
+++ b/src/__tests__/dashboard-security.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from "node:fs";
+
+describe("dashboard credential handling", () => {
+  const dashboards = [
+    readFileSync(new URL("../../cloud/public/dashboard.html", import.meta.url), "utf8"),
+    readFileSync(
+      new URL("../../site/public/dashboard-embed.html", import.meta.url),
+      "utf8",
+    ),
+  ];
+
+  it("never persists the API key in browser storage", () => {
+    for (const dashboard of dashboards) {
+      expect(dashboard).not.toContain("th_cloud_key");
+      expect(dashboard).not.toMatch(/(?:local|session)Storage\.setItem\([^)]*apiKey/i);
+    }
+  });
+
+  it("continues to persist the non-sensitive API base URL", () => {
+    expect(dashboards[0]).toContain('localStorage.setItem("th_cloud_base", apiBase())');
+    expect(dashboards[1]).toContain('sessionStorage.setItem("th_cloud_base", apiBase())');
+  });
+});

--- a/src/__tests__/healers.test.ts
+++ b/src/__tests__/healers.test.ts
@@ -56,6 +56,22 @@ describe("healer registry", () => {
   });
 });
 
+describe("healer diagnostic parsing safety", () => {
+  it("handles adversarially long repeated diagnostics without regex backtracking", async () => {
+    const repeated = " repeated-token".repeat(20_000);
+
+    const [cypress, jest, playwright] = await Promise.all([
+      cypressHealer.repair("cypress/e2e/home.cy.ts", `cy.wait${repeated}`),
+      jestHealer.repair("src/app.test.ts", `Snapshot${repeated}`),
+      playwrightHealer.repair("tests/login.spec.ts", `locator.${repeated}`),
+    ]);
+
+    expect(cypress.failureType).toBe("unknown");
+    expect(jest.failureType).toBe("unknown");
+    expect(playwright.failureType).toBe("unknown");
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Jest healer
 // ---------------------------------------------------------------------------

--- a/src/__tests__/risk-engine.test.ts
+++ b/src/__tests__/risk-engine.test.ts
@@ -289,6 +289,21 @@ describe("risk-engine", () => {
       const result = detectDependencyChanges(files);
       expect(result).toBeNull();
     });
+
+    it("parses long dependency lines and nested paths without unsafe backtracking", () => {
+      const files = [
+        {
+          filename: "packages/web/package.json",
+          changes: 2,
+          patch:
+            '@@ -1,3 +1,3 @@\n  "dependencies": {\n-    "example": "1.0.0"\n+    "example": "' +
+            " ".repeat(100_000) +
+            '"\n   }\n',
+        },
+      ];
+
+      expect(detectDependencyChanges(files)?.type).toBe("dependency_changes");
+    });
   });
 
   describe("decideGate", () => {

--- a/src/healers/cypress.ts
+++ b/src/healers/cypress.ts
@@ -1,14 +1,28 @@
 import type { TestHealer } from "./index.js";
 
-const SELECTOR_PATTERN =
-  /Timed out retrying.*cy\.(get|find|contains)|Expected to find element|querying for.*element/i;
-const INTERCEPT_PATTERN = /cy\.intercept|cy\.wait.*alias|No request ever occurred/i;
-const TIMEOUT_PATTERN = /Timed out retrying after (\d+)ms|CypressError.*timeout/i;
-
 function detectFailureType(errorOutput: string): string {
-  if (INTERCEPT_PATTERN.test(errorOutput)) return "intercept-drift";
-  if (SELECTOR_PATTERN.test(errorOutput)) return "selector-drift";
-  if (TIMEOUT_PATTERN.test(errorOutput)) return "timeout";
+  const normalized = errorOutput.toLowerCase();
+  if (
+    normalized.includes("cy.intercept") ||
+    (normalized.includes("cy.wait") && normalized.includes("alias")) ||
+    normalized.includes("no request ever occurred")
+  ) {
+    return "intercept-drift";
+  }
+  if (
+    (normalized.includes("timed out retrying") &&
+      ["cy.get", "cy.find", "cy.contains"].some((token) => normalized.includes(token))) ||
+    normalized.includes("expected to find element") ||
+    (normalized.includes("querying for") && normalized.includes("element"))
+  ) {
+    return "selector-drift";
+  }
+  if (
+    normalized.includes("timed out retrying after ") ||
+    (normalized.includes("cypresserror") && normalized.includes("timeout"))
+  ) {
+    return "timeout";
+  }
   return "unknown";
 }
 
@@ -41,7 +55,7 @@ function repairIntercept(
   errorOutput: string,
 ): { diff: string; success: boolean } {
   const aliasMatch = errorOutput.match(
-    /cy\.wait\(['"]@([^'"]+)['"]\)|alias.*['"]@([^'"]+)['"]/,
+    /cy\.wait\(['"]@([^'"\r\n]{1,200})['"]\)|alias[^'"\r\n]{0,200}['"]@([^'"\r\n]{1,200})['"]/,
   );
   const alias = aliasMatch?.[1] ?? aliasMatch?.[2] ?? "(unknown)";
 

--- a/src/healers/jest.ts
+++ b/src/healers/jest.ts
@@ -1,13 +1,19 @@
 import type { TestHealer } from "./index.js";
 
-const SNAPSHOT_PATTERN = /Snapshot .* mismatched|›.*Snapshot/i;
 const IMPORT_PATTERN = /Cannot find module ['"]([^'"]+)['"]/i;
-const MOCK_DRIFT_PATTERN = /TypeError:.*is not a function/i;
 
 function detectFailureType(errorOutput: string): string {
-  if (SNAPSHOT_PATTERN.test(errorOutput)) return "snapshot-mismatch";
+  const normalized = errorOutput.toLowerCase();
+  if (
+    (normalized.includes("snapshot") && normalized.includes("mismatched")) ||
+    (errorOutput.includes("›") && normalized.includes("snapshot"))
+  ) {
+    return "snapshot-mismatch";
+  }
   if (IMPORT_PATTERN.test(errorOutput)) return "import-resolution";
-  if (MOCK_DRIFT_PATTERN.test(errorOutput)) return "mock-drift";
+  if (normalized.includes("typeerror:") && normalized.includes("is not a function")) {
+    return "mock-drift";
+  }
   return "unknown";
 }
 

--- a/src/healers/playwright.ts
+++ b/src/healers/playwright.ts
@@ -1,14 +1,27 @@
 import type { TestHealer } from "./index.js";
 
-const TIMEOUT_PATTERN = /Timeout (\d+)ms exceeded|Test timeout of (\d+)ms exceeded/i;
-const NAVIGATION_PATTERN = /page\.goto.*net::|ERR_CONNECTION_REFUSED|Navigation failed/i;
-const SELECTOR_PATTERN =
-  /locator\..*resolved to (\d+) element|waiting for (locator|selector)|element not found/i;
-
 function detectFailureType(errorOutput: string): string {
-  if (TIMEOUT_PATTERN.test(errorOutput)) return "timeout";
-  if (NAVIGATION_PATTERN.test(errorOutput)) return "navigation-failure";
-  if (SELECTOR_PATTERN.test(errorOutput)) return "selector-drift";
+  const normalized = errorOutput.toLowerCase();
+  if (normalized.includes("timeout") && normalized.includes("ms exceeded")) {
+    return "timeout";
+  }
+  if (
+    (normalized.includes("page.goto") && normalized.includes("net::")) ||
+    normalized.includes("err_connection_refused") ||
+    normalized.includes("navigation failed")
+  ) {
+    return "navigation-failure";
+  }
+  if (
+    (normalized.includes("locator.") &&
+      normalized.includes("resolved to") &&
+      normalized.includes("element")) ||
+    normalized.includes("waiting for locator") ||
+    normalized.includes("waiting for selector") ||
+    normalized.includes("element not found")
+  ) {
+    return "selector-drift";
+  }
   return "unknown";
 }
 
@@ -16,7 +29,9 @@ function repairSelector(
   testFile: string,
   errorOutput: string,
 ): { diff: string; success: boolean } {
-  const selectorMatch = errorOutput.match(/(?:locator|getBy\w+)\(['"]([^'"]+)['"]\)/);
+  const selectorMatch = errorOutput.match(
+    /(?:locator|getBy[A-Za-z]{1,32})\(['"]([^'"\r\n]{1,500})['"]\)/,
+  );
   const selector = selectorMatch?.[1] ?? "(unknown selector)";
 
   return {

--- a/src/risk-engine.ts
+++ b/src/risk-engine.ts
@@ -471,8 +471,12 @@ export function computeRiskScore(
 // ---------------------------------------------------------------------------
 
 export function detectDependencyChanges(files: FileInfo[]): RiskFactorResult | null {
+  const dependencyBasename = (filename: string): string => {
+    const separator = Math.max(filename.lastIndexOf("/"), filename.lastIndexOf("\\"));
+    return separator >= 0 ? filename.slice(separator + 1) : filename;
+  };
   const depFiles = files.filter((f) =>
-    DEPENDENCY_FILES.some((p) => p.test(f.filename.replace(/.*\//, ""))),
+    DEPENDENCY_FILES.some((p) => p.test(dependencyBasename(f.filename))),
   );
   if (depFiles.length === 0) return null;
 
@@ -507,7 +511,7 @@ export function detectDependencyChanges(files: FileInfo[]): RiskFactorResult | n
       const closeCount = (line.match(/\}/g) ?? []).length;
       sectionDepth += openCount - closeCount;
 
-      if (prefix !== " " && /^\s*"[^"]+"\s*:\s*".*"\s*,?\s*$/.test(line)) {
+      if (prefix !== " " && /^\s*"[^"\r\n]+"\s*:\s*"[^"\r\n]*"\s*,?\s*$/.test(line)) {
         return true;
       }
 
@@ -521,7 +525,7 @@ export function detectDependencyChanges(files: FileInfo[]): RiskFactorResult | n
   };
 
   const relevantDepFiles = depFiles.filter((f) => {
-    const base = f.filename.replace(/.*\//, "");
+    const base = dependencyBasename(f.filename);
     if (base === "package.json") {
       return packageJsonTouchesDependencies(f.patch);
     }

--- a/src/risk-engine.ts
+++ b/src/risk-engine.ts
@@ -487,6 +487,19 @@ export function detectDependencyChanges(files: FileInfo[]): RiskFactorResult | n
     if (!patch) return true;
     let activeSection: string | null = null;
     let sectionDepth = 0;
+    const isStringProperty = (line: string): boolean => {
+      let candidate = line.trim();
+      if (candidate.endsWith(",")) candidate = candidate.slice(0, -1).trimEnd();
+      if (!candidate.startsWith('"')) return false;
+
+      const keyEnd = candidate.indexOf('"', 1);
+      if (keyEnd < 2) return false;
+      const afterKey = candidate.slice(keyEnd + 1).trimStart();
+      if (!afterKey.startsWith(":")) return false;
+
+      const value = afterKey.slice(1).trim();
+      return value.length >= 2 && value.startsWith('"') && value.endsWith('"');
+    };
 
     for (const rawLine of patch.split("\n")) {
       if (rawLine.startsWith("@@")) continue;
@@ -511,7 +524,7 @@ export function detectDependencyChanges(files: FileInfo[]): RiskFactorResult | n
       const closeCount = (line.match(/\}/g) ?? []).length;
       sectionDepth += openCount - closeCount;
 
-      if (prefix !== " " && /^\s*"[^"\r\n]+"\s*:\s*"[^"\r\n]*"\s*,?\s*$/.test(line)) {
+      if (prefix !== " " && isStringProperty(line)) {
         return true;
       }
 


### PR DESCRIPTION
## What changed

- replace super-linear healer diagnostic regexes with bounded/string-based parsing
- harden package-diff parsing and remove dynamic regex construction from the legacy rollout helper
- stop persisting Trailhead API keys in both dashboard surfaces
- regenerate the Action and MCP runtime artifacts
- add adversarial long-input and dashboard credential-storage regression tests

## Why

Closes the 13 high-severity CodeQL alerts open on main: alerts #1-#12 and #14. These covered polynomial ReDoS, clear-text credential storage, and incomplete sanitization.

## Validation

- 857 root tests with coverage
- 49 cloud tests
- 42 site tests
- root lint and TypeScript checks
- App, MCP, cloud, and site TypeScript checks
- Action and MCP builds
- all formerly flagged patterns absent from source and generated artifacts

The PR is draft until CodeQL confirms that the 13 alerts close on this head.