### PR TITLE
chore(deps): js-yaml ^4.2.0 security bump (root + cli)

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -18,7 +18,7 @@
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^25.8.0",
         "@vercel/ncc": "^0.38.4",
-        "js-yaml": "^4.1.1",
+        "js-yaml": "^4.2.0",
         "typescript": "^6.0.3",
         "zod": "^3.24.0"
       }
@@ -305,10 +305,20 @@
       "license": "Python-2.0"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/cli/package.json
+++ b/cli/package.json
@@ -32,7 +32,7 @@
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^25.8.0",
     "@vercel/ncc": "^0.38.4",
-    "js-yaml": "^4.1.1",
+    "js-yaml": "^4.2.0",
     "typescript": "^6.0.3",
     "zod": "^3.24.0"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@actions/core": "^3.0.1",
         "@actions/github": "^9.1.1",
         "@swc/core": "^1.15.40",
-        "js-yaml": "^4.1.1",
+        "js-yaml": "^4.2.0",
         "zod": "^3.24.0"
       },
       "devDependencies": {
@@ -2622,9 +2622,19 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@actions/core": "^3.0.1",
     "@actions/github": "^9.1.1",
     "@swc/core": "^1.15.40",
-    "js-yaml": "^4.1.1",
+    "js-yaml": "^4.2.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Bumps `js-yaml` to `^4.2.0` in root and cli package.json (moderate advisory GHSA-h67p-54hq-rp68), with minimal lockfile regeneration only.

Closes the fleet task 9a8dd84f lineage: the agent-prepared patch files had fabricated context lines and never applied cleanly; this is the one-line manual fix the 08-07 currency audit prescribed.

No merge until review per standing rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)