### PR TITLE
fix: eliminate PR gate false positives and file truncation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Trailhead will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **PR evaluation no longer truncates at 100 files** ([#344](https://github.com/KomatikAI/trailhead/issues/344)) — the Action, GitHub App, MCP policy tools, and DORA file scans now paginate GitHub's PR-files endpoint. Large PR risk, scope, and submission checks receive the complete available file set.
+- **Submission and CI-integrity false positives** ([#344](https://github.com/KomatikAI/trailhead/issues/344)) — CI bypass checks inspect added lines only; API-route auth uses full current route bodies plus configurable auth helpers and verified 410 tombstones; inert test/CI fixture labels and Stripe placeholders no longer masquerade as production mocks or credentials; PR-scope remediation reads the detector's actual camelCase counts.
+
 ### Security
 
 - **Legacy CodeQL high-severity backlog cleared** — replaces potentially super-linear diagnostic and package-diff regexes with bounded or string-based parsing, removes clear-text dashboard API-key persistence, and avoids incomplete dynamic-regex escaping in the v4.3 rollout helper.

--- a/app/src/ci-integrity.ts
+++ b/app/src/ci-integrity.ts
@@ -1,0 +1,76 @@
+export interface CiIntegrityFile {
+  filename: string;
+  additions?: number;
+  deletions?: number;
+  patch?: string;
+}
+
+export interface CiIntegrityResult {
+  score: number;
+  blockingPatterns: string[];
+  warningSignals: string[];
+}
+
+function addedPatchLines(patch: string | undefined): string[] {
+  if (!patch) return [];
+  return patch
+    .split("\n")
+    .filter((line) => line.startsWith("+") && !line.startsWith("+++"))
+    .map((line) => line.slice(1));
+}
+
+/** Detect newly introduced CI bypasses, never unchanged or deleted context. */
+export function detectCiIntegrity(files: CiIntegrityFile[]): CiIntegrityResult {
+  const blockingPatterns: string[] = [];
+  const warningSignals: string[] = [];
+  let score = 0;
+
+  for (const file of files.filter((entry) =>
+    entry.filename.startsWith(".github/workflows/"),
+  )) {
+    const added = addedPatchLines(file.patch).join("\n");
+    if (/\|\|\s*true/.test(added)) {
+      blockingPatterns.push(`${file.filename}: workflow bypass pattern "|| true"`);
+      score += 45;
+    }
+    if (/^\s*continue-on-error:\s*true\b/m.test(added)) {
+      blockingPatterns.push(`${file.filename}: introduced "continue-on-error: true"`);
+      score += 45;
+    }
+    if (/^\s*if:\s*\$\{\{\s*always\(\)\s*\}\}/m.test(added)) {
+      warningSignals.push(`${file.filename}: always() condition added to workflow gate`);
+      score += 20;
+    }
+  }
+
+  for (const file of files.filter((entry) =>
+    /\.(test|spec)\.(ts|tsx|js|jsx)$|__tests__\/|\.cy\.(ts|js)$/.test(entry.filename),
+  )) {
+    const additions = file.additions ?? 0;
+    const deletions = file.deletions ?? 0;
+    if (deletions > additions * 2 && deletions >= 10) {
+      warningSignals.push(
+        `${file.filename}: heavy test deletion (${deletions} deleted / ${additions} added)`,
+      );
+      score += 25;
+    }
+  }
+
+  for (const file of files) {
+    const patch = file.patch ?? "";
+    if (!patch) continue;
+    if (
+      /^-\s*(branches|functions|lines|statements)\s*:\s*\d+/m.test(patch) &&
+      /^\+\s*(branches|functions|lines|statements)\s*:\s*\d+/m.test(patch)
+    ) {
+      warningSignals.push(`${file.filename}: coverage threshold definition changed`);
+      score += 20;
+    }
+  }
+
+  return {
+    score: Math.min(100, score),
+    blockingPatterns,
+    warningSignals,
+  };
+}

--- a/app/src/github-pagination.ts
+++ b/app/src/github-pagination.ts
@@ -1,0 +1,58 @@
+export interface PaginationResult<T> {
+  items: T[];
+  pages: number;
+  complete: boolean;
+}
+
+export interface PaginationOptions {
+  /** GitHub REST APIs cap per_page at 100. */
+  perPage?: number;
+  /** Safety ceiling for endpoints with a documented result cap. */
+  maxPages?: number;
+}
+
+/**
+ * Collect a GitHub REST endpoint page-by-page. A full final page is treated as
+ * incomplete when maxPages is reached so callers can surface truncated input.
+ */
+export async function collectGitHubPages<T>(
+  fetchPage: (page: number, perPage: number) => Promise<T[]>,
+  options: PaginationOptions = {},
+): Promise<PaginationResult<T>> {
+  const perPage = Math.min(100, Math.max(1, options.perPage ?? 100));
+  const maxPages = Math.max(1, options.maxPages ?? 30);
+  const items: T[] = [];
+
+  for (let page = 1; page <= maxPages; page += 1) {
+    const pageItems = await fetchPage(page, perPage);
+    items.push(...pageItems);
+
+    if (pageItems.length < perPage) {
+      return { items, pages: page, complete: true };
+    }
+  }
+
+  return { items, pages: maxPages, complete: false };
+}
+
+/** Fetch every available JSON-array page from a GitHub REST URL. */
+export async function fetchGitHubJsonPages<T>(
+  url: string,
+  init: RequestInit,
+  options: PaginationOptions = {},
+): Promise<PaginationResult<T>> {
+  return collectGitHubPages<T>(async (page, perPage) => {
+    const pageUrl = new URL(url);
+    pageUrl.searchParams.set("per_page", String(perPage));
+    pageUrl.searchParams.set("page", String(page));
+    const response = await fetch(pageUrl, init);
+    if (!response.ok) {
+      throw new Error(`GitHub request failed: HTTP ${response.status}`);
+    }
+    const data = (await response.json()) as unknown;
+    if (!Array.isArray(data)) {
+      throw new Error("GitHub paginated response was not an array");
+    }
+    return data as T[];
+  }, options);
+}

--- a/app/src/handler.ts
+++ b/app/src/handler.ts
@@ -11,6 +11,7 @@ import { matchContext, resolveGateMode } from "./context-matcher.js";
 import { evaluateDeploymentGate } from "./deployment-gate.js";
 import { isInFreezeWindow, type FileInfo } from "./risk-engine.js";
 import type { ContextCiConfig, RepoConfig } from "./types.js";
+import { fetchGitHubJsonPages } from "./github-pagination.js";
 
 // ---------------------------------------------------------------------------
 // Configuration from environment
@@ -130,12 +131,23 @@ async function fetchChangedFilesFromApi(
   repo: string,
   prNumber: number,
 ): Promise<FileInfo[]> {
-  const res = await fetch(
-    `https://api.github.com/repos/${owner}/${repo}/pulls/${prNumber}/files?per_page=300`,
+  const result = await fetchGitHubJsonPages<FileInfo>(
+    `https://api.github.com/repos/${owner}/${repo}/pulls/${prNumber}/files`,
     { headers: ghHeaders(token) },
+    { perPage: 100, maxPages: 30 },
   );
-  if (!res.ok) return [];
-  return (await res.json()) as FileInfo[];
+  if (!result.complete) {
+    process.stdout.write(
+      JSON.stringify({
+        level: "warn",
+        msg: "PR file enumeration reached GitHub's 3,000-file API ceiling",
+        service: "trailhead-app",
+        ts: new Date().toISOString(),
+        fileCount: result.items.length,
+      }) + "\n",
+    );
+  }
+  return result.items;
 }
 
 async function fetchChangedFilesFromCommits(
@@ -144,12 +156,11 @@ async function fetchChangedFilesFromCommits(
   repo: string,
   prNumber: number,
 ): Promise<FileInfo[]> {
-  const commitsRes = await fetch(
-    `https://api.github.com/repos/${owner}/${repo}/pulls/${prNumber}/commits?per_page=250`,
+  const { items: commits } = await fetchGitHubJsonPages<{ sha: string }>(
+    `https://api.github.com/repos/${owner}/${repo}/pulls/${prNumber}/commits`,
     { headers: ghHeaders(token) },
+    { perPage: 100, maxPages: 3 },
   );
-  if (!commitsRes.ok) return [];
-  const commits = (await commitsRes.json()) as Array<{ sha: string }>;
 
   const fileMap = new Map<string, FileInfo>();
   for (const commit of commits) {

--- a/app/src/remediation.ts
+++ b/app/src/remediation.ts
@@ -153,8 +153,14 @@ const factorCues: Record<string, FactorCue> = {
     triggerScore: 50,
     advisoryScore: 20,
     build: (factor) => {
-      const files = (factor.detail?.file_count as number | undefined) ?? 0;
-      const changes = (factor.detail?.line_count as number | undefined) ?? 0;
+      const files =
+        (factor.detail?.fileCount as number | undefined) ??
+        (factor.detail?.file_count as number | undefined) ??
+        0;
+      const changes =
+        (factor.detail?.totalChanges as number | undefined) ??
+        (factor.detail?.line_count as number | undefined) ??
+        0;
       return {
         code: "policy.pr_scope",
         severity: "warn",

--- a/app/src/submission-checks/detectors.ts
+++ b/app/src/submission-checks/detectors.ts
@@ -53,6 +53,35 @@ const SECRET_PATTERNS: Array<{ name: string; pattern: RegExp }> = [
   },
 ];
 
+function isCiConfigurationPath(filename: string): boolean {
+  return /^\.github\/(?:workflows|actions)\//.test(normalizePath(filename));
+}
+
+function isCredentialFixturePath(filename: string): boolean {
+  return isTestPath(filename) || isCiConfigurationPath(filename);
+}
+
+function isObviouslyInertCiFixtureLine(line: string, filename: string): boolean {
+  if (!isCiConfigurationPath(filename)) return false;
+  const assignment = /^\s*[\w.-]+\s*:\s*["']?([^"'#\s]+)["']?(?:\s*#.*)?$/.exec(line);
+  if (!assignment?.[1]) return false;
+  return /^(?:sk_(?:test|live)_)?(?:placeholder|example|dummy|fake|test|x{10,}|0{10,})$/i.test(
+    assignment[1],
+  );
+}
+
+function isObviouslyInertStripeFixture(
+  patternName: string,
+  match: string,
+  filename: string,
+): boolean {
+  if (!isCredentialFixturePath(filename) || !patternName.startsWith("Stripe ")) {
+    return false;
+  }
+  const suffix = match.replace(/^sk_(?:test|live)_/i, "");
+  return /^(?:placeholder|example|dummy|fake|test|x{10,}|0{10,})$/i.test(suffix);
+}
+
 const HARDCODED_ENV_PATTERNS: Array<{ name: string; pattern: RegExp }> = [
   { name: "localhost with port", pattern: /(?:['"`])localhost:\d{2,5}(?:['"`])/g },
   {
@@ -102,6 +131,7 @@ export function detectMockPlaceholder(
 ): SubmissionCheckResult | null {
   const hits = scanAddedContent(ctx.files, (line, filename) => {
     if (isTestPath(filename)) return false;
+    if (isObviouslyInertCiFixtureLine(line, filename)) return false;
     if (/\.(md|txt)$/i.test(filename)) return false;
     return MOCK_PATTERNS.some((re) => {
       re.lastIndex = 0;
@@ -120,10 +150,12 @@ export function detectMockPlaceholder(
 }
 
 export function detectSecrets(ctx: SubmissionCheckContext): SubmissionCheckResult | null {
-  const hits = scanAddedContent(ctx.files, (line) =>
+  const hits = scanAddedContent(ctx.files, (line, filename) =>
     SECRET_PATTERNS.some((entry) => {
       entry.pattern.lastIndex = 0;
-      return entry.pattern.test(line);
+      return [...line.matchAll(entry.pattern)].some(
+        (match) => !isObviouslyInertStripeFixture(entry.name, match[0] ?? "", filename),
+      );
     }),
   );
   if (hits.length === 0) return null;
@@ -501,20 +533,34 @@ function isRouteAllowlisted(path: string, allowlist: string[]): boolean {
   return allowlist.some((entry) => path.includes(entry.replace(/^\//, "")));
 }
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function isRetiredRoute(path: string, content: string, allowlist: string[]): boolean {
+  if (!isRouteAllowlisted(path, allowlist)) return false;
+  return /\bstatus\s*:\s*410\b/.test(content);
+}
+
 export function detectAuthRouteAuth(
   ctx: SubmissionCheckContext,
 ): SubmissionCheckResult | null {
   const routePattern =
     /(?:^|\/)(?:app\/api\/.+\/route|pages\/api\/.+)\.(?:ts|tsx|js|jsx)$/;
-  const authPattern =
-    /\b(getUser|getSession|getServerSession|auth|requireAuth|withAuth)\s*\(/;
+  const helpers = [...new Set(ctx.authRouteHelpers)].filter((helper) =>
+    /^[A-Za-z_$][\w$]*$/.test(helper),
+  );
+  const authPattern = new RegExp(`\\b(?:${helpers.map(escapeRegExp).join("|")})\\s*\\(`);
   const hits: string[] = [];
 
   for (const file of ctx.files) {
     const normalized = normalizePath(file.filename);
     if (!routePattern.test(normalized)) continue;
+    if (file.status === "removed") continue;
     if (isRouteAllowlisted(normalized, ctx.authRouteAllowlist)) continue;
-    if (!authPattern.test(fileContent(file))) hits.push(normalized);
+    const content = fileContent(file);
+    if (isRetiredRoute(normalized, content, ctx.retiredRouteAllowlist)) continue;
+    if (helpers.length === 0 || !authPattern.test(content)) hits.push(normalized);
   }
 
   if (hits.length === 0) return null;

--- a/app/src/submission-checks/helpers.ts
+++ b/app/src/submission-checks/helpers.ts
@@ -79,7 +79,11 @@ export function prPathSet(files: SubmissionFileInfo[]): Set<string> {
 }
 
 export function isTestPath(filename: string): boolean {
-  return /\/__tests__\/|\/test\/|\/fixtures\/|\.test\.|\.spec\./.test(filename);
+  const path = `/${normalizePath(filename).toLowerCase()}`;
+  return (
+    /\/(?:__tests__|__fixtures__|tests?|test-fixtures|fixtures)\//.test(path) ||
+    /\.(?:test|spec)\.[^./]+$/.test(path)
+  );
 }
 
 /** Default archived/stale path segments skipped by context_freshness. */

--- a/app/src/submission-checks/types.ts
+++ b/app/src/submission-checks/types.ts
@@ -30,6 +30,8 @@ export interface SubmissionCheckContext {
   staleTerms: string[];
   namingAllowlist: NamingAllowlistConfig;
   authRouteAllowlist: string[];
+  authRouteHelpers: string[];
+  retiredRouteAllowlist: string[];
   maxFileLines: number;
   declaredPackages: Set<string>;
   /** Extra path segments to skip for context_freshness (merged with defaults). */

--- a/app/src/submission-engine.ts
+++ b/app/src/submission-engine.ts
@@ -27,6 +27,15 @@ const DEFAULT_AUTH_ROUTE_ALLOWLIST = [
   "/api/metrics/",
 ];
 
+const DEFAULT_AUTH_ROUTE_HELPERS = [
+  "getUser",
+  "getSession",
+  "getServerSession",
+  "auth",
+  "requireAuth",
+  "withAuth",
+];
+
 /** Package names declared in a package.json (legacy gate parity). */
 export function declaredPackageNamesFromPackageJson(
   pkg: Record<string, unknown>,
@@ -88,6 +97,11 @@ function buildContext(options: SubmissionEngineOptions): SubmissionCheckContext 
     namingAllowlist: repoConfig?.submission?.naming_allowlist ?? {},
     authRouteAllowlist:
       repoConfig?.submission?.auth_route_allowlist ?? DEFAULT_AUTH_ROUTE_ALLOWLIST,
+    authRouteHelpers: [
+      ...DEFAULT_AUTH_ROUTE_HELPERS,
+      ...(repoConfig?.submission?.auth_route_helpers ?? []),
+    ],
+    retiredRouteAllowlist: repoConfig?.submission?.retired_route_allowlist ?? [],
     maxFileLines: repoConfig?.submission?.max_file_lines ?? 1000,
     declaredPackages: declared,
     pathIgnorePatterns: repoConfig?.submission?.path_ignore ?? [],

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,14 +1,14 @@
 require('./sourcemap-register.js');/******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
-/***/ 8066:
+/***/ 3465:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = require(__nccwpck_require__.ab + "swc.win32-x64-msvc.node")
 
 /***/ }),
 
-/***/ 4844:
+/***/ 4866:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -62,9 +62,9 @@ exports.getProxyUrl = getProxyUrl;
 exports.isHttps = isHttps;
 const http = __importStar(__nccwpck_require__(8611));
 const https = __importStar(__nccwpck_require__(5692));
-const pm = __importStar(__nccwpck_require__(4988));
-const tunnel = __importStar(__nccwpck_require__(770));
-const undici_1 = __nccwpck_require__(6752);
+const pm = __importStar(__nccwpck_require__(3390));
+const tunnel = __importStar(__nccwpck_require__(6628));
+const undici_1 = __nccwpck_require__(4258);
 var HttpCodes;
 (function (HttpCodes) {
     HttpCodes[HttpCodes["OK"] = 200] = "OK";
@@ -752,7 +752,7 @@ const lowercaseKeys = (obj) => Object.keys(obj).reduce((c, k) => ((c[k.toLowerCa
 
 /***/ }),
 
-/***/ 4988:
+/***/ 3390:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -853,7 +853,7 @@ class DecodedURL extends URL {
 
 /***/ }),
 
-/***/ 898:
+/***/ 4680:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 // prettier-ignore
@@ -918,24 +918,24 @@ function requireNative() {
   if (process.platform === 'android') {
     if (process.arch === 'arm64') {
       try {
-        return __nccwpck_require__(8685)
+        return __nccwpck_require__(4528)
       } catch (e) {
         loadErrors.push(e)
       }
       try {
-        return __nccwpck_require__(607)
+        return __nccwpck_require__(6212)
       } catch (e) {
         loadErrors.push(e)
       }
 
     } else if (process.arch === 'arm') {
       try {
-        return __nccwpck_require__(9665)
+        return __nccwpck_require__(430)
       } catch (e) {
         loadErrors.push(e)
       }
       try {
-        return __nccwpck_require__(727)
+        return __nccwpck_require__(694)
       } catch (e) {
         loadErrors.push(e)
       }
@@ -946,36 +946,36 @@ function requireNative() {
   } else if (process.platform === 'win32') {
     if (process.arch === 'x64') {
       try {
-        return __nccwpck_require__(2665)
+        return __nccwpck_require__(802)
       } catch (e) {
         loadErrors.push(e)
       }
       try {
-        return __nccwpck_require__(8066)
+        return __nccwpck_require__(3465)
       } catch (e) {
         loadErrors.push(e)
       }
 
     } else if (process.arch === 'ia32') {
       try {
-        return __nccwpck_require__(8152)
+        return __nccwpck_require__(5017)
       } catch (e) {
         loadErrors.push(e)
       }
       try {
-        return __nccwpck_require__(1612)
+        return __nccwpck_require__(7411)
       } catch (e) {
         loadErrors.push(e)
       }
 
     } else if (process.arch === 'arm64') {
       try {
-        return __nccwpck_require__(3535)
+        return __nccwpck_require__(6640)
       } catch (e) {
         loadErrors.push(e)
       }
       try {
-        return __nccwpck_require__(293)
+        return __nccwpck_require__(6200)
       } catch (e) {
         loadErrors.push(e)
       }
@@ -985,36 +985,36 @@ function requireNative() {
     }
   } else if (process.platform === 'darwin') {
     try {
-        return __nccwpck_require__(8818)
+        return __nccwpck_require__(8533)
       } catch (e) {
         loadErrors.push(e)
       }
       try {
-        return __nccwpck_require__(3890)
+        return __nccwpck_require__(9963)
       } catch (e) {
         loadErrors.push(e)
       }
 
     if (process.arch === 'x64') {
       try {
-        return __nccwpck_require__(8009)
+        return __nccwpck_require__(3530)
       } catch (e) {
         loadErrors.push(e)
       }
       try {
-        return __nccwpck_require__(8139)
+        return __nccwpck_require__(2766)
       } catch (e) {
         loadErrors.push(e)
       }
 
     } else if (process.arch === 'arm64') {
       try {
-        return __nccwpck_require__(475)
+        return __nccwpck_require__(4000)
       } catch (e) {
         loadErrors.push(e)
       }
       try {
-        return __nccwpck_require__(5049)
+        return __nccwpck_require__(2560)
       } catch (e) {
         loadErrors.push(e)
       }
@@ -1025,24 +1025,24 @@ function requireNative() {
   } else if (process.platform === 'freebsd') {
     if (process.arch === 'x64') {
       try {
-        return __nccwpck_require__(3291)
+        return __nccwpck_require__(9638)
       } catch (e) {
         loadErrors.push(e)
       }
       try {
-        return __nccwpck_require__(6229)
+        return __nccwpck_require__(3242)
       } catch (e) {
         loadErrors.push(e)
       }
 
     } else if (process.arch === 'arm64') {
       try {
-        return __nccwpck_require__(3873)
+        return __nccwpck_require__(3588)
       } catch (e) {
         loadErrors.push(e)
       }
       try {
-        return __nccwpck_require__(5367)
+        return __nccwpck_require__(7860)
       } catch (e) {
         loadErrors.push(e)
       }
@@ -1054,24 +1054,24 @@ function requireNative() {
     if (process.arch === 'x64') {
       if (isMusl()) {
         try {
-        return __nccwpck_require__(2356)
+        return __nccwpck_require__(3795)
       } catch (e) {
         loadErrors.push(e)
       }
       try {
-        return __nccwpck_require__(6900)
+        return __nccwpck_require__(5169)
       } catch (e) {
         loadErrors.push(e)
       }
 
       } else {
         try {
-        return __nccwpck_require__(4675)
+        return __nccwpck_require__(5146)
       } catch (e) {
         loadErrors.push(e)
       }
       try {
-        return __nccwpck_require__(7793)
+        return __nccwpck_require__(746)
       } catch (e) {
         loadErrors.push(e)
       }
@@ -1080,24 +1080,24 @@ function requireNative() {
     } else if (process.arch === 'arm64') {
       if (isMusl()) {
         try {
-        return __nccwpck_require__(7602)
+        return __nccwpck_require__(4073)
       } catch (e) {
         loadErrors.push(e)
       }
       try {
-        return __nccwpck_require__(5254)
+        return __nccwpck_require__(7915)
       } catch (e) {
         loadErrors.push(e)
       }
 
       } else {
         try {
-        return __nccwpck_require__(8337)
+        return __nccwpck_require__(1464)
       } catch (e) {
         loadErrors.push(e)
       }
       try {
-        return __nccwpck_require__(6571)
+        return __nccwpck_require__(6244)
       } catch (e) {
         loadErrors.push(e)
       }
@@ -1105,12 +1105,12 @@ function requireNative() {
       }
     } else if (process.arch === 'arm') {
       try {
-        return __nccwpck_require__(7222)
+        return __nccwpck_require__(91)
       } catch (e) {
         loadErrors.push(e)
       }
       try {
-        return __nccwpck_require__(1638)
+        return __nccwpck_require__(1225)
       } catch (e) {
         loadErrors.push(e)
       }
@@ -1118,24 +1118,24 @@ function requireNative() {
     } else if (process.arch === 'riscv64') {
       if (isMusl()) {
         try {
-        return __nccwpck_require__(8593)
+        return __nccwpck_require__(6786)
       } catch (e) {
         loadErrors.push(e)
       }
       try {
-        return __nccwpck_require__(8879)
+        return __nccwpck_require__(5930)
       } catch (e) {
         loadErrors.push(e)
       }
 
       } else {
         try {
-        return __nccwpck_require__(9312)
+        return __nccwpck_require__(1553)
       } catch (e) {
         loadErrors.push(e)
       }
       try {
-        return __nccwpck_require__(9008)
+        return __nccwpck_require__(8199)
       } catch (e) {
         loadErrors.push(e)
       }
@@ -1143,24 +1143,24 @@ function requireNative() {
       }
     } else if (process.arch === 'ppc64') {
       try {
-        return __nccwpck_require__(1446)
+        return __nccwpck_require__(1887)
       } catch (e) {
         loadErrors.push(e)
       }
       try {
-        return __nccwpck_require__(3586)
+        return __nccwpck_require__(1329)
       } catch (e) {
         loadErrors.push(e)
       }
 
     } else if (process.arch === 's390x') {
       try {
-        return __nccwpck_require__(2644)
+        return __nccwpck_require__(5217)
       } catch (e) {
         loadErrors.push(e)
       }
       try {
-        return __nccwpck_require__(8600)
+        return __nccwpck_require__(6635)
       } catch (e) {
         loadErrors.push(e)
       }
@@ -1177,7 +1177,7 @@ nativeBinding = requireNative()
 
 if (!nativeBinding || process.env.NAPI_RS_FORCE_WASI) {
   try {
-    nativeBinding = __nccwpck_require__(6681)
+    nativeBinding = __nccwpck_require__(300)
   } catch (err) {
     if (process.env.NAPI_RS_FORCE_WASI) {
       console.error(err)
@@ -1185,7 +1185,7 @@ if (!nativeBinding || process.env.NAPI_RS_FORCE_WASI) {
   }
   if (!nativeBinding) {
     try {
-      nativeBinding = __nccwpck_require__(9301)
+      nativeBinding = __nccwpck_require__(7722)
     } catch (err) {
       if (process.env.NAPI_RS_FORCE_WASI) {
         console.error(err)
@@ -1228,7 +1228,7 @@ module.exports.transformSync = nativeBinding.transformSync
 
 /***/ }),
 
-/***/ 5971:
+/***/ 5229:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -1297,9 +1297,9 @@ exports.__experimental_registerGlobalTraceConfig = __experimental_registerGlobal
 exports.getBinaryMetadata = getBinaryMetadata;
 const path_1 = __nccwpck_require__(6928);
 // @ts-ignore
-var binding_1 = __nccwpck_require__(898);
+var binding_1 = __nccwpck_require__(4680);
 Object.defineProperty(exports, "experimental_newMangleNameCache", ({ enumerable: true, get: function () { return binding_1.newMangleNameCache; } }));
-const spack_1 = __nccwpck_require__(8579);
+const spack_1 = __nccwpck_require__(8501);
 const assert = __importStar(__nccwpck_require__(2613));
 // Allow overrides to the location of the .node binding file
 const bindingsOverride = process.env["SWC_BINARY_PATH"];
@@ -1311,7 +1311,7 @@ const bindings = (() => {
     try {
         binding = !!bindingsOverride
             ? require((0, path_1.resolve)(bindingsOverride))
-            : __nccwpck_require__(898);
+            : __nccwpck_require__(4680);
         // If native binding loaded successfully, it should return proper target triple constant.
         const triple = binding.getTargetTriple();
         assert.ok(triple, "Failed to read target triple from native binary.");
@@ -1319,7 +1319,7 @@ const bindings = (() => {
     }
     catch (_) {
         // postinstall supposed to install `@swc/wasm` already
-        fallbackBindings = __nccwpck_require__(5855);
+        fallbackBindings = __nccwpck_require__(4196);
     }
     finally {
         return binding;
@@ -1328,7 +1328,7 @@ const bindings = (() => {
 /**
  * Version of the swc binding.
  */
-exports.version = __nccwpck_require__(155).version;
+exports.version = __nccwpck_require__(6662).version;
 /**
  * @deprecated JavaScript API is deprecated. Please use Wasm plugin instead.
  */
@@ -1679,7 +1679,7 @@ function toBuffer(t) {
 
 /***/ }),
 
-/***/ 8579:
+/***/ 8501:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -1774,15 +1774,15 @@ function config(c) {
 
 /***/ }),
 
-/***/ 770:
+/***/ 6628:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-module.exports = __nccwpck_require__(218);
+module.exports = __nccwpck_require__(3188);
 
 
 /***/ }),
 
-/***/ 218:
+/***/ 3188:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -2054,34 +2054,34 @@ exports.debug = debug; // for test
 
 /***/ }),
 
-/***/ 6752:
+/***/ 4258:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const Client = __nccwpck_require__(3701)
-const Dispatcher = __nccwpck_require__(883)
-const Pool = __nccwpck_require__(628)
-const BalancedPool = __nccwpck_require__(837)
-const Agent = __nccwpck_require__(7405)
-const ProxyAgent = __nccwpck_require__(6672)
-const EnvHttpProxyAgent = __nccwpck_require__(3137)
-const RetryAgent = __nccwpck_require__(50)
-const errors = __nccwpck_require__(8707)
-const util = __nccwpck_require__(3440)
+const Client = __nccwpck_require__(2539)
+const Dispatcher = __nccwpck_require__(8989)
+const Pool = __nccwpck_require__(2690)
+const BalancedPool = __nccwpck_require__(1115)
+const Agent = __nccwpck_require__(8103)
+const ProxyAgent = __nccwpck_require__(114)
+const EnvHttpProxyAgent = __nccwpck_require__(3535)
+const RetryAgent = __nccwpck_require__(2148)
+const errors = __nccwpck_require__(7013)
+const util = __nccwpck_require__(4742)
 const { InvalidArgumentError } = errors
-const api = __nccwpck_require__(6615)
-const buildConnector = __nccwpck_require__(9136)
-const MockClient = __nccwpck_require__(7365)
-const MockAgent = __nccwpck_require__(7501)
-const MockPool = __nccwpck_require__(4004)
-const mockErrors = __nccwpck_require__(2429)
-const RetryHandler = __nccwpck_require__(7816)
-const { getGlobalDispatcher, setGlobalDispatcher } = __nccwpck_require__(2581)
-const DecoratorHandler = __nccwpck_require__(8155)
-const RedirectHandler = __nccwpck_require__(8754)
-const createRedirectInterceptor = __nccwpck_require__(5092)
+const api = __nccwpck_require__(477)
+const buildConnector = __nccwpck_require__(4278)
+const MockClient = __nccwpck_require__(8747)
+const MockAgent = __nccwpck_require__(7319)
+const MockPool = __nccwpck_require__(706)
+const mockErrors = __nccwpck_require__(3559)
+const RetryHandler = __nccwpck_require__(9586)
+const { getGlobalDispatcher, setGlobalDispatcher } = __nccwpck_require__(3723)
+const DecoratorHandler = __nccwpck_require__(1881)
+const RedirectHandler = __nccwpck_require__(8276)
+const createRedirectInterceptor = __nccwpck_require__(5038)
 
 Object.assign(Dispatcher.prototype, api)
 
@@ -2099,10 +2099,10 @@ module.exports.DecoratorHandler = DecoratorHandler
 module.exports.RedirectHandler = RedirectHandler
 module.exports.createRedirectInterceptor = createRedirectInterceptor
 module.exports.interceptors = {
-  redirect: __nccwpck_require__(1514),
-  retry: __nccwpck_require__(2026),
-  dump: __nccwpck_require__(8060),
-  dns: __nccwpck_require__(379)
+  redirect: __nccwpck_require__(9704),
+  retry: __nccwpck_require__(7400),
+  dump: __nccwpck_require__(7278),
+  dns: __nccwpck_require__(3241)
 }
 
 module.exports.buildConnector = buildConnector
@@ -2164,7 +2164,7 @@ function makeDispatcher (fn) {
 module.exports.setGlobalDispatcher = setGlobalDispatcher
 module.exports.getGlobalDispatcher = getGlobalDispatcher
 
-const fetchImpl = (__nccwpck_require__(4398).fetch)
+const fetchImpl = (__nccwpck_require__(2104).fetch)
 module.exports.fetch = async function fetch (init, options = undefined) {
   try {
     return await fetchImpl(init, options)
@@ -2176,39 +2176,39 @@ module.exports.fetch = async function fetch (init, options = undefined) {
     throw err
   }
 }
-module.exports.Headers = __nccwpck_require__(660).Headers
-module.exports.Response = __nccwpck_require__(9051).Response
-module.exports.Request = __nccwpck_require__(9967).Request
-module.exports.FormData = __nccwpck_require__(5910).FormData
+module.exports.Headers = __nccwpck_require__(7386).Headers
+module.exports.Response = __nccwpck_require__(2929).Response
+module.exports.Request = __nccwpck_require__(4309).Request
+module.exports.FormData = __nccwpck_require__(6124).FormData
 module.exports.File = globalThis.File ?? (__nccwpck_require__(4573).File)
-module.exports.FileReader = __nccwpck_require__(8355).FileReader
+module.exports.FileReader = __nccwpck_require__(6413).FileReader
 
-const { setGlobalOrigin, getGlobalOrigin } = __nccwpck_require__(1059)
+const { setGlobalOrigin, getGlobalOrigin } = __nccwpck_require__(9553)
 
 module.exports.setGlobalOrigin = setGlobalOrigin
 module.exports.getGlobalOrigin = getGlobalOrigin
 
-const { CacheStorage } = __nccwpck_require__(3245)
-const { kConstruct } = __nccwpck_require__(109)
+const { CacheStorage } = __nccwpck_require__(1823)
+const { kConstruct } = __nccwpck_require__(6123)
 
 // Cache & CacheStorage are tightly coupled with fetch. Even if it may run
 // in an older version of Node, it doesn't have any use without fetch.
 module.exports.caches = new CacheStorage(kConstruct)
 
-const { deleteCookie, getCookies, getSetCookies, setCookie } = __nccwpck_require__(9061)
+const { deleteCookie, getCookies, getSetCookies, setCookie } = __nccwpck_require__(107)
 
 module.exports.deleteCookie = deleteCookie
 module.exports.getCookies = getCookies
 module.exports.getSetCookies = getSetCookies
 module.exports.setCookie = setCookie
 
-const { parseMIMEType, serializeAMimeType } = __nccwpck_require__(1900)
+const { parseMIMEType, serializeAMimeType } = __nccwpck_require__(9634)
 
 module.exports.parseMIMEType = parseMIMEType
 module.exports.serializeAMimeType = serializeAMimeType
 
-const { CloseEvent, ErrorEvent, MessageEvent } = __nccwpck_require__(5188)
-module.exports.WebSocket = __nccwpck_require__(3726).WebSocket
+const { CloseEvent, ErrorEvent, MessageEvent } = __nccwpck_require__(4194)
+module.exports.WebSocket = __nccwpck_require__(564).WebSocket
 module.exports.CloseEvent = CloseEvent
 module.exports.ErrorEvent = ErrorEvent
 module.exports.MessageEvent = MessageEvent
@@ -2224,18 +2224,18 @@ module.exports.MockPool = MockPool
 module.exports.MockAgent = MockAgent
 module.exports.mockErrors = mockErrors
 
-const { EventSource } = __nccwpck_require__(1238)
+const { EventSource } = __nccwpck_require__(5108)
 
 module.exports.EventSource = EventSource
 
 
 /***/ }),
 
-/***/ 158:
+/***/ 5532:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-const { addAbortListener } = __nccwpck_require__(3440)
-const { RequestAbortedError } = __nccwpck_require__(8707)
+const { addAbortListener } = __nccwpck_require__(4742)
+const { RequestAbortedError } = __nccwpck_require__(7013)
 
 const kListener = Symbol('kListener')
 const kSignal = Symbol('kSignal')
@@ -2295,7 +2295,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 2279:
+/***/ 9826:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -2303,9 +2303,9 @@ module.exports = {
 
 const assert = __nccwpck_require__(4589)
 const { AsyncResource } = __nccwpck_require__(6698)
-const { InvalidArgumentError, SocketError } = __nccwpck_require__(8707)
-const util = __nccwpck_require__(3440)
-const { addSignal, removeSignal } = __nccwpck_require__(158)
+const { InvalidArgumentError, SocketError } = __nccwpck_require__(7013)
+const util = __nccwpck_require__(4742)
+const { addSignal, removeSignal } = __nccwpck_require__(5532)
 
 class ConnectHandler extends AsyncResource {
   constructor (opts, callback) {
@@ -2411,7 +2411,7 @@ module.exports = connect
 
 /***/ }),
 
-/***/ 6862:
+/***/ 4280:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -2426,10 +2426,10 @@ const {
   InvalidArgumentError,
   InvalidReturnValueError,
   RequestAbortedError
-} = __nccwpck_require__(8707)
-const util = __nccwpck_require__(3440)
+} = __nccwpck_require__(7013)
+const util = __nccwpck_require__(4742)
 const { AsyncResource } = __nccwpck_require__(6698)
-const { addSignal, removeSignal } = __nccwpck_require__(158)
+const { addSignal, removeSignal } = __nccwpck_require__(5532)
 const assert = __nccwpck_require__(4589)
 
 const kResume = Symbol('resume')
@@ -2670,17 +2670,17 @@ module.exports = pipeline
 
 /***/ }),
 
-/***/ 4043:
+/***/ 1725:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 const assert = __nccwpck_require__(4589)
-const { Readable } = __nccwpck_require__(9927)
-const { InvalidArgumentError, RequestAbortedError } = __nccwpck_require__(8707)
-const util = __nccwpck_require__(3440)
-const { getResolveErrorBodyCallback } = __nccwpck_require__(7655)
+const { Readable } = __nccwpck_require__(4501)
+const { InvalidArgumentError, RequestAbortedError } = __nccwpck_require__(7013)
+const util = __nccwpck_require__(4742)
+const { getResolveErrorBodyCallback } = __nccwpck_require__(6253)
 const { AsyncResource } = __nccwpck_require__(6698)
 
 class RequestHandler extends AsyncResource {
@@ -2892,7 +2892,7 @@ module.exports.RequestHandler = RequestHandler
 
 /***/ }),
 
-/***/ 3560:
+/***/ 4318:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -2900,11 +2900,11 @@ module.exports.RequestHandler = RequestHandler
 
 const assert = __nccwpck_require__(4589)
 const { finished, PassThrough } = __nccwpck_require__(7075)
-const { InvalidArgumentError, InvalidReturnValueError } = __nccwpck_require__(8707)
-const util = __nccwpck_require__(3440)
-const { getResolveErrorBodyCallback } = __nccwpck_require__(7655)
+const { InvalidArgumentError, InvalidReturnValueError } = __nccwpck_require__(7013)
+const util = __nccwpck_require__(4742)
+const { getResolveErrorBodyCallback } = __nccwpck_require__(6253)
 const { AsyncResource } = __nccwpck_require__(6698)
-const { addSignal, removeSignal } = __nccwpck_require__(158)
+const { addSignal, removeSignal } = __nccwpck_require__(5532)
 
 class StreamHandler extends AsyncResource {
   constructor (opts, factory, callback) {
@@ -3120,16 +3120,16 @@ module.exports = stream
 
 /***/ }),
 
-/***/ 1882:
+/***/ 8892:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { InvalidArgumentError, SocketError } = __nccwpck_require__(8707)
+const { InvalidArgumentError, SocketError } = __nccwpck_require__(7013)
 const { AsyncResource } = __nccwpck_require__(6698)
-const util = __nccwpck_require__(3440)
-const { addSignal, removeSignal } = __nccwpck_require__(158)
+const util = __nccwpck_require__(4742)
+const { addSignal, removeSignal } = __nccwpck_require__(5532)
 const assert = __nccwpck_require__(4589)
 
 class UpgradeHandler extends AsyncResource {
@@ -3236,22 +3236,22 @@ module.exports = upgrade
 
 /***/ }),
 
-/***/ 6615:
+/***/ 477:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-module.exports.request = __nccwpck_require__(4043)
-module.exports.stream = __nccwpck_require__(3560)
-module.exports.pipeline = __nccwpck_require__(6862)
-module.exports.upgrade = __nccwpck_require__(1882)
-module.exports.connect = __nccwpck_require__(2279)
+module.exports.request = __nccwpck_require__(1725)
+module.exports.stream = __nccwpck_require__(4318)
+module.exports.pipeline = __nccwpck_require__(4280)
+module.exports.upgrade = __nccwpck_require__(8892)
+module.exports.connect = __nccwpck_require__(9826)
 
 
 /***/ }),
 
-/***/ 9927:
+/***/ 4501:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -3261,9 +3261,9 @@ module.exports.connect = __nccwpck_require__(2279)
 
 const assert = __nccwpck_require__(4589)
 const { Readable } = __nccwpck_require__(7075)
-const { RequestAbortedError, NotSupportedError, InvalidArgumentError, AbortError } = __nccwpck_require__(8707)
-const util = __nccwpck_require__(3440)
-const { ReadableStreamFrom } = __nccwpck_require__(3440)
+const { RequestAbortedError, NotSupportedError, InvalidArgumentError, AbortError } = __nccwpck_require__(7013)
+const util = __nccwpck_require__(4742)
+const { ReadableStreamFrom } = __nccwpck_require__(4742)
 
 const kConsume = Symbol('kConsume')
 const kReading = Symbol('kReading')
@@ -3644,15 +3644,15 @@ module.exports = { Readable: BodyReadable, chunksDecode }
 
 /***/ }),
 
-/***/ 7655:
+/***/ 6253:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 const assert = __nccwpck_require__(4589)
 const {
   ResponseStatusCodeError
-} = __nccwpck_require__(8707)
+} = __nccwpck_require__(7013)
 
-const { chunksDecode } = __nccwpck_require__(9927)
+const { chunksDecode } = __nccwpck_require__(4501)
 const CHUNK_LIMIT = 128 * 1024
 
 async function getResolveErrorBodyCallback ({ callback, body, contentType, statusCode, statusMessage, headers }) {
@@ -3744,7 +3744,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 9136:
+/***/ 4278:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -3752,9 +3752,9 @@ module.exports = {
 
 const net = __nccwpck_require__(7030)
 const assert = __nccwpck_require__(4589)
-const util = __nccwpck_require__(3440)
-const { InvalidArgumentError, ConnectTimeoutError } = __nccwpck_require__(8707)
-const timers = __nccwpck_require__(6603)
+const util = __nccwpck_require__(4742)
+const { InvalidArgumentError, ConnectTimeoutError } = __nccwpck_require__(7013)
+const timers = __nccwpck_require__(3325)
 
 function noop () {}
 
@@ -3992,7 +3992,7 @@ module.exports = buildConnector
 
 /***/ }),
 
-/***/ 735:
+/***/ 2041:
 /***/ ((module) => {
 
 "use strict";
@@ -4118,7 +4118,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 2414:
+/***/ 8664:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -4328,7 +4328,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 8707:
+/***/ 7013:
 /***/ ((module) => {
 
 "use strict";
@@ -4761,7 +4761,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 4655:
+/***/ 1241:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -4770,7 +4770,7 @@ module.exports = {
 const {
   InvalidArgumentError,
   NotSupportedError
-} = __nccwpck_require__(8707)
+} = __nccwpck_require__(7013)
 const assert = __nccwpck_require__(4589)
 const {
   isValidHTTPToken,
@@ -4785,9 +4785,9 @@ const {
   validateHandler,
   getServerName,
   normalizedMethodRecords
-} = __nccwpck_require__(3440)
-const { channels } = __nccwpck_require__(2414)
-const { headerNameLowerCasedRecord } = __nccwpck_require__(735)
+} = __nccwpck_require__(4742)
+const { channels } = __nccwpck_require__(8664)
+const { headerNameLowerCasedRecord } = __nccwpck_require__(2041)
 
 // Verifies that a given path is valid does not contain control chars \x00 to \x20
 const invalidPathRegex = /[^\u0021-\u00ff]/
@@ -5174,7 +5174,7 @@ module.exports = Request
 
 /***/ }),
 
-/***/ 6443:
+/***/ 7573:
 /***/ ((module) => {
 
 module.exports = {
@@ -5248,7 +5248,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 7752:
+/***/ 5322:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -5257,7 +5257,7 @@ module.exports = {
 const {
   wellknownHeaderNames,
   headerNameLowerCasedRecord
-} = __nccwpck_require__(735)
+} = __nccwpck_require__(2041)
 
 class TstNode {
   /** @type {any} */
@@ -5408,14 +5408,14 @@ module.exports = {
 
 /***/ }),
 
-/***/ 3440:
+/***/ 4742:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 const assert = __nccwpck_require__(4589)
-const { kDestroyed, kBodyUsed, kListeners, kBody } = __nccwpck_require__(6443)
+const { kDestroyed, kBodyUsed, kListeners, kBody } = __nccwpck_require__(7573)
 const { IncomingMessage } = __nccwpck_require__(7067)
 const stream = __nccwpck_require__(7075)
 const net = __nccwpck_require__(7030)
@@ -5423,9 +5423,9 @@ const { Blob } = __nccwpck_require__(4573)
 const nodeUtil = __nccwpck_require__(7975)
 const { stringify } = __nccwpck_require__(1792)
 const { EventEmitter: EE } = __nccwpck_require__(8474)
-const { InvalidArgumentError } = __nccwpck_require__(8707)
-const { headerNameLowerCasedRecord } = __nccwpck_require__(735)
-const { tree } = __nccwpck_require__(7752)
+const { InvalidArgumentError } = __nccwpck_require__(7013)
+const { headerNameLowerCasedRecord } = __nccwpck_require__(2041)
+const { tree } = __nccwpck_require__(5322)
 
 const [nodeMajor, nodeMinor] = process.versions.node.split('.').map(v => Number(v))
 
@@ -6135,19 +6135,19 @@ module.exports = {
 
 /***/ }),
 
-/***/ 7405:
+/***/ 8103:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { InvalidArgumentError } = __nccwpck_require__(8707)
-const { kClients, kRunning, kClose, kDestroy, kDispatch, kInterceptors } = __nccwpck_require__(6443)
-const DispatcherBase = __nccwpck_require__(1841)
-const Pool = __nccwpck_require__(628)
-const Client = __nccwpck_require__(3701)
-const util = __nccwpck_require__(3440)
-const createRedirectInterceptor = __nccwpck_require__(5092)
+const { InvalidArgumentError } = __nccwpck_require__(7013)
+const { kClients, kRunning, kClose, kDestroy, kDispatch, kInterceptors } = __nccwpck_require__(7573)
+const DispatcherBase = __nccwpck_require__(9199)
+const Pool = __nccwpck_require__(2690)
+const Client = __nccwpck_require__(2539)
+const util = __nccwpck_require__(4742)
+const createRedirectInterceptor = __nccwpck_require__(5038)
 
 const kOnConnect = Symbol('onConnect')
 const kOnDisconnect = Symbol('onDisconnect')
@@ -6272,7 +6272,7 @@ module.exports = Agent
 
 /***/ }),
 
-/***/ 837:
+/***/ 1115:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -6281,7 +6281,7 @@ module.exports = Agent
 const {
   BalancedPoolMissingUpstreamError,
   InvalidArgumentError
-} = __nccwpck_require__(8707)
+} = __nccwpck_require__(7013)
 const {
   PoolBase,
   kClients,
@@ -6289,10 +6289,10 @@ const {
   kAddClient,
   kRemoveClient,
   kGetDispatcher
-} = __nccwpck_require__(2128)
-const Pool = __nccwpck_require__(628)
-const { kUrl, kInterceptors } = __nccwpck_require__(6443)
-const { parseOrigin } = __nccwpck_require__(3440)
+} = __nccwpck_require__(8122)
+const Pool = __nccwpck_require__(2690)
+const { kUrl, kInterceptors } = __nccwpck_require__(7573)
+const { parseOrigin } = __nccwpck_require__(4742)
 const kFactory = Symbol('factory')
 
 const kOptions = Symbol('options')
@@ -6489,7 +6489,7 @@ module.exports = BalancedPool
 
 /***/ }),
 
-/***/ 637:
+/***/ 3335:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -6498,9 +6498,9 @@ module.exports = BalancedPool
 /* global WebAssembly */
 
 const assert = __nccwpck_require__(4589)
-const util = __nccwpck_require__(3440)
-const { channels } = __nccwpck_require__(2414)
-const timers = __nccwpck_require__(6603)
+const util = __nccwpck_require__(4742)
+const { channels } = __nccwpck_require__(8664)
+const timers = __nccwpck_require__(3325)
 const {
   RequestContentLengthMismatchError,
   ResponseContentLengthMismatchError,
@@ -6512,7 +6512,7 @@ const {
   BodyTimeoutError,
   HTTPParserError,
   ResponseExceededMaxSizeError
-} = __nccwpck_require__(8707)
+} = __nccwpck_require__(7013)
 const {
   kUrl,
   kReset,
@@ -6545,9 +6545,9 @@ const {
   kOnError,
   kResume,
   kHTTPContext
-} = __nccwpck_require__(6443)
+} = __nccwpck_require__(7573)
 
-const constants = __nccwpck_require__(2824)
+const constants = __nccwpck_require__(4998)
 const EMPTY_BUF = Buffer.alloc(0)
 const FastBuffer = Buffer[Symbol.species]
 const addListener = util.addListener
@@ -6556,11 +6556,11 @@ const removeAllListeners = util.removeAllListeners
 let extractBody
 
 async function lazyllhttp () {
-  const llhttpWasmData = process.env.JEST_WORKER_ID ? __nccwpck_require__(3870) : undefined
+  const llhttpWasmData = process.env.JEST_WORKER_ID ? __nccwpck_require__(7724) : undefined
 
   let mod
   try {
-    mod = await WebAssembly.compile(__nccwpck_require__(3434))
+    mod = await WebAssembly.compile(__nccwpck_require__(8772))
   } catch (e) {
     /* istanbul ignore next */
 
@@ -6568,7 +6568,7 @@ async function lazyllhttp () {
     // being enabled, but the occurring of this other error
     // * https://github.com/emscripten-core/emscripten/issues/11495
     // got me to remove that check to avoid breaking Node 12.
-    mod = await WebAssembly.compile(llhttpWasmData || __nccwpck_require__(3870))
+    mod = await WebAssembly.compile(llhttpWasmData || __nccwpck_require__(7724))
   }
 
   return await WebAssembly.instantiate(mod, {
@@ -7363,7 +7363,7 @@ function writeH1 (client, request) {
 
   if (util.isFormDataLike(body)) {
     if (!extractBody) {
-      extractBody = (__nccwpck_require__(4492).extractBody)
+      extractBody = (__nccwpck_require__(1294).extractBody)
     }
 
     const [bodyStream, contentType] = extractBody(body)
@@ -7867,7 +7867,7 @@ module.exports = connectH1
 
 /***/ }),
 
-/***/ 8788:
+/***/ 9610:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -7875,13 +7875,13 @@ module.exports = connectH1
 
 const assert = __nccwpck_require__(4589)
 const { pipeline } = __nccwpck_require__(7075)
-const util = __nccwpck_require__(3440)
+const util = __nccwpck_require__(4742)
 const {
   RequestContentLengthMismatchError,
   RequestAbortedError,
   SocketError,
   InformationalError
-} = __nccwpck_require__(8707)
+} = __nccwpck_require__(7013)
 const {
   kUrl,
   kReset,
@@ -7900,7 +7900,7 @@ const {
   kResume,
   kSize,
   kHTTPContext
-} = __nccwpck_require__(6443)
+} = __nccwpck_require__(7573)
 
 const kOpenStreams = Symbol('open streams')
 
@@ -8259,7 +8259,7 @@ function writeH2 (client, request) {
   let contentLength = util.bodyLength(body)
 
   if (util.isFormDataLike(body)) {
-    extractBody ??= (__nccwpck_require__(4492).extractBody)
+    extractBody ??= (__nccwpck_require__(1294).extractBody)
 
     const [bodyStream, contentType] = extractBody(body)
     headers['content-type'] = contentType
@@ -8619,7 +8619,7 @@ module.exports = connectH2
 
 /***/ }),
 
-/***/ 3701:
+/***/ 2539:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -8630,16 +8630,16 @@ module.exports = connectH2
 const assert = __nccwpck_require__(4589)
 const net = __nccwpck_require__(7030)
 const http = __nccwpck_require__(7067)
-const util = __nccwpck_require__(3440)
-const { channels } = __nccwpck_require__(2414)
-const Request = __nccwpck_require__(4655)
-const DispatcherBase = __nccwpck_require__(1841)
+const util = __nccwpck_require__(4742)
+const { channels } = __nccwpck_require__(8664)
+const Request = __nccwpck_require__(1241)
+const DispatcherBase = __nccwpck_require__(9199)
 const {
   InvalidArgumentError,
   InformationalError,
   ClientDestroyedError
-} = __nccwpck_require__(8707)
-const buildConnector = __nccwpck_require__(9136)
+} = __nccwpck_require__(7013)
+const buildConnector = __nccwpck_require__(4278)
 const {
   kUrl,
   kServerName,
@@ -8681,9 +8681,9 @@ const {
   kHTTPContext,
   kMaxConcurrentStreams,
   kResume
-} = __nccwpck_require__(6443)
-const connectH1 = __nccwpck_require__(637)
-const connectH2 = __nccwpck_require__(8788)
+} = __nccwpck_require__(7573)
+const connectH1 = __nccwpck_require__(3335)
+const connectH2 = __nccwpck_require__(9610)
 let deprecatedInterceptorWarned = false
 
 const kClosedResolve = Symbol('kClosedResolve')
@@ -8989,7 +8989,7 @@ class Client extends DispatcherBase {
   }
 }
 
-const createRedirectInterceptor = __nccwpck_require__(5092)
+const createRedirectInterceptor = __nccwpck_require__(5038)
 
 function onError (client, err) {
   if (
@@ -9249,19 +9249,19 @@ module.exports = Client
 
 /***/ }),
 
-/***/ 1841:
+/***/ 9199:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const Dispatcher = __nccwpck_require__(883)
+const Dispatcher = __nccwpck_require__(8989)
 const {
   ClientDestroyedError,
   ClientClosedError,
   InvalidArgumentError
-} = __nccwpck_require__(8707)
-const { kDestroy, kClose, kClosed, kDestroyed, kDispatch, kInterceptors } = __nccwpck_require__(6443)
+} = __nccwpck_require__(7013)
+const { kDestroy, kClose, kClosed, kDestroyed, kDispatch, kInterceptors } = __nccwpck_require__(7573)
 
 const kOnDestroyed = Symbol('onDestroyed')
 const kOnClosed = Symbol('onClosed')
@@ -9447,7 +9447,7 @@ module.exports = DispatcherBase
 
 /***/ }),
 
-/***/ 883:
+/***/ 8989:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -9520,16 +9520,16 @@ module.exports = Dispatcher
 
 /***/ }),
 
-/***/ 3137:
+/***/ 3535:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const DispatcherBase = __nccwpck_require__(1841)
-const { kClose, kDestroy, kClosed, kDestroyed, kDispatch, kNoProxyAgent, kHttpProxyAgent, kHttpsProxyAgent } = __nccwpck_require__(6443)
-const ProxyAgent = __nccwpck_require__(6672)
-const Agent = __nccwpck_require__(7405)
+const DispatcherBase = __nccwpck_require__(9199)
+const { kClose, kDestroy, kClosed, kDestroyed, kDispatch, kNoProxyAgent, kHttpProxyAgent, kHttpsProxyAgent } = __nccwpck_require__(7573)
+const ProxyAgent = __nccwpck_require__(114)
+const Agent = __nccwpck_require__(8103)
 
 const DEFAULT_PORTS = {
   'http:': 80,
@@ -9688,7 +9688,7 @@ module.exports = EnvHttpProxyAgent
 
 /***/ }),
 
-/***/ 4660:
+/***/ 7842:
 /***/ ((module) => {
 
 "use strict";
@@ -9813,16 +9813,16 @@ module.exports = class FixedQueue {
 
 /***/ }),
 
-/***/ 2128:
+/***/ 8122:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const DispatcherBase = __nccwpck_require__(1841)
-const FixedQueue = __nccwpck_require__(4660)
-const { kConnected, kSize, kRunning, kPending, kQueued, kBusy, kFree, kUrl, kClose, kDestroy, kDispatch } = __nccwpck_require__(6443)
-const PoolStats = __nccwpck_require__(3246)
+const DispatcherBase = __nccwpck_require__(9199)
+const FixedQueue = __nccwpck_require__(7842)
+const { kConnected, kSize, kRunning, kPending, kQueued, kBusy, kFree, kUrl, kClose, kDestroy, kDispatch } = __nccwpck_require__(7573)
+const PoolStats = __nccwpck_require__(7404)
 
 const kClients = Symbol('clients')
 const kNeedDrain = Symbol('needDrain')
@@ -10015,10 +10015,10 @@ module.exports = {
 
 /***/ }),
 
-/***/ 3246:
+/***/ 7404:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-const { kFree, kConnected, kPending, kQueued, kRunning, kSize } = __nccwpck_require__(6443)
+const { kFree, kConnected, kPending, kQueued, kRunning, kSize } = __nccwpck_require__(7573)
 const kPool = Symbol('pool')
 
 class PoolStats {
@@ -10056,7 +10056,7 @@ module.exports = PoolStats
 
 /***/ }),
 
-/***/ 628:
+/***/ 2690:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -10068,14 +10068,14 @@ const {
   kNeedDrain,
   kAddClient,
   kGetDispatcher
-} = __nccwpck_require__(2128)
-const Client = __nccwpck_require__(3701)
+} = __nccwpck_require__(8122)
+const Client = __nccwpck_require__(2539)
 const {
   InvalidArgumentError
-} = __nccwpck_require__(8707)
-const util = __nccwpck_require__(3440)
-const { kUrl, kInterceptors } = __nccwpck_require__(6443)
-const buildConnector = __nccwpck_require__(9136)
+} = __nccwpck_require__(7013)
+const util = __nccwpck_require__(4742)
+const { kUrl, kInterceptors } = __nccwpck_require__(7573)
+const buildConnector = __nccwpck_require__(4278)
 
 const kOptions = Symbol('options')
 const kConnections = Symbol('connections')
@@ -10171,20 +10171,20 @@ module.exports = Pool
 
 /***/ }),
 
-/***/ 6672:
+/***/ 114:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { kProxy, kClose, kDestroy, kDispatch, kInterceptors } = __nccwpck_require__(6443)
+const { kProxy, kClose, kDestroy, kDispatch, kInterceptors } = __nccwpck_require__(7573)
 const { URL } = __nccwpck_require__(3136)
-const Agent = __nccwpck_require__(7405)
-const Pool = __nccwpck_require__(628)
-const DispatcherBase = __nccwpck_require__(1841)
-const { InvalidArgumentError, RequestAbortedError, SecureProxyConnectionError } = __nccwpck_require__(8707)
-const buildConnector = __nccwpck_require__(9136)
-const Client = __nccwpck_require__(3701)
+const Agent = __nccwpck_require__(8103)
+const Pool = __nccwpck_require__(2690)
+const DispatcherBase = __nccwpck_require__(9199)
+const { InvalidArgumentError, RequestAbortedError, SecureProxyConnectionError } = __nccwpck_require__(7013)
+const buildConnector = __nccwpck_require__(4278)
+const Client = __nccwpck_require__(2539)
 
 const kAgent = Symbol('proxy agent')
 const kClient = Symbol('proxy client')
@@ -10453,14 +10453,14 @@ module.exports = ProxyAgent
 
 /***/ }),
 
-/***/ 50:
+/***/ 2148:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const Dispatcher = __nccwpck_require__(883)
-const RetryHandler = __nccwpck_require__(7816)
+const Dispatcher = __nccwpck_require__(8989)
+const RetryHandler = __nccwpck_require__(9586)
 
 class RetryAgent extends Dispatcher {
   #agent = null
@@ -10496,7 +10496,7 @@ module.exports = RetryAgent
 
 /***/ }),
 
-/***/ 2581:
+/***/ 3723:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -10505,8 +10505,8 @@ module.exports = RetryAgent
 // We include a version number for the Dispatcher API. In case of breaking changes,
 // this version number must be increased to avoid conflicts.
 const globalDispatcher = Symbol.for('undici.globalDispatcher.1')
-const { InvalidArgumentError } = __nccwpck_require__(8707)
-const Agent = __nccwpck_require__(7405)
+const { InvalidArgumentError } = __nccwpck_require__(7013)
+const Agent = __nccwpck_require__(8103)
 
 if (getGlobalDispatcher() === undefined) {
   setGlobalDispatcher(new Agent())
@@ -10536,7 +10536,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 8155:
+/***/ 1881:
 /***/ ((module) => {
 
 "use strict";
@@ -10588,16 +10588,16 @@ module.exports = class DecoratorHandler {
 
 /***/ }),
 
-/***/ 8754:
+/***/ 8276:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const util = __nccwpck_require__(3440)
-const { kBodyUsed } = __nccwpck_require__(6443)
+const util = __nccwpck_require__(4742)
+const { kBodyUsed } = __nccwpck_require__(7573)
 const assert = __nccwpck_require__(4589)
-const { InvalidArgumentError } = __nccwpck_require__(8707)
+const { InvalidArgumentError } = __nccwpck_require__(7013)
 const EE = __nccwpck_require__(8474)
 
 const redirectableStatusCodes = [300, 301, 302, 303, 307, 308]
@@ -10828,21 +10828,21 @@ module.exports = RedirectHandler
 
 /***/ }),
 
-/***/ 7816:
+/***/ 9586:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 const assert = __nccwpck_require__(4589)
 
-const { kRetryHandlerDefaultRetry } = __nccwpck_require__(6443)
-const { RequestRetryError } = __nccwpck_require__(8707)
+const { kRetryHandlerDefaultRetry } = __nccwpck_require__(7573)
+const { RequestRetryError } = __nccwpck_require__(7013)
 const {
   isDisturbed,
   parseHeaders,
   parseRangeHeader,
   wrapRequestBody
-} = __nccwpck_require__(3440)
+} = __nccwpck_require__(4742)
 
 function calculateRetryAfterHeader (retryAfter) {
   const current = Date.now()
@@ -11210,15 +11210,15 @@ module.exports = RetryHandler
 
 /***/ }),
 
-/***/ 379:
+/***/ 3241:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 const { isIP } = __nccwpck_require__(7030)
 const { lookup } = __nccwpck_require__(610)
-const DecoratorHandler = __nccwpck_require__(8155)
-const { InvalidArgumentError, InformationalError } = __nccwpck_require__(8707)
+const DecoratorHandler = __nccwpck_require__(1881)
+const { InvalidArgumentError, InformationalError } = __nccwpck_require__(7013)
 const maxInt = Math.pow(2, 31) - 1
 
 class DNSInstance {
@@ -11593,15 +11593,15 @@ module.exports = interceptorOpts => {
 
 /***/ }),
 
-/***/ 8060:
+/***/ 7278:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const util = __nccwpck_require__(3440)
-const { InvalidArgumentError, RequestAbortedError } = __nccwpck_require__(8707)
-const DecoratorHandler = __nccwpck_require__(8155)
+const util = __nccwpck_require__(4742)
+const { InvalidArgumentError, RequestAbortedError } = __nccwpck_require__(7013)
+const DecoratorHandler = __nccwpck_require__(1881)
 
 class DumpHandler extends DecoratorHandler {
   #maxSize = 1024 * 1024
@@ -11724,13 +11724,13 @@ module.exports = createDumpInterceptor
 
 /***/ }),
 
-/***/ 5092:
+/***/ 5038:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const RedirectHandler = __nccwpck_require__(8754)
+const RedirectHandler = __nccwpck_require__(8276)
 
 function createRedirectInterceptor ({ maxRedirections: defaultMaxRedirections }) {
   return (dispatch) => {
@@ -11753,12 +11753,12 @@ module.exports = createRedirectInterceptor
 
 /***/ }),
 
-/***/ 1514:
+/***/ 9704:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
-const RedirectHandler = __nccwpck_require__(8754)
+const RedirectHandler = __nccwpck_require__(8276)
 
 module.exports = opts => {
   const globalMaxRedirections = opts?.maxRedirections
@@ -11785,12 +11785,12 @@ module.exports = opts => {
 
 /***/ }),
 
-/***/ 2026:
+/***/ 7400:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
-const RetryHandler = __nccwpck_require__(7816)
+const RetryHandler = __nccwpck_require__(9586)
 
 module.exports = globalOpts => {
   return dispatch => {
@@ -11812,14 +11812,14 @@ module.exports = globalOpts => {
 
 /***/ }),
 
-/***/ 2824:
+/***/ 4998:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.SPECIAL_HEADERS = exports.HEADER_STATE = exports.MINOR = exports.MAJOR = exports.CONNECTION_TOKEN_CHARS = exports.HEADER_CHARS = exports.TOKEN = exports.STRICT_TOKEN = exports.HEX = exports.URL_CHAR = exports.STRICT_URL_CHAR = exports.USERINFO_CHARS = exports.MARK = exports.ALPHANUM = exports.NUM = exports.HEX_MAP = exports.NUM_MAP = exports.ALPHA = exports.FINISH = exports.H_METHOD_MAP = exports.METHOD_MAP = exports.METHODS_RTSP = exports.METHODS_ICE = exports.METHODS_HTTP = exports.METHODS = exports.LENIENT_FLAGS = exports.FLAGS = exports.TYPE = exports.ERROR = void 0;
-const utils_1 = __nccwpck_require__(172);
+const utils_1 = __nccwpck_require__(4094);
 // C headers
 var ERROR;
 (function (ERROR) {
@@ -12097,7 +12097,7 @@ exports.SPECIAL_HEADERS = {
 
 /***/ }),
 
-/***/ 3870:
+/***/ 7724:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -12110,7 +12110,7 @@ module.exports = Buffer.from('AGFzbQEAAAABJwdgAX8Bf2ADf39/AX9gAX8AYAJ/fwBgBH9/f3
 
 /***/ }),
 
-/***/ 3434:
+/***/ 8772:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -12123,7 +12123,7 @@ module.exports = Buffer.from('AGFzbQEAAAABJwdgAX8Bf2ADf39/AX9gAX8AYAJ/fwBgBH9/f3
 
 /***/ }),
 
-/***/ 172:
+/***/ 4094:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -12145,14 +12145,14 @@ exports.enumToMap = enumToMap;
 
 /***/ }),
 
-/***/ 7501:
+/***/ 7319:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { kClients } = __nccwpck_require__(6443)
-const Agent = __nccwpck_require__(7405)
+const { kClients } = __nccwpck_require__(7573)
+const Agent = __nccwpck_require__(8103)
 const {
   kAgent,
   kMockAgentSet,
@@ -12163,14 +12163,14 @@ const {
   kGetNetConnect,
   kOptions,
   kFactory
-} = __nccwpck_require__(1117)
-const MockClient = __nccwpck_require__(7365)
-const MockPool = __nccwpck_require__(4004)
-const { matchValue, buildMockOptions } = __nccwpck_require__(3397)
-const { InvalidArgumentError, UndiciError } = __nccwpck_require__(8707)
-const Dispatcher = __nccwpck_require__(883)
-const Pluralizer = __nccwpck_require__(1529)
-const PendingInterceptorsFormatter = __nccwpck_require__(6142)
+} = __nccwpck_require__(4847)
+const MockClient = __nccwpck_require__(8747)
+const MockPool = __nccwpck_require__(706)
+const { matchValue, buildMockOptions } = __nccwpck_require__(9763)
+const { InvalidArgumentError, UndiciError } = __nccwpck_require__(7013)
+const Dispatcher = __nccwpck_require__(8989)
+const Pluralizer = __nccwpck_require__(5403)
+const PendingInterceptorsFormatter = __nccwpck_require__(7456)
 
 class MockAgent extends Dispatcher {
   constructor (opts) {
@@ -12313,15 +12313,15 @@ module.exports = MockAgent
 
 /***/ }),
 
-/***/ 7365:
+/***/ 8747:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 const { promisify } = __nccwpck_require__(7975)
-const Client = __nccwpck_require__(3701)
-const { buildMockDispatch } = __nccwpck_require__(3397)
+const Client = __nccwpck_require__(2539)
+const { buildMockDispatch } = __nccwpck_require__(9763)
 const {
   kDispatches,
   kMockAgent,
@@ -12330,10 +12330,10 @@ const {
   kOrigin,
   kOriginalDispatch,
   kConnected
-} = __nccwpck_require__(1117)
-const { MockInterceptor } = __nccwpck_require__(1511)
-const Symbols = __nccwpck_require__(6443)
-const { InvalidArgumentError } = __nccwpck_require__(8707)
+} = __nccwpck_require__(4847)
+const { MockInterceptor } = __nccwpck_require__(5437)
+const Symbols = __nccwpck_require__(7573)
+const { InvalidArgumentError } = __nccwpck_require__(7013)
 
 /**
  * MockClient provides an API that extends the Client to influence the mockDispatches.
@@ -12380,13 +12380,13 @@ module.exports = MockClient
 
 /***/ }),
 
-/***/ 2429:
+/***/ 3559:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { UndiciError } = __nccwpck_require__(8707)
+const { UndiciError } = __nccwpck_require__(7013)
 
 const kMockNotMatchedError = Symbol.for('undici.error.UND_MOCK_ERR_MOCK_NOT_MATCHED')
 
@@ -12416,13 +12416,13 @@ module.exports = {
 
 /***/ }),
 
-/***/ 1511:
+/***/ 5437:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { getResponseData, buildKey, addMockDispatch } = __nccwpck_require__(3397)
+const { getResponseData, buildKey, addMockDispatch } = __nccwpck_require__(9763)
 const {
   kDispatches,
   kDispatchKey,
@@ -12430,9 +12430,9 @@ const {
   kDefaultTrailers,
   kContentLength,
   kMockDispatch
-} = __nccwpck_require__(1117)
-const { InvalidArgumentError } = __nccwpck_require__(8707)
-const { buildURL } = __nccwpck_require__(3440)
+} = __nccwpck_require__(4847)
+const { InvalidArgumentError } = __nccwpck_require__(7013)
+const { buildURL } = __nccwpck_require__(4742)
 
 /**
  * Defines the scope API for an interceptor reply
@@ -12631,15 +12631,15 @@ module.exports.MockScope = MockScope
 
 /***/ }),
 
-/***/ 4004:
+/***/ 706:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 const { promisify } = __nccwpck_require__(7975)
-const Pool = __nccwpck_require__(628)
-const { buildMockDispatch } = __nccwpck_require__(3397)
+const Pool = __nccwpck_require__(2690)
+const { buildMockDispatch } = __nccwpck_require__(9763)
 const {
   kDispatches,
   kMockAgent,
@@ -12648,10 +12648,10 @@ const {
   kOrigin,
   kOriginalDispatch,
   kConnected
-} = __nccwpck_require__(1117)
-const { MockInterceptor } = __nccwpck_require__(1511)
-const Symbols = __nccwpck_require__(6443)
-const { InvalidArgumentError } = __nccwpck_require__(8707)
+} = __nccwpck_require__(4847)
+const { MockInterceptor } = __nccwpck_require__(5437)
+const Symbols = __nccwpck_require__(7573)
+const { InvalidArgumentError } = __nccwpck_require__(7013)
 
 /**
  * MockPool provides an API that extends the Pool to influence the mockDispatches.
@@ -12698,7 +12698,7 @@ module.exports = MockPool
 
 /***/ }),
 
-/***/ 1117:
+/***/ 4847:
 /***/ ((module) => {
 
 "use strict";
@@ -12729,21 +12729,21 @@ module.exports = {
 
 /***/ }),
 
-/***/ 3397:
+/***/ 9763:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { MockNotMatchedError } = __nccwpck_require__(2429)
+const { MockNotMatchedError } = __nccwpck_require__(3559)
 const {
   kDispatches,
   kMockAgent,
   kOriginalDispatch,
   kOrigin,
   kGetNetConnect
-} = __nccwpck_require__(1117)
-const { buildURL } = __nccwpck_require__(3440)
+} = __nccwpck_require__(4847)
+const { buildURL } = __nccwpck_require__(4742)
 const { STATUS_CODES } = __nccwpck_require__(7067)
 const {
   types: {
@@ -13104,7 +13104,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 6142:
+/***/ 7456:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -13155,7 +13155,7 @@ module.exports = class PendingInterceptorsFormatter {
 
 /***/ }),
 
-/***/ 1529:
+/***/ 5403:
 /***/ ((module) => {
 
 "use strict";
@@ -13192,7 +13192,7 @@ module.exports = class Pluralizer {
 
 /***/ }),
 
-/***/ 6603:
+/***/ 3325:
 /***/ ((module) => {
 
 "use strict";
@@ -13623,21 +13623,21 @@ module.exports = {
 
 /***/ }),
 
-/***/ 9634:
+/***/ 1440:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { kConstruct } = __nccwpck_require__(109)
-const { urlEquals, getFieldValues } = __nccwpck_require__(6798)
-const { kEnumerableProperty, isDisturbed } = __nccwpck_require__(3440)
-const { webidl } = __nccwpck_require__(5893)
-const { Response, cloneResponse, fromInnerResponse } = __nccwpck_require__(9051)
-const { Request, fromInnerRequest } = __nccwpck_require__(9967)
-const { kState } = __nccwpck_require__(3627)
-const { fetching } = __nccwpck_require__(4398)
-const { urlIsHttpHttpsScheme, createDeferredPromise, readAllBytes } = __nccwpck_require__(3168)
+const { kConstruct } = __nccwpck_require__(6123)
+const { urlEquals, getFieldValues } = __nccwpck_require__(8848)
+const { kEnumerableProperty, isDisturbed } = __nccwpck_require__(4742)
+const { webidl } = __nccwpck_require__(735)
+const { Response, cloneResponse, fromInnerResponse } = __nccwpck_require__(2929)
+const { Request, fromInnerRequest } = __nccwpck_require__(4309)
+const { kState } = __nccwpck_require__(5785)
+const { fetching } = __nccwpck_require__(2104)
+const { urlIsHttpHttpsScheme, createDeferredPromise, readAllBytes } = __nccwpck_require__(18)
 const assert = __nccwpck_require__(4589)
 
 /**
@@ -14490,16 +14490,16 @@ module.exports = {
 
 /***/ }),
 
-/***/ 3245:
+/***/ 1823:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { kConstruct } = __nccwpck_require__(109)
-const { Cache } = __nccwpck_require__(9634)
-const { webidl } = __nccwpck_require__(5893)
-const { kEnumerableProperty } = __nccwpck_require__(3440)
+const { kConstruct } = __nccwpck_require__(6123)
+const { Cache } = __nccwpck_require__(1440)
+const { webidl } = __nccwpck_require__(735)
+const { kEnumerableProperty } = __nccwpck_require__(4742)
 
 class CacheStorage {
   /**
@@ -14650,28 +14650,28 @@ module.exports = {
 
 /***/ }),
 
-/***/ 109:
+/***/ 6123:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 module.exports = {
-  kConstruct: (__nccwpck_require__(6443).kConstruct)
+  kConstruct: (__nccwpck_require__(7573).kConstruct)
 }
 
 
 /***/ }),
 
-/***/ 6798:
+/***/ 8848:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 const assert = __nccwpck_require__(4589)
-const { URLSerializer } = __nccwpck_require__(1900)
-const { isValidHeaderName } = __nccwpck_require__(3168)
+const { URLSerializer } = __nccwpck_require__(9634)
+const { isValidHeaderName } = __nccwpck_require__(18)
 
 /**
  * @see https://url.spec.whatwg.org/#concept-url-equals
@@ -14716,7 +14716,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 1276:
+/***/ 8542:
 /***/ ((module) => {
 
 "use strict";
@@ -14736,16 +14736,16 @@ module.exports = {
 
 /***/ }),
 
-/***/ 9061:
+/***/ 107:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { parseSetCookie } = __nccwpck_require__(1978)
-const { stringify } = __nccwpck_require__(7797)
-const { webidl } = __nccwpck_require__(5893)
-const { Headers } = __nccwpck_require__(660)
+const { parseSetCookie } = __nccwpck_require__(916)
+const { stringify } = __nccwpck_require__(3667)
+const { webidl } = __nccwpck_require__(735)
+const { Headers } = __nccwpck_require__(7386)
 
 /**
  * @typedef {Object} Cookie
@@ -14928,15 +14928,15 @@ module.exports = {
 
 /***/ }),
 
-/***/ 1978:
+/***/ 916:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { maxNameValuePairSize, maxAttributeValueSize } = __nccwpck_require__(1276)
-const { isCTLExcludingHtab } = __nccwpck_require__(7797)
-const { collectASequenceOfCodePointsFast } = __nccwpck_require__(1900)
+const { maxNameValuePairSize, maxAttributeValueSize } = __nccwpck_require__(8542)
+const { isCTLExcludingHtab } = __nccwpck_require__(3667)
+const { collectASequenceOfCodePointsFast } = __nccwpck_require__(9634)
 const assert = __nccwpck_require__(4589)
 
 /**
@@ -15253,7 +15253,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 7797:
+/***/ 3667:
 /***/ ((module) => {
 
 "use strict";
@@ -15543,13 +15543,13 @@ module.exports = {
 
 /***/ }),
 
-/***/ 4031:
+/***/ 1009:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 const { Transform } = __nccwpck_require__(7075)
-const { isASCIINumber, isValidLastEventId } = __nccwpck_require__(4811)
+const { isASCIINumber, isValidLastEventId } = __nccwpck_require__(2893)
 
 /**
  * @type {number[]} BOM
@@ -15949,23 +15949,23 @@ module.exports = {
 
 /***/ }),
 
-/***/ 1238:
+/***/ 5108:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 const { pipeline } = __nccwpck_require__(7075)
-const { fetching } = __nccwpck_require__(4398)
-const { makeRequest } = __nccwpck_require__(9967)
-const { webidl } = __nccwpck_require__(5893)
-const { EventSourceStream } = __nccwpck_require__(4031)
-const { parseMIMEType } = __nccwpck_require__(1900)
-const { createFastMessageEvent } = __nccwpck_require__(5188)
-const { isNetworkError } = __nccwpck_require__(9051)
-const { delay } = __nccwpck_require__(4811)
-const { kEnumerableProperty } = __nccwpck_require__(3440)
-const { environmentSettingsObject } = __nccwpck_require__(3168)
+const { fetching } = __nccwpck_require__(2104)
+const { makeRequest } = __nccwpck_require__(4309)
+const { webidl } = __nccwpck_require__(735)
+const { EventSourceStream } = __nccwpck_require__(1009)
+const { parseMIMEType } = __nccwpck_require__(9634)
+const { createFastMessageEvent } = __nccwpck_require__(4194)
+const { isNetworkError } = __nccwpck_require__(2929)
+const { delay } = __nccwpck_require__(2893)
+const { kEnumerableProperty } = __nccwpck_require__(4742)
+const { environmentSettingsObject } = __nccwpck_require__(18)
 
 let experimentalWarned = false
 
@@ -16437,7 +16437,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 4811:
+/***/ 2893:
 /***/ ((module) => {
 
 "use strict";
@@ -16482,13 +16482,13 @@ module.exports = {
 
 /***/ }),
 
-/***/ 4492:
+/***/ 1294:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const util = __nccwpck_require__(3440)
+const util = __nccwpck_require__(4742)
 const {
   ReadableStreamFrom,
   isBlobLike,
@@ -16498,16 +16498,16 @@ const {
   fullyReadBody,
   extractMimeType,
   utf8DecodeBytes
-} = __nccwpck_require__(3168)
-const { FormData } = __nccwpck_require__(5910)
-const { kState } = __nccwpck_require__(3627)
-const { webidl } = __nccwpck_require__(5893)
+} = __nccwpck_require__(18)
+const { FormData } = __nccwpck_require__(6124)
+const { kState } = __nccwpck_require__(5785)
+const { webidl } = __nccwpck_require__(735)
 const { Blob } = __nccwpck_require__(4573)
 const assert = __nccwpck_require__(4589)
 const { isErrored, isDisturbed } = __nccwpck_require__(7075)
 const { isArrayBuffer } = __nccwpck_require__(3429)
-const { serializeAMimeType } = __nccwpck_require__(1900)
-const { multipartFormDataParser } = __nccwpck_require__(116)
+const { serializeAMimeType } = __nccwpck_require__(9634)
+const { multipartFormDataParser } = __nccwpck_require__(8850)
 let random
 
 try {
@@ -17019,7 +17019,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 4495:
+/***/ 7997:
 /***/ ((module) => {
 
 "use strict";
@@ -17151,7 +17151,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 1900:
+/***/ 9634:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -17903,13 +17903,13 @@ module.exports = {
 
 /***/ }),
 
-/***/ 6653:
+/***/ 6547:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { kConnected, kSize } = __nccwpck_require__(6443)
+const { kConnected, kSize } = __nccwpck_require__(7573)
 
 class CompatWeakRef {
   constructor (value) {
@@ -17957,15 +17957,15 @@ module.exports = function () {
 
 /***/ }),
 
-/***/ 7114:
+/***/ 5336:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 const { Blob, File } = __nccwpck_require__(4573)
-const { kState } = __nccwpck_require__(3627)
-const { webidl } = __nccwpck_require__(5893)
+const { kState } = __nccwpck_require__(5785)
+const { webidl } = __nccwpck_require__(735)
 
 // TODO(@KhafraDev): remove
 class FileLike {
@@ -18091,17 +18091,17 @@ module.exports = { FileLike, isFileLike }
 
 /***/ }),
 
-/***/ 116:
+/***/ 8850:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { isUSVString, bufferToLowerCasedHeaderName } = __nccwpck_require__(3440)
-const { utf8DecodeBytes } = __nccwpck_require__(3168)
-const { HTTP_TOKEN_CODEPOINTS, isomorphicDecode } = __nccwpck_require__(1900)
-const { isFileLike } = __nccwpck_require__(7114)
-const { makeEntry } = __nccwpck_require__(5910)
+const { isUSVString, bufferToLowerCasedHeaderName } = __nccwpck_require__(4742)
+const { utf8DecodeBytes } = __nccwpck_require__(18)
+const { HTTP_TOKEN_CODEPOINTS, isomorphicDecode } = __nccwpck_require__(9634)
+const { isFileLike } = __nccwpck_require__(5336)
+const { makeEntry } = __nccwpck_require__(6124)
 const assert = __nccwpck_require__(4589)
 const { File: NodeFile } = __nccwpck_require__(4573)
 
@@ -18573,17 +18573,17 @@ module.exports = {
 
 /***/ }),
 
-/***/ 5910:
+/***/ 6124:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { isBlobLike, iteratorMixin } = __nccwpck_require__(3168)
-const { kState } = __nccwpck_require__(3627)
-const { kEnumerableProperty } = __nccwpck_require__(3440)
-const { FileLike, isFileLike } = __nccwpck_require__(7114)
-const { webidl } = __nccwpck_require__(5893)
+const { isBlobLike, iteratorMixin } = __nccwpck_require__(18)
+const { kState } = __nccwpck_require__(5785)
+const { kEnumerableProperty } = __nccwpck_require__(4742)
+const { FileLike, isFileLike } = __nccwpck_require__(5336)
+const { webidl } = __nccwpck_require__(735)
 const { File: NativeFile } = __nccwpck_require__(4573)
 const nodeUtil = __nccwpck_require__(7975)
 
@@ -18833,7 +18833,7 @@ module.exports = { FormData, makeEntry }
 
 /***/ }),
 
-/***/ 1059:
+/***/ 9553:
 /***/ ((module) => {
 
 "use strict";
@@ -18881,7 +18881,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 660:
+/***/ 7386:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -18889,14 +18889,14 @@ module.exports = {
 
 
 
-const { kConstruct } = __nccwpck_require__(6443)
-const { kEnumerableProperty } = __nccwpck_require__(3440)
+const { kConstruct } = __nccwpck_require__(7573)
+const { kEnumerableProperty } = __nccwpck_require__(4742)
 const {
   iteratorMixin,
   isValidHeaderName,
   isValidHeaderValue
-} = __nccwpck_require__(3168)
-const { webidl } = __nccwpck_require__(5893)
+} = __nccwpck_require__(18)
+const { webidl } = __nccwpck_require__(735)
 const assert = __nccwpck_require__(4589)
 const util = __nccwpck_require__(7975)
 
@@ -19576,7 +19576,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 4398:
+/***/ 2104:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -19590,9 +19590,9 @@ const {
   filterResponse,
   makeResponse,
   fromInnerResponse
-} = __nccwpck_require__(9051)
-const { HeadersList } = __nccwpck_require__(660)
-const { Request, cloneRequest } = __nccwpck_require__(9967)
+} = __nccwpck_require__(2929)
+const { HeadersList } = __nccwpck_require__(7386)
+const { Request, cloneRequest } = __nccwpck_require__(4309)
 const zlib = __nccwpck_require__(8522)
 const {
   bytesMatch,
@@ -19628,23 +19628,23 @@ const {
   buildContentRange,
   createInflate,
   extractMimeType
-} = __nccwpck_require__(3168)
-const { kState, kDispatcher } = __nccwpck_require__(3627)
+} = __nccwpck_require__(18)
+const { kState, kDispatcher } = __nccwpck_require__(5785)
 const assert = __nccwpck_require__(4589)
-const { safelyExtractBody, extractBody } = __nccwpck_require__(4492)
+const { safelyExtractBody, extractBody } = __nccwpck_require__(1294)
 const {
   redirectStatusSet,
   nullBodyStatus,
   safeMethodsSet,
   requestBodyHeader,
   subresourceSet
-} = __nccwpck_require__(4495)
+} = __nccwpck_require__(7997)
 const EE = __nccwpck_require__(8474)
 const { Readable, pipeline, finished } = __nccwpck_require__(7075)
-const { addAbortListener, isErrored, isReadable, bufferToLowerCasedHeaderName } = __nccwpck_require__(3440)
-const { dataURLProcessor, serializeAMimeType, minimizeSupportedMimeType } = __nccwpck_require__(1900)
-const { getGlobalDispatcher } = __nccwpck_require__(2581)
-const { webidl } = __nccwpck_require__(5893)
+const { addAbortListener, isErrored, isReadable, bufferToLowerCasedHeaderName } = __nccwpck_require__(4742)
+const { dataURLProcessor, serializeAMimeType, minimizeSupportedMimeType } = __nccwpck_require__(9634)
+const { getGlobalDispatcher } = __nccwpck_require__(3723)
+const { webidl } = __nccwpck_require__(735)
 const { STATUS_CODES } = __nccwpck_require__(7067)
 const GET_OR_HEAD = ['GET', 'HEAD']
 
@@ -21856,7 +21856,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 9967:
+/***/ 4309:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -21864,16 +21864,16 @@ module.exports = {
 
 
 
-const { extractBody, mixinBody, cloneBody, bodyUnusable } = __nccwpck_require__(4492)
-const { Headers, fill: fillHeaders, HeadersList, setHeadersGuard, getHeadersGuard, setHeadersList, getHeadersList } = __nccwpck_require__(660)
-const { FinalizationRegistry } = __nccwpck_require__(6653)()
-const util = __nccwpck_require__(3440)
+const { extractBody, mixinBody, cloneBody, bodyUnusable } = __nccwpck_require__(1294)
+const { Headers, fill: fillHeaders, HeadersList, setHeadersGuard, getHeadersGuard, setHeadersList, getHeadersList } = __nccwpck_require__(7386)
+const { FinalizationRegistry } = __nccwpck_require__(6547)()
+const util = __nccwpck_require__(4742)
 const nodeUtil = __nccwpck_require__(7975)
 const {
   isValidHTTPToken,
   sameOrigin,
   environmentSettingsObject
-} = __nccwpck_require__(3168)
+} = __nccwpck_require__(18)
 const {
   forbiddenMethodsSet,
   corsSafeListedMethodsSet,
@@ -21883,12 +21883,12 @@ const {
   requestCredentials,
   requestCache,
   requestDuplex
-} = __nccwpck_require__(4495)
+} = __nccwpck_require__(7997)
 const { kEnumerableProperty, normalizedMethodRecordsBase, normalizedMethodRecords } = util
-const { kHeaders, kSignal, kState, kDispatcher } = __nccwpck_require__(3627)
-const { webidl } = __nccwpck_require__(5893)
-const { URLSerializer } = __nccwpck_require__(1900)
-const { kConstruct } = __nccwpck_require__(6443)
+const { kHeaders, kSignal, kState, kDispatcher } = __nccwpck_require__(5785)
+const { webidl } = __nccwpck_require__(735)
+const { URLSerializer } = __nccwpck_require__(9634)
+const { kConstruct } = __nccwpck_require__(7573)
 const assert = __nccwpck_require__(4589)
 const { getMaxListeners, setMaxListeners, getEventListeners, defaultMaxListeners } = __nccwpck_require__(8474)
 
@@ -22901,15 +22901,15 @@ module.exports = { Request, makeRequest, fromInnerRequest, cloneRequest }
 
 /***/ }),
 
-/***/ 9051:
+/***/ 2929:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { Headers, HeadersList, fill, getHeadersGuard, setHeadersGuard, setHeadersList } = __nccwpck_require__(660)
-const { extractBody, cloneBody, mixinBody, hasFinalizationRegistry, streamRegistry, bodyUnusable } = __nccwpck_require__(4492)
-const util = __nccwpck_require__(3440)
+const { Headers, HeadersList, fill, getHeadersGuard, setHeadersGuard, setHeadersList } = __nccwpck_require__(7386)
+const { extractBody, cloneBody, mixinBody, hasFinalizationRegistry, streamRegistry, bodyUnusable } = __nccwpck_require__(1294)
+const util = __nccwpck_require__(4742)
 const nodeUtil = __nccwpck_require__(7975)
 const { kEnumerableProperty } = util
 const {
@@ -22921,16 +22921,16 @@ const {
   isErrorLike,
   isomorphicEncode,
   environmentSettingsObject: relevantRealm
-} = __nccwpck_require__(3168)
+} = __nccwpck_require__(18)
 const {
   redirectStatusSet,
   nullBodyStatus
-} = __nccwpck_require__(4495)
-const { kState, kHeaders } = __nccwpck_require__(3627)
-const { webidl } = __nccwpck_require__(5893)
-const { FormData } = __nccwpck_require__(5910)
-const { URLSerializer } = __nccwpck_require__(1900)
-const { kConstruct } = __nccwpck_require__(6443)
+} = __nccwpck_require__(7997)
+const { kState, kHeaders } = __nccwpck_require__(5785)
+const { webidl } = __nccwpck_require__(735)
+const { FormData } = __nccwpck_require__(6124)
+const { URLSerializer } = __nccwpck_require__(9634)
+const { kConstruct } = __nccwpck_require__(7573)
 const assert = __nccwpck_require__(4589)
 const { types } = __nccwpck_require__(7975)
 
@@ -23519,7 +23519,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 3627:
+/***/ 5785:
 /***/ ((module) => {
 
 "use strict";
@@ -23536,7 +23536,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 3168:
+/***/ 18:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -23544,14 +23544,14 @@ module.exports = {
 
 const { Transform } = __nccwpck_require__(7075)
 const zlib = __nccwpck_require__(8522)
-const { redirectStatusSet, referrerPolicySet: referrerPolicyTokens, badPortsSet } = __nccwpck_require__(4495)
-const { getGlobalOrigin } = __nccwpck_require__(1059)
-const { collectASequenceOfCodePoints, collectAnHTTPQuotedString, removeChars, parseMIMEType } = __nccwpck_require__(1900)
+const { redirectStatusSet, referrerPolicySet: referrerPolicyTokens, badPortsSet } = __nccwpck_require__(7997)
+const { getGlobalOrigin } = __nccwpck_require__(9553)
+const { collectASequenceOfCodePoints, collectAnHTTPQuotedString, removeChars, parseMIMEType } = __nccwpck_require__(9634)
 const { performance } = __nccwpck_require__(643)
-const { isBlobLike, ReadableStreamFrom, isValidHTTPToken, normalizedMethodRecordsBase } = __nccwpck_require__(3440)
+const { isBlobLike, ReadableStreamFrom, isValidHTTPToken, normalizedMethodRecordsBase } = __nccwpck_require__(4742)
 const assert = __nccwpck_require__(4589)
 const { isUint8Array } = __nccwpck_require__(3429)
-const { webidl } = __nccwpck_require__(5893)
+const { webidl } = __nccwpck_require__(735)
 
 let supportedHashes = []
 
@@ -25176,7 +25176,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 5893:
+/***/ 735:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -25184,7 +25184,7 @@ module.exports = {
 
 const { types, inspect } = __nccwpck_require__(7975)
 const { markAsUncloneable } = __nccwpck_require__(5919)
-const { toUSVString } = __nccwpck_require__(3440)
+const { toUSVString } = __nccwpck_require__(4742)
 
 /** @type {import('../../../types/webidl').Webidl} */
 const webidl = {}
@@ -25879,7 +25879,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 2607:
+/***/ 4281:
 /***/ ((module) => {
 
 "use strict";
@@ -26177,7 +26177,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 8355:
+/***/ 6413:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -26187,16 +26187,16 @@ const {
   staticPropertyDescriptors,
   readOperation,
   fireAProgressEvent
-} = __nccwpck_require__(3610)
+} = __nccwpck_require__(4968)
 const {
   kState,
   kError,
   kResult,
   kEvents,
   kAborted
-} = __nccwpck_require__(961)
-const { webidl } = __nccwpck_require__(5893)
-const { kEnumerableProperty } = __nccwpck_require__(3440)
+} = __nccwpck_require__(227)
+const { webidl } = __nccwpck_require__(735)
+const { kEnumerableProperty } = __nccwpck_require__(4742)
 
 class FileReader extends EventTarget {
   constructor () {
@@ -26529,13 +26529,13 @@ module.exports = {
 
 /***/ }),
 
-/***/ 8573:
+/***/ 1519:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { webidl } = __nccwpck_require__(5893)
+const { webidl } = __nccwpck_require__(735)
 
 const kState = Symbol('ProgressEvent state')
 
@@ -26615,7 +26615,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 961:
+/***/ 227:
 /***/ ((module) => {
 
 "use strict";
@@ -26633,7 +26633,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 3610:
+/***/ 4968:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -26645,10 +26645,10 @@ const {
   kResult,
   kAborted,
   kLastProgressEventFired
-} = __nccwpck_require__(961)
-const { ProgressEvent } = __nccwpck_require__(8573)
-const { getEncoding } = __nccwpck_require__(2607)
-const { serializeAMimeType, parseMIMEType } = __nccwpck_require__(1900)
+} = __nccwpck_require__(227)
+const { ProgressEvent } = __nccwpck_require__(1519)
+const { getEncoding } = __nccwpck_require__(4281)
+const { serializeAMimeType, parseMIMEType } = __nccwpck_require__(9634)
 const { types } = __nccwpck_require__(7975)
 const { StringDecoder } = __nccwpck_require__(3193)
 const { btoa } = __nccwpck_require__(4573)
@@ -27032,28 +27032,28 @@ module.exports = {
 
 /***/ }),
 
-/***/ 6897:
+/***/ 8863:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { uid, states, sentCloseFrameState, emptyBuffer, opcodes } = __nccwpck_require__(736)
+const { uid, states, sentCloseFrameState, emptyBuffer, opcodes } = __nccwpck_require__(8742)
 const {
   kReadyState,
   kSentClose,
   kByteParser,
   kReceivedClose,
   kResponse
-} = __nccwpck_require__(1216)
-const { fireEvent, failWebsocketConnection, isClosing, isClosed, isEstablished, parseExtensions } = __nccwpck_require__(8625)
-const { channels } = __nccwpck_require__(2414)
-const { CloseEvent } = __nccwpck_require__(5188)
-const { makeRequest } = __nccwpck_require__(9967)
-const { fetching } = __nccwpck_require__(4398)
-const { Headers, getHeadersList } = __nccwpck_require__(660)
-const { getDecodeSplit } = __nccwpck_require__(3168)
-const { WebsocketFrameSend } = __nccwpck_require__(3264)
+} = __nccwpck_require__(358)
+const { fireEvent, failWebsocketConnection, isClosing, isClosed, isEstablished, parseExtensions } = __nccwpck_require__(5259)
+const { channels } = __nccwpck_require__(8664)
+const { CloseEvent } = __nccwpck_require__(4194)
+const { makeRequest } = __nccwpck_require__(4309)
+const { fetching } = __nccwpck_require__(2104)
+const { Headers, getHeadersList } = __nccwpck_require__(7386)
+const { getDecodeSplit } = __nccwpck_require__(18)
+const { WebsocketFrameSend } = __nccwpck_require__(6062)
 
 /** @type {import('crypto')} */
 let crypto
@@ -27411,7 +27411,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 736:
+/***/ 8742:
 /***/ ((module) => {
 
 "use strict";
@@ -27485,15 +27485,15 @@ module.exports = {
 
 /***/ }),
 
-/***/ 5188:
+/***/ 4194:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { webidl } = __nccwpck_require__(5893)
-const { kEnumerableProperty } = __nccwpck_require__(3440)
-const { kConstruct } = __nccwpck_require__(6443)
+const { webidl } = __nccwpck_require__(735)
+const { kEnumerableProperty } = __nccwpck_require__(4742)
+const { kConstruct } = __nccwpck_require__(7573)
 const { MessagePort } = __nccwpck_require__(5919)
 
 /**
@@ -27822,13 +27822,13 @@ module.exports = {
 
 /***/ }),
 
-/***/ 3264:
+/***/ 6062:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { maxUnsigned16Bit } = __nccwpck_require__(736)
+const { maxUnsigned16Bit } = __nccwpck_require__(8742)
 
 const BUFFER_SIZE = 16386
 
@@ -27926,15 +27926,15 @@ module.exports = {
 
 /***/ }),
 
-/***/ 9469:
+/***/ 5275:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 const { createInflateRaw, Z_DEFAULT_WINDOWBITS } = __nccwpck_require__(8522)
-const { isValidClientWindowBits } = __nccwpck_require__(8625)
-const { MessageSizeExceededError } = __nccwpck_require__(8707)
+const { isValidClientWindowBits } = __nccwpck_require__(5259)
+const { MessageSizeExceededError } = __nccwpck_require__(7013)
 
 const tail = Buffer.from([0x00, 0x00, 0xff, 0xff])
 const kBuffer = Symbol('kBuffer')
@@ -28052,7 +28052,7 @@ module.exports = { PerMessageDeflate }
 
 /***/ }),
 
-/***/ 1652:
+/***/ 9646:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -28060,9 +28060,9 @@ module.exports = { PerMessageDeflate }
 
 const { Writable } = __nccwpck_require__(7075)
 const assert = __nccwpck_require__(4589)
-const { parserStates, opcodes, states, emptyBuffer, sentCloseFrameState } = __nccwpck_require__(736)
-const { kReadyState, kSentClose, kResponse, kReceivedClose } = __nccwpck_require__(1216)
-const { channels } = __nccwpck_require__(2414)
+const { parserStates, opcodes, states, emptyBuffer, sentCloseFrameState } = __nccwpck_require__(8742)
+const { kReadyState, kSentClose, kResponse, kReceivedClose } = __nccwpck_require__(358)
+const { channels } = __nccwpck_require__(8664)
 const {
   isValidStatusCode,
   isValidOpcode,
@@ -28072,10 +28072,10 @@ const {
   isControlFrame,
   isTextBinaryFrame,
   isContinuationFrame
-} = __nccwpck_require__(8625)
-const { WebsocketFrameSend } = __nccwpck_require__(3264)
-const { closeWebSocketConnection } = __nccwpck_require__(6897)
-const { PerMessageDeflate } = __nccwpck_require__(9469)
+} = __nccwpck_require__(5259)
+const { WebsocketFrameSend } = __nccwpck_require__(6062)
+const { closeWebSocketConnection } = __nccwpck_require__(8863)
+const { PerMessageDeflate } = __nccwpck_require__(5275)
 
 // This code was influenced by ws released under the MIT license.
 // Copyright (c) 2011 Einar Otto Stangvik <einaros@gmail.com>
@@ -28487,15 +28487,15 @@ module.exports = {
 
 /***/ }),
 
-/***/ 3900:
+/***/ 8002:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { WebsocketFrameSend } = __nccwpck_require__(3264)
-const { opcodes, sendHints } = __nccwpck_require__(736)
-const FixedQueue = __nccwpck_require__(4660)
+const { WebsocketFrameSend } = __nccwpck_require__(6062)
+const { opcodes, sendHints } = __nccwpck_require__(8742)
+const FixedQueue = __nccwpck_require__(7842)
 
 /** @type {typeof Uint8Array} */
 const FastBuffer = Buffer[Symbol.species]
@@ -28599,7 +28599,7 @@ module.exports = { SendQueue }
 
 /***/ }),
 
-/***/ 1216:
+/***/ 358:
 /***/ ((module) => {
 
 "use strict";
@@ -28619,17 +28619,17 @@ module.exports = {
 
 /***/ }),
 
-/***/ 8625:
+/***/ 5259:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { kReadyState, kController, kResponse, kBinaryType, kWebSocketURL } = __nccwpck_require__(1216)
-const { states, opcodes } = __nccwpck_require__(736)
-const { ErrorEvent, createFastMessageEvent } = __nccwpck_require__(5188)
+const { kReadyState, kController, kResponse, kBinaryType, kWebSocketURL } = __nccwpck_require__(358)
+const { states, opcodes } = __nccwpck_require__(8742)
+const { ErrorEvent, createFastMessageEvent } = __nccwpck_require__(4194)
 const { isUtf8 } = __nccwpck_require__(4573)
-const { collectASequenceOfCodePointsFast, removeHTTPWhitespace } = __nccwpck_require__(1900)
+const { collectASequenceOfCodePointsFast, removeHTTPWhitespace } = __nccwpck_require__(9634)
 
 /* globals Blob */
 
@@ -28949,16 +28949,16 @@ module.exports = {
 
 /***/ }),
 
-/***/ 3726:
+/***/ 564:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { webidl } = __nccwpck_require__(5893)
-const { URLSerializer } = __nccwpck_require__(1900)
-const { environmentSettingsObject } = __nccwpck_require__(3168)
-const { staticPropertyDescriptors, states, sentCloseFrameState, sendHints } = __nccwpck_require__(736)
+const { webidl } = __nccwpck_require__(735)
+const { URLSerializer } = __nccwpck_require__(9634)
+const { environmentSettingsObject } = __nccwpck_require__(18)
+const { staticPropertyDescriptors, states, sentCloseFrameState, sendHints } = __nccwpck_require__(8742)
 const {
   kWebSocketURL,
   kReadyState,
@@ -28967,21 +28967,21 @@ const {
   kResponse,
   kSentClose,
   kByteParser
-} = __nccwpck_require__(1216)
+} = __nccwpck_require__(358)
 const {
   isConnecting,
   isEstablished,
   isClosing,
   isValidSubprotocol,
   fireEvent
-} = __nccwpck_require__(8625)
-const { establishWebSocketConnection, closeWebSocketConnection } = __nccwpck_require__(6897)
-const { ByteParser } = __nccwpck_require__(1652)
-const { kEnumerableProperty, isBlobLike } = __nccwpck_require__(3440)
-const { getGlobalDispatcher } = __nccwpck_require__(2581)
+} = __nccwpck_require__(5259)
+const { establishWebSocketConnection, closeWebSocketConnection } = __nccwpck_require__(8863)
+const { ByteParser } = __nccwpck_require__(9646)
+const { kEnumerableProperty, isBlobLike } = __nccwpck_require__(4742)
+const { getGlobalDispatcher } = __nccwpck_require__(3723)
 const { types } = __nccwpck_require__(7975)
-const { ErrorEvent, CloseEvent } = __nccwpck_require__(5188)
-const { SendQueue } = __nccwpck_require__(3900)
+const { ErrorEvent, CloseEvent } = __nccwpck_require__(4194)
+const { SendQueue } = __nccwpck_require__(8002)
 
 // https://websockets.spec.whatwg.org/#interface-definition
 class WebSocket extends EventTarget {
@@ -29545,7 +29545,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 9665:
+/***/ 430:
 /***/ ((module) => {
 
 module.exports = eval("require")("./swc.android-arm-eabi.node");
@@ -29553,7 +29553,7 @@ module.exports = eval("require")("./swc.android-arm-eabi.node");
 
 /***/ }),
 
-/***/ 8685:
+/***/ 4528:
 /***/ ((module) => {
 
 module.exports = eval("require")("./swc.android-arm64.node");
@@ -29561,7 +29561,7 @@ module.exports = eval("require")("./swc.android-arm64.node");
 
 /***/ }),
 
-/***/ 475:
+/***/ 4000:
 /***/ ((module) => {
 
 module.exports = eval("require")("./swc.darwin-arm64.node");
@@ -29569,7 +29569,7 @@ module.exports = eval("require")("./swc.darwin-arm64.node");
 
 /***/ }),
 
-/***/ 8818:
+/***/ 8533:
 /***/ ((module) => {
 
 module.exports = eval("require")("./swc.darwin-universal.node");
@@ -29577,7 +29577,7 @@ module.exports = eval("require")("./swc.darwin-universal.node");
 
 /***/ }),
 
-/***/ 8009:
+/***/ 3530:
 /***/ ((module) => {
 
 module.exports = eval("require")("./swc.darwin-x64.node");
@@ -29585,7 +29585,7 @@ module.exports = eval("require")("./swc.darwin-x64.node");
 
 /***/ }),
 
-/***/ 3873:
+/***/ 3588:
 /***/ ((module) => {
 
 module.exports = eval("require")("./swc.freebsd-arm64.node");
@@ -29593,7 +29593,7 @@ module.exports = eval("require")("./swc.freebsd-arm64.node");
 
 /***/ }),
 
-/***/ 3291:
+/***/ 9638:
 /***/ ((module) => {
 
 module.exports = eval("require")("./swc.freebsd-x64.node");
@@ -29601,7 +29601,7 @@ module.exports = eval("require")("./swc.freebsd-x64.node");
 
 /***/ }),
 
-/***/ 7222:
+/***/ 91:
 /***/ ((module) => {
 
 module.exports = eval("require")("./swc.linux-arm-gnueabihf.node");
@@ -29609,7 +29609,7 @@ module.exports = eval("require")("./swc.linux-arm-gnueabihf.node");
 
 /***/ }),
 
-/***/ 8337:
+/***/ 1464:
 /***/ ((module) => {
 
 module.exports = eval("require")("./swc.linux-arm64-gnu.node");
@@ -29617,7 +29617,7 @@ module.exports = eval("require")("./swc.linux-arm64-gnu.node");
 
 /***/ }),
 
-/***/ 7602:
+/***/ 4073:
 /***/ ((module) => {
 
 module.exports = eval("require")("./swc.linux-arm64-musl.node");
@@ -29625,7 +29625,7 @@ module.exports = eval("require")("./swc.linux-arm64-musl.node");
 
 /***/ }),
 
-/***/ 1446:
+/***/ 1887:
 /***/ ((module) => {
 
 module.exports = eval("require")("./swc.linux-ppc64-gnu.node");
@@ -29633,7 +29633,7 @@ module.exports = eval("require")("./swc.linux-ppc64-gnu.node");
 
 /***/ }),
 
-/***/ 9312:
+/***/ 1553:
 /***/ ((module) => {
 
 module.exports = eval("require")("./swc.linux-riscv64-gnu.node");
@@ -29641,7 +29641,7 @@ module.exports = eval("require")("./swc.linux-riscv64-gnu.node");
 
 /***/ }),
 
-/***/ 8593:
+/***/ 6786:
 /***/ ((module) => {
 
 module.exports = eval("require")("./swc.linux-riscv64-musl.node");
@@ -29649,7 +29649,7 @@ module.exports = eval("require")("./swc.linux-riscv64-musl.node");
 
 /***/ }),
 
-/***/ 2644:
+/***/ 5217:
 /***/ ((module) => {
 
 module.exports = eval("require")("./swc.linux-s390x-gnu.node");
@@ -29657,7 +29657,7 @@ module.exports = eval("require")("./swc.linux-s390x-gnu.node");
 
 /***/ }),
 
-/***/ 4675:
+/***/ 5146:
 /***/ ((module) => {
 
 module.exports = eval("require")("./swc.linux-x64-gnu.node");
@@ -29665,7 +29665,7 @@ module.exports = eval("require")("./swc.linux-x64-gnu.node");
 
 /***/ }),
 
-/***/ 2356:
+/***/ 3795:
 /***/ ((module) => {
 
 module.exports = eval("require")("./swc.linux-x64-musl.node");
@@ -29673,7 +29673,7 @@ module.exports = eval("require")("./swc.linux-x64-musl.node");
 
 /***/ }),
 
-/***/ 6681:
+/***/ 300:
 /***/ ((module) => {
 
 module.exports = eval("require")("./swc.wasi.cjs");
@@ -29681,7 +29681,7 @@ module.exports = eval("require")("./swc.wasi.cjs");
 
 /***/ }),
 
-/***/ 3535:
+/***/ 6640:
 /***/ ((module) => {
 
 module.exports = eval("require")("./swc.win32-arm64-msvc.node");
@@ -29689,7 +29689,7 @@ module.exports = eval("require")("./swc.win32-arm64-msvc.node");
 
 /***/ }),
 
-/***/ 8152:
+/***/ 5017:
 /***/ ((module) => {
 
 module.exports = eval("require")("./swc.win32-ia32-msvc.node");
@@ -29697,7 +29697,7 @@ module.exports = eval("require")("./swc.win32-ia32-msvc.node");
 
 /***/ }),
 
-/***/ 2665:
+/***/ 802:
 /***/ ((module) => {
 
 module.exports = eval("require")("./swc.win32-x64-msvc.node");
@@ -29705,7 +29705,7 @@ module.exports = eval("require")("./swc.win32-x64-msvc.node");
 
 /***/ }),
 
-/***/ 727:
+/***/ 694:
 /***/ ((module) => {
 
 module.exports = eval("require")("@swc/core-android-arm-eabi");
@@ -29713,7 +29713,7 @@ module.exports = eval("require")("@swc/core-android-arm-eabi");
 
 /***/ }),
 
-/***/ 607:
+/***/ 6212:
 /***/ ((module) => {
 
 module.exports = eval("require")("@swc/core-android-arm64");
@@ -29721,7 +29721,7 @@ module.exports = eval("require")("@swc/core-android-arm64");
 
 /***/ }),
 
-/***/ 5049:
+/***/ 2560:
 /***/ ((module) => {
 
 module.exports = eval("require")("@swc/core-darwin-arm64");
@@ -29729,7 +29729,7 @@ module.exports = eval("require")("@swc/core-darwin-arm64");
 
 /***/ }),
 
-/***/ 3890:
+/***/ 9963:
 /***/ ((module) => {
 
 module.exports = eval("require")("@swc/core-darwin-universal");
@@ -29737,7 +29737,7 @@ module.exports = eval("require")("@swc/core-darwin-universal");
 
 /***/ }),
 
-/***/ 8139:
+/***/ 2766:
 /***/ ((module) => {
 
 module.exports = eval("require")("@swc/core-darwin-x64");
@@ -29745,7 +29745,7 @@ module.exports = eval("require")("@swc/core-darwin-x64");
 
 /***/ }),
 
-/***/ 5367:
+/***/ 7860:
 /***/ ((module) => {
 
 module.exports = eval("require")("@swc/core-freebsd-arm64");
@@ -29753,7 +29753,7 @@ module.exports = eval("require")("@swc/core-freebsd-arm64");
 
 /***/ }),
 
-/***/ 6229:
+/***/ 3242:
 /***/ ((module) => {
 
 module.exports = eval("require")("@swc/core-freebsd-x64");
@@ -29761,7 +29761,7 @@ module.exports = eval("require")("@swc/core-freebsd-x64");
 
 /***/ }),
 
-/***/ 1638:
+/***/ 1225:
 /***/ ((module) => {
 
 module.exports = eval("require")("@swc/core-linux-arm-gnueabihf");
@@ -29769,7 +29769,7 @@ module.exports = eval("require")("@swc/core-linux-arm-gnueabihf");
 
 /***/ }),
 
-/***/ 6571:
+/***/ 6244:
 /***/ ((module) => {
 
 module.exports = eval("require")("@swc/core-linux-arm64-gnu");
@@ -29777,7 +29777,7 @@ module.exports = eval("require")("@swc/core-linux-arm64-gnu");
 
 /***/ }),
 
-/***/ 5254:
+/***/ 7915:
 /***/ ((module) => {
 
 module.exports = eval("require")("@swc/core-linux-arm64-musl");
@@ -29785,7 +29785,7 @@ module.exports = eval("require")("@swc/core-linux-arm64-musl");
 
 /***/ }),
 
-/***/ 3586:
+/***/ 1329:
 /***/ ((module) => {
 
 module.exports = eval("require")("@swc/core-linux-ppc64-gnu");
@@ -29793,7 +29793,7 @@ module.exports = eval("require")("@swc/core-linux-ppc64-gnu");
 
 /***/ }),
 
-/***/ 9008:
+/***/ 8199:
 /***/ ((module) => {
 
 module.exports = eval("require")("@swc/core-linux-riscv64-gnu");
@@ -29801,7 +29801,7 @@ module.exports = eval("require")("@swc/core-linux-riscv64-gnu");
 
 /***/ }),
 
-/***/ 8879:
+/***/ 5930:
 /***/ ((module) => {
 
 module.exports = eval("require")("@swc/core-linux-riscv64-musl");
@@ -29809,7 +29809,7 @@ module.exports = eval("require")("@swc/core-linux-riscv64-musl");
 
 /***/ }),
 
-/***/ 8600:
+/***/ 6635:
 /***/ ((module) => {
 
 module.exports = eval("require")("@swc/core-linux-s390x-gnu");
@@ -29817,7 +29817,7 @@ module.exports = eval("require")("@swc/core-linux-s390x-gnu");
 
 /***/ }),
 
-/***/ 7793:
+/***/ 746:
 /***/ ((module) => {
 
 module.exports = eval("require")("@swc/core-linux-x64-gnu");
@@ -29825,7 +29825,7 @@ module.exports = eval("require")("@swc/core-linux-x64-gnu");
 
 /***/ }),
 
-/***/ 6900:
+/***/ 5169:
 /***/ ((module) => {
 
 module.exports = eval("require")("@swc/core-linux-x64-musl");
@@ -29833,7 +29833,7 @@ module.exports = eval("require")("@swc/core-linux-x64-musl");
 
 /***/ }),
 
-/***/ 9301:
+/***/ 7722:
 /***/ ((module) => {
 
 module.exports = eval("require")("@swc/core-wasm32-wasi");
@@ -29841,7 +29841,7 @@ module.exports = eval("require")("@swc/core-wasm32-wasi");
 
 /***/ }),
 
-/***/ 293:
+/***/ 6200:
 /***/ ((module) => {
 
 module.exports = eval("require")("@swc/core-win32-arm64-msvc");
@@ -29849,7 +29849,7 @@ module.exports = eval("require")("@swc/core-win32-arm64-msvc");
 
 /***/ }),
 
-/***/ 1612:
+/***/ 7411:
 /***/ ((module) => {
 
 module.exports = eval("require")("@swc/core-win32-ia32-msvc");
@@ -29857,7 +29857,7 @@ module.exports = eval("require")("@swc/core-win32-ia32-msvc");
 
 /***/ }),
 
-/***/ 5855:
+/***/ 4196:
 /***/ ((module) => {
 
 module.exports = eval("require")("@swc/wasm");
@@ -30113,7 +30113,7 @@ module.exports = require("util");
 
 /***/ }),
 
-/***/ 1120:
+/***/ 2602:
 /***/ ((module) => {
 
 "use strict";
@@ -30291,7 +30291,7 @@ __webpack_unused_export__ = defaultContentType
 
 /***/ }),
 
-/***/ 155:
+/***/ 6662:
 /***/ ((module) => {
 
 "use strict";
@@ -30373,7 +30373,7 @@ var __webpack_exports__ = {};
 
 ;// CONCATENATED MODULE: external "os"
 const external_os_namespaceObject = require("os");
-;// CONCATENATED MODULE: ./node_modules/@actions/core/lib/utils.js
+;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/@actions/core/lib/utils.js
 // We use any as a valid input type
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /**
@@ -30409,7 +30409,7 @@ function utils_toCommandProperties(annotationProperties) {
     };
 }
 //# sourceMappingURL=utils.js.map
-;// CONCATENATED MODULE: ./node_modules/@actions/core/lib/command.js
+;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/@actions/core/lib/command.js
 
 
 /**
@@ -30505,7 +30505,7 @@ function escapeProperty(s) {
 const external_crypto_namespaceObject = require("crypto");
 // EXTERNAL MODULE: external "fs"
 var external_fs_ = __nccwpck_require__(9896);
-;// CONCATENATED MODULE: ./node_modules/@actions/core/lib/file-command.js
+;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/@actions/core/lib/file-command.js
 // For internal use, subject to change.
 // We use any as a valid input type
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -30546,7 +30546,7 @@ var external_path_ = __nccwpck_require__(6928);
 var external_http_ = __nccwpck_require__(8611);
 // EXTERNAL MODULE: external "https"
 var external_https_ = __nccwpck_require__(5692);
-;// CONCATENATED MODULE: ./node_modules/@actions/core/node_modules/@actions/http-client/lib/proxy.js
+;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/@actions/core/node_modules/@actions/http-client/lib/proxy.js
 function getProxyUrl(reqUrl) {
     const usingSsl = reqUrl.protocol === 'https:';
     if (checkBypass(reqUrl)) {
@@ -30637,11 +30637,11 @@ class DecodedURL extends URL {
     }
 }
 //# sourceMappingURL=proxy.js.map
-// EXTERNAL MODULE: ./node_modules/tunnel/index.js
-var node_modules_tunnel = __nccwpck_require__(770);
-// EXTERNAL MODULE: ./node_modules/undici/index.js
-var undici = __nccwpck_require__(6752);
-;// CONCATENATED MODULE: ./node_modules/@actions/core/node_modules/@actions/http-client/lib/index.js
+// EXTERNAL MODULE: ../../Users/david/Projects/trailhead/node_modules/tunnel/index.js
+var node_modules_tunnel = __nccwpck_require__(6628);
+// EXTERNAL MODULE: ../../Users/david/Projects/trailhead/node_modules/undici/index.js
+var undici = __nccwpck_require__(4258);
+;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/@actions/core/node_modules/@actions/http-client/lib/index.js
 /* eslint-disable @typescript-eslint/no-explicit-any */
 var __awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
@@ -31338,7 +31338,7 @@ class lib_HttpClient {
 }
 const lowercaseKeys = (obj) => Object.keys(obj).reduce((c, k) => ((c[k.toLowerCase()] = obj[k]), c), {});
 //# sourceMappingURL=index.js.map
-;// CONCATENATED MODULE: ./node_modules/@actions/core/node_modules/@actions/http-client/lib/auth.js
+;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/@actions/core/node_modules/@actions/http-client/lib/auth.js
 var auth_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -31414,7 +31414,7 @@ class PersonalAccessTokenCredentialHandler {
     }
 }
 //# sourceMappingURL=auth.js.map
-;// CONCATENATED MODULE: ./node_modules/@actions/core/lib/oidc-utils.js
+;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/@actions/core/lib/oidc-utils.js
 var oidc_utils_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -31488,7 +31488,7 @@ class oidc_utils_OidcClient {
     }
 }
 //# sourceMappingURL=oidc-utils.js.map
-;// CONCATENATED MODULE: ./node_modules/@actions/core/lib/summary.js
+;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/@actions/core/lib/summary.js
 var summary_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -31769,7 +31769,7 @@ const _summary = new Summary();
 const markdownSummary = (/* unused pure expression or super */ null && (_summary));
 const summary = _summary;
 //# sourceMappingURL=summary.js.map
-;// CONCATENATED MODULE: ./node_modules/@actions/core/lib/path-utils.js
+;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/@actions/core/lib/path-utils.js
 
 /**
  * toPosixPath converts the given path to the posix form. On Windows, \\ will be
@@ -31811,7 +31811,7 @@ var external_events_ = __nccwpck_require__(4434);
 var external_child_process_ = __nccwpck_require__(5317);
 // EXTERNAL MODULE: external "assert"
 var external_assert_ = __nccwpck_require__(2613);
-;// CONCATENATED MODULE: ./node_modules/@actions/io/lib/io-util.js
+;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/@actions/io/lib/io-util.js
 var io_util_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -31991,7 +31991,7 @@ function getCmdPath() {
     return (_a = process.env['COMSPEC']) !== null && _a !== void 0 ? _a : `cmd.exe`;
 }
 //# sourceMappingURL=io-util.js.map
-;// CONCATENATED MODULE: ./node_modules/@actions/io/lib/io.js
+;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/@actions/io/lib/io.js
 var io_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -32265,7 +32265,7 @@ function io_copyFile(srcFile, destFile, force) {
 //# sourceMappingURL=io.js.map
 ;// CONCATENATED MODULE: external "timers"
 const external_timers_namespaceObject = require("timers");
-;// CONCATENATED MODULE: ./node_modules/@actions/exec/lib/toolrunner.js
+;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/@actions/exec/lib/toolrunner.js
 var toolrunner_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -32853,7 +32853,7 @@ class ExecState extends external_events_.EventEmitter {
     }
 }
 //# sourceMappingURL=toolrunner.js.map
-;// CONCATENATED MODULE: ./node_modules/@actions/exec/lib/exec.js
+;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/@actions/exec/lib/exec.js
 var exec_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -32933,7 +32933,7 @@ function getExecOutput(commandLine, args, options) {
     });
 }
 //# sourceMappingURL=exec.js.map
-;// CONCATENATED MODULE: ./node_modules/@actions/core/lib/platform.js
+;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/@actions/core/lib/platform.js
 var platform_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -32998,7 +32998,7 @@ function getDetails() {
     });
 }
 //# sourceMappingURL=platform.js.map
-;// CONCATENATED MODULE: ./node_modules/@actions/core/lib/core.js
+;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/@actions/core/lib/core.js
 var core_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -33316,7 +33316,7 @@ function getIDToken(aud) {
  */
 
 //# sourceMappingURL=core.js.map
-;// CONCATENATED MODULE: ./node_modules/@actions/github/lib/context.js
+;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/@actions/github/lib/context.js
 
 
 class Context {
@@ -33369,9 +33369,9 @@ class Context {
     }
 }
 //# sourceMappingURL=context.js.map
-// EXTERNAL MODULE: ./node_modules/@actions/http-client/lib/index.js
-var lib = __nccwpck_require__(4844);
-;// CONCATENATED MODULE: ./node_modules/@actions/github/lib/internal/utils.js
+// EXTERNAL MODULE: ../../Users/david/Projects/trailhead/node_modules/@actions/http-client/lib/index.js
+var lib = __nccwpck_require__(4866);
+;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/@actions/github/lib/internal/utils.js
 var utils_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -33424,7 +33424,7 @@ function getUserAgentWithOrchestrationId(baseUserAgent) {
     return baseUserAgent;
 }
 //# sourceMappingURL=utils.js.map
-;// CONCATENATED MODULE: ./node_modules/universal-user-agent/index.js
+;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/universal-user-agent/index.js
 function getUserAgent() {
   if (typeof navigator === "object" && "userAgent" in navigator) {
     return navigator.userAgent;
@@ -33439,7 +33439,7 @@ function getUserAgent() {
   return "<environment undetectable>";
 }
 
-;// CONCATENATED MODULE: ./node_modules/before-after-hook/lib/register.js
+;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/before-after-hook/lib/register.js
 // @ts-check
 
 function register(state, name, method, options) {
@@ -33468,7 +33468,7 @@ function register(state, name, method, options) {
   });
 }
 
-;// CONCATENATED MODULE: ./node_modules/before-after-hook/lib/add.js
+;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/before-after-hook/lib/add.js
 // @ts-check
 
 function addHook(state, kind, name, hook) {
@@ -33516,7 +33516,7 @@ function addHook(state, kind, name, hook) {
   });
 }
 
-;// CONCATENATED MODULE: ./node_modules/before-after-hook/lib/remove.js
+;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/before-after-hook/lib/remove.js
 // @ts-check
 
 function removeHook(state, name, method) {
@@ -33537,7 +33537,7 @@ function removeHook(state, name, method) {
   state.registry[name].splice(index, 1);
 }
 
-;// CONCATENATED MODULE: ./node_modules/before-after-hook/index.js
+;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/before-after-hook/index.js
 // @ts-check
 
 
@@ -33584,7 +33584,7 @@ function Collection() {
 
 /* harmony default export */ const before_after_hook = ({ Singular, Collection });
 
-;// CONCATENATED MODULE: ./node_modules/@octokit/endpoint/dist-bundle/index.js
+;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/@octokit/endpoint/dist-bundle/index.js
 // pkg/dist-src/defaults.js
 
 
@@ -33930,9 +33930,9 @@ function withDefaults(oldDefaults, newDefaults) {
 var endpoint = withDefaults(null, DEFAULTS);
 
 
-// EXTERNAL MODULE: ./node_modules/fast-content-type-parse/index.js
-var fast_content_type_parse = __nccwpck_require__(1120);
-;// CONCATENATED MODULE: ./node_modules/json-with-bigint/json-with-bigint.js
+// EXTERNAL MODULE: ../../Users/david/Projects/trailhead/node_modules/fast-content-type-parse/index.js
+var fast_content_type_parse = __nccwpck_require__(2602);
+;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/json-with-bigint/json-with-bigint.js
 const intRegex = /^-?\d+$/;
 const noiseValue = /^-?\d+n+$/; // Noise - strings that match the custom format before being converted to it
 const originalStringify = JSON.stringify;
@@ -34149,7 +34149,7 @@ const JSONParse = (text, reviver) => {
 
 
 
-;// CONCATENATED MODULE: ./node_modules/@octokit/request-error/dist-src/index.js
+;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/@octokit/request-error/dist-src/index.js
 class RequestError extends Error {
   name;
   /**
@@ -34190,7 +34190,7 @@ class RequestError extends Error {
 }
 
 
-;// CONCATENATED MODULE: ./node_modules/@octokit/request/dist-bundle/index.js
+;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/@octokit/request/dist-bundle/index.js
 // pkg/dist-src/index.js
 
 
@@ -34393,7 +34393,7 @@ var request = dist_bundle_withDefaults(endpoint, defaults_default);
 /* v8 ignore next -- @preserve */
 /* v8 ignore else -- @preserve */
 
-;// CONCATENATED MODULE: ./node_modules/@octokit/graphql/dist-bundle/index.js
+;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/@octokit/graphql/dist-bundle/index.js
 // pkg/dist-src/index.js
 
 
@@ -34520,7 +34520,7 @@ function withCustomRequest(customRequest) {
 }
 
 
-;// CONCATENATED MODULE: ./node_modules/@octokit/auth-token/dist-bundle/index.js
+;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/@octokit/auth-token/dist-bundle/index.js
 // pkg/dist-src/is-jwt.js
 var b64url = "(?:[a-zA-Z0-9_-]+)";
 var sep = "\\.";
@@ -34575,11 +34575,11 @@ var createTokenAuth = function createTokenAuth2(token) {
 };
 
 
-;// CONCATENATED MODULE: ./node_modules/@octokit/core/dist-src/version.js
+;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/@octokit/core/dist-src/version.js
 const version_VERSION = "7.0.6";
 
 
-;// CONCATENATED MODULE: ./node_modules/@octokit/core/dist-src/index.js
+;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/@octokit/core/dist-src/index.js
 
 
 
@@ -34720,12 +34720,12 @@ class Octokit {
 }
 
 
-;// CONCATENATED MODULE: ./node_modules/@octokit/plugin-rest-endpoint-methods/dist-src/version.js
+;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/@octokit/plugin-rest-endpoint-methods/dist-src/version.js
 const dist_src_version_VERSION = "17.0.0";
 
 //# sourceMappingURL=version.js.map
 
-;// CONCATENATED MODULE: ./node_modules/@octokit/plugin-rest-endpoint-methods/dist-src/generated/endpoints.js
+;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/@octokit/plugin-rest-endpoint-methods/dist-src/generated/endpoints.js
 const Endpoints = {
   actions: {
     addCustomLabelsToSelfHostedRunnerForOrg: [
@@ -37019,7 +37019,7 @@ var endpoints_default = Endpoints;
 
 //# sourceMappingURL=endpoints.js.map
 
-;// CONCATENATED MODULE: ./node_modules/@octokit/plugin-rest-endpoint-methods/dist-src/endpoints-to-methods.js
+;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/@octokit/plugin-rest-endpoint-methods/dist-src/endpoints-to-methods.js
 
 const endpointMethodsMap = /* @__PURE__ */ new Map();
 for (const [scope, endpoints] of Object.entries(endpoints_default)) {
@@ -37145,7 +37145,7 @@ function decorate(octokit, scope, methodName, defaults, decorations) {
 
 //# sourceMappingURL=endpoints-to-methods.js.map
 
-;// CONCATENATED MODULE: ./node_modules/@octokit/plugin-rest-endpoint-methods/dist-src/index.js
+;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/@octokit/plugin-rest-endpoint-methods/dist-src/index.js
 
 
 function restEndpointMethods(octokit) {
@@ -37166,7 +37166,7 @@ legacyRestEndpointMethods.VERSION = dist_src_version_VERSION;
 
 //# sourceMappingURL=index.js.map
 
-;// CONCATENATED MODULE: ./node_modules/@octokit/plugin-paginate-rest/dist-bundle/index.js
+;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/@octokit/plugin-paginate-rest/dist-bundle/index.js
 // pkg/dist-src/version.js
 var plugin_paginate_rest_dist_bundle_VERSION = "0.0.0-development";
 
@@ -37578,7 +37578,7 @@ function paginateRest(octokit) {
 paginateRest.VERSION = plugin_paginate_rest_dist_bundle_VERSION;
 
 
-;// CONCATENATED MODULE: ./node_modules/@actions/github/lib/utils.js
+;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/@actions/github/lib/utils.js
 
 
 // octokit + plugins
@@ -37617,7 +37617,7 @@ function getOctokitOptions(token, options) {
     return opts;
 }
 //# sourceMappingURL=utils.js.map
-;// CONCATENATED MODULE: ./node_modules/@actions/github/lib/github.js
+;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/@actions/github/lib/github.js
 
 
 const github_context = new Context();
@@ -37632,7 +37632,7 @@ function getOctokit(token, options, ...additionalPlugins) {
     return new GitHubWithPlugins(getOctokitOptions(token, options));
 }
 //# sourceMappingURL=github.js.map
-;// CONCATENATED MODULE: ./node_modules/zod/v3/helpers/util.js
+;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/zod/v3/helpers/util.js
 var util;
 (function (util) {
     util.assertEqual = (_) => { };
@@ -37767,7 +37767,7 @@ const getParsedType = (data) => {
     }
 };
 
-;// CONCATENATED MODULE: ./node_modules/zod/v3/ZodError.js
+;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/zod/v3/ZodError.js
 
 const ZodIssueCode = util.arrayToEnum([
     "invalid_type",
@@ -37902,7 +37902,7 @@ ZodError.create = (issues) => {
     return error;
 };
 
-;// CONCATENATED MODULE: ./node_modules/zod/v3/locales/en.js
+;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/zod/v3/locales/en.js
 
 
 const errorMap = (issue, _ctx) => {
@@ -38013,7 +38013,7 @@ const errorMap = (issue, _ctx) => {
 };
 /* harmony default export */ const en = (errorMap);
 
-;// CONCATENATED MODULE: ./node_modules/zod/v3/errors.js
+;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/zod/v3/errors.js
 
 let overrideErrorMap = en;
 
@@ -38024,7 +38024,7 @@ function getErrorMap() {
     return overrideErrorMap;
 }
 
-;// CONCATENATED MODULE: ./node_modules/zod/v3/helpers/errorUtil.js
+;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/zod/v3/helpers/errorUtil.js
 var errorUtil;
 (function (errorUtil) {
     errorUtil.errToObj = (message) => typeof message === "string" ? { message } : message || {};
@@ -38032,7 +38032,7 @@ var errorUtil;
     errorUtil.toString = (message) => typeof message === "string" ? message : message?.message;
 })(errorUtil || (errorUtil = {}));
 
-;// CONCATENATED MODULE: ./node_modules/zod/v3/helpers/parseUtil.js
+;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/zod/v3/helpers/parseUtil.js
 
 
 const makeIssue = (params) => {
@@ -38143,7 +38143,7 @@ const isDirty = (x) => x.status === "dirty";
 const isValid = (x) => x.status === "valid";
 const isAsync = (x) => typeof Promise !== "undefined" && x instanceof Promise;
 
-;// CONCATENATED MODULE: ./node_modules/zod/v3/types.js
+;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/zod/v3/types.js
 
 
 
@@ -42229,6 +42229,10 @@ const SubmissionConfig = objectType({
     mode: enumType(["warn", "block"]).default("block"),
     stale_terms: arrayType(stringType()).optional(),
     auth_route_allowlist: arrayType(stringType()).optional(),
+    /** Additional function identifiers that prove an API route authenticated. */
+    auth_route_helpers: arrayType(stringType().min(1)).optional(),
+    /** Side-effect-free tombstone routes; each body must still return HTTP 410. */
+    retired_route_allowlist: arrayType(stringType()).optional(),
     max_file_lines: numberType().int().positive().optional(),
     /** Path substrings to skip for context_freshness (e.g. archived suggestion dirs). */
     path_ignore: arrayType(stringType()).optional(),
@@ -44115,7 +44119,9 @@ function prPathSet(files) {
     return new Set(files.map((f) => normalizePath(f.filename)));
 }
 function isTestPath(filename) {
-    return /\/__tests__\/|\/test\/|\/fixtures\/|\.test\.|\.spec\./.test(filename);
+    const path = `/${normalizePath(filename).toLowerCase()}`;
+    return (/\/(?:__tests__|__fixtures__|tests?|test-fixtures|fixtures)\//.test(path) ||
+        /\.(?:test|spec)\.[^./]+$/.test(path));
 }
 /** Default archived/stale path segments skipped by context_freshness. */
 const DEFAULT_STALE_PATH_IGNORE = ["/_stale/", "/_archive/", "/.archive/"];
@@ -44599,7 +44605,7 @@ function runPhase0Detectors(ctx) {
         .filter((check) => check !== null);
 }
 
-;// CONCATENATED MODULE: ./node_modules/js-yaml/dist/js-yaml.mjs
+;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/js-yaml/dist/js-yaml.mjs
 
 /*! js-yaml 4.1.1 https://github.com/nodeca/js-yaml @license MIT */
 function isNothing(subject) {
@@ -48966,8 +48972,8 @@ function detectPromotionCoherence(ctx) {
     };
 }
 
-// EXTERNAL MODULE: ./node_modules/@swc/core/index.js
-var _swc_core = __nccwpck_require__(5971);
+// EXTERNAL MODULE: ../../Users/david/Projects/trailhead/node_modules/@swc/core/index.js
+var _swc_core = __nccwpck_require__(5229);
 ;// CONCATENATED MODULE: ./src/submission-checks/syntax-validity.ts
 // Real parse-based syntax validation for Gate 1 (no bracket-count fallback).
 // Parses full file content only — never a partial diff hunk (see submission-gate.md).
@@ -49151,6 +49157,27 @@ const SECRET_PATTERNS = [
         pattern: /api[_-]?key\s*[:=]\s*['"][A-Za-z0-9_-]{32,}['"]/gi,
     },
 ];
+function isCiConfigurationPath(filename) {
+    return /^\.github\/(?:workflows|actions)\//.test(normalizePath(filename));
+}
+function isCredentialFixturePath(filename) {
+    return isTestPath(filename) || isCiConfigurationPath(filename);
+}
+function isObviouslyInertCiFixtureLine(line, filename) {
+    if (!isCiConfigurationPath(filename))
+        return false;
+    const assignment = /^\s*[\w.-]+\s*:\s*["']?([^"'#\s]+)["']?(?:\s*#.*)?$/.exec(line);
+    if (!assignment?.[1])
+        return false;
+    return /^(?:sk_(?:test|live)_)?(?:placeholder|example|dummy|fake|test|x{10,}|0{10,})$/i.test(assignment[1]);
+}
+function isObviouslyInertStripeFixture(patternName, match, filename) {
+    if (!isCredentialFixturePath(filename) || !patternName.startsWith("Stripe ")) {
+        return false;
+    }
+    const suffix = match.replace(/^sk_(?:test|live)_/i, "");
+    return /^(?:placeholder|example|dummy|fake|test|x{10,}|0{10,})$/i.test(suffix);
+}
 const HARDCODED_ENV_PATTERNS = [
     { name: "localhost with port", pattern: /(?:['"`])localhost:\d{2,5}(?:['"`])/g },
     {
@@ -49191,6 +49218,8 @@ function detectMockPlaceholder(ctx) {
     const hits = scanAddedContent(ctx.files, (line, filename) => {
         if (isTestPath(filename))
             return false;
+        if (isObviouslyInertCiFixtureLine(line, filename))
+            return false;
         if (/\.(md|txt)$/i.test(filename))
             return false;
         return MOCK_PATTERNS.some((re) => {
@@ -49210,9 +49239,9 @@ function detectMockPlaceholder(ctx) {
     });
 }
 function detectSecrets(ctx) {
-    const hits = scanAddedContent(ctx.files, (line) => SECRET_PATTERNS.some((entry) => {
+    const hits = scanAddedContent(ctx.files, (line, filename) => SECRET_PATTERNS.some((entry) => {
         entry.pattern.lastIndex = 0;
-        return entry.pattern.test(line);
+        return [...line.matchAll(entry.pattern)].some((match) => !isObviouslyInertStripeFixture(entry.name, match[0] ?? "", filename));
     }));
     if (hits.length === 0)
         return null;
@@ -49532,17 +49561,31 @@ function detectRlsNewTables(ctx) {
 function isRouteAllowlisted(path, allowlist) {
     return allowlist.some((entry) => path.includes(entry.replace(/^\//, "")));
 }
+function escapeRegExp(value) {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+function isRetiredRoute(path, content, allowlist) {
+    if (!isRouteAllowlisted(path, allowlist))
+        return false;
+    return /\bstatus\s*:\s*410\b/.test(content);
+}
 function detectAuthRouteAuth(ctx) {
     const routePattern = /(?:^|\/)(?:app\/api\/.+\/route|pages\/api\/.+)\.(?:ts|tsx|js|jsx)$/;
-    const authPattern = /\b(getUser|getSession|getServerSession|auth|requireAuth|withAuth)\s*\(/;
+    const helpers = [...new Set(ctx.authRouteHelpers)].filter((helper) => /^[A-Za-z_$][\w$]*$/.test(helper));
+    const authPattern = new RegExp(`\\b(?:${helpers.map(escapeRegExp).join("|")})\\s*\\(`);
     const hits = [];
     for (const file of ctx.files) {
         const normalized = normalizePath(file.filename);
         if (!routePattern.test(normalized))
             continue;
+        if (file.status === "removed")
+            continue;
         if (isRouteAllowlisted(normalized, ctx.authRouteAllowlist))
             continue;
-        if (!authPattern.test(fileContent(file)))
+        const content = fileContent(file);
+        if (isRetiredRoute(normalized, content, ctx.retiredRouteAllowlist))
+            continue;
+        if (helpers.length === 0 || !authPattern.test(content))
             hits.push(normalized);
     }
     if (hits.length === 0)
@@ -49715,6 +49758,14 @@ const DEFAULT_AUTH_ROUTE_ALLOWLIST = [
     "/api/health/",
     "/api/metrics/",
 ];
+const DEFAULT_AUTH_ROUTE_HELPERS = [
+    "getUser",
+    "getSession",
+    "getServerSession",
+    "auth",
+    "requireAuth",
+    "withAuth",
+];
 /** Package names declared in a package.json (legacy gate parity). */
 function declaredPackageNamesFromPackageJson(pkg) {
     const sections = [
@@ -49744,6 +49795,11 @@ function buildContext(options) {
         staleTerms,
         namingAllowlist: repoConfig?.submission?.naming_allowlist ?? {},
         authRouteAllowlist: repoConfig?.submission?.auth_route_allowlist ?? DEFAULT_AUTH_ROUTE_ALLOWLIST,
+        authRouteHelpers: [
+            ...DEFAULT_AUTH_ROUTE_HELPERS,
+            ...(repoConfig?.submission?.auth_route_helpers ?? []),
+        ],
+        retiredRouteAllowlist: repoConfig?.submission?.retired_route_allowlist ?? [],
         maxFileLines: repoConfig?.submission?.max_file_lines ?? 1000,
         declaredPackages: declared,
         pathIgnorePatterns: repoConfig?.submission?.path_ignore ?? [],
@@ -49951,8 +50007,12 @@ const factorCues = {
         triggerScore: 50,
         advisoryScore: 20,
         build: (factor) => {
-            const files = factor.detail?.file_count ?? 0;
-            const changes = factor.detail?.line_count ?? 0;
+            const files = factor.detail?.fileCount ??
+                factor.detail?.file_count ??
+                0;
+            const changes = factor.detail?.totalChanges ??
+                factor.detail?.line_count ??
+                0;
             return {
                 code: "policy.pr_scope",
                 severity: "warn",
@@ -50892,7 +50952,99 @@ function readTrustRuntime(env = process.env) {
     };
 }
 
+;// CONCATENATED MODULE: ./src/ci-integrity.ts
+function addedPatchLines(patch) {
+    if (!patch)
+        return [];
+    return patch
+        .split("\n")
+        .filter((line) => line.startsWith("+") && !line.startsWith("+++"))
+        .map((line) => line.slice(1));
+}
+/** Detect newly introduced CI bypasses, never unchanged or deleted context. */
+function detectCiIntegrity(files) {
+    const blockingPatterns = [];
+    const warningSignals = [];
+    let score = 0;
+    for (const file of files.filter((entry) => entry.filename.startsWith(".github/workflows/"))) {
+        const added = addedPatchLines(file.patch).join("\n");
+        if (/\|\|\s*true/.test(added)) {
+            blockingPatterns.push(`${file.filename}: workflow bypass pattern "|| true"`);
+            score += 45;
+        }
+        if (/^\s*continue-on-error:\s*true\b/m.test(added)) {
+            blockingPatterns.push(`${file.filename}: introduced "continue-on-error: true"`);
+            score += 45;
+        }
+        if (/^\s*if:\s*\$\{\{\s*always\(\)\s*\}\}/m.test(added)) {
+            warningSignals.push(`${file.filename}: always() condition added to workflow gate`);
+            score += 20;
+        }
+    }
+    for (const file of files.filter((entry) => /\.(test|spec)\.(ts|tsx|js|jsx)$|__tests__\/|\.cy\.(ts|js)$/.test(entry.filename))) {
+        const additions = file.additions ?? 0;
+        const deletions = file.deletions ?? 0;
+        if (deletions > additions * 2 && deletions >= 10) {
+            warningSignals.push(`${file.filename}: heavy test deletion (${deletions} deleted / ${additions} added)`);
+            score += 25;
+        }
+    }
+    for (const file of files) {
+        const patch = file.patch ?? "";
+        if (!patch)
+            continue;
+        if (/^-\s*(branches|functions|lines|statements)\s*:\s*\d+/m.test(patch) &&
+            /^\+\s*(branches|functions|lines|statements)\s*:\s*\d+/m.test(patch)) {
+            warningSignals.push(`${file.filename}: coverage threshold definition changed`);
+            score += 20;
+        }
+    }
+    return {
+        score: Math.min(100, score),
+        blockingPatterns,
+        warningSignals,
+    };
+}
+
+;// CONCATENATED MODULE: ./src/github-pagination.ts
+/**
+ * Collect a GitHub REST endpoint page-by-page. A full final page is treated as
+ * incomplete when maxPages is reached so callers can surface truncated input.
+ */
+async function collectGitHubPages(fetchPage, options = {}) {
+    const perPage = Math.min(100, Math.max(1, options.perPage ?? 100));
+    const maxPages = Math.max(1, options.maxPages ?? 30);
+    const items = [];
+    for (let page = 1; page <= maxPages; page += 1) {
+        const pageItems = await fetchPage(page, perPage);
+        items.push(...pageItems);
+        if (pageItems.length < perPage) {
+            return { items, pages: page, complete: true };
+        }
+    }
+    return { items, pages: maxPages, complete: false };
+}
+/** Fetch every available JSON-array page from a GitHub REST URL. */
+async function fetchGitHubJsonPages(url, init, options = {}) {
+    return collectGitHubPages(async (page, perPage) => {
+        const pageUrl = new URL(url);
+        pageUrl.searchParams.set("per_page", String(perPage));
+        pageUrl.searchParams.set("page", String(page));
+        const response = await fetch(pageUrl, init);
+        if (!response.ok) {
+            throw new Error(`GitHub request failed: HTTP ${response.status}`);
+        }
+        const data = (await response.json());
+        if (!Array.isArray(data)) {
+            throw new Error("GitHub paginated response was not an array");
+        }
+        return data;
+    }, options);
+}
+
 ;// CONCATENATED MODULE: ./src/gate.ts
+
+
 
 
 
@@ -50937,30 +51089,39 @@ function parseDeclaredPackages(raw) {
 // PR diff fetching via @actions/github
 // ---------------------------------------------------------------------------
 async function fetchPrFilesFromApi(octokit, owner, repo, prNumber) {
-    const { data: files } = await octokit.rest.pulls.listFiles({
-        owner,
-        repo,
-        pull_number: prNumber,
-        per_page: 300,
-    });
-    if (files.length >= 300) {
-        core_warning("PR has 300+ files — risk analysis may be incomplete (GitHub API pagination limit)");
+    const result = await collectGitHubPages(async (page, perPage) => {
+        const { data } = await octokit.rest.pulls.listFiles({
+            owner,
+            repo,
+            pull_number: prNumber,
+            per_page: perPage,
+            page,
+        });
+        return data;
+    }, { perPage: 100, maxPages: 30 });
+    if (!result.complete) {
+        core_warning("PR file enumeration reached GitHub's 3,000-file API ceiling; risk analysis is incomplete.");
     }
-    return files.map((f) => ({
+    return result.items.map((f) => ({
         filename: f.filename,
         additions: f.additions,
         deletions: f.deletions,
         changes: f.changes,
         patch: f.patch,
+        status: f.status,
     }));
 }
 async function fetchPrFilesFromCommits(octokit, owner, repo, prNumber) {
-    const { data: commits } = await octokit.rest.pulls.listCommits({
-        owner,
-        repo,
-        pull_number: prNumber,
-        per_page: 250,
-    });
+    const { items: commits } = await collectGitHubPages(async (page, perPage) => {
+        const { data } = await octokit.rest.pulls.listCommits({
+            owner,
+            repo,
+            pull_number: prNumber,
+            per_page: perPage,
+            page,
+        });
+        return data;
+    }, { perPage: 100, maxPages: 3 });
     const fileMap = new Map();
     for (const commit of commits) {
         const { data: detail } = await octokit.rest.repos.getCommit({
@@ -50993,6 +51154,31 @@ const DRIFT_CHECK_FILE_THRESHOLD = 30;
 // If the API reports more than 2x the files the commits actually touch,
 // the merge-base is stale and we use the commit-derived list instead.
 const MERGE_BASE_DRIFT_RATIO = 2.0;
+const API_ROUTE_FILE = /(?:^|\/)(?:app\/api\/.+\/route|pages\/api\/.+)\.(?:ts|tsx|js|jsx)$/;
+async function hydrateChangedRouteContents(octokit, owner, repo, ref, files) {
+    const routes = files.filter((file) => file.status !== "removed" && API_ROUTE_FILE.test(file.filename.replace(/\\/g, "/")));
+    // Keep the request fan-out bounded while still avoiding serial latency on
+    // route-heavy PRs. Route bodies are the source of truth for auth checks.
+    const batchSize = 8;
+    for (let start = 0; start < routes.length; start += batchSize) {
+        await Promise.all(routes.slice(start, start + batchSize).map(async (file) => {
+            try {
+                const { data } = await octokit.rest.repos.getContent({
+                    owner,
+                    repo,
+                    path: file.filename,
+                    ref,
+                });
+                if (Array.isArray(data) || data.type !== "file" || !data.content)
+                    return;
+                file.content = Buffer.from(data.content, "base64").toString("utf8");
+            }
+            catch (error) {
+                core_debug(`Could not fetch current route body for ${file.filename}: ${error}`);
+            }
+        }));
+    }
+}
 async function fetchPrFiles(prNumber, token) {
     if (!token)
         return [];
@@ -51000,31 +51186,35 @@ async function fetchPrFiles(prNumber, token) {
         const octokit = getOctokit(token);
         const { owner, repo } = github_context.repo;
         const apiFiles = await fetchPrFilesFromApi(octokit, owner, repo, prNumber);
-        if (apiFiles.length <= DRIFT_CHECK_FILE_THRESHOLD) {
-            return apiFiles;
+        let selectedFiles = apiFiles;
+        if (apiFiles.length > DRIFT_CHECK_FILE_THRESHOLD) {
+            // GitHub's pulls.listFiles uses a merge-base diff that can include
+            // files from unrelated commits when the base branch has diverged
+            // from the PR branch point. Cross-check against the files the PR's
+            // commits actually touch and fall back when inflation is detected.
+            info(`PR reports ${apiFiles.length} files (>${DRIFT_CHECK_FILE_THRESHOLD}), ` +
+                `cross-checking against commit-level file list for merge-base drift.`);
+            let commitFiles = [];
+            try {
+                commitFiles = await fetchPrFilesFromCommits(octokit, owner, repo, prNumber);
+            }
+            catch (err) {
+                core_debug(`Commit-level file enumeration failed, using API list: ${err}`);
+            }
+            if (commitFiles.length > 0 &&
+                apiFiles.length > commitFiles.length * MERGE_BASE_DRIFT_RATIO) {
+                core_warning(`Merge-base drift: API reported ${apiFiles.length} files, ` +
+                    `but PR commits only touch ${commitFiles.length}. ` +
+                    `Using commit-derived file list to avoid inflated risk scores.`);
+                const apiByName = new Map(apiFiles.map((file) => [file.filename, file]));
+                selectedFiles = commitFiles.map((file) => ({
+                    ...file,
+                    patch: apiByName.get(file.filename)?.patch,
+                    status: apiByName.get(file.filename)?.status,
+                }));
+            }
         }
-        // GitHub's pulls.listFiles uses a merge-base diff that can include
-        // files from unrelated commits when the base branch has diverged
-        // from the PR branch point.  Cross-check against the files the PR's
-        // commits actually touch and fall back when inflation is detected.
-        info(`PR reports ${apiFiles.length} files (>${DRIFT_CHECK_FILE_THRESHOLD}), ` +
-            `cross-checking against commit-level file list for merge-base drift.`);
-        let commitFiles;
-        try {
-            commitFiles = await fetchPrFilesFromCommits(octokit, owner, repo, prNumber);
-        }
-        catch (err) {
-            core_debug(`Commit-level file enumeration failed, using API list: ${err}`);
-            return apiFiles;
-        }
-        if (commitFiles.length > 0 &&
-            apiFiles.length > commitFiles.length * MERGE_BASE_DRIFT_RATIO) {
-            core_warning(`Merge-base drift: API reported ${apiFiles.length} files, ` +
-                `but PR commits only touch ${commitFiles.length}. ` +
-                `Using commit-derived file list to avoid inflated risk scores.`);
-            return commitFiles;
-        }
-        return apiFiles;
+        return selectedFiles;
     }
     catch (error) {
         core_debug(`Failed to fetch PR files: ${error}`);
@@ -51298,42 +51488,7 @@ async function detectPrProvenance(prNumber, token) {
     }
 }
 function detectCiIntegrityRisk(files) {
-    const blockingPatterns = [];
-    const warningSignals = [];
-    let score = 0;
-    const workflowFiles = files.filter((f) => f.filename.startsWith(".github/workflows/"));
-    const testFiles = files.filter((f) => /\.(test|spec)\.(ts|tsx|js|jsx)$|__tests__\/|\.cy\.(ts|js)$/.test(f.filename));
-    for (const file of workflowFiles) {
-        const patch = file.patch ?? "";
-        if (/\|\|\s*true/.test(patch)) {
-            blockingPatterns.push(`${file.filename}: workflow bypass pattern "|| true"`);
-            score += 45;
-        }
-        if (/^\+\s*continue-on-error:\s*true\b/m.test(patch)) {
-            blockingPatterns.push(`${file.filename}: introduced "continue-on-error: true"`);
-            score += 45;
-        }
-        if (/^\+\s*if:\s*\$\{\{\s*always\(\)\s*\}\}/m.test(patch)) {
-            warningSignals.push(`${file.filename}: always() condition added to workflow gate`);
-            score += 20;
-        }
-    }
-    for (const file of testFiles) {
-        if (file.deletions > file.additions * 2 && file.deletions >= 10) {
-            warningSignals.push(`${file.filename}: heavy test deletion (${file.deletions} deleted / ${file.additions} added)`);
-            score += 25;
-        }
-    }
-    for (const file of files) {
-        const patch = file.patch ?? "";
-        if (!patch)
-            continue;
-        if (/^-\s*(branches|functions|lines|statements)\s*:\s*\d+/m.test(patch) &&
-            /^\+\s*(branches|functions|lines|statements)\s*:\s*\d+/m.test(patch)) {
-            warningSignals.push(`${file.filename}: coverage threshold definition changed`);
-            score += 20;
-        }
-    }
+    const { score, blockingPatterns, warningSignals } = detectCiIntegrity(files);
     if (score === 0) {
         return { factor: null, blockingPatterns: [] };
     }
@@ -52063,6 +52218,13 @@ async function evaluateGate(config, commitSha, prNumber) {
         prNumber ? fetchPrFiles(prNumber, config.githubToken) : Promise.resolve([]),
         loadRepoConfig(config.githubToken),
     ]);
+    const submissionMode = repoConfig?.submission?.mode ?? "block";
+    const submissionEnabled = config.submissionGate === true || repoConfig?.submission?.enabled === true;
+    if (submissionEnabled && config.githubToken) {
+        const octokit = getOctokit(config.githubToken);
+        const { owner, repo } = github_context.repo;
+        await hydrateChangedRouteContents(octokit, owner, repo, commitSha, files);
+    }
     const changedFiles = files.map((f) => f.filename);
     const [authorFactor, prAgeFactor, provenance, httpHealthChecks, vercelCheck, supabaseCheck, mcpCheck, securityAlerts,] = await Promise.all([
         prNumber && config.githubToken && !isMergeQueue
@@ -52259,8 +52421,6 @@ async function evaluateGate(config, commitSha, prNumber) {
         policyFindings.push(...agentPolicy.findings);
     }
     let submissionChecks = [];
-    const submissionMode = repoConfig?.submission?.mode ?? "block";
-    const submissionEnabled = config.submissionGate === true || repoConfig?.submission?.enabled === true;
     if (submissionEnabled && files.length > 0) {
         for (const warning of getSubmissionConfigWarnings(repoConfig?.submission)) {
             core_warning(warning);
@@ -52287,6 +52447,8 @@ async function evaluateGate(config, commitSha, prNumber) {
             files: files.map((f) => ({
                 filename: f.filename,
                 patch: f.patch,
+                status: f.status,
+                content: f.content,
                 additions: f.additions,
             })),
             repoConfig,
@@ -54051,6 +54213,7 @@ async function meterDeployCheck(evaluation, config, user) {
 ;// CONCATENATED MODULE: ./src/dora.ts
 
 
+
 function rateDeploymentFrequency(deploysPerWeek) {
     if (deploysPerWeek >= 7)
         return "elite";
@@ -54513,12 +54676,16 @@ async function computeChangeReworkRate(token, windowDays, servicePaths) {
         const sampleSize = Math.min(total, 30);
         for (const pr of mergedInWindow.slice(0, sampleSize)) {
             try {
-                const { data: files } = await octokit.rest.pulls.listFiles({
-                    owner,
-                    repo,
-                    pull_number: pr.number,
-                    per_page: 100,
-                });
+                const { items: files } = await collectGitHubPages(async (page, perPage) => {
+                    const { data } = await octokit.rest.pulls.listFiles({
+                        owner,
+                        repo,
+                        pull_number: pr.number,
+                        per_page: perPage,
+                        page,
+                    });
+                    return data;
+                }, { perPage: 100, maxPages: 30 });
                 prFiles.set(pr.number, new Set(files.map((f) => f.filename)));
             }
             catch {
@@ -54575,12 +54742,16 @@ async function filterPrsByServicePaths(octokit, owner, repo, prs, servicePaths) 
     const sampleSize = Math.min(prs.length, 30);
     for (const pr of prs.slice(0, sampleSize)) {
         try {
-            const { data: files } = await octokit.rest.pulls.listFiles({
-                owner,
-                repo,
-                pull_number: pr.number,
-                per_page: 100,
-            });
+            const { items: files } = await collectGitHubPages(async (page, perPage) => {
+                const { data } = await octokit.rest.pulls.listFiles({
+                    owner,
+                    repo,
+                    pull_number: pr.number,
+                    per_page: perPage,
+                    page,
+                });
+                return data;
+            }, { perPage: 100, maxPages: 30 });
             const touchesService = files.some((f) => pathPatterns.some((p) => p.test(f.filename)));
             if (touchesService) {
                 filtered.push(pr);

--- a/docs/submission-gate.md
+++ b/docs/submission-gate.md
@@ -36,7 +36,7 @@ Phase 0 runs only on markdown under `agents/*/suggestions/**` (or any `**/sugges
 
 `artifact_integrity`, `mock_placeholder`, `context_freshness`, `destructive_sql`, `secrets`, `path_format`, `syntax_validity`, `import_resolution`, `rls_new_tables`, `auth_route_auth`, `hardcoded_env`, `external_package_deps`, `sql_syntax_basic`, `large_file`, `soul_integrity` (Komatik instance only).
 
-**`syntax_validity`** uses `@swc/core` (JS/TS), `JSON.parse` (`.json`), and `js-yaml` (`.yaml`/`.yml`/markdown frontmatter). It runs only when **`file.content`** holds the full file body — never on a partial diff hunk. Patch-only inputs (typical PR diff mode in the Action) are skipped; whole-file submission mode (`validate-submission`, suggestion bundles) is the supported path. The ncc Action bundle ships platform `@swc/core` native bindings in `dist/swc.*.node`.
+**`syntax_validity`** uses `@swc/core` (JS/TS), `JSON.parse` (`.json`), and `js-yaml` (`.yaml`/`.yml`/markdown frontmatter). It runs only when **`file.content`** holds the full file body — never on a partial diff hunk. The Action hydrates changed API route bodies for `auth_route_auth`; other patch-only inputs are skipped by whole-file-only checks. Whole-file submission mode (`validate-submission`, suggestion bundles) remains the supported path for full syntax analysis. The ncc Action bundle ships platform `@swc/core` native bindings in `dist/swc.*.node`.
 
 **`external_package_deps`** resolves declared packages from the submission's **`projectSlug` package.json`** (same lookup order as legacy: `{slug}/package.json`, `projects/{slug}/package.json`, root fallback). Callers must pass the matching `declaredPackages` list — see `declaredPackageNamesFromPackageJson()` and `npm run shadow-compare`.
 
@@ -51,12 +51,16 @@ submission:
   enabled: true
   mode: block
   stale_terms: [] # explicit only; omit for OLD_NAME_PATTERNS-only (legacy default)
+  auth_route_helpers: [getAcmeAuthUser] # merged with built-in auth helper names
+  retired_route_allowlist: [/api/legacy-checkout] # must still return status: 410
   path_ignore: ["/archive/"] # merged with default _stale/_archive skips
   naming_allowlist:
     skip_extensions: [".sql"]
     skip_path_patterns: ["migrations/", "schema/"]
     skip_comment_markers: ["historical:", "migration:", "deprecated:"]
 ```
+
+`auth_route_auth` evaluates the full current body of every changed API route, not reconstructed diff hunks. `auth_route_helpers` adds project-specific function identifiers. `retired_route_allowlist` is separate from public auth exemptions and only suppresses a finding when the current route body explicitly returns HTTP 410.
 
 ### Detector policy (#256)
 

--- a/mcp/dist/ci-integrity.d.ts
+++ b/mcp/dist/ci-integrity.d.ts
@@ -1,0 +1,13 @@
+export interface CiIntegrityFile {
+    filename: string;
+    additions?: number;
+    deletions?: number;
+    patch?: string;
+}
+export interface CiIntegrityResult {
+    score: number;
+    blockingPatterns: string[];
+    warningSignals: string[];
+}
+/** Detect newly introduced CI bypasses, never unchanged or deleted context. */
+export declare function detectCiIntegrity(files: CiIntegrityFile[]): CiIntegrityResult;

--- a/mcp/dist/ci-integrity.js
+++ b/mcp/dist/ci-integrity.js
@@ -1,0 +1,52 @@
+function addedPatchLines(patch) {
+    if (!patch)
+        return [];
+    return patch
+        .split("\n")
+        .filter((line) => line.startsWith("+") && !line.startsWith("+++"))
+        .map((line) => line.slice(1));
+}
+/** Detect newly introduced CI bypasses, never unchanged or deleted context. */
+export function detectCiIntegrity(files) {
+    const blockingPatterns = [];
+    const warningSignals = [];
+    let score = 0;
+    for (const file of files.filter((entry) => entry.filename.startsWith(".github/workflows/"))) {
+        const added = addedPatchLines(file.patch).join("\n");
+        if (/\|\|\s*true/.test(added)) {
+            blockingPatterns.push(`${file.filename}: workflow bypass pattern "|| true"`);
+            score += 45;
+        }
+        if (/^\s*continue-on-error:\s*true\b/m.test(added)) {
+            blockingPatterns.push(`${file.filename}: introduced "continue-on-error: true"`);
+            score += 45;
+        }
+        if (/^\s*if:\s*\$\{\{\s*always\(\)\s*\}\}/m.test(added)) {
+            warningSignals.push(`${file.filename}: always() condition added to workflow gate`);
+            score += 20;
+        }
+    }
+    for (const file of files.filter((entry) => /\.(test|spec)\.(ts|tsx|js|jsx)$|__tests__\/|\.cy\.(ts|js)$/.test(entry.filename))) {
+        const additions = file.additions ?? 0;
+        const deletions = file.deletions ?? 0;
+        if (deletions > additions * 2 && deletions >= 10) {
+            warningSignals.push(`${file.filename}: heavy test deletion (${deletions} deleted / ${additions} added)`);
+            score += 25;
+        }
+    }
+    for (const file of files) {
+        const patch = file.patch ?? "";
+        if (!patch)
+            continue;
+        if (/^-\s*(branches|functions|lines|statements)\s*:\s*\d+/m.test(patch) &&
+            /^\+\s*(branches|functions|lines|statements)\s*:\s*\d+/m.test(patch)) {
+            warningSignals.push(`${file.filename}: coverage threshold definition changed`);
+            score += 20;
+        }
+    }
+    return {
+        score: Math.min(100, score),
+        blockingPatterns,
+        warningSignals,
+    };
+}

--- a/mcp/dist/github-pagination.d.ts
+++ b/mcp/dist/github-pagination.d.ts
@@ -1,0 +1,18 @@
+export interface PaginationResult<T> {
+    items: T[];
+    pages: number;
+    complete: boolean;
+}
+export interface PaginationOptions {
+    /** GitHub REST APIs cap per_page at 100. */
+    perPage?: number;
+    /** Safety ceiling for endpoints with a documented result cap. */
+    maxPages?: number;
+}
+/**
+ * Collect a GitHub REST endpoint page-by-page. A full final page is treated as
+ * incomplete when maxPages is reached so callers can surface truncated input.
+ */
+export declare function collectGitHubPages<T>(fetchPage: (page: number, perPage: number) => Promise<T[]>, options?: PaginationOptions): Promise<PaginationResult<T>>;
+/** Fetch every available JSON-array page from a GitHub REST URL. */
+export declare function fetchGitHubJsonPages<T>(url: string, init: RequestInit, options?: PaginationOptions): Promise<PaginationResult<T>>;

--- a/mcp/dist/github-pagination.js
+++ b/mcp/dist/github-pagination.js
@@ -1,0 +1,34 @@
+/**
+ * Collect a GitHub REST endpoint page-by-page. A full final page is treated as
+ * incomplete when maxPages is reached so callers can surface truncated input.
+ */
+export async function collectGitHubPages(fetchPage, options = {}) {
+    const perPage = Math.min(100, Math.max(1, options.perPage ?? 100));
+    const maxPages = Math.max(1, options.maxPages ?? 30);
+    const items = [];
+    for (let page = 1; page <= maxPages; page += 1) {
+        const pageItems = await fetchPage(page, perPage);
+        items.push(...pageItems);
+        if (pageItems.length < perPage) {
+            return { items, pages: page, complete: true };
+        }
+    }
+    return { items, pages: maxPages, complete: false };
+}
+/** Fetch every available JSON-array page from a GitHub REST URL. */
+export async function fetchGitHubJsonPages(url, init, options = {}) {
+    return collectGitHubPages(async (page, perPage) => {
+        const pageUrl = new URL(url);
+        pageUrl.searchParams.set("per_page", String(perPage));
+        pageUrl.searchParams.set("page", String(page));
+        const response = await fetch(pageUrl, init);
+        if (!response.ok) {
+            throw new Error(`GitHub request failed: HTTP ${response.status}`);
+        }
+        const data = (await response.json());
+        if (!Array.isArray(data)) {
+            throw new Error("GitHub paginated response was not an array");
+        }
+        return data;
+    }, options);
+}

--- a/mcp/dist/remediation.js
+++ b/mcp/dist/remediation.js
@@ -95,8 +95,12 @@ const factorCues = {
         triggerScore: 50,
         advisoryScore: 20,
         build: (factor) => {
-            const files = factor.detail?.file_count ?? 0;
-            const changes = factor.detail?.line_count ?? 0;
+            const files = factor.detail?.fileCount ??
+                factor.detail?.file_count ??
+                0;
+            const changes = factor.detail?.totalChanges ??
+                factor.detail?.line_count ??
+                0;
             return {
                 code: "policy.pr_scope",
                 severity: "warn",

--- a/mcp/dist/server.js
+++ b/mcp/dist/server.js
@@ -15,6 +15,8 @@ import { buildAutofixPlan, selectAutofixCommit } from "./fixer-core.js";
 import { assessColdStartFromMetrics } from "./agent-trust-metrics.js";
 import { computeAgentTrustScore } from "./trust-score.js";
 import { buildGateVerdict } from "./verdict.js";
+import { detectCiIntegrity as detectCiIntegrityShared } from "./ci-integrity.js";
+import { fetchGitHubJsonPages } from "./github-pagination.js";
 registerAllAdapters();
 const HEALTH_CHECK_TIMEOUT_MS = 10_000;
 const VERCEL_TIMEOUT_MS = 10_000;
@@ -62,37 +64,7 @@ function classifyProvenanceSignals(signals) {
     };
 }
 function detectCiIntegrity(files) {
-    const blockingPatterns = [];
-    const warningSignals = [];
-    let score = 0;
-    for (const file of files.filter((f) => f.filename.startsWith(".github/workflows/"))) {
-        const patch = file.patch ?? "";
-        if (/\|\|\s*true/.test(patch)) {
-            blockingPatterns.push(`${file.filename}: workflow bypass pattern "|| true"`);
-            score += 45;
-        }
-        if (/^\+\s*continue-on-error:\s*true\b/m.test(patch)) {
-            blockingPatterns.push(`${file.filename}: introduced "continue-on-error: true"`);
-            score += 45;
-        }
-        if (/^\+\s*if:\s*\$\{\{\s*always\(\)\s*\}\}/m.test(patch)) {
-            warningSignals.push(`${file.filename}: always() condition added to workflow gate`);
-            score += 20;
-        }
-    }
-    for (const file of files.filter((f) => /\.(test|spec)\.(ts|tsx|js|jsx)$|__tests__\/|\.cy\.(ts|js)$/.test(f.filename))) {
-        const additions = file.additions ?? 0;
-        const deletions = file.deletions ?? 0;
-        if (deletions > additions * 2 && deletions >= 10) {
-            warningSignals.push(`${file.filename}: heavy test deletion (${deletions} deleted / ${additions} added)`);
-            score += 25;
-        }
-    }
-    return {
-        score: Math.min(100, score),
-        blockingPatterns,
-        warningSignals,
-    };
+    return detectCiIntegrityShared(files);
 }
 function detectSupplyChain(files) {
     const blockingPatterns = [];
@@ -451,6 +423,10 @@ const GITHUB_HEADERS = () => {
         "X-GitHub-Api-Version": "2022-11-28",
     };
 };
+async function fetchAllPrFiles(owner, repo, prNumber, headers) {
+    const result = await fetchGitHubJsonPages(`https://api.github.com/repos/${owner}/${repo}/pulls/${prNumber}/files`, { headers }, { perPage: 100, maxPages: 30 });
+    return result.items;
+}
 async function fetchGitHubCheckRuns(owner, repo, ref, headers) {
     const runs = [];
     let page = 1;
@@ -596,10 +572,7 @@ server.tool("compare-risk-history", "Compare risk characteristics across recent 
     const results = await Promise.all(merged.map(async (pr) => {
         let files = [];
         try {
-            const filesRes = await fetch(`https://api.github.com/repos/${owner}/${repo}/pulls/${pr.number}/files?per_page=300`, { headers });
-            if (filesRes.ok) {
-                files = (await filesRes.json());
-            }
+            files = await fetchAllPrFiles(owner, repo, pr.number, headers);
         }
         catch {
             /* skip */
@@ -726,8 +699,13 @@ server.tool("get-pr-release-status", "Return composite release readiness for a P
         });
     }
     const pr = (await prRes.json());
-    const filesRes = await fetch(`https://api.github.com/repos/${owner}/${repo}/pulls/${prNumber}/files?per_page=300`, { headers });
-    const files = filesRes.ok ? (await filesRes.json()) : [];
+    let files = [];
+    try {
+        files = await fetchAllPrFiles(owner, repo, prNumber, headers);
+    }
+    catch {
+        // Preserve the MCP tool's existing fail-open behavior for API outages.
+    }
     const { score: riskScore, factors: riskFactors } = computeRiskScore(files);
     const gateDecision = decideGate(riskScore, 100, riskThreshold, riskThreshold - 15);
     const rawChecks = await fetchGitHubCheckRuns(owner, repo, pr.head.sha, headers);
@@ -784,10 +762,7 @@ server.tool("evaluate-policy", "Run a full Trailhead policy evaluation for a PR 
     let files = [];
     if (prNumber) {
         try {
-            const filesRes = await fetch(`https://api.github.com/repos/${owner}/${repo}/pulls/${prNumber}/files?per_page=300`, { headers });
-            if (filesRes.ok) {
-                files = (await filesRes.json());
-            }
+            files = await fetchAllPrFiles(owner, repo, prNumber, headers);
             if (files.length > 30) {
                 try {
                     const commitsRes = await fetch(`https://api.github.com/repos/${owner}/${repo}/pulls/${prNumber}/commits?per_page=250`, { headers });
@@ -1472,6 +1447,9 @@ server.tool("validate-submission", "Run Gate 1 submission checks (including Phas
             skip_in_imports: z.boolean().optional(),
         })
             .optional(),
+        auth_route_allowlist: z.array(z.string()).optional(),
+        auth_route_helpers: z.array(z.string()).optional(),
+        retired_route_allowlist: z.array(z.string()).optional(),
         detectors: z
             .record(z.object({
             enabled: z.boolean().optional(),

--- a/mcp/dist/submission-checks/detectors.js
+++ b/mcp/dist/submission-checks/detectors.js
@@ -35,6 +35,27 @@ const SECRET_PATTERNS = [
         pattern: /api[_-]?key\s*[:=]\s*['"][A-Za-z0-9_-]{32,}['"]/gi,
     },
 ];
+function isCiConfigurationPath(filename) {
+    return /^\.github\/(?:workflows|actions)\//.test(normalizePath(filename));
+}
+function isCredentialFixturePath(filename) {
+    return isTestPath(filename) || isCiConfigurationPath(filename);
+}
+function isObviouslyInertCiFixtureLine(line, filename) {
+    if (!isCiConfigurationPath(filename))
+        return false;
+    const assignment = /^\s*[\w.-]+\s*:\s*["']?([^"'#\s]+)["']?(?:\s*#.*)?$/.exec(line);
+    if (!assignment?.[1])
+        return false;
+    return /^(?:sk_(?:test|live)_)?(?:placeholder|example|dummy|fake|test|x{10,}|0{10,})$/i.test(assignment[1]);
+}
+function isObviouslyInertStripeFixture(patternName, match, filename) {
+    if (!isCredentialFixturePath(filename) || !patternName.startsWith("Stripe ")) {
+        return false;
+    }
+    const suffix = match.replace(/^sk_(?:test|live)_/i, "");
+    return /^(?:placeholder|example|dummy|fake|test|x{10,}|0{10,})$/i.test(suffix);
+}
 const HARDCODED_ENV_PATTERNS = [
     { name: "localhost with port", pattern: /(?:['"`])localhost:\d{2,5}(?:['"`])/g },
     {
@@ -75,6 +96,8 @@ export function detectMockPlaceholder(ctx) {
     const hits = scanAddedContent(ctx.files, (line, filename) => {
         if (isTestPath(filename))
             return false;
+        if (isObviouslyInertCiFixtureLine(line, filename))
+            return false;
         if (/\.(md|txt)$/i.test(filename))
             return false;
         return MOCK_PATTERNS.some((re) => {
@@ -94,9 +117,9 @@ export function detectMockPlaceholder(ctx) {
     });
 }
 export function detectSecrets(ctx) {
-    const hits = scanAddedContent(ctx.files, (line) => SECRET_PATTERNS.some((entry) => {
+    const hits = scanAddedContent(ctx.files, (line, filename) => SECRET_PATTERNS.some((entry) => {
         entry.pattern.lastIndex = 0;
-        return entry.pattern.test(line);
+        return [...line.matchAll(entry.pattern)].some((match) => !isObviouslyInertStripeFixture(entry.name, match[0] ?? "", filename));
     }));
     if (hits.length === 0)
         return null;
@@ -416,17 +439,31 @@ export function detectRlsNewTables(ctx) {
 function isRouteAllowlisted(path, allowlist) {
     return allowlist.some((entry) => path.includes(entry.replace(/^\//, "")));
 }
+function escapeRegExp(value) {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+function isRetiredRoute(path, content, allowlist) {
+    if (!isRouteAllowlisted(path, allowlist))
+        return false;
+    return /\bstatus\s*:\s*410\b/.test(content);
+}
 export function detectAuthRouteAuth(ctx) {
     const routePattern = /(?:^|\/)(?:app\/api\/.+\/route|pages\/api\/.+)\.(?:ts|tsx|js|jsx)$/;
-    const authPattern = /\b(getUser|getSession|getServerSession|auth|requireAuth|withAuth)\s*\(/;
+    const helpers = [...new Set(ctx.authRouteHelpers)].filter((helper) => /^[A-Za-z_$][\w$]*$/.test(helper));
+    const authPattern = new RegExp(`\\b(?:${helpers.map(escapeRegExp).join("|")})\\s*\\(`);
     const hits = [];
     for (const file of ctx.files) {
         const normalized = normalizePath(file.filename);
         if (!routePattern.test(normalized))
             continue;
+        if (file.status === "removed")
+            continue;
         if (isRouteAllowlisted(normalized, ctx.authRouteAllowlist))
             continue;
-        if (!authPattern.test(fileContent(file)))
+        const content = fileContent(file);
+        if (isRetiredRoute(normalized, content, ctx.retiredRouteAllowlist))
+            continue;
+        if (helpers.length === 0 || !authPattern.test(content))
             hits.push(normalized);
     }
     if (hits.length === 0)

--- a/mcp/dist/submission-checks/helpers.js
+++ b/mcp/dist/submission-checks/helpers.js
@@ -63,7 +63,9 @@ export function prPathSet(files) {
     return new Set(files.map((f) => normalizePath(f.filename)));
 }
 export function isTestPath(filename) {
-    return /\/__tests__\/|\/test\/|\/fixtures\/|\.test\.|\.spec\./.test(filename);
+    const path = `/${normalizePath(filename).toLowerCase()}`;
+    return (/\/(?:__tests__|__fixtures__|tests?|test-fixtures|fixtures)\//.test(path) ||
+        /\.(?:test|spec)\.[^./]+$/.test(path));
 }
 /** Default archived/stale path segments skipped by context_freshness. */
 export const DEFAULT_STALE_PATH_IGNORE = ["/_stale/", "/_archive/", "/.archive/"];

--- a/mcp/dist/submission-checks/types.d.ts
+++ b/mcp/dist/submission-checks/types.d.ts
@@ -27,6 +27,8 @@ export interface SubmissionCheckContext {
     staleTerms: string[];
     namingAllowlist: NamingAllowlistConfig;
     authRouteAllowlist: string[];
+    authRouteHelpers: string[];
+    retiredRouteAllowlist: string[];
     maxFileLines: number;
     declaredPackages: Set<string>;
     /** Extra path segments to skip for context_freshness (merged with defaults). */

--- a/mcp/dist/submission-engine.js
+++ b/mcp/dist/submission-engine.js
@@ -13,6 +13,14 @@ const DEFAULT_AUTH_ROUTE_ALLOWLIST = [
     "/api/health/",
     "/api/metrics/",
 ];
+const DEFAULT_AUTH_ROUTE_HELPERS = [
+    "getUser",
+    "getSession",
+    "getServerSession",
+    "auth",
+    "requireAuth",
+    "withAuth",
+];
 /** Package names declared in a package.json (legacy gate parity). */
 export function declaredPackageNamesFromPackageJson(pkg) {
     const sections = [
@@ -42,6 +50,11 @@ function buildContext(options) {
         staleTerms,
         namingAllowlist: repoConfig?.submission?.naming_allowlist ?? {},
         authRouteAllowlist: repoConfig?.submission?.auth_route_allowlist ?? DEFAULT_AUTH_ROUTE_ALLOWLIST,
+        authRouteHelpers: [
+            ...DEFAULT_AUTH_ROUTE_HELPERS,
+            ...(repoConfig?.submission?.auth_route_helpers ?? []),
+        ],
+        retiredRouteAllowlist: repoConfig?.submission?.retired_route_allowlist ?? [],
         maxFileLines: repoConfig?.submission?.max_file_lines ?? 1000,
         declaredPackages: declared,
         pathIgnorePatterns: repoConfig?.submission?.path_ignore ?? [],

--- a/mcp/dist/types.d.ts
+++ b/mcp/dist/types.d.ts
@@ -1733,6 +1733,10 @@ export declare const SubmissionConfig: z.ZodObject<{
     mode: z.ZodDefault<z.ZodEnum<["warn", "block"]>>;
     stale_terms: z.ZodOptional<z.ZodArray<z.ZodString, "many">>;
     auth_route_allowlist: z.ZodOptional<z.ZodArray<z.ZodString, "many">>;
+    /** Additional function identifiers that prove an API route authenticated. */
+    auth_route_helpers: z.ZodOptional<z.ZodArray<z.ZodString, "many">>;
+    /** Side-effect-free tombstone routes; each body must still return HTTP 410. */
+    retired_route_allowlist: z.ZodOptional<z.ZodArray<z.ZodString, "many">>;
     max_file_lines: z.ZodOptional<z.ZodNumber>;
     /** Path substrings to skip for context_freshness (e.g. archived suggestion dirs). */
     path_ignore: z.ZodOptional<z.ZodArray<z.ZodString, "many">>;
@@ -1848,6 +1852,8 @@ export declare const SubmissionConfig: z.ZodObject<{
     path_ignore?: string[] | undefined;
     stale_terms?: string[] | undefined;
     auth_route_allowlist?: string[] | undefined;
+    auth_route_helpers?: string[] | undefined;
+    retired_route_allowlist?: string[] | undefined;
     max_file_lines?: number | undefined;
     naming_allowlist?: {
         skip_extensions?: string[] | undefined;
@@ -1883,6 +1889,8 @@ export declare const SubmissionConfig: z.ZodObject<{
     path_ignore?: string[] | undefined;
     stale_terms?: string[] | undefined;
     auth_route_allowlist?: string[] | undefined;
+    auth_route_helpers?: string[] | undefined;
+    retired_route_allowlist?: string[] | undefined;
     max_file_lines?: number | undefined;
     naming_allowlist?: {
         skip_extensions?: string[] | undefined;
@@ -1984,6 +1992,10 @@ export declare const RepoConfig: z.ZodObject<{
         mode: z.ZodDefault<z.ZodEnum<["warn", "block"]>>;
         stale_terms: z.ZodOptional<z.ZodArray<z.ZodString, "many">>;
         auth_route_allowlist: z.ZodOptional<z.ZodArray<z.ZodString, "many">>;
+        /** Additional function identifiers that prove an API route authenticated. */
+        auth_route_helpers: z.ZodOptional<z.ZodArray<z.ZodString, "many">>;
+        /** Side-effect-free tombstone routes; each body must still return HTTP 410. */
+        retired_route_allowlist: z.ZodOptional<z.ZodArray<z.ZodString, "many">>;
         max_file_lines: z.ZodOptional<z.ZodNumber>;
         /** Path substrings to skip for context_freshness (e.g. archived suggestion dirs). */
         path_ignore: z.ZodOptional<z.ZodArray<z.ZodString, "many">>;
@@ -2099,6 +2111,8 @@ export declare const RepoConfig: z.ZodObject<{
         path_ignore?: string[] | undefined;
         stale_terms?: string[] | undefined;
         auth_route_allowlist?: string[] | undefined;
+        auth_route_helpers?: string[] | undefined;
+        retired_route_allowlist?: string[] | undefined;
         max_file_lines?: number | undefined;
         naming_allowlist?: {
             skip_extensions?: string[] | undefined;
@@ -2134,6 +2148,8 @@ export declare const RepoConfig: z.ZodObject<{
         path_ignore?: string[] | undefined;
         stale_terms?: string[] | undefined;
         auth_route_allowlist?: string[] | undefined;
+        auth_route_helpers?: string[] | undefined;
+        retired_route_allowlist?: string[] | undefined;
         max_file_lines?: number | undefined;
         naming_allowlist?: {
             skip_extensions?: string[] | undefined;
@@ -2930,6 +2946,8 @@ export declare const RepoConfig: z.ZodObject<{
         path_ignore?: string[] | undefined;
         stale_terms?: string[] | undefined;
         auth_route_allowlist?: string[] | undefined;
+        auth_route_helpers?: string[] | undefined;
+        retired_route_allowlist?: string[] | undefined;
         max_file_lines?: number | undefined;
         naming_allowlist?: {
             skip_extensions?: string[] | undefined;
@@ -3015,6 +3033,8 @@ export declare const RepoConfig: z.ZodObject<{
         path_ignore?: string[] | undefined;
         stale_terms?: string[] | undefined;
         auth_route_allowlist?: string[] | undefined;
+        auth_route_helpers?: string[] | undefined;
+        retired_route_allowlist?: string[] | undefined;
         max_file_lines?: number | undefined;
         naming_allowlist?: {
             skip_extensions?: string[] | undefined;

--- a/mcp/dist/types.js
+++ b/mcp/dist/types.js
@@ -397,6 +397,10 @@ export const SubmissionConfig = z.object({
     mode: z.enum(["warn", "block"]).default("block"),
     stale_terms: z.array(z.string()).optional(),
     auth_route_allowlist: z.array(z.string()).optional(),
+    /** Additional function identifiers that prove an API route authenticated. */
+    auth_route_helpers: z.array(z.string().min(1)).optional(),
+    /** Side-effect-free tombstone routes; each body must still return HTTP 410. */
+    retired_route_allowlist: z.array(z.string()).optional(),
     max_file_lines: z.number().int().positive().optional(),
     /** Path substrings to skip for context_freshness (e.g. archived suggestion dirs). */
     path_ignore: z.array(z.string()).optional(),

--- a/mcp/src/ci-integrity.ts
+++ b/mcp/src/ci-integrity.ts
@@ -1,0 +1,76 @@
+export interface CiIntegrityFile {
+  filename: string;
+  additions?: number;
+  deletions?: number;
+  patch?: string;
+}
+
+export interface CiIntegrityResult {
+  score: number;
+  blockingPatterns: string[];
+  warningSignals: string[];
+}
+
+function addedPatchLines(patch: string | undefined): string[] {
+  if (!patch) return [];
+  return patch
+    .split("\n")
+    .filter((line) => line.startsWith("+") && !line.startsWith("+++"))
+    .map((line) => line.slice(1));
+}
+
+/** Detect newly introduced CI bypasses, never unchanged or deleted context. */
+export function detectCiIntegrity(files: CiIntegrityFile[]): CiIntegrityResult {
+  const blockingPatterns: string[] = [];
+  const warningSignals: string[] = [];
+  let score = 0;
+
+  for (const file of files.filter((entry) =>
+    entry.filename.startsWith(".github/workflows/"),
+  )) {
+    const added = addedPatchLines(file.patch).join("\n");
+    if (/\|\|\s*true/.test(added)) {
+      blockingPatterns.push(`${file.filename}: workflow bypass pattern "|| true"`);
+      score += 45;
+    }
+    if (/^\s*continue-on-error:\s*true\b/m.test(added)) {
+      blockingPatterns.push(`${file.filename}: introduced "continue-on-error: true"`);
+      score += 45;
+    }
+    if (/^\s*if:\s*\$\{\{\s*always\(\)\s*\}\}/m.test(added)) {
+      warningSignals.push(`${file.filename}: always() condition added to workflow gate`);
+      score += 20;
+    }
+  }
+
+  for (const file of files.filter((entry) =>
+    /\.(test|spec)\.(ts|tsx|js|jsx)$|__tests__\/|\.cy\.(ts|js)$/.test(entry.filename),
+  )) {
+    const additions = file.additions ?? 0;
+    const deletions = file.deletions ?? 0;
+    if (deletions > additions * 2 && deletions >= 10) {
+      warningSignals.push(
+        `${file.filename}: heavy test deletion (${deletions} deleted / ${additions} added)`,
+      );
+      score += 25;
+    }
+  }
+
+  for (const file of files) {
+    const patch = file.patch ?? "";
+    if (!patch) continue;
+    if (
+      /^-\s*(branches|functions|lines|statements)\s*:\s*\d+/m.test(patch) &&
+      /^\+\s*(branches|functions|lines|statements)\s*:\s*\d+/m.test(patch)
+    ) {
+      warningSignals.push(`${file.filename}: coverage threshold definition changed`);
+      score += 20;
+    }
+  }
+
+  return {
+    score: Math.min(100, score),
+    blockingPatterns,
+    warningSignals,
+  };
+}

--- a/mcp/src/github-pagination.ts
+++ b/mcp/src/github-pagination.ts
@@ -1,0 +1,58 @@
+export interface PaginationResult<T> {
+  items: T[];
+  pages: number;
+  complete: boolean;
+}
+
+export interface PaginationOptions {
+  /** GitHub REST APIs cap per_page at 100. */
+  perPage?: number;
+  /** Safety ceiling for endpoints with a documented result cap. */
+  maxPages?: number;
+}
+
+/**
+ * Collect a GitHub REST endpoint page-by-page. A full final page is treated as
+ * incomplete when maxPages is reached so callers can surface truncated input.
+ */
+export async function collectGitHubPages<T>(
+  fetchPage: (page: number, perPage: number) => Promise<T[]>,
+  options: PaginationOptions = {},
+): Promise<PaginationResult<T>> {
+  const perPage = Math.min(100, Math.max(1, options.perPage ?? 100));
+  const maxPages = Math.max(1, options.maxPages ?? 30);
+  const items: T[] = [];
+
+  for (let page = 1; page <= maxPages; page += 1) {
+    const pageItems = await fetchPage(page, perPage);
+    items.push(...pageItems);
+
+    if (pageItems.length < perPage) {
+      return { items, pages: page, complete: true };
+    }
+  }
+
+  return { items, pages: maxPages, complete: false };
+}
+
+/** Fetch every available JSON-array page from a GitHub REST URL. */
+export async function fetchGitHubJsonPages<T>(
+  url: string,
+  init: RequestInit,
+  options: PaginationOptions = {},
+): Promise<PaginationResult<T>> {
+  return collectGitHubPages<T>(async (page, perPage) => {
+    const pageUrl = new URL(url);
+    pageUrl.searchParams.set("per_page", String(perPage));
+    pageUrl.searchParams.set("page", String(page));
+    const response = await fetch(pageUrl, init);
+    if (!response.ok) {
+      throw new Error(`GitHub request failed: HTTP ${response.status}`);
+    }
+    const data = (await response.json()) as unknown;
+    if (!Array.isArray(data)) {
+      throw new Error("GitHub paginated response was not an array");
+    }
+    return data as T[];
+  }, options);
+}

--- a/mcp/src/remediation.ts
+++ b/mcp/src/remediation.ts
@@ -153,8 +153,14 @@ const factorCues: Record<string, FactorCue> = {
     triggerScore: 50,
     advisoryScore: 20,
     build: (factor) => {
-      const files = (factor.detail?.file_count as number | undefined) ?? 0;
-      const changes = (factor.detail?.line_count as number | undefined) ?? 0;
+      const files =
+        (factor.detail?.fileCount as number | undefined) ??
+        (factor.detail?.file_count as number | undefined) ??
+        0;
+      const changes =
+        (factor.detail?.totalChanges as number | undefined) ??
+        (factor.detail?.line_count as number | undefined) ??
+        0;
       return {
         code: "policy.pr_scope",
         severity: "warn",

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -52,6 +52,8 @@ import { assessColdStartFromMetrics } from "./agent-trust-metrics.js";
 import { computeAgentTrustScore } from "./trust-score.js";
 import { buildGateVerdict } from "./verdict.js";
 import type { GateDecision, GateEvaluation, RiskFactor } from "./types.js";
+import { detectCiIntegrity as detectCiIntegrityShared } from "./ci-integrity.js";
+import { fetchGitHubJsonPages } from "./github-pagination.js";
 
 registerAllAdapters();
 
@@ -135,44 +137,7 @@ function detectCiIntegrity(
     patch?: string;
   }>,
 ): { score: number; blockingPatterns: string[]; warningSignals: string[] } {
-  const blockingPatterns: string[] = [];
-  const warningSignals: string[] = [];
-  let score = 0;
-
-  for (const file of files.filter((f) => f.filename.startsWith(".github/workflows/"))) {
-    const patch = file.patch ?? "";
-    if (/\|\|\s*true/.test(patch)) {
-      blockingPatterns.push(`${file.filename}: workflow bypass pattern "|| true"`);
-      score += 45;
-    }
-    if (/^\+\s*continue-on-error:\s*true\b/m.test(patch)) {
-      blockingPatterns.push(`${file.filename}: introduced "continue-on-error: true"`);
-      score += 45;
-    }
-    if (/^\+\s*if:\s*\$\{\{\s*always\(\)\s*\}\}/m.test(patch)) {
-      warningSignals.push(`${file.filename}: always() condition added to workflow gate`);
-      score += 20;
-    }
-  }
-
-  for (const file of files.filter((f) =>
-    /\.(test|spec)\.(ts|tsx|js|jsx)$|__tests__\/|\.cy\.(ts|js)$/.test(f.filename),
-  )) {
-    const additions = file.additions ?? 0;
-    const deletions = file.deletions ?? 0;
-    if (deletions > additions * 2 && deletions >= 10) {
-      warningSignals.push(
-        `${file.filename}: heavy test deletion (${deletions} deleted / ${additions} added)`,
-      );
-      score += 25;
-    }
-  }
-
-  return {
-    score: Math.min(100, score),
-    blockingPatterns,
-    warningSignals,
-  };
+  return detectCiIntegrityShared(files);
 }
 
 function detectSupplyChain(files: Array<{ filename: string; patch?: string }>): {
@@ -647,6 +612,20 @@ const GITHUB_HEADERS = () => {
   };
 };
 
+async function fetchAllPrFiles(
+  owner: string,
+  repo: string,
+  prNumber: number,
+  headers: Record<string, string>,
+): Promise<FileInfo[]> {
+  const result = await fetchGitHubJsonPages<FileInfo>(
+    `https://api.github.com/repos/${owner}/${repo}/pulls/${prNumber}/files`,
+    { headers },
+    { perPage: 100, maxPages: 30 },
+  );
+  return result.items;
+}
+
 async function fetchGitHubCheckRuns(
   owner: string,
   repo: string,
@@ -865,13 +844,7 @@ server.tool(
       merged.map(async (pr) => {
         let files: FileInfo[] = [];
         try {
-          const filesRes = await fetch(
-            `https://api.github.com/repos/${owner}/${repo}/pulls/${pr.number}/files?per_page=300`,
-            { headers },
-          );
-          if (filesRes.ok) {
-            files = (await filesRes.json()) as FileInfo[];
-          }
+          files = await fetchAllPrFiles(owner, repo, pr.number, headers);
         } catch {
           /* skip */
         }
@@ -1056,11 +1029,12 @@ server.tool(
       base: { ref: string };
     };
 
-    const filesRes = await fetch(
-      `https://api.github.com/repos/${owner}/${repo}/pulls/${prNumber}/files?per_page=300`,
-      { headers },
-    );
-    const files: FileInfo[] = filesRes.ok ? ((await filesRes.json()) as FileInfo[]) : [];
+    let files: FileInfo[] = [];
+    try {
+      files = await fetchAllPrFiles(owner, repo, prNumber, headers);
+    } catch {
+      // Preserve the MCP tool's existing fail-open behavior for API outages.
+    }
     const { score: riskScore, factors: riskFactors } = computeRiskScore(files);
     const gateDecision = decideGate(riskScore, 100, riskThreshold, riskThreshold - 15);
 
@@ -1129,13 +1103,7 @@ server.tool(
     let files: FileInfo[] = [];
     if (prNumber) {
       try {
-        const filesRes = await fetch(
-          `https://api.github.com/repos/${owner}/${repo}/pulls/${prNumber}/files?per_page=300`,
-          { headers },
-        );
-        if (filesRes.ok) {
-          files = (await filesRes.json()) as FileInfo[];
-        }
+        files = await fetchAllPrFiles(owner, repo, prNumber, headers);
 
         if (files.length > 30) {
           try {
@@ -2030,6 +1998,9 @@ server.tool(
             skip_in_imports: z.boolean().optional(),
           })
           .optional(),
+        auth_route_allowlist: z.array(z.string()).optional(),
+        auth_route_helpers: z.array(z.string()).optional(),
+        retired_route_allowlist: z.array(z.string()).optional(),
         detectors: z
           .record(
             z.object({

--- a/mcp/src/submission-checks/detectors.ts
+++ b/mcp/src/submission-checks/detectors.ts
@@ -53,6 +53,35 @@ const SECRET_PATTERNS: Array<{ name: string; pattern: RegExp }> = [
   },
 ];
 
+function isCiConfigurationPath(filename: string): boolean {
+  return /^\.github\/(?:workflows|actions)\//.test(normalizePath(filename));
+}
+
+function isCredentialFixturePath(filename: string): boolean {
+  return isTestPath(filename) || isCiConfigurationPath(filename);
+}
+
+function isObviouslyInertCiFixtureLine(line: string, filename: string): boolean {
+  if (!isCiConfigurationPath(filename)) return false;
+  const assignment = /^\s*[\w.-]+\s*:\s*["']?([^"'#\s]+)["']?(?:\s*#.*)?$/.exec(line);
+  if (!assignment?.[1]) return false;
+  return /^(?:sk_(?:test|live)_)?(?:placeholder|example|dummy|fake|test|x{10,}|0{10,})$/i.test(
+    assignment[1],
+  );
+}
+
+function isObviouslyInertStripeFixture(
+  patternName: string,
+  match: string,
+  filename: string,
+): boolean {
+  if (!isCredentialFixturePath(filename) || !patternName.startsWith("Stripe ")) {
+    return false;
+  }
+  const suffix = match.replace(/^sk_(?:test|live)_/i, "");
+  return /^(?:placeholder|example|dummy|fake|test|x{10,}|0{10,})$/i.test(suffix);
+}
+
 const HARDCODED_ENV_PATTERNS: Array<{ name: string; pattern: RegExp }> = [
   { name: "localhost with port", pattern: /(?:['"`])localhost:\d{2,5}(?:['"`])/g },
   {
@@ -102,6 +131,7 @@ export function detectMockPlaceholder(
 ): SubmissionCheckResult | null {
   const hits = scanAddedContent(ctx.files, (line, filename) => {
     if (isTestPath(filename)) return false;
+    if (isObviouslyInertCiFixtureLine(line, filename)) return false;
     if (/\.(md|txt)$/i.test(filename)) return false;
     return MOCK_PATTERNS.some((re) => {
       re.lastIndex = 0;
@@ -120,10 +150,12 @@ export function detectMockPlaceholder(
 }
 
 export function detectSecrets(ctx: SubmissionCheckContext): SubmissionCheckResult | null {
-  const hits = scanAddedContent(ctx.files, (line) =>
+  const hits = scanAddedContent(ctx.files, (line, filename) =>
     SECRET_PATTERNS.some((entry) => {
       entry.pattern.lastIndex = 0;
-      return entry.pattern.test(line);
+      return [...line.matchAll(entry.pattern)].some(
+        (match) => !isObviouslyInertStripeFixture(entry.name, match[0] ?? "", filename),
+      );
     }),
   );
   if (hits.length === 0) return null;
@@ -501,20 +533,34 @@ function isRouteAllowlisted(path: string, allowlist: string[]): boolean {
   return allowlist.some((entry) => path.includes(entry.replace(/^\//, "")));
 }
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function isRetiredRoute(path: string, content: string, allowlist: string[]): boolean {
+  if (!isRouteAllowlisted(path, allowlist)) return false;
+  return /\bstatus\s*:\s*410\b/.test(content);
+}
+
 export function detectAuthRouteAuth(
   ctx: SubmissionCheckContext,
 ): SubmissionCheckResult | null {
   const routePattern =
     /(?:^|\/)(?:app\/api\/.+\/route|pages\/api\/.+)\.(?:ts|tsx|js|jsx)$/;
-  const authPattern =
-    /\b(getUser|getSession|getServerSession|auth|requireAuth|withAuth)\s*\(/;
+  const helpers = [...new Set(ctx.authRouteHelpers)].filter((helper) =>
+    /^[A-Za-z_$][\w$]*$/.test(helper),
+  );
+  const authPattern = new RegExp(`\\b(?:${helpers.map(escapeRegExp).join("|")})\\s*\\(`);
   const hits: string[] = [];
 
   for (const file of ctx.files) {
     const normalized = normalizePath(file.filename);
     if (!routePattern.test(normalized)) continue;
+    if (file.status === "removed") continue;
     if (isRouteAllowlisted(normalized, ctx.authRouteAllowlist)) continue;
-    if (!authPattern.test(fileContent(file))) hits.push(normalized);
+    const content = fileContent(file);
+    if (isRetiredRoute(normalized, content, ctx.retiredRouteAllowlist)) continue;
+    if (helpers.length === 0 || !authPattern.test(content)) hits.push(normalized);
   }
 
   if (hits.length === 0) return null;

--- a/mcp/src/submission-checks/helpers.ts
+++ b/mcp/src/submission-checks/helpers.ts
@@ -79,7 +79,11 @@ export function prPathSet(files: SubmissionFileInfo[]): Set<string> {
 }
 
 export function isTestPath(filename: string): boolean {
-  return /\/__tests__\/|\/test\/|\/fixtures\/|\.test\.|\.spec\./.test(filename);
+  const path = `/${normalizePath(filename).toLowerCase()}`;
+  return (
+    /\/(?:__tests__|__fixtures__|tests?|test-fixtures|fixtures)\//.test(path) ||
+    /\.(?:test|spec)\.[^./]+$/.test(path)
+  );
 }
 
 /** Default archived/stale path segments skipped by context_freshness. */

--- a/mcp/src/submission-checks/types.ts
+++ b/mcp/src/submission-checks/types.ts
@@ -30,6 +30,8 @@ export interface SubmissionCheckContext {
   staleTerms: string[];
   namingAllowlist: NamingAllowlistConfig;
   authRouteAllowlist: string[];
+  authRouteHelpers: string[];
+  retiredRouteAllowlist: string[];
   maxFileLines: number;
   declaredPackages: Set<string>;
   /** Extra path segments to skip for context_freshness (merged with defaults). */

--- a/mcp/src/submission-engine.ts
+++ b/mcp/src/submission-engine.ts
@@ -27,6 +27,15 @@ const DEFAULT_AUTH_ROUTE_ALLOWLIST = [
   "/api/metrics/",
 ];
 
+const DEFAULT_AUTH_ROUTE_HELPERS = [
+  "getUser",
+  "getSession",
+  "getServerSession",
+  "auth",
+  "requireAuth",
+  "withAuth",
+];
+
 /** Package names declared in a package.json (legacy gate parity). */
 export function declaredPackageNamesFromPackageJson(
   pkg: Record<string, unknown>,
@@ -88,6 +97,11 @@ function buildContext(options: SubmissionEngineOptions): SubmissionCheckContext 
     namingAllowlist: repoConfig?.submission?.naming_allowlist ?? {},
     authRouteAllowlist:
       repoConfig?.submission?.auth_route_allowlist ?? DEFAULT_AUTH_ROUTE_ALLOWLIST,
+    authRouteHelpers: [
+      ...DEFAULT_AUTH_ROUTE_HELPERS,
+      ...(repoConfig?.submission?.auth_route_helpers ?? []),
+    ],
+    retiredRouteAllowlist: repoConfig?.submission?.retired_route_allowlist ?? [],
     maxFileLines: repoConfig?.submission?.max_file_lines ?? 1000,
     declaredPackages: declared,
     pathIgnorePatterns: repoConfig?.submission?.path_ignore ?? [],

--- a/scripts/copy-shared-src.mjs
+++ b/scripts/copy-shared-src.mjs
@@ -44,6 +44,8 @@ const sharedFiles = [
   "trust-runtime.ts",
   "remediation-lanes.ts",
   "trailhead-events.ts",
+  "ci-integrity.ts",
+  "github-pagination.ts",
   "autofix-executor.ts",
   "autofix-builders.ts",
   "github-git-writer.ts",

--- a/src/__tests__/autofix-executor.test.ts
+++ b/src/__tests__/autofix-executor.test.ts
@@ -21,6 +21,8 @@ function ctx(files: SubmissionFileInfo[]): SubmissionCheckContext {
     staleTerms: [],
     namingAllowlist: {},
     authRouteAllowlist: [],
+    authRouteHelpers: [],
+    retiredRouteAllowlist: [],
     maxFileLines: 1000,
     declaredPackages: new Set(),
     pathIgnorePatterns: [],

--- a/src/__tests__/catalog-heal.test.ts
+++ b/src/__tests__/catalog-heal.test.ts
@@ -17,6 +17,8 @@ function ctx(files: SubmissionFileInfo[]): SubmissionCheckContext {
     staleTerms: [],
     namingAllowlist: {},
     authRouteAllowlist: [],
+    authRouteHelpers: [],
+    retiredRouteAllowlist: [],
     maxFileLines: 1000,
     declaredPackages: new Set(),
     pathIgnorePatterns: [],

--- a/src/__tests__/ci-integrity-precision.test.ts
+++ b/src/__tests__/ci-integrity-precision.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { detectCiIntegrity } from "../ci-integrity.js";
+
+describe("CI integrity diff precision", () => {
+  it("ignores unchanged and deleted bypass context", () => {
+    const result = detectCiIntegrity([
+      {
+        filename: ".github/workflows/ci.yml",
+        patch: [
+          "@@ -10,3 +10,4 @@",
+          "  run: du -sh coverage || true",
+          "- run: legacy-check || true",
+          "+ run: npm test",
+        ].join("\n"),
+      },
+    ]);
+
+    expect(result.blockingPatterns).toEqual([]);
+    expect(result.score).toBe(0);
+  });
+
+  it("still blocks a newly added bypass", () => {
+    const result = detectCiIntegrity([
+      {
+        filename: ".github/workflows/ci.yml",
+        patch: "@@ -1,1 +1,2 @@\n+      run: npm test || true",
+      },
+    ]);
+
+    expect(result.blockingPatterns).toHaveLength(1);
+    expect(result.score).toBe(45);
+  });
+});

--- a/src/__tests__/claim-anchoring.test.ts
+++ b/src/__tests__/claim-anchoring.test.ts
@@ -13,6 +13,8 @@ function ctx(files: SubmissionFileInfo[]): SubmissionCheckContext {
     staleTerms: [],
     namingAllowlist: {},
     authRouteAllowlist: [],
+    authRouteHelpers: [],
+    retiredRouteAllowlist: [],
     maxFileLines: 1000,
     declaredPackages: new Set(),
     pathIgnorePatterns: [],

--- a/src/__tests__/close-on-ship-link.test.ts
+++ b/src/__tests__/close-on-ship-link.test.ts
@@ -18,6 +18,8 @@ function ctx(
     komatikInstance: true,
     staleTerms: [],
     authRouteAllowlist: [],
+    authRouteHelpers: [],
+    retiredRouteAllowlist: [],
     maxFileLines: 1000,
     declaredPackages: new Set(),
     namingAllowlist: {},

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -411,6 +411,17 @@ contexts:
     expect(parsed.data.gate.mode).toBe("risk-only");
     expect(parsed.data.contexts).toEqual([]);
   });
+
+  it("parses custom auth helpers and explicit retired routes", () => {
+    const parsed = parseRepoConfigContent(`schema_version: 2
+submission:
+  enabled: true
+  auth_route_helpers: [getLodgeAuthUser]
+  retired_route_allowlist: [/api/lodge/checkout]
+`);
+    expect(parsed?.submission?.auth_route_helpers).toEqual(["getLodgeAuthUser"]);
+    expect(parsed?.submission?.retired_route_allowlist).toEqual(["/api/lodge/checkout"]);
+  });
 });
 
 describe("matchesGlobs (re-exported from risk-engine)", () => {

--- a/src/__tests__/contract-integrity.test.ts
+++ b/src/__tests__/contract-integrity.test.ts
@@ -16,6 +16,8 @@ function ctx(
     staleTerms: [],
     namingAllowlist: {},
     authRouteAllowlist: [],
+    authRouteHelpers: [],
+    retiredRouteAllowlist: [],
     maxFileLines: 1000,
     declaredPackages: new Set(),
     pathIgnorePatterns: [],

--- a/src/__tests__/destructive-change.test.ts
+++ b/src/__tests__/destructive-change.test.ts
@@ -13,6 +13,8 @@ function ctx(files: SubmissionFileInfo[]): SubmissionCheckContext {
     staleTerms: [],
     namingAllowlist: {},
     authRouteAllowlist: [],
+    authRouteHelpers: [],
+    retiredRouteAllowlist: [],
     maxFileLines: 1000,
     declaredPackages: new Set(),
     pathIgnorePatterns: [],

--- a/src/__tests__/evaluate-gate.test.ts
+++ b/src/__tests__/evaluate-gate.test.ts
@@ -21,6 +21,28 @@ const githubMockState = vi.hoisted(() => ({
     details_url?: string;
   }>,
   checkRefs: [] as string[],
+  listFileCalls: [] as number[],
+  filePages: undefined as
+    | Record<
+        number,
+        Array<{
+          filename: string;
+          additions: number;
+          deletions: number;
+          changes: number;
+          patch?: string;
+          status?: string;
+        }>
+      >
+    | undefined,
+  commitFiles: [] as Array<{
+    filename: string;
+    additions: number;
+    deletions: number;
+    changes: number;
+  }>,
+  routeContents: {} as Record<string, string>,
+  contentRequests: [] as string[],
 }));
 
 vi.mock("@actions/core", () => ({
@@ -45,8 +67,9 @@ vi.mock("@actions/github", () => ({
   getOctokit: (_token: string) => ({
     rest: {
       pulls: {
-        listFiles: vi.fn().mockResolvedValue({
-          data: [
+        listFiles: vi.fn().mockImplementation(async ({ page = 1 }) => {
+          githubMockState.listFileCalls.push(page);
+          const fallback = [
             { filename: "src/app.ts", additions: 40, deletions: 10, changes: 50 },
             { filename: "src/utils.ts", additions: 20, deletions: 5, changes: 25 },
             {
@@ -55,7 +78,14 @@ vi.mock("@actions/github", () => ({
               deletions: 0,
               changes: 30,
             },
-          ],
+          ];
+          return {
+            data: githubMockState.filePages
+              ? (githubMockState.filePages[page] ?? [])
+              : page === 1
+                ? fallback
+                : [],
+          };
         }),
         listCommits: vi.fn().mockResolvedValue({
           data: [
@@ -83,6 +113,21 @@ vi.mock("@actions/github", () => ({
         }),
       },
       repos: {
+        getCommit: vi.fn().mockImplementation(async () => ({
+          data: { files: githubMockState.commitFiles },
+        })),
+        getContent: vi.fn().mockImplementation(async ({ path }: { path: string }) => {
+          githubMockState.contentRequests.push(path);
+          const content = githubMockState.routeContents[path];
+          if (content === undefined) throw new Error("not found");
+          return {
+            data: {
+              type: "file",
+              content: Buffer.from(content, "utf8").toString("base64"),
+              encoding: "base64",
+            },
+          };
+        }),
         listCommits: vi.fn().mockResolvedValue({
           data: Array.from({ length: 12 }, (_, i) => ({
             sha: `commit-${i}`,
@@ -143,6 +188,11 @@ describe("evaluateGate (integration)", () => {
     githubMockState.reviews = [];
     githubMockState.checkRuns = [];
     githubMockState.checkRefs = [];
+    githubMockState.listFileCalls = [];
+    githubMockState.filePages = undefined;
+    githubMockState.commitFiles = [];
+    githubMockState.routeContents = {};
+    githubMockState.contentRequests = [];
     // Avoid loading repo .trailhead.yml on CI (GITHUB_WORKSPACE is set there).
     vi.stubEnv("GITHUB_WORKSPACE", "");
   });
@@ -172,6 +222,73 @@ describe("evaluateGate (integration)", () => {
       "src/utils.ts",
       "src/__tests__/app.test.ts",
     ]);
+  });
+
+  it("evaluates all 214 PR files across GitHub's 100-item pages", async () => {
+    const files = Array.from({ length: 214 }, (_, index) => ({
+      filename: `src/file-${index}.ts`,
+      additions: 1,
+      deletions: 0,
+      changes: 1,
+    }));
+    githubMockState.filePages = {
+      1: files.slice(0, 100),
+      2: files.slice(100, 200),
+      3: files.slice(200),
+    };
+    githubMockState.commitFiles = files;
+
+    const result = await evaluateGate(
+      makeConfig({ githubToken: "ghp_test", securityGate: false }),
+      "pull-request-head-sha",
+      42,
+    );
+
+    expect(result.files).toHaveLength(214);
+    expect(githubMockState.listFileCalls).toEqual([1, 2, 3]);
+  });
+
+  it("hydrates the current route body before evaluating configured auth helpers", async () => {
+    const route = "apps/web/app/api/lodge/flow/route.ts";
+    githubMockState.filePages = {
+      1: [
+        {
+          filename: route,
+          additions: 2,
+          deletions: 0,
+          changes: 2,
+          status: "modified",
+          patch:
+            "@@ -20,1 +20,2 @@\n+export async function POST() {\n+  return Response.json({ ok: true });\n",
+        },
+      ],
+    };
+    githubMockState.routeContents[route] =
+      "export async function POST() { const user = await getLodgeAuthUser(); return Response.json({ user }); }";
+
+    const result = await withLocalTrailheadConfig(
+      `schema_version: 2
+submission:
+  enabled: true
+  mode: block
+  auth_route_helpers: [getLodgeAuthUser]
+`,
+      () =>
+        evaluateGate(
+          makeConfig({
+            githubToken: "ghp_test",
+            submissionGate: true,
+            securityGate: false,
+          }),
+          "pull-request-head-sha",
+          42,
+        ),
+    );
+
+    expect(githubMockState.contentRequests).toContain(route);
+    expect(
+      (result.submissionChecks ?? []).some((check) => check.code === "auth_route_auth"),
+    ).toBe(false);
   });
 
   it("fails release readiness when a required check fails on the PR head SHA", async () => {

--- a/src/__tests__/gate-autofix.test.ts
+++ b/src/__tests__/gate-autofix.test.ts
@@ -26,6 +26,8 @@ function ctx(files: SubmissionFileInfo[]): SubmissionCheckContext {
     staleTerms: [],
     namingAllowlist: {},
     authRouteAllowlist: [],
+    authRouteHelpers: [],
+    retiredRouteAllowlist: [],
     maxFileLines: 1000,
     declaredPackages: new Set(),
     pathIgnorePatterns: [],

--- a/src/__tests__/github-pagination.test.ts
+++ b/src/__tests__/github-pagination.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { collectGitHubPages, fetchGitHubJsonPages } from "../github-pagination.js";
+
+describe("GitHub pagination", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("collects every page for a 214-file pull request", async () => {
+    const pages = [
+      Array.from({ length: 100 }, (_, index) => index),
+      Array.from({ length: 100 }, (_, index) => index + 100),
+      Array.from({ length: 14 }, (_, index) => index + 200),
+    ];
+    const fetchPage = vi.fn(async (page: number) => pages[page - 1] ?? []);
+
+    const result = await collectGitHubPages(fetchPage);
+
+    expect(result.items).toHaveLength(214);
+    expect(result.pages).toBe(3);
+    expect(result.complete).toBe(true);
+    expect(fetchPage).toHaveBeenCalledTimes(3);
+  });
+
+  it("marks a full safety-ceiling page as incomplete", async () => {
+    const result = await collectGitHubPages(
+      async () => Array.from({ length: 100 }, (_, index) => index),
+      { maxPages: 2 },
+    );
+
+    expect(result.items).toHaveLength(200);
+    expect(result.complete).toBe(false);
+  });
+
+  it("sets GitHub's supported page parameters on fetch requests", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => [1, 2] });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await fetchGitHubJsonPages<number>(
+      "https://api.github.com/repos/acme/repo/pulls/7/files?ignored=kept",
+      { headers: { Authorization: "Bearer test" } },
+    );
+
+    expect(result.items).toEqual([1, 2]);
+    const requested = new URL(String(fetchMock.mock.calls[0]?.[0]));
+    expect(requested.searchParams.get("per_page")).toBe("100");
+    expect(requested.searchParams.get("page")).toBe("1");
+    expect(requested.searchParams.get("ignored")).toBe("kept");
+  });
+});

--- a/src/__tests__/import-resolution.test.ts
+++ b/src/__tests__/import-resolution.test.ts
@@ -18,6 +18,8 @@ function ctx(
     komatikInstance: true,
     staleTerms: [],
     authRouteAllowlist: [],
+    authRouteHelpers: [],
+    retiredRouteAllowlist: [],
     maxFileLines: 1000,
     declaredPackages: new Set(),
     namingAllowlist: {},

--- a/src/__tests__/phase0-detectors.test.ts
+++ b/src/__tests__/phase0-detectors.test.ts
@@ -29,6 +29,8 @@ function ctx(
     komatikInstance: true,
     staleTerms: [],
     authRouteAllowlist: [],
+    authRouteHelpers: [],
+    retiredRouteAllowlist: [],
     maxFileLines: 1000,
     declaredPackages: new Set(),
     namingAllowlist: {},

--- a/src/__tests__/promotion-coherence.test.ts
+++ b/src/__tests__/promotion-coherence.test.ts
@@ -16,6 +16,8 @@ function ctx(
     staleTerms: [],
     namingAllowlist: {},
     authRouteAllowlist: [],
+    authRouteHelpers: [],
+    retiredRouteAllowlist: [],
     maxFileLines: 1000,
     declaredPackages: new Set(),
     pathIgnorePatterns: [],

--- a/src/__tests__/remediation.test.ts
+++ b/src/__tests__/remediation.test.ts
@@ -189,6 +189,17 @@ describe("buildRemediation", () => {
   });
 
   describe("deduplication and ordering", () => {
+    it("renders the camelCase PR-scope detail emitted by the risk detector", () => {
+      const remediation = buildRemediation({
+        evaluation: evaluationFixture({
+          gateDecision: "warn",
+          riskFactors: [factor("pr_scope", 90, { fileCount: 214, totalChanges: 30306 })],
+        }),
+      });
+      const fix = remediation.fixes.find((entry) => entry.code === "policy.pr_scope");
+      expect(fix?.detail).toContain("214 files / 30306 lines");
+    });
+
     it("deduplicates by code keeping the highest severity", () => {
       const remediation = buildRemediation({
         evaluation: evaluationFixture({

--- a/src/__tests__/safe-deprecation.test.ts
+++ b/src/__tests__/safe-deprecation.test.ts
@@ -13,6 +13,8 @@ function ctx(files: SubmissionFileInfo[]): SubmissionCheckContext {
     staleTerms: [],
     namingAllowlist: {},
     authRouteAllowlist: [],
+    authRouteHelpers: [],
+    retiredRouteAllowlist: [],
     maxFileLines: 1000,
     declaredPackages: new Set(),
     pathIgnorePatterns: [],

--- a/src/__tests__/submission-detectors-precision.test.ts
+++ b/src/__tests__/submission-detectors-precision.test.ts
@@ -3,7 +3,9 @@ import {
   detectArtifactIntegrity,
   detectContextFreshness,
   detectExternalPackageDeps,
+  detectAuthRouteAuth,
   detectMockPlaceholder,
+  detectSecrets,
   detectSqlSyntaxBasic,
   detectSyntaxValidity,
 } from "../submission-checks/detectors.js";
@@ -23,6 +25,15 @@ function ctx(partial: Partial<SubmissionCheckContext>): SubmissionCheckContext {
     staleTerms: [],
     namingAllowlist: {},
     authRouteAllowlist: [],
+    authRouteHelpers: [
+      "getUser",
+      "getSession",
+      "getServerSession",
+      "auth",
+      "requireAuth",
+      "withAuth",
+    ],
+    retiredRouteAllowlist: [],
     maxFileLines: 1000,
     declaredPackages: new Set(),
     pathIgnorePatterns: [],
@@ -222,6 +233,130 @@ describe("mock_placeholder", () => {
       }),
     );
     expect(check?.code).toBe("mock_placeholder");
+  });
+
+  it("ignores CI fixture labels", () => {
+    const check = detectMockPlaceholder(
+      ctx({
+        files: [
+          {
+            filename: ".github/workflows/ci.yml",
+            patch: "@@\n+          TEST_LABEL: placeholder\n",
+          },
+        ],
+      }),
+    );
+    expect(check).toBeNull();
+  });
+
+  it("still flags a placeholder used by a CI command", () => {
+    const check = detectMockPlaceholder(
+      ctx({
+        files: [
+          {
+            filename: ".github/workflows/release.yml",
+            patch: "@@\n+      run: deploy placeholder\n",
+          },
+        ],
+      }),
+    );
+    expect(check?.code).toBe("mock_placeholder");
+  });
+});
+
+describe("secrets fixture precision", () => {
+  it("ignores an explicitly inert Stripe fixture value", () => {
+    const check = detectSecrets(
+      ctx({
+        files: [
+          {
+            filename: ".github/workflows/ci.yml",
+            patch: "@@\n+          STRIPE_KEY: sk_test_placeholder\n",
+          },
+        ],
+      }),
+    );
+    expect(check).toBeNull();
+  });
+
+  it("still blocks a credential-shaped value in a test file", () => {
+    const credential = ["sk", "test", "51RealLookingToken1234567890"].join("_");
+    const check = detectSecrets(
+      ctx({
+        files: [
+          {
+            filename: "src/__tests__/billing.test.ts",
+            patch: `@@\n+const key = '${credential}';\n`,
+          },
+        ],
+      }),
+    );
+    expect(check?.code).toBe("secrets");
+  });
+});
+
+describe("auth_route_auth precision", () => {
+  it("recognizes a configured helper in the full current route body", () => {
+    const check = detectAuthRouteAuth(
+      ctx({
+        authRouteHelpers: ["getUser", "getLodgeAuthUser"],
+        files: [
+          {
+            filename: "apps/web/app/api/lodge/flow/route.ts",
+            patch:
+              "@@\n+export async function POST() {\n+  return Response.json({ ok: true });\n+}\n",
+            content:
+              "export async function POST() { const user = await getLodgeAuthUser(); return Response.json({ user }); }",
+          },
+        ],
+      }),
+    );
+    expect(check).toBeNull();
+  });
+
+  it("allows an explicitly retired route only when its current body returns 410", () => {
+    const retired = "apps/web/app/api/lodge/checkout/route.ts";
+    const allowed = detectAuthRouteAuth(
+      ctx({
+        retiredRouteAllowlist: ["/api/lodge/checkout"],
+        files: [
+          {
+            filename: retired,
+            content:
+              "export function POST() { return Response.json({}, { status: 410 }); }",
+          },
+        ],
+      }),
+    );
+    const unsafe = detectAuthRouteAuth(
+      ctx({
+        retiredRouteAllowlist: ["/api/lodge/checkout"],
+        files: [
+          {
+            filename: retired,
+            content: "export function POST() { return Response.json({ ok: true }); }",
+          },
+        ],
+      }),
+    );
+
+    expect(allowed).toBeNull();
+    expect(unsafe?.code).toBe("auth_route_auth");
+  });
+
+  it("does not scan a removed route", () => {
+    const check = detectAuthRouteAuth(
+      ctx({
+        files: [
+          {
+            filename: "apps/web/app/api/old/route.ts",
+            status: "removed",
+            patch: "@@\n-export function POST() {}\n",
+          },
+        ],
+      }),
+    );
+    expect(check).toBeNull();
   });
 });
 

--- a/src/ci-integrity.ts
+++ b/src/ci-integrity.ts
@@ -1,0 +1,76 @@
+export interface CiIntegrityFile {
+  filename: string;
+  additions?: number;
+  deletions?: number;
+  patch?: string;
+}
+
+export interface CiIntegrityResult {
+  score: number;
+  blockingPatterns: string[];
+  warningSignals: string[];
+}
+
+function addedPatchLines(patch: string | undefined): string[] {
+  if (!patch) return [];
+  return patch
+    .split("\n")
+    .filter((line) => line.startsWith("+") && !line.startsWith("+++"))
+    .map((line) => line.slice(1));
+}
+
+/** Detect newly introduced CI bypasses, never unchanged or deleted context. */
+export function detectCiIntegrity(files: CiIntegrityFile[]): CiIntegrityResult {
+  const blockingPatterns: string[] = [];
+  const warningSignals: string[] = [];
+  let score = 0;
+
+  for (const file of files.filter((entry) =>
+    entry.filename.startsWith(".github/workflows/"),
+  )) {
+    const added = addedPatchLines(file.patch).join("\n");
+    if (/\|\|\s*true/.test(added)) {
+      blockingPatterns.push(`${file.filename}: workflow bypass pattern "|| true"`);
+      score += 45;
+    }
+    if (/^\s*continue-on-error:\s*true\b/m.test(added)) {
+      blockingPatterns.push(`${file.filename}: introduced "continue-on-error: true"`);
+      score += 45;
+    }
+    if (/^\s*if:\s*\$\{\{\s*always\(\)\s*\}\}/m.test(added)) {
+      warningSignals.push(`${file.filename}: always() condition added to workflow gate`);
+      score += 20;
+    }
+  }
+
+  for (const file of files.filter((entry) =>
+    /\.(test|spec)\.(ts|tsx|js|jsx)$|__tests__\/|\.cy\.(ts|js)$/.test(entry.filename),
+  )) {
+    const additions = file.additions ?? 0;
+    const deletions = file.deletions ?? 0;
+    if (deletions > additions * 2 && deletions >= 10) {
+      warningSignals.push(
+        `${file.filename}: heavy test deletion (${deletions} deleted / ${additions} added)`,
+      );
+      score += 25;
+    }
+  }
+
+  for (const file of files) {
+    const patch = file.patch ?? "";
+    if (!patch) continue;
+    if (
+      /^-\s*(branches|functions|lines|statements)\s*:\s*\d+/m.test(patch) &&
+      /^\+\s*(branches|functions|lines|statements)\s*:\s*\d+/m.test(patch)
+    ) {
+      warningSignals.push(`${file.filename}: coverage threshold definition changed`);
+      score += 20;
+    }
+  }
+
+  return {
+    score: Math.min(100, score),
+    blockingPatterns,
+    warningSignals,
+  };
+}

--- a/src/dora.ts
+++ b/src/dora.ts
@@ -1,5 +1,6 @@
 import * as core from "@actions/core";
 import * as github from "@actions/github";
+import { collectGitHubPages } from "./github-pagination.js";
 
 // ---------------------------------------------------------------------------
 // DORA rating bands (per dora.dev benchmarks)
@@ -685,12 +686,19 @@ async function computeChangeReworkRate(
 
     for (const pr of mergedInWindow.slice(0, sampleSize)) {
       try {
-        const { data: files } = await octokit.rest.pulls.listFiles({
-          owner,
-          repo,
-          pull_number: pr.number,
-          per_page: 100,
-        });
+        const { items: files } = await collectGitHubPages(
+          async (page, perPage) => {
+            const { data } = await octokit.rest.pulls.listFiles({
+              owner,
+              repo,
+              pull_number: pr.number,
+              per_page: perPage,
+              page,
+            });
+            return data;
+          },
+          { perPage: 100, maxPages: 30 },
+        );
         prFiles.set(pr.number, new Set(files.map((f) => f.filename)));
       } catch {
         // skip PRs we can't fetch files for
@@ -774,12 +782,19 @@ async function filterPrsByServicePaths<T extends PrMinimal>(
 
   for (const pr of prs.slice(0, sampleSize)) {
     try {
-      const { data: files } = await octokit.rest.pulls.listFiles({
-        owner,
-        repo,
-        pull_number: pr.number,
-        per_page: 100,
-      });
+      const { items: files } = await collectGitHubPages(
+        async (page, perPage) => {
+          const { data } = await octokit.rest.pulls.listFiles({
+            owner,
+            repo,
+            pull_number: pr.number,
+            per_page: perPage,
+            page,
+          });
+          return data;
+        },
+        { perPage: 100, maxPages: 30 },
+      );
 
       const touchesService = files.some((f) =>
         pathPatterns.some((p) => p.test(f.filename)),

--- a/src/gate.ts
+++ b/src/gate.ts
@@ -82,6 +82,8 @@ import type { SubmissionCheckResult } from "./types.js";
 import { computeAgentTrustScore, strictnessFromTrust } from "./trust-score.js";
 import { parseAgentTrustMetrics } from "./agent-trust-metrics.js";
 import { readTrustRuntime } from "./trust-runtime.js";
+import { detectCiIntegrity } from "./ci-integrity.js";
+import { collectGitHubPages } from "./github-pagination.js";
 
 export {
   isSensitiveFile,
@@ -125,6 +127,8 @@ interface PrFileInfo {
   deletions: number;
   changes: number;
   patch?: string;
+  status?: string;
+  content?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -137,25 +141,33 @@ async function fetchPrFilesFromApi(
   repo: string,
   prNumber: number,
 ): Promise<PrFileInfo[]> {
-  const { data: files } = await octokit.rest.pulls.listFiles({
-    owner,
-    repo,
-    pull_number: prNumber,
-    per_page: 300,
-  });
+  const result = await collectGitHubPages(
+    async (page, perPage) => {
+      const { data } = await octokit.rest.pulls.listFiles({
+        owner,
+        repo,
+        pull_number: prNumber,
+        per_page: perPage,
+        page,
+      });
+      return data;
+    },
+    { perPage: 100, maxPages: 30 },
+  );
 
-  if (files.length >= 300) {
+  if (!result.complete) {
     core.warning(
-      "PR has 300+ files — risk analysis may be incomplete (GitHub API pagination limit)",
+      "PR file enumeration reached GitHub's 3,000-file API ceiling; risk analysis is incomplete.",
     );
   }
 
-  return files.map((f) => ({
+  return result.items.map((f) => ({
     filename: f.filename,
     additions: f.additions,
     deletions: f.deletions,
     changes: f.changes,
     patch: f.patch,
+    status: f.status,
   }));
 }
 
@@ -165,12 +177,19 @@ async function fetchPrFilesFromCommits(
   repo: string,
   prNumber: number,
 ): Promise<PrFileInfo[]> {
-  const { data: commits } = await octokit.rest.pulls.listCommits({
-    owner,
-    repo,
-    pull_number: prNumber,
-    per_page: 250,
-  });
+  const { items: commits } = await collectGitHubPages(
+    async (page, perPage) => {
+      const { data } = await octokit.rest.pulls.listCommits({
+        owner,
+        repo,
+        pull_number: prNumber,
+        per_page: perPage,
+        page,
+      });
+      return data;
+    },
+    { perPage: 100, maxPages: 3 },
+  );
 
   const fileMap = new Map<string, PrFileInfo>();
 
@@ -208,6 +227,44 @@ const DRIFT_CHECK_FILE_THRESHOLD = 30;
 // the merge-base is stale and we use the commit-derived list instead.
 const MERGE_BASE_DRIFT_RATIO = 2.0;
 
+const API_ROUTE_FILE =
+  /(?:^|\/)(?:app\/api\/.+\/route|pages\/api\/.+)\.(?:ts|tsx|js|jsx)$/;
+
+async function hydrateChangedRouteContents(
+  octokit: ReturnType<typeof github.getOctokit>,
+  owner: string,
+  repo: string,
+  ref: string,
+  files: PrFileInfo[],
+): Promise<void> {
+  const routes = files.filter(
+    (file) =>
+      file.status !== "removed" && API_ROUTE_FILE.test(file.filename.replace(/\\/g, "/")),
+  );
+
+  // Keep the request fan-out bounded while still avoiding serial latency on
+  // route-heavy PRs. Route bodies are the source of truth for auth checks.
+  const batchSize = 8;
+  for (let start = 0; start < routes.length; start += batchSize) {
+    await Promise.all(
+      routes.slice(start, start + batchSize).map(async (file) => {
+        try {
+          const { data } = await octokit.rest.repos.getContent({
+            owner,
+            repo,
+            path: file.filename,
+            ref,
+          });
+          if (Array.isArray(data) || data.type !== "file" || !data.content) return;
+          file.content = Buffer.from(data.content, "base64").toString("utf8");
+        } catch (error) {
+          core.debug(`Could not fetch current route body for ${file.filename}: ${error}`);
+        }
+      }),
+    );
+  }
+}
+
 async function fetchPrFiles(prNumber: number, token?: string): Promise<PrFileInfo[]> {
   if (!token) return [];
 
@@ -217,40 +274,44 @@ async function fetchPrFiles(prNumber: number, token?: string): Promise<PrFileInf
 
     const apiFiles = await fetchPrFilesFromApi(octokit, owner, repo, prNumber);
 
-    if (apiFiles.length <= DRIFT_CHECK_FILE_THRESHOLD) {
-      return apiFiles;
-    }
+    let selectedFiles = apiFiles;
 
-    // GitHub's pulls.listFiles uses a merge-base diff that can include
-    // files from unrelated commits when the base branch has diverged
-    // from the PR branch point.  Cross-check against the files the PR's
-    // commits actually touch and fall back when inflation is detected.
-    core.info(
-      `PR reports ${apiFiles.length} files (>${DRIFT_CHECK_FILE_THRESHOLD}), ` +
-        `cross-checking against commit-level file list for merge-base drift.`,
-    );
-
-    let commitFiles: PrFileInfo[];
-    try {
-      commitFiles = await fetchPrFilesFromCommits(octokit, owner, repo, prNumber);
-    } catch (err) {
-      core.debug(`Commit-level file enumeration failed, using API list: ${err}`);
-      return apiFiles;
-    }
-
-    if (
-      commitFiles.length > 0 &&
-      apiFiles.length > commitFiles.length * MERGE_BASE_DRIFT_RATIO
-    ) {
-      core.warning(
-        `Merge-base drift: API reported ${apiFiles.length} files, ` +
-          `but PR commits only touch ${commitFiles.length}. ` +
-          `Using commit-derived file list to avoid inflated risk scores.`,
+    if (apiFiles.length > DRIFT_CHECK_FILE_THRESHOLD) {
+      // GitHub's pulls.listFiles uses a merge-base diff that can include
+      // files from unrelated commits when the base branch has diverged
+      // from the PR branch point. Cross-check against the files the PR's
+      // commits actually touch and fall back when inflation is detected.
+      core.info(
+        `PR reports ${apiFiles.length} files (>${DRIFT_CHECK_FILE_THRESHOLD}), ` +
+          `cross-checking against commit-level file list for merge-base drift.`,
       );
-      return commitFiles;
+
+      let commitFiles: PrFileInfo[] = [];
+      try {
+        commitFiles = await fetchPrFilesFromCommits(octokit, owner, repo, prNumber);
+      } catch (err) {
+        core.debug(`Commit-level file enumeration failed, using API list: ${err}`);
+      }
+
+      if (
+        commitFiles.length > 0 &&
+        apiFiles.length > commitFiles.length * MERGE_BASE_DRIFT_RATIO
+      ) {
+        core.warning(
+          `Merge-base drift: API reported ${apiFiles.length} files, ` +
+            `but PR commits only touch ${commitFiles.length}. ` +
+            `Using commit-derived file list to avoid inflated risk scores.`,
+        );
+        const apiByName = new Map(apiFiles.map((file) => [file.filename, file]));
+        selectedFiles = commitFiles.map((file) => ({
+          ...file,
+          patch: apiByName.get(file.filename)?.patch,
+          status: apiByName.get(file.filename)?.status,
+        }));
+      }
     }
 
-    return apiFiles;
+    return selectedFiles;
   } catch (error) {
     core.debug(`Failed to fetch PR files: ${error}`);
     return [];
@@ -569,51 +630,7 @@ interface CiIntegrityDetection {
 }
 
 function detectCiIntegrityRisk(files: PrFileInfo[]): CiIntegrityDetection {
-  const blockingPatterns: string[] = [];
-  const warningSignals: string[] = [];
-  let score = 0;
-
-  const workflowFiles = files.filter((f) => f.filename.startsWith(".github/workflows/"));
-  const testFiles = files.filter((f) =>
-    /\.(test|spec)\.(ts|tsx|js|jsx)$|__tests__\/|\.cy\.(ts|js)$/.test(f.filename),
-  );
-
-  for (const file of workflowFiles) {
-    const patch = file.patch ?? "";
-    if (/\|\|\s*true/.test(patch)) {
-      blockingPatterns.push(`${file.filename}: workflow bypass pattern "|| true"`);
-      score += 45;
-    }
-    if (/^\+\s*continue-on-error:\s*true\b/m.test(patch)) {
-      blockingPatterns.push(`${file.filename}: introduced "continue-on-error: true"`);
-      score += 45;
-    }
-    if (/^\+\s*if:\s*\$\{\{\s*always\(\)\s*\}\}/m.test(patch)) {
-      warningSignals.push(`${file.filename}: always() condition added to workflow gate`);
-      score += 20;
-    }
-  }
-
-  for (const file of testFiles) {
-    if (file.deletions > file.additions * 2 && file.deletions >= 10) {
-      warningSignals.push(
-        `${file.filename}: heavy test deletion (${file.deletions} deleted / ${file.additions} added)`,
-      );
-      score += 25;
-    }
-  }
-
-  for (const file of files) {
-    const patch = file.patch ?? "";
-    if (!patch) continue;
-    if (
-      /^-\s*(branches|functions|lines|statements)\s*:\s*\d+/m.test(patch) &&
-      /^\+\s*(branches|functions|lines|statements)\s*:\s*\d+/m.test(patch)
-    ) {
-      warningSignals.push(`${file.filename}: coverage threshold definition changed`);
-      score += 20;
-    }
-  }
+  const { score, blockingPatterns, warningSignals } = detectCiIntegrity(files);
 
   if (score === 0) {
     return { factor: null, blockingPatterns: [] };
@@ -1616,6 +1633,14 @@ export async function evaluateGate(
     prNumber ? fetchPrFiles(prNumber, config.githubToken) : Promise.resolve([]),
     loadRepoConfig(config.githubToken),
   ]);
+  const submissionMode = repoConfig?.submission?.mode ?? "block";
+  const submissionEnabled =
+    config.submissionGate === true || repoConfig?.submission?.enabled === true;
+  if (submissionEnabled && config.githubToken) {
+    const octokit = github.getOctokit(config.githubToken);
+    const { owner, repo } = github.context.repo;
+    await hydrateChangedRouteContents(octokit, owner, repo, commitSha, files);
+  }
   const changedFiles = files.map((f) => f.filename);
 
   const [
@@ -1879,9 +1904,6 @@ export async function evaluateGate(
   }
 
   let submissionChecks: SubmissionCheckResult[] = [];
-  const submissionMode = repoConfig?.submission?.mode ?? "block";
-  const submissionEnabled =
-    config.submissionGate === true || repoConfig?.submission?.enabled === true;
   if (submissionEnabled && files.length > 0) {
     for (const warning of getSubmissionConfigWarnings(repoConfig?.submission)) {
       core.warning(warning);
@@ -1912,6 +1934,8 @@ export async function evaluateGate(
       files: files.map((f) => ({
         filename: f.filename,
         patch: f.patch,
+        status: f.status,
+        content: f.content,
         additions: f.additions,
       })),
       repoConfig,

--- a/src/github-pagination.ts
+++ b/src/github-pagination.ts
@@ -1,0 +1,58 @@
+export interface PaginationResult<T> {
+  items: T[];
+  pages: number;
+  complete: boolean;
+}
+
+export interface PaginationOptions {
+  /** GitHub REST APIs cap per_page at 100. */
+  perPage?: number;
+  /** Safety ceiling for endpoints with a documented result cap. */
+  maxPages?: number;
+}
+
+/**
+ * Collect a GitHub REST endpoint page-by-page. A full final page is treated as
+ * incomplete when maxPages is reached so callers can surface truncated input.
+ */
+export async function collectGitHubPages<T>(
+  fetchPage: (page: number, perPage: number) => Promise<T[]>,
+  options: PaginationOptions = {},
+): Promise<PaginationResult<T>> {
+  const perPage = Math.min(100, Math.max(1, options.perPage ?? 100));
+  const maxPages = Math.max(1, options.maxPages ?? 30);
+  const items: T[] = [];
+
+  for (let page = 1; page <= maxPages; page += 1) {
+    const pageItems = await fetchPage(page, perPage);
+    items.push(...pageItems);
+
+    if (pageItems.length < perPage) {
+      return { items, pages: page, complete: true };
+    }
+  }
+
+  return { items, pages: maxPages, complete: false };
+}
+
+/** Fetch every available JSON-array page from a GitHub REST URL. */
+export async function fetchGitHubJsonPages<T>(
+  url: string,
+  init: RequestInit,
+  options: PaginationOptions = {},
+): Promise<PaginationResult<T>> {
+  return collectGitHubPages<T>(async (page, perPage) => {
+    const pageUrl = new URL(url);
+    pageUrl.searchParams.set("per_page", String(perPage));
+    pageUrl.searchParams.set("page", String(page));
+    const response = await fetch(pageUrl, init);
+    if (!response.ok) {
+      throw new Error(`GitHub request failed: HTTP ${response.status}`);
+    }
+    const data = (await response.json()) as unknown;
+    if (!Array.isArray(data)) {
+      throw new Error("GitHub paginated response was not an array");
+    }
+    return data as T[];
+  }, options);
+}

--- a/src/remediation.ts
+++ b/src/remediation.ts
@@ -153,8 +153,14 @@ const factorCues: Record<string, FactorCue> = {
     triggerScore: 50,
     advisoryScore: 20,
     build: (factor) => {
-      const files = (factor.detail?.file_count as number | undefined) ?? 0;
-      const changes = (factor.detail?.line_count as number | undefined) ?? 0;
+      const files =
+        (factor.detail?.fileCount as number | undefined) ??
+        (factor.detail?.file_count as number | undefined) ??
+        0;
+      const changes =
+        (factor.detail?.totalChanges as number | undefined) ??
+        (factor.detail?.line_count as number | undefined) ??
+        0;
       return {
         code: "policy.pr_scope",
         severity: "warn",

--- a/src/submission-checks/detectors.ts
+++ b/src/submission-checks/detectors.ts
@@ -53,6 +53,35 @@ const SECRET_PATTERNS: Array<{ name: string; pattern: RegExp }> = [
   },
 ];
 
+function isCiConfigurationPath(filename: string): boolean {
+  return /^\.github\/(?:workflows|actions)\//.test(normalizePath(filename));
+}
+
+function isCredentialFixturePath(filename: string): boolean {
+  return isTestPath(filename) || isCiConfigurationPath(filename);
+}
+
+function isObviouslyInertCiFixtureLine(line: string, filename: string): boolean {
+  if (!isCiConfigurationPath(filename)) return false;
+  const assignment = /^\s*[\w.-]+\s*:\s*["']?([^"'#\s]+)["']?(?:\s*#.*)?$/.exec(line);
+  if (!assignment?.[1]) return false;
+  return /^(?:sk_(?:test|live)_)?(?:placeholder|example|dummy|fake|test|x{10,}|0{10,})$/i.test(
+    assignment[1],
+  );
+}
+
+function isObviouslyInertStripeFixture(
+  patternName: string,
+  match: string,
+  filename: string,
+): boolean {
+  if (!isCredentialFixturePath(filename) || !patternName.startsWith("Stripe ")) {
+    return false;
+  }
+  const suffix = match.replace(/^sk_(?:test|live)_/i, "");
+  return /^(?:placeholder|example|dummy|fake|test|x{10,}|0{10,})$/i.test(suffix);
+}
+
 const HARDCODED_ENV_PATTERNS: Array<{ name: string; pattern: RegExp }> = [
   { name: "localhost with port", pattern: /(?:['"`])localhost:\d{2,5}(?:['"`])/g },
   {
@@ -102,6 +131,7 @@ export function detectMockPlaceholder(
 ): SubmissionCheckResult | null {
   const hits = scanAddedContent(ctx.files, (line, filename) => {
     if (isTestPath(filename)) return false;
+    if (isObviouslyInertCiFixtureLine(line, filename)) return false;
     if (/\.(md|txt)$/i.test(filename)) return false;
     return MOCK_PATTERNS.some((re) => {
       re.lastIndex = 0;
@@ -120,10 +150,12 @@ export function detectMockPlaceholder(
 }
 
 export function detectSecrets(ctx: SubmissionCheckContext): SubmissionCheckResult | null {
-  const hits = scanAddedContent(ctx.files, (line) =>
+  const hits = scanAddedContent(ctx.files, (line, filename) =>
     SECRET_PATTERNS.some((entry) => {
       entry.pattern.lastIndex = 0;
-      return entry.pattern.test(line);
+      return [...line.matchAll(entry.pattern)].some(
+        (match) => !isObviouslyInertStripeFixture(entry.name, match[0] ?? "", filename),
+      );
     }),
   );
   if (hits.length === 0) return null;
@@ -501,20 +533,34 @@ function isRouteAllowlisted(path: string, allowlist: string[]): boolean {
   return allowlist.some((entry) => path.includes(entry.replace(/^\//, "")));
 }
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function isRetiredRoute(path: string, content: string, allowlist: string[]): boolean {
+  if (!isRouteAllowlisted(path, allowlist)) return false;
+  return /\bstatus\s*:\s*410\b/.test(content);
+}
+
 export function detectAuthRouteAuth(
   ctx: SubmissionCheckContext,
 ): SubmissionCheckResult | null {
   const routePattern =
     /(?:^|\/)(?:app\/api\/.+\/route|pages\/api\/.+)\.(?:ts|tsx|js|jsx)$/;
-  const authPattern =
-    /\b(getUser|getSession|getServerSession|auth|requireAuth|withAuth)\s*\(/;
+  const helpers = [...new Set(ctx.authRouteHelpers)].filter((helper) =>
+    /^[A-Za-z_$][\w$]*$/.test(helper),
+  );
+  const authPattern = new RegExp(`\\b(?:${helpers.map(escapeRegExp).join("|")})\\s*\\(`);
   const hits: string[] = [];
 
   for (const file of ctx.files) {
     const normalized = normalizePath(file.filename);
     if (!routePattern.test(normalized)) continue;
+    if (file.status === "removed") continue;
     if (isRouteAllowlisted(normalized, ctx.authRouteAllowlist)) continue;
-    if (!authPattern.test(fileContent(file))) hits.push(normalized);
+    const content = fileContent(file);
+    if (isRetiredRoute(normalized, content, ctx.retiredRouteAllowlist)) continue;
+    if (helpers.length === 0 || !authPattern.test(content)) hits.push(normalized);
   }
 
   if (hits.length === 0) return null;

--- a/src/submission-checks/helpers.ts
+++ b/src/submission-checks/helpers.ts
@@ -79,7 +79,11 @@ export function prPathSet(files: SubmissionFileInfo[]): Set<string> {
 }
 
 export function isTestPath(filename: string): boolean {
-  return /\/__tests__\/|\/test\/|\/fixtures\/|\.test\.|\.spec\./.test(filename);
+  const path = `/${normalizePath(filename).toLowerCase()}`;
+  return (
+    /\/(?:__tests__|__fixtures__|tests?|test-fixtures|fixtures)\//.test(path) ||
+    /\.(?:test|spec)\.[^./]+$/.test(path)
+  );
 }
 
 /** Default archived/stale path segments skipped by context_freshness. */

--- a/src/submission-checks/types.ts
+++ b/src/submission-checks/types.ts
@@ -30,6 +30,8 @@ export interface SubmissionCheckContext {
   staleTerms: string[];
   namingAllowlist: NamingAllowlistConfig;
   authRouteAllowlist: string[];
+  authRouteHelpers: string[];
+  retiredRouteAllowlist: string[];
   maxFileLines: number;
   declaredPackages: Set<string>;
   /** Extra path segments to skip for context_freshness (merged with defaults). */

--- a/src/submission-engine.ts
+++ b/src/submission-engine.ts
@@ -27,6 +27,15 @@ const DEFAULT_AUTH_ROUTE_ALLOWLIST = [
   "/api/metrics/",
 ];
 
+const DEFAULT_AUTH_ROUTE_HELPERS = [
+  "getUser",
+  "getSession",
+  "getServerSession",
+  "auth",
+  "requireAuth",
+  "withAuth",
+];
+
 /** Package names declared in a package.json (legacy gate parity). */
 export function declaredPackageNamesFromPackageJson(
   pkg: Record<string, unknown>,
@@ -88,6 +97,11 @@ function buildContext(options: SubmissionEngineOptions): SubmissionCheckContext 
     namingAllowlist: repoConfig?.submission?.naming_allowlist ?? {},
     authRouteAllowlist:
       repoConfig?.submission?.auth_route_allowlist ?? DEFAULT_AUTH_ROUTE_ALLOWLIST,
+    authRouteHelpers: [
+      ...DEFAULT_AUTH_ROUTE_HELPERS,
+      ...(repoConfig?.submission?.auth_route_helpers ?? []),
+    ],
+    retiredRouteAllowlist: repoConfig?.submission?.retired_route_allowlist ?? [],
     maxFileLines: repoConfig?.submission?.max_file_lines ?? 1000,
     declaredPackages: declared,
     pathIgnorePatterns: repoConfig?.submission?.path_ignore ?? [],

--- a/src/types.ts
+++ b/src/types.ts
@@ -486,6 +486,10 @@ export const SubmissionConfig = z.object({
   mode: z.enum(["warn", "block"]).default("block"),
   stale_terms: z.array(z.string()).optional(),
   auth_route_allowlist: z.array(z.string()).optional(),
+  /** Additional function identifiers that prove an API route authenticated. */
+  auth_route_helpers: z.array(z.string().min(1)).optional(),
+  /** Side-effect-free tombstone routes; each body must still return HTTP 410. */
+  retired_route_allowlist: z.array(z.string()).optional(),
   max_file_lines: z.number().int().positive().optional(),
   /** Path substrings to skip for context_freshness (e.g. archived suggestion dirs). */
   path_ignore: z.array(z.string()).optional(),


### PR DESCRIPTION
## Summary

- paginate pull-request files and commits instead of truncating large changesets
- evaluate CI bypasses from added lines only and narrow fixture/mock exceptions
- hydrate changed API routes at the pull-request head SHA before auth checks
- support configured auth helpers and explicit retired-route allowlists
- report real pull-request file and line counts in remediation output
- keep Action, GitHub App, CLI, and MCP gate behavior aligned

Closes #341.
Closes #342.
Closes #344.

## Validation

- formatting and lint
- root, app, MCP, cloud, and CLI typechecks
- 873 root tests and V8 coverage gate
- 49 cloud tests
- CLI bundle and offline doctor
- simulator smoke test
- rebuilt tracked Action and MCP distributions

## Precision cases covered

- unchanged or deleted `|| true` does not block; newly added bypasses do
- 214-file pull requests are fully evaluated
- changed route bodies are fetched at the head SHA
- configured helper calls, removed routes, and explicitly retired 410 routes
- inert CI mocks and Stripe fixtures avoid false positives while realistic credentials still block
- remediation output reports 214 files and 30,306 changed lines
