### PR TITLE
draft: add fail-closed release evidence contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Trailhead will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Fail-closed release evidence contracts** ([#343](https://github.com/KomatikAI/trailhead/issues/343)) — production contexts can require a fresh service-owned attestation. Trailhead emits an actionable finding and evidence link for every failed, pending, or missing condition while leaving staging/shadow contexts unaffected.
+
 ### Fixed
 
 - **PR evaluation no longer truncates at 100 files** ([#344](https://github.com/KomatikAI/trailhead/issues/344)) — the Action, GitHub App, MCP policy tools, and DORA file scans now paginate GitHub's PR-files endpoint. Large PR risk, scope, and submission checks receive the complete available file set.

--- a/README.md
+++ b/README.md
@@ -405,6 +405,20 @@ security:
 canary:
   webhook_type: vercel
 
+# Service-owned production evidence. Trailhead fetches this only in the named
+# environments and blocks once for every required condition that is not proven.
+release_evidence:
+  url: https://myapp.example.com/api/release-evidence
+  environments: [production]
+  mode: block
+  max_age_minutes: 60
+  expected_subject: myapp-production
+  required_checks:
+    - deployment.target
+    - billing.policy
+    - canary.charge
+    - canary.refund
+
 escalation:
   targets: ["slack:#release-ops", "email:oncall@example.com"]
   acknowledge_sla_minutes: 30
@@ -467,6 +481,9 @@ ignore:
 Trailhead first loads `.trailhead.yml` from the checked-out workspace, then falls back to
 the GitHub Contents API. Existing repositories can keep using the legacy v1 config filename;
 Trailhead will read it when `.trailhead.yml` is not present.
+
+See [Release evidence contracts](./docs/release-evidence.md) for the endpoint schema,
+freshness rules, evidence-link behavior, and a credits-only production example.
 
 This repository's own `.trailhead.yml` ignores generated MCP copy/artifact paths
 (`mcp/src/adapters/**`, `mcp/dist/adapters/**`, and `mcp/dist/risk-engine.*`) so the gate

--- a/docs/release-evidence.md
+++ b/docs/release-evidence.md
@@ -1,0 +1,79 @@
+# Release evidence contracts
+
+Ordinary HTTP health checks remain operational signals. A release evidence contract is
+different: it is an explicit, fail-closed proof that the commercial and deployment
+conditions for a production promotion are currently true.
+
+The application owns an HTTPS endpoint and keeps provider, database, and payment
+credentials behind that server boundary. Trailhead fetches only a bounded JSON
+attestation. It does not receive those credentials.
+
+## Configuration
+
+```yaml
+schema_version: 2
+
+contexts:
+  - name: production
+    match:
+      base_branch: [main]
+    environment: production
+
+release_evidence:
+  url: https://lodge.komatik.xyz/api/lodge/release-evidence
+  environments: [production]
+  mode: block
+  max_age_minutes: 60
+  expected_subject: lodge-production
+  required_checks:
+    - deployment.vercel_project
+    - deployment.production_domain
+    - credits.enforced
+    - credits.prices
+    - credits.model_rates
+    - credits.cogs_ceilings
+    - canary.debits
+    - canary.refund
+    - canary.topup
+    - canary.usage
+    - runtime.failure_contract
+```
+
+The endpoint is dormant outside the configured environments. `mode: warn` supports a
+shadow rollout; `mode: block` makes any failed, pending, missing, stale, malformed, or
+unreachable evidence prevent release readiness.
+
+## Endpoint response
+
+```json
+{
+  "schema_version": 1,
+  "subject": "lodge-production",
+  "generated_at": "2026-07-22T19:45:00.000Z",
+  "evidence_url": "https://evidence.example.com/lodge/canary-42",
+  "checks": [
+    {
+      "id": "credits.prices",
+      "status": "pass",
+      "summary": "chat_turn=1 and activity=3 with no paid tier",
+      "evidence_url": "https://evidence.example.com/lodge/policy-42"
+    },
+    {
+      "id": "canary.refund",
+      "status": "pending",
+      "summary": "No recent provider-failure refund canary"
+    }
+  ]
+}
+```
+
+`status` is `pass`, `fail`, or `pending`. Check IDs must be unique. Trailhead evaluates
+only configured required IDs, emits one policy finding per non-passing or missing ID,
+and includes the check-level evidence link when present (falling back to the document
+link). Documents older than `max_age_minutes` fail as stale. Future timestamps more than
+one minute ahead also fail.
+
+For safety, Trailhead requires HTTPS, refuses redirects, applies a ten-second timeout,
+and rejects responses larger than 1 MB. The endpoint should publish no user identifiers,
+tokens, secrets, raw ledger payloads, or other sensitive material; link to access-controlled
+operator evidence when details are required.

--- a/scripts/copy-shared-src.mjs
+++ b/scripts/copy-shared-src.mjs
@@ -46,6 +46,7 @@ const sharedFiles = [
   "trailhead-events.ts",
   "ci-integrity.ts",
   "github-pagination.ts",
+  "release-evidence.ts",
   "autofix-executor.ts",
   "autofix-builders.ts",
   "github-git-writer.ts",

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -422,6 +422,24 @@ submission:
     expect(parsed?.submission?.auth_route_helpers).toEqual(["getLodgeAuthUser"]);
     expect(parsed?.submission?.retired_route_allowlist).toEqual(["/api/lodge/checkout"]);
   });
+
+  it("parses a fail-closed production release evidence contract", () => {
+    const parsed = parseRepoConfigContent(`schema_version: 2
+release_evidence:
+  url: https://lodge.example.com/api/release-evidence
+  expected_subject: lodge-production
+  required_checks: [credits.policy, canary.refund]
+`);
+
+    expect(parsed?.release_evidence).toMatchObject({
+      url: "https://lodge.example.com/api/release-evidence",
+      expected_subject: "lodge-production",
+      environments: ["production"],
+      mode: "block",
+      max_age_minutes: 60,
+      required_checks: ["credits.policy", "canary.refund"],
+    });
+  });
 });
 
 describe("matchesGlobs (re-exported from risk-engine)", () => {

--- a/src/__tests__/evaluate-gate.test.ts
+++ b/src/__tests__/evaluate-gate.test.ts
@@ -224,6 +224,64 @@ describe("evaluateGate (integration)", () => {
     ]);
   });
 
+  it("fails a production release on each missing release-evidence condition", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          schema_version: 1,
+          subject: "lodge-production",
+          generated_at: new Date().toISOString(),
+          checks: [
+            {
+              id: "deployment.target",
+              status: "fail",
+              summary: "wrong Vercel project",
+              evidence_url: "https://vercel.example.com/project",
+            },
+          ],
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const result = await withLocalTrailheadConfig(
+      `
+schema_version: 2
+gate:
+  mode: release-ready
+contexts:
+  - name: production
+    match:
+      base_branch: [main]
+    environment: production
+release_evidence:
+  url: https://lodge.example.com/api/release-evidence
+  expected_subject: lodge-production
+  environments: [production]
+  mode: block
+  max_age_minutes: 60
+  required_checks:
+    - deployment.target
+    - credits.policy
+`,
+      () => evaluateGate(makeConfig({ githubToken: "ghp_test" }), "abc1234567890", 42),
+    );
+
+    expect(result.gateDecision).toBe("block");
+    expect(result.releaseReady).toBe(false);
+    expect(result.healthChecks.map((check) => check.target)).toEqual([
+      "release-evidence:deployment.target",
+      "release-evidence:credits.policy",
+    ]);
+    expect(result.policyFindings).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("wrong Vercel project"),
+        expect.stringContaining('"credits.policy"'),
+      ]),
+    );
+  });
+
   it("evaluates all 214 PR files across GitHub's 100-item pages", async () => {
     const files = Array.from({ length: 214 }, (_, index) => ({
       filename: `src/file-${index}.ts`,

--- a/src/__tests__/release-evidence.test.ts
+++ b/src/__tests__/release-evidence.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it, vi } from "vitest";
+import { evaluateReleaseEvidence } from "../release-evidence.js";
+import type { ReleaseEvidenceConfig } from "../types.js";
+
+const NOW = Date.parse("2026-07-22T20:00:00.000Z");
+
+function config(overrides: Partial<ReleaseEvidenceConfig> = {}): ReleaseEvidenceConfig {
+  return {
+    enabled: true,
+    url: "https://lodge.example.com/api/release-evidence",
+    environments: ["production"],
+    mode: "block",
+    max_age_minutes: 60,
+    expected_subject: "lodge-production",
+    required_checks: ["deployment.target", "credits.policy", "canary.refund"],
+    ...overrides,
+  };
+}
+
+function response(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function document(
+  checks: Array<{
+    id: string;
+    status: "pass" | "fail" | "pending";
+    summary: string;
+    evidence_url?: string;
+  }>,
+) {
+  return {
+    schema_version: 1,
+    subject: "lodge-production",
+    generated_at: "2026-07-22T19:45:00.000Z",
+    evidence_url: "https://evidence.example.com/run/42",
+    checks,
+  };
+}
+
+describe("evaluateReleaseEvidence", () => {
+  it("is dormant outside configured environments", async () => {
+    const fetchImpl = vi.fn();
+    const result = await evaluateReleaseEvidence(config(), "staging", {
+      now: NOW,
+      fetchImpl,
+    });
+
+    expect(result).toEqual({
+      active: false,
+      shouldBlock: false,
+      findings: [],
+      healthChecks: [],
+    });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("passes when every fresh required condition is proven", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      response(
+        document([
+          { id: "deployment.target", status: "pass", summary: "lodge-web verified" },
+          { id: "credits.policy", status: "pass", summary: "1/3-credit policy" },
+          { id: "canary.refund", status: "pass", summary: "refund reconciled" },
+        ]),
+      ),
+    );
+
+    const result = await evaluateReleaseEvidence(config(), "production", {
+      now: NOW,
+      fetchImpl,
+    });
+
+    expect(result.active).toBe(true);
+    expect(result.shouldBlock).toBe(false);
+    expect(result.findings).toEqual([]);
+    expect(result.healthChecks).toHaveLength(3);
+    expect(result.healthChecks.every((check) => check.status === "allow")).toBe(true);
+  });
+
+  it("emits one actionable finding for every failed, pending, or missing condition", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      response(
+        document([
+          {
+            id: "deployment.target",
+            status: "fail",
+            summary: "Vercel project is lyra-web",
+            evidence_url: "https://vercel.example.com/wrong-project",
+          },
+          {
+            id: "credits.policy",
+            status: "pending",
+            summary: "credit enforcement is still shadow-only",
+          },
+        ]),
+      ),
+    );
+
+    const result = await evaluateReleaseEvidence(config(), "production", {
+      now: NOW,
+      fetchImpl,
+    });
+
+    expect(result.shouldBlock).toBe(true);
+    expect(result.findings).toHaveLength(3);
+    expect(result.findings[0]).toContain("Vercel project is lyra-web");
+    expect(result.findings[0]).toContain("[evidence]");
+    expect(result.findings[1]).toContain("shadow-only");
+    expect(result.findings[2]).toContain("required check is missing");
+    expect(result.healthChecks.map((check) => check.status)).toEqual([
+      "block",
+      "block",
+      "block",
+    ]);
+  });
+
+  it("keeps failed evidence non-blocking in warn mode", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(response(document([])));
+    const result = await evaluateReleaseEvidence(
+      config({ mode: "warn", required_checks: ["credits.policy"] }),
+      "production",
+      { now: NOW, fetchImpl },
+    );
+
+    expect(result.shouldBlock).toBe(false);
+    expect(result.healthChecks[0]?.status).toBe("warn");
+  });
+
+  it("fails closed when the document is stale", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      response({
+        ...document([]),
+        generated_at: "2026-07-22T10:00:00.000Z",
+      }),
+    );
+    const result = await evaluateReleaseEvidence(config(), "production", {
+      now: NOW,
+      fetchImpl,
+    });
+
+    expect(result.shouldBlock).toBe(true);
+    expect(result.findings[0]).toContain("document is stale");
+  });
+
+  it("rejects insecure endpoints before issuing a request", async () => {
+    const fetchImpl = vi.fn();
+    const result = await evaluateReleaseEvidence(
+      config({ url: "http://lodge.example.com/api/release-evidence" }),
+      "production",
+      { now: NOW, fetchImpl },
+    );
+
+    expect(result.shouldBlock).toBe(true);
+    expect(result.findings[0]).toContain("must use HTTPS");
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the endpoint is unavailable", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(response({}, 503));
+    const result = await evaluateReleaseEvidence(config(), "production", {
+      now: NOW,
+      fetchImpl,
+    });
+
+    expect(result.shouldBlock).toBe(true);
+    expect(result.findings[0]).toContain("HTTP 503");
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -34,6 +34,7 @@ const KNOWN_TOP_LEVEL_KEYS = new Set([
   "tuning",
   "submission",
   "risk",
+  "release_evidence",
 ]);
 
 function warnUnknownTopLevelKeys(raw: unknown, configPath: string): void {

--- a/src/gate.ts
+++ b/src/gate.ts
@@ -84,6 +84,7 @@ import { parseAgentTrustMetrics } from "./agent-trust-metrics.js";
 import { readTrustRuntime } from "./trust-runtime.js";
 import { detectCiIntegrity } from "./ci-integrity.js";
 import { collectGitHubPages } from "./github-pagination.js";
+import { evaluateReleaseEvidence } from "./release-evidence.js";
 
 export {
   isSensitiveFile,
@@ -1695,6 +1696,11 @@ export async function evaluateGate(
   const effectiveEnvironment =
     config.environment ?? matchedContext?.matched.environment ?? undefined;
 
+  const releaseEvidencePromise = evaluateReleaseEvidence(
+    repoConfig?.release_evidence,
+    effectiveEnvironment,
+  );
+
   const envConfig = effectiveEnvironment
     ? repoConfig?.environments?.[effectiveEnvironment]
     : undefined;
@@ -1982,10 +1988,16 @@ export async function evaluateGate(
     }
   }
 
+  const releaseEvidence = await releaseEvidencePromise;
+  if (releaseEvidence.findings.length > 0) {
+    policyFindings.push(...releaseEvidence.findings);
+  }
+
   const healthChecks: HealthCheckResult[] = [...httpHealthChecks];
   if (vercelCheck) healthChecks.push(vercelCheck);
   if (supabaseCheck) healthChecks.push(supabaseCheck);
   if (mcpCheck) healthChecks.push(mcpCheck);
+  healthChecks.push(...releaseEvidence.healthChecks);
 
   const healthScore = aggregateHealthScore(healthChecks);
   // GATE-3: Use riskScoreWithPenalties for gate decision
@@ -2024,6 +2036,7 @@ export async function evaluateGate(
       sessionCfg &&
       sessionCorrelation.burstCount >= sessionCfg.threshold &&
       sessionCfg.mode === "block") ||
+    releaseEvidence.shouldBlock ||
     (submissionChecks.length > 0 &&
       submissionGateShouldBlock(submissionChecks, submissionMode))
       ? ("block" as GateDecision)

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,6 +91,7 @@ export { playwrightHealer } from "./healers/playwright.js";
 export { cypressHealer } from "./healers/cypress.js";
 export { loadRepoConfig } from "./config.js";
 export { matchContext, resolveGateMode } from "./context-matcher.js";
+export { evaluateReleaseEvidence } from "./release-evidence.js";
 export {
   classifyCheck,
   evaluateRequiredChecks,
@@ -124,6 +125,7 @@ export type {
   ServiceMapping,
   SecurityConfig,
   CanaryConfig,
+  ReleaseEvidenceConfig,
   FreezeWindow,
   GateMode,
   TrailheadContext,

--- a/src/release-evidence.ts
+++ b/src/release-evidence.ts
@@ -1,0 +1,229 @@
+import { z } from "zod";
+import type { HealthCheckResult, ReleaseEvidenceConfig } from "./types.js";
+
+const RELEASE_EVIDENCE_TIMEOUT_MS = 10_000;
+const MAX_RELEASE_EVIDENCE_BYTES = 1_000_000;
+
+const ReleaseEvidenceCheck = z.object({
+  id: z.string().min(1),
+  status: z.enum(["pass", "fail", "pending"]),
+  summary: z.string().min(1).max(1_000),
+  evidence_url: z.string().url().optional(),
+});
+
+const ReleaseEvidenceDocument = z.object({
+  schema_version: z.literal(1),
+  subject: z.string().min(1),
+  generated_at: z.string().datetime({ offset: true }),
+  evidence_url: z.string().url().optional(),
+  checks: z.array(ReleaseEvidenceCheck),
+});
+
+export type ReleaseEvidenceDocument = z.infer<typeof ReleaseEvidenceDocument>;
+
+export interface ReleaseEvidenceEvaluation {
+  active: boolean;
+  shouldBlock: boolean;
+  findings: string[];
+  healthChecks: HealthCheckResult[];
+}
+
+interface EvaluateReleaseEvidenceOptions {
+  now?: number;
+  fetchImpl?: typeof fetch;
+}
+
+function markdownEvidenceLink(url: string | undefined): string {
+  return url ? ` ([evidence](${url}))` : "";
+}
+
+function failureEvaluation(
+  config: ReleaseEvidenceConfig,
+  summary: string,
+  latencyMs: number,
+): ReleaseEvidenceEvaluation {
+  return {
+    active: true,
+    shouldBlock: config.mode === "block",
+    findings: [`Release evidence requires action: ${summary}`],
+    healthChecks: [
+      {
+        target: "release-evidence:document",
+        status: config.mode === "block" ? "block" : "warn",
+        latencyMs,
+        detail: { summary, sourceUrl: config.url },
+      },
+    ],
+  };
+}
+
+function uniqueRequiredChecks(config: ReleaseEvidenceConfig): string[] {
+  return [...new Set(config.required_checks)];
+}
+
+/**
+ * Evaluate a service-owned release evidence document for the current
+ * environment. Every required condition produces its own health check and,
+ * when not passing, its own actionable policy finding.
+ */
+export async function evaluateReleaseEvidence(
+  config: ReleaseEvidenceConfig | undefined,
+  environment: string | undefined,
+  options: EvaluateReleaseEvidenceOptions = {},
+): Promise<ReleaseEvidenceEvaluation> {
+  if (
+    !config ||
+    config.enabled === false ||
+    !environment ||
+    !config.environments.includes(environment)
+  ) {
+    return { active: false, shouldBlock: false, findings: [], healthChecks: [] };
+  }
+
+  const startedAt = Date.now();
+  let sourceUrl: URL;
+  try {
+    sourceUrl = new URL(config.url);
+  } catch {
+    return failureEvaluation(config, `configured URL is invalid: ${config.url}`, 0);
+  }
+  if (sourceUrl.protocol !== "https:") {
+    return failureEvaluation(config, "configured URL must use HTTPS", 0);
+  }
+
+  try {
+    const response = await (options.fetchImpl ?? fetch)(sourceUrl, {
+      method: "GET",
+      headers: {
+        Accept: "application/vnd.trailhead.release-evidence+json, application/json",
+      },
+      redirect: "error",
+      signal: AbortSignal.timeout(RELEASE_EVIDENCE_TIMEOUT_MS),
+    });
+    const latencyMs = Date.now() - startedAt;
+    if (!response.ok) {
+      return failureEvaluation(
+        config,
+        `endpoint returned HTTP ${response.status} (${config.url})`,
+        latencyMs,
+      );
+    }
+
+    const text = await response.text();
+    if (Buffer.byteLength(text, "utf8") > MAX_RELEASE_EVIDENCE_BYTES) {
+      return failureEvaluation(
+        config,
+        "document exceeds the 1 MB safety limit",
+        latencyMs,
+      );
+    }
+
+    let decoded: unknown;
+    try {
+      decoded = JSON.parse(text);
+    } catch {
+      return failureEvaluation(config, "endpoint did not return valid JSON", latencyMs);
+    }
+
+    const parsed = ReleaseEvidenceDocument.safeParse(decoded);
+    if (!parsed.success) {
+      return failureEvaluation(
+        config,
+        `document does not match schema_version 1: ${parsed.error.issues[0]?.message ?? "invalid document"}`,
+        latencyMs,
+      );
+    }
+
+    const document = parsed.data;
+    if (config.expected_subject && document.subject !== config.expected_subject) {
+      return failureEvaluation(
+        config,
+        `subject mismatch: expected "${config.expected_subject}", received "${document.subject}"`,
+        latencyMs,
+      );
+    }
+
+    const now = options.now ?? Date.now();
+    const generatedAt = Date.parse(document.generated_at);
+    const maxAgeMs = config.max_age_minutes * 60_000;
+    if (generatedAt > now + 60_000 || now - generatedAt > maxAgeMs) {
+      return failureEvaluation(
+        config,
+        `document is stale; generated_at=${document.generated_at}, max_age=${config.max_age_minutes}m${markdownEvidenceLink(document.evidence_url)}`,
+        latencyMs,
+      );
+    }
+
+    const duplicateIds = new Set<string>();
+    const checksById = new Map<string, z.infer<typeof ReleaseEvidenceCheck>>();
+    for (const check of document.checks) {
+      if (checksById.has(check.id)) duplicateIds.add(check.id);
+      checksById.set(check.id, check);
+    }
+    if (duplicateIds.size > 0) {
+      return failureEvaluation(
+        config,
+        `document contains duplicate check IDs: ${[...duplicateIds].join(", ")}`,
+        latencyMs,
+      );
+    }
+
+    const findings: string[] = [];
+    const healthChecks: HealthCheckResult[] = [];
+    let hasFailure = false;
+
+    for (const id of uniqueRequiredChecks(config)) {
+      const check = checksById.get(id);
+      if (!check) {
+        hasFailure = true;
+        findings.push(
+          `Release evidence "${id}" requires action: required check is missing.`,
+        );
+        healthChecks.push({
+          target: `release-evidence:${id}`,
+          status: config.mode === "block" ? "block" : "warn",
+          latencyMs,
+          detail: {
+            summary: "required check is missing",
+            sourceUrl: config.url,
+            generatedAt: document.generated_at,
+          },
+        });
+        continue;
+      }
+
+      const passed = check.status === "pass";
+      if (!passed) {
+        hasFailure = true;
+        findings.push(
+          `Release evidence "${id}" requires action: ${check.summary}${markdownEvidenceLink(check.evidence_url ?? document.evidence_url)}.`,
+        );
+      }
+      healthChecks.push({
+        target: `release-evidence:${id}`,
+        status: passed ? "allow" : config.mode === "block" ? "block" : "warn",
+        latencyMs,
+        detail: {
+          summary: check.summary,
+          evidenceUrl: check.evidence_url ?? document.evidence_url,
+          sourceUrl: config.url,
+          generatedAt: document.generated_at,
+          evidenceStatus: check.status,
+        },
+      });
+    }
+
+    return {
+      active: true,
+      shouldBlock: hasFailure && config.mode === "block",
+      findings,
+      healthChecks,
+    };
+  } catch (error) {
+    return failureEvaluation(
+      config,
+      `endpoint could not be evaluated: ${error instanceof Error ? error.message : String(error)}`,
+      Date.now() - startedAt,
+    );
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -382,6 +382,23 @@ export const CanaryConfig = z.object({
 });
 export type CanaryConfig = z.infer<typeof CanaryConfig>;
 
+/**
+ * A service-owned release attestation consumed by Trailhead. The endpoint is
+ * intentionally unauthenticated from the Action's perspective: it publishes
+ * only pass/fail evidence, while the service keeps database/provider
+ * credentials behind its own server boundary.
+ */
+export const ReleaseEvidenceConfig = z.object({
+  enabled: z.boolean().default(true),
+  url: z.string().url(),
+  environments: z.array(z.string().min(1)).default(["production"]),
+  mode: z.enum(["warn", "block"]).default("block"),
+  max_age_minutes: z.number().int().positive().default(60),
+  expected_subject: z.string().min(1).optional(),
+  required_checks: z.array(z.string().min(1)).min(1),
+});
+export type ReleaseEvidenceConfig = z.infer<typeof ReleaseEvidenceConfig>;
+
 export const RiskProfileMatch = z.object({
   files_include: z.array(z.string()).default([]),
   files_exclude: z.array(z.string()).default([]),
@@ -568,6 +585,7 @@ export const RepoConfig = z.object({
   consumer_registry: z.record(ServiceConsumerRef).default({}),
   security: SecurityConfig.default({}),
   canary: CanaryConfig.optional(),
+  release_evidence: ReleaseEvidenceConfig.optional(),
   escalation: z
     .object({
       targets: z.array(z.string()).default([]),


### PR DESCRIPTION
## Session handoff

This is a deliberately incomplete draft preserved while the Lodge release program is paused.

It introduces a generic, service-owned release-evidence contract for production contexts:

- HTTPS-only, bounded, fresh schema-v1 evidence documents
- one actionable Trailhead finding per failed, pending, or missing required check
- evidence links retained in gate output
- fail-closed `block` mode and shadow-safe `warn` mode
- dormant behavior outside configured environments

## Validation completed

- targeted Prettier check
- targeted ESLint
- root TypeScript typecheck
- 57 focused/config/integration tests passed

## Remaining before ready

- full repository test, coverage, build, App/MCP/CLI parity, and generated bundles
- final API/security review
- Lodge-owned evidence endpoint and configuration
- real Komatik credit capability and canary evidence

Tracks #343. This draft does not close the issue and must not be merged yet.
