### PR TITLE
ADR-011 (Proposed): Release Brief and Input Relevance Policy — closing the communication gap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to Trailhead will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Release Brief** ([ADR-011](docs/adr/011-release-brief-and-input-relevance.md)) — every evaluation now leads its PR comment, job summary, and check-run summary with a structured brief: verdict, risk with effective threshold and top movers, **enumerated** findings, one row per CI input with its disposition and reason, a one-line delta against the previous evaluation, next actions, and the override record. Findings are enumerated, never counted — `"CI integrity blocking patterns detected (4)"` is now four addressable findings with evidence. A run that cannot evaluate at all still posts a `cannot_evaluate` brief naming the failure ("silence is a bug"). See [docs/release-brief.md](docs/release-brief.md).
+- **Input relevance dispositions** ([ADR-011](docs/adr/011-release-brief-and-input-relevance.md) §2) — new `contexts[].input_relevance` config maps a check pattern to `blocking` / `advisory` / `irrelevant(reason)` per branch pair, extending ADR-009's status enum with what a check _means_ for this decision. `missing_blocking` is derived from ADR-009 `missing` on a blocking check. Repos with no `input_relevance` block are unaffected: the default mapping (required → blocking, non-required → advisory) reproduces the previous rollup exactly.
+- **`risk_only` override scope** ([ADR-011](docs/adr/011-release-brief-and-input-relevance.md) §3) — the `trailhead-override` label override now carries a scope. `risk_only` overrides the risk verdict and policy findings but never mechanical blocking inputs (red tests stay red), and records which blocking reasons it cleared versus which survived. Existing overrides keep their previous `full` behaviour.
+- **Per-context availability stance** ([ADR-011](docs/adr/011-release-brief-and-input-relevance.md) §4) — new `contexts[].availability: fail_open | fail_closed`. When the evaluation itself fails, the matched context's stance overrides the `fail-mode` action input; with no stance configured, behaviour is unchanged.
+- **`release-brief-json` Action output** — the Release Brief as JSON for downstream workflow steps. Also set, with verdict `cannot_evaluate`, when the evaluation fails.
+- **Evaluation store: `release_brief` + `enumerated_findings`** — new `jsonb` columns (`cloud/migrations/006_release_brief.sql`, Komatik copy in `docs/komatik-migrations/`), and `policy_override` now always records an explicit `scope`. Stores that have not applied the migration degrade gracefully rather than failing: the insert is retried without the new columns and the delta lookup falls back to its previous select.
+
 ### Fixed
 
 - **PR evaluation no longer truncates at 100 files** ([#344](https://github.com/KomatikAI/trailhead/issues/344)) — the Action, GitHub App, MCP policy tools, and DORA file scans now paginate GitHub's PR-files endpoint. Large PR risk, scope, and submission checks receive the complete available file set.

--- a/action.yml
+++ b/action.yml
@@ -229,6 +229,8 @@ outputs:
     description: "URL to the full evaluation report (only set when using a remote API)."
   evaluation-json:
     description: "Full gate evaluation as JSON for downstream workflow steps."
+  release-brief-json:
+    description: "ADR-011 Release Brief as JSON (verdict, findings, input dispositions, delta, actions, override). Also set — with verdict cannot_evaluate — when the evaluation itself fails."
   cross-repo-opener-json:
     description: "Cross-repo PR opener result as JSON (ADR-010): opened/dry-run/exists outcomes per owning repo, plus unresolved dangling contract refs."
   verdict-json:

--- a/app/src/loop-bookkeeping.ts
+++ b/app/src/loop-bookkeeping.ts
@@ -1,8 +1,22 @@
 // Pure loop bookkeeping helpers — no framework dependencies.
 
-import type { GateEvaluation, Remediation } from "./types.js";
+import type { GateDecision, Remediation } from "./types.js";
 
-export type PreviousEvaluationSnapshot = Pick<GateEvaluation, "id" | "remediation">;
+/**
+ * What the store returns about the previous evaluation of a PR. `id`/`remediation`
+ * drive loop bookkeeping; the rest is ADR-011 §1 delta material and is present only
+ * when the backend actually returned those columns — every consumer must treat the
+ * optional fields as "unknown", never as "unchanged".
+ */
+export interface PreviousEvaluationSnapshot {
+  id: string;
+  remediation?: Remediation;
+  riskScore?: number;
+  gateDecision?: GateDecision;
+  releaseReady?: boolean;
+  /** Ids of the previous evaluation's enumerated findings (ADR-011 §1). */
+  findingIds?: string[];
+}
 
 export function resolveLoopRound(
   previous: PreviousEvaluationSnapshot | null | undefined,
@@ -15,6 +29,32 @@ export function parseAgentIdFromHeadRef(headRef: string | undefined): string | n
   if (!headRef) return null;
   const match = headRef.match(/^agent\/([a-z0-9-]+)\//);
   return match?.[1] ?? null;
+}
+
+function pick(record: Record<string, unknown>, ...keys: string[]): unknown {
+  for (const key of keys) {
+    const value = record[key];
+    if (value !== undefined && value !== null) return value;
+  }
+  return undefined;
+}
+
+function readFindingIds(record: Record<string, unknown>): string[] | undefined {
+  const direct = pick(record, "enumerated_findings", "enumeratedFindings");
+  const brief = pick(record, "release_brief", "releaseBrief");
+  const raw =
+    direct ??
+    (brief && typeof brief === "object"
+      ? (brief as Record<string, unknown>).findings
+      : undefined);
+  if (!Array.isArray(raw)) return undefined;
+  const ids: string[] = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== "object") continue;
+    const id = (entry as Record<string, unknown>).id;
+    if (typeof id === "string") ids.push(id);
+  }
+  return ids;
 }
 
 export function parsePreviousEvaluationRow(
@@ -30,7 +70,29 @@ export function parsePreviousEvaluationRow(
     remediation = record.remediation as Remediation;
   }
 
-  return { id, remediation };
+  const snapshot: PreviousEvaluationSnapshot = { id, remediation };
+
+  const riskScore = pick(record, "risk_score", "riskScore");
+  if (typeof riskScore === "number" && Number.isFinite(riskScore)) {
+    snapshot.riskScore = riskScore;
+  }
+
+  const gateDecision = pick(record, "gate_decision", "gateDecision");
+  if (gateDecision === "allow" || gateDecision === "warn" || gateDecision === "block") {
+    snapshot.gateDecision = gateDecision;
+  }
+
+  const releaseReady = pick(record, "release_ready", "releaseReady");
+  if (typeof releaseReady === "boolean") {
+    snapshot.releaseReady = releaseReady;
+  }
+
+  const findingIds = readFindingIds(record);
+  if (findingIds !== undefined) {
+    snapshot.findingIds = findingIds;
+  }
+
+  return snapshot;
 }
 
 export function pickLatestPreviousEvaluation(

--- a/cloud/migrations/006_release_brief.sql
+++ b/cloud/migrations/006_release_brief.sql
@@ -1,0 +1,14 @@
+-- migrate:skip — Supabase SQL-editor reference copy (targets the legacy
+-- `trailhead_evaluations` table); NOT applied by the plain-pg runner
+-- (cloud/scripts/migrate.ts), which manages the hosted contract schema.
+-- ADR-011 Release Brief columns (reference copy for hosted tier).
+-- Komatik fleet store uses docs/komatik-migrations/20260808120000_trailhead_release_brief.sql
+
+ALTER TABLE trailhead_evaluations
+  ADD COLUMN IF NOT EXISTS release_brief jsonb,
+  ADD COLUMN IF NOT EXISTS enumerated_findings jsonb;
+
+COMMENT ON COLUMN trailhead_evaluations.release_brief IS
+  'ADR-011 Release Brief: verdict, risk + top movers, enumerated findings, per-input dispositions, delta, actions, override.';
+COMMENT ON COLUMN trailhead_evaluations.enumerated_findings IS
+  'ADR-011 §1: findings as {id,title,evidence,severity} rows. policy_findings keeps the legacy count strings.';

--- a/dist/index.js
+++ b/dist/index.js
@@ -44095,7 +44095,9 @@ const DEFAULT_MAX_CHARS = 60000;
 const EVIDENCE_CAP_CHARS = 300;
 const EMPTY_CELL = "—";
 function escapePipes(value) {
-    return value.replace(/\|/g, "\\|");
+    // Backslashes first, or a pre-existing "\" would neutralize the pipe escape
+    // and break the cell structure (CodeQL js/incomplete-sanitization).
+    return value.replace(/\\/g, "\\\\").replace(/\|/g, "\\|");
 }
 /** Table cells must be single-line and must not break the column structure. */
 function cell(value) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,14 +1,14 @@
 require('./sourcemap-register.js');/******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
-/***/ 3465:
+/***/ 8066:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = require(__nccwpck_require__.ab + "swc.win32-x64-msvc.node")
 
 /***/ }),
 
-/***/ 4866:
+/***/ 4844:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -62,9 +62,9 @@ exports.getProxyUrl = getProxyUrl;
 exports.isHttps = isHttps;
 const http = __importStar(__nccwpck_require__(8611));
 const https = __importStar(__nccwpck_require__(5692));
-const pm = __importStar(__nccwpck_require__(3390));
-const tunnel = __importStar(__nccwpck_require__(6628));
-const undici_1 = __nccwpck_require__(4258);
+const pm = __importStar(__nccwpck_require__(4988));
+const tunnel = __importStar(__nccwpck_require__(770));
+const undici_1 = __nccwpck_require__(6752);
 var HttpCodes;
 (function (HttpCodes) {
     HttpCodes[HttpCodes["OK"] = 200] = "OK";
@@ -752,7 +752,7 @@ const lowercaseKeys = (obj) => Object.keys(obj).reduce((c, k) => ((c[k.toLowerCa
 
 /***/ }),
 
-/***/ 3390:
+/***/ 4988:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -853,7 +853,7 @@ class DecodedURL extends URL {
 
 /***/ }),
 
-/***/ 4680:
+/***/ 898:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 // prettier-ignore
@@ -918,24 +918,24 @@ function requireNative() {
   if (process.platform === 'android') {
     if (process.arch === 'arm64') {
       try {
-        return __nccwpck_require__(4528)
+        return __nccwpck_require__(8685)
       } catch (e) {
         loadErrors.push(e)
       }
       try {
-        return __nccwpck_require__(6212)
+        return __nccwpck_require__(607)
       } catch (e) {
         loadErrors.push(e)
       }
 
     } else if (process.arch === 'arm') {
       try {
-        return __nccwpck_require__(430)
+        return __nccwpck_require__(9665)
       } catch (e) {
         loadErrors.push(e)
       }
       try {
-        return __nccwpck_require__(694)
+        return __nccwpck_require__(727)
       } catch (e) {
         loadErrors.push(e)
       }
@@ -946,36 +946,36 @@ function requireNative() {
   } else if (process.platform === 'win32') {
     if (process.arch === 'x64') {
       try {
-        return __nccwpck_require__(802)
+        return __nccwpck_require__(2665)
       } catch (e) {
         loadErrors.push(e)
       }
       try {
-        return __nccwpck_require__(3465)
+        return __nccwpck_require__(8066)
       } catch (e) {
         loadErrors.push(e)
       }
 
     } else if (process.arch === 'ia32') {
       try {
-        return __nccwpck_require__(5017)
+        return __nccwpck_require__(8152)
       } catch (e) {
         loadErrors.push(e)
       }
       try {
-        return __nccwpck_require__(7411)
+        return __nccwpck_require__(1612)
       } catch (e) {
         loadErrors.push(e)
       }
 
     } else if (process.arch === 'arm64') {
       try {
-        return __nccwpck_require__(6640)
+        return __nccwpck_require__(3535)
       } catch (e) {
         loadErrors.push(e)
       }
       try {
-        return __nccwpck_require__(6200)
+        return __nccwpck_require__(293)
       } catch (e) {
         loadErrors.push(e)
       }
@@ -985,36 +985,36 @@ function requireNative() {
     }
   } else if (process.platform === 'darwin') {
     try {
-        return __nccwpck_require__(8533)
+        return __nccwpck_require__(8818)
       } catch (e) {
         loadErrors.push(e)
       }
       try {
-        return __nccwpck_require__(9963)
+        return __nccwpck_require__(3890)
       } catch (e) {
         loadErrors.push(e)
       }
 
     if (process.arch === 'x64') {
       try {
-        return __nccwpck_require__(3530)
+        return __nccwpck_require__(8009)
       } catch (e) {
         loadErrors.push(e)
       }
       try {
-        return __nccwpck_require__(2766)
+        return __nccwpck_require__(8139)
       } catch (e) {
         loadErrors.push(e)
       }
 
     } else if (process.arch === 'arm64') {
       try {
-        return __nccwpck_require__(4000)
+        return __nccwpck_require__(475)
       } catch (e) {
         loadErrors.push(e)
       }
       try {
-        return __nccwpck_require__(2560)
+        return __nccwpck_require__(5049)
       } catch (e) {
         loadErrors.push(e)
       }
@@ -1025,24 +1025,24 @@ function requireNative() {
   } else if (process.platform === 'freebsd') {
     if (process.arch === 'x64') {
       try {
-        return __nccwpck_require__(9638)
+        return __nccwpck_require__(3291)
       } catch (e) {
         loadErrors.push(e)
       }
       try {
-        return __nccwpck_require__(3242)
+        return __nccwpck_require__(6229)
       } catch (e) {
         loadErrors.push(e)
       }
 
     } else if (process.arch === 'arm64') {
       try {
-        return __nccwpck_require__(3588)
+        return __nccwpck_require__(3873)
       } catch (e) {
         loadErrors.push(e)
       }
       try {
-        return __nccwpck_require__(7860)
+        return __nccwpck_require__(5367)
       } catch (e) {
         loadErrors.push(e)
       }
@@ -1054,24 +1054,24 @@ function requireNative() {
     if (process.arch === 'x64') {
       if (isMusl()) {
         try {
-        return __nccwpck_require__(3795)
+        return __nccwpck_require__(2356)
       } catch (e) {
         loadErrors.push(e)
       }
       try {
-        return __nccwpck_require__(5169)
+        return __nccwpck_require__(6900)
       } catch (e) {
         loadErrors.push(e)
       }
 
       } else {
         try {
-        return __nccwpck_require__(5146)
+        return __nccwpck_require__(4675)
       } catch (e) {
         loadErrors.push(e)
       }
       try {
-        return __nccwpck_require__(746)
+        return __nccwpck_require__(7793)
       } catch (e) {
         loadErrors.push(e)
       }
@@ -1080,24 +1080,24 @@ function requireNative() {
     } else if (process.arch === 'arm64') {
       if (isMusl()) {
         try {
-        return __nccwpck_require__(4073)
+        return __nccwpck_require__(7602)
       } catch (e) {
         loadErrors.push(e)
       }
       try {
-        return __nccwpck_require__(7915)
+        return __nccwpck_require__(5254)
       } catch (e) {
         loadErrors.push(e)
       }
 
       } else {
         try {
-        return __nccwpck_require__(1464)
+        return __nccwpck_require__(8337)
       } catch (e) {
         loadErrors.push(e)
       }
       try {
-        return __nccwpck_require__(6244)
+        return __nccwpck_require__(6571)
       } catch (e) {
         loadErrors.push(e)
       }
@@ -1105,12 +1105,12 @@ function requireNative() {
       }
     } else if (process.arch === 'arm') {
       try {
-        return __nccwpck_require__(91)
+        return __nccwpck_require__(7222)
       } catch (e) {
         loadErrors.push(e)
       }
       try {
-        return __nccwpck_require__(1225)
+        return __nccwpck_require__(1638)
       } catch (e) {
         loadErrors.push(e)
       }
@@ -1118,24 +1118,24 @@ function requireNative() {
     } else if (process.arch === 'riscv64') {
       if (isMusl()) {
         try {
-        return __nccwpck_require__(6786)
+        return __nccwpck_require__(8593)
       } catch (e) {
         loadErrors.push(e)
       }
       try {
-        return __nccwpck_require__(5930)
+        return __nccwpck_require__(8879)
       } catch (e) {
         loadErrors.push(e)
       }
 
       } else {
         try {
-        return __nccwpck_require__(1553)
+        return __nccwpck_require__(9312)
       } catch (e) {
         loadErrors.push(e)
       }
       try {
-        return __nccwpck_require__(8199)
+        return __nccwpck_require__(9008)
       } catch (e) {
         loadErrors.push(e)
       }
@@ -1143,24 +1143,24 @@ function requireNative() {
       }
     } else if (process.arch === 'ppc64') {
       try {
-        return __nccwpck_require__(1887)
+        return __nccwpck_require__(1446)
       } catch (e) {
         loadErrors.push(e)
       }
       try {
-        return __nccwpck_require__(1329)
+        return __nccwpck_require__(3586)
       } catch (e) {
         loadErrors.push(e)
       }
 
     } else if (process.arch === 's390x') {
       try {
-        return __nccwpck_require__(5217)
+        return __nccwpck_require__(2644)
       } catch (e) {
         loadErrors.push(e)
       }
       try {
-        return __nccwpck_require__(6635)
+        return __nccwpck_require__(8600)
       } catch (e) {
         loadErrors.push(e)
       }
@@ -1177,7 +1177,7 @@ nativeBinding = requireNative()
 
 if (!nativeBinding || process.env.NAPI_RS_FORCE_WASI) {
   try {
-    nativeBinding = __nccwpck_require__(300)
+    nativeBinding = __nccwpck_require__(6681)
   } catch (err) {
     if (process.env.NAPI_RS_FORCE_WASI) {
       console.error(err)
@@ -1185,7 +1185,7 @@ if (!nativeBinding || process.env.NAPI_RS_FORCE_WASI) {
   }
   if (!nativeBinding) {
     try {
-      nativeBinding = __nccwpck_require__(7722)
+      nativeBinding = __nccwpck_require__(9301)
     } catch (err) {
       if (process.env.NAPI_RS_FORCE_WASI) {
         console.error(err)
@@ -1228,7 +1228,7 @@ module.exports.transformSync = nativeBinding.transformSync
 
 /***/ }),
 
-/***/ 5229:
+/***/ 5971:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -1297,9 +1297,9 @@ exports.__experimental_registerGlobalTraceConfig = __experimental_registerGlobal
 exports.getBinaryMetadata = getBinaryMetadata;
 const path_1 = __nccwpck_require__(6928);
 // @ts-ignore
-var binding_1 = __nccwpck_require__(4680);
+var binding_1 = __nccwpck_require__(898);
 Object.defineProperty(exports, "experimental_newMangleNameCache", ({ enumerable: true, get: function () { return binding_1.newMangleNameCache; } }));
-const spack_1 = __nccwpck_require__(8501);
+const spack_1 = __nccwpck_require__(8579);
 const assert = __importStar(__nccwpck_require__(2613));
 // Allow overrides to the location of the .node binding file
 const bindingsOverride = process.env["SWC_BINARY_PATH"];
@@ -1311,7 +1311,7 @@ const bindings = (() => {
     try {
         binding = !!bindingsOverride
             ? require((0, path_1.resolve)(bindingsOverride))
-            : __nccwpck_require__(4680);
+            : __nccwpck_require__(898);
         // If native binding loaded successfully, it should return proper target triple constant.
         const triple = binding.getTargetTriple();
         assert.ok(triple, "Failed to read target triple from native binary.");
@@ -1319,7 +1319,7 @@ const bindings = (() => {
     }
     catch (_) {
         // postinstall supposed to install `@swc/wasm` already
-        fallbackBindings = __nccwpck_require__(4196);
+        fallbackBindings = __nccwpck_require__(5855);
     }
     finally {
         return binding;
@@ -1328,7 +1328,7 @@ const bindings = (() => {
 /**
  * Version of the swc binding.
  */
-exports.version = __nccwpck_require__(6662).version;
+exports.version = __nccwpck_require__(155).version;
 /**
  * @deprecated JavaScript API is deprecated. Please use Wasm plugin instead.
  */
@@ -1679,7 +1679,7 @@ function toBuffer(t) {
 
 /***/ }),
 
-/***/ 8501:
+/***/ 8579:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -1774,15 +1774,15 @@ function config(c) {
 
 /***/ }),
 
-/***/ 6628:
+/***/ 770:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-module.exports = __nccwpck_require__(3188);
+module.exports = __nccwpck_require__(218);
 
 
 /***/ }),
 
-/***/ 3188:
+/***/ 218:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -2054,34 +2054,34 @@ exports.debug = debug; // for test
 
 /***/ }),
 
-/***/ 4258:
+/***/ 6752:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const Client = __nccwpck_require__(2539)
-const Dispatcher = __nccwpck_require__(8989)
-const Pool = __nccwpck_require__(2690)
-const BalancedPool = __nccwpck_require__(1115)
-const Agent = __nccwpck_require__(8103)
-const ProxyAgent = __nccwpck_require__(114)
-const EnvHttpProxyAgent = __nccwpck_require__(3535)
-const RetryAgent = __nccwpck_require__(2148)
-const errors = __nccwpck_require__(7013)
-const util = __nccwpck_require__(4742)
+const Client = __nccwpck_require__(3701)
+const Dispatcher = __nccwpck_require__(883)
+const Pool = __nccwpck_require__(628)
+const BalancedPool = __nccwpck_require__(837)
+const Agent = __nccwpck_require__(7405)
+const ProxyAgent = __nccwpck_require__(6672)
+const EnvHttpProxyAgent = __nccwpck_require__(3137)
+const RetryAgent = __nccwpck_require__(50)
+const errors = __nccwpck_require__(8707)
+const util = __nccwpck_require__(3440)
 const { InvalidArgumentError } = errors
-const api = __nccwpck_require__(477)
-const buildConnector = __nccwpck_require__(4278)
-const MockClient = __nccwpck_require__(8747)
-const MockAgent = __nccwpck_require__(7319)
-const MockPool = __nccwpck_require__(706)
-const mockErrors = __nccwpck_require__(3559)
-const RetryHandler = __nccwpck_require__(9586)
-const { getGlobalDispatcher, setGlobalDispatcher } = __nccwpck_require__(3723)
-const DecoratorHandler = __nccwpck_require__(1881)
-const RedirectHandler = __nccwpck_require__(8276)
-const createRedirectInterceptor = __nccwpck_require__(5038)
+const api = __nccwpck_require__(6615)
+const buildConnector = __nccwpck_require__(9136)
+const MockClient = __nccwpck_require__(7365)
+const MockAgent = __nccwpck_require__(7501)
+const MockPool = __nccwpck_require__(4004)
+const mockErrors = __nccwpck_require__(2429)
+const RetryHandler = __nccwpck_require__(7816)
+const { getGlobalDispatcher, setGlobalDispatcher } = __nccwpck_require__(2581)
+const DecoratorHandler = __nccwpck_require__(8155)
+const RedirectHandler = __nccwpck_require__(8754)
+const createRedirectInterceptor = __nccwpck_require__(5092)
 
 Object.assign(Dispatcher.prototype, api)
 
@@ -2099,10 +2099,10 @@ module.exports.DecoratorHandler = DecoratorHandler
 module.exports.RedirectHandler = RedirectHandler
 module.exports.createRedirectInterceptor = createRedirectInterceptor
 module.exports.interceptors = {
-  redirect: __nccwpck_require__(9704),
-  retry: __nccwpck_require__(7400),
-  dump: __nccwpck_require__(7278),
-  dns: __nccwpck_require__(3241)
+  redirect: __nccwpck_require__(1514),
+  retry: __nccwpck_require__(2026),
+  dump: __nccwpck_require__(8060),
+  dns: __nccwpck_require__(379)
 }
 
 module.exports.buildConnector = buildConnector
@@ -2164,7 +2164,7 @@ function makeDispatcher (fn) {
 module.exports.setGlobalDispatcher = setGlobalDispatcher
 module.exports.getGlobalDispatcher = getGlobalDispatcher
 
-const fetchImpl = (__nccwpck_require__(2104).fetch)
+const fetchImpl = (__nccwpck_require__(4398).fetch)
 module.exports.fetch = async function fetch (init, options = undefined) {
   try {
     return await fetchImpl(init, options)
@@ -2176,39 +2176,39 @@ module.exports.fetch = async function fetch (init, options = undefined) {
     throw err
   }
 }
-module.exports.Headers = __nccwpck_require__(7386).Headers
-module.exports.Response = __nccwpck_require__(2929).Response
-module.exports.Request = __nccwpck_require__(4309).Request
-module.exports.FormData = __nccwpck_require__(6124).FormData
+module.exports.Headers = __nccwpck_require__(660).Headers
+module.exports.Response = __nccwpck_require__(9051).Response
+module.exports.Request = __nccwpck_require__(9967).Request
+module.exports.FormData = __nccwpck_require__(5910).FormData
 module.exports.File = globalThis.File ?? (__nccwpck_require__(4573).File)
-module.exports.FileReader = __nccwpck_require__(6413).FileReader
+module.exports.FileReader = __nccwpck_require__(8355).FileReader
 
-const { setGlobalOrigin, getGlobalOrigin } = __nccwpck_require__(9553)
+const { setGlobalOrigin, getGlobalOrigin } = __nccwpck_require__(1059)
 
 module.exports.setGlobalOrigin = setGlobalOrigin
 module.exports.getGlobalOrigin = getGlobalOrigin
 
-const { CacheStorage } = __nccwpck_require__(1823)
-const { kConstruct } = __nccwpck_require__(6123)
+const { CacheStorage } = __nccwpck_require__(3245)
+const { kConstruct } = __nccwpck_require__(109)
 
 // Cache & CacheStorage are tightly coupled with fetch. Even if it may run
 // in an older version of Node, it doesn't have any use without fetch.
 module.exports.caches = new CacheStorage(kConstruct)
 
-const { deleteCookie, getCookies, getSetCookies, setCookie } = __nccwpck_require__(107)
+const { deleteCookie, getCookies, getSetCookies, setCookie } = __nccwpck_require__(9061)
 
 module.exports.deleteCookie = deleteCookie
 module.exports.getCookies = getCookies
 module.exports.getSetCookies = getSetCookies
 module.exports.setCookie = setCookie
 
-const { parseMIMEType, serializeAMimeType } = __nccwpck_require__(9634)
+const { parseMIMEType, serializeAMimeType } = __nccwpck_require__(1900)
 
 module.exports.parseMIMEType = parseMIMEType
 module.exports.serializeAMimeType = serializeAMimeType
 
-const { CloseEvent, ErrorEvent, MessageEvent } = __nccwpck_require__(4194)
-module.exports.WebSocket = __nccwpck_require__(564).WebSocket
+const { CloseEvent, ErrorEvent, MessageEvent } = __nccwpck_require__(5188)
+module.exports.WebSocket = __nccwpck_require__(3726).WebSocket
 module.exports.CloseEvent = CloseEvent
 module.exports.ErrorEvent = ErrorEvent
 module.exports.MessageEvent = MessageEvent
@@ -2224,18 +2224,18 @@ module.exports.MockPool = MockPool
 module.exports.MockAgent = MockAgent
 module.exports.mockErrors = mockErrors
 
-const { EventSource } = __nccwpck_require__(5108)
+const { EventSource } = __nccwpck_require__(1238)
 
 module.exports.EventSource = EventSource
 
 
 /***/ }),
 
-/***/ 5532:
+/***/ 158:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-const { addAbortListener } = __nccwpck_require__(4742)
-const { RequestAbortedError } = __nccwpck_require__(7013)
+const { addAbortListener } = __nccwpck_require__(3440)
+const { RequestAbortedError } = __nccwpck_require__(8707)
 
 const kListener = Symbol('kListener')
 const kSignal = Symbol('kSignal')
@@ -2295,7 +2295,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 9826:
+/***/ 2279:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -2303,9 +2303,9 @@ module.exports = {
 
 const assert = __nccwpck_require__(4589)
 const { AsyncResource } = __nccwpck_require__(6698)
-const { InvalidArgumentError, SocketError } = __nccwpck_require__(7013)
-const util = __nccwpck_require__(4742)
-const { addSignal, removeSignal } = __nccwpck_require__(5532)
+const { InvalidArgumentError, SocketError } = __nccwpck_require__(8707)
+const util = __nccwpck_require__(3440)
+const { addSignal, removeSignal } = __nccwpck_require__(158)
 
 class ConnectHandler extends AsyncResource {
   constructor (opts, callback) {
@@ -2411,7 +2411,7 @@ module.exports = connect
 
 /***/ }),
 
-/***/ 4280:
+/***/ 6862:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -2426,10 +2426,10 @@ const {
   InvalidArgumentError,
   InvalidReturnValueError,
   RequestAbortedError
-} = __nccwpck_require__(7013)
-const util = __nccwpck_require__(4742)
+} = __nccwpck_require__(8707)
+const util = __nccwpck_require__(3440)
 const { AsyncResource } = __nccwpck_require__(6698)
-const { addSignal, removeSignal } = __nccwpck_require__(5532)
+const { addSignal, removeSignal } = __nccwpck_require__(158)
 const assert = __nccwpck_require__(4589)
 
 const kResume = Symbol('resume')
@@ -2670,17 +2670,17 @@ module.exports = pipeline
 
 /***/ }),
 
-/***/ 1725:
+/***/ 4043:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 const assert = __nccwpck_require__(4589)
-const { Readable } = __nccwpck_require__(4501)
-const { InvalidArgumentError, RequestAbortedError } = __nccwpck_require__(7013)
-const util = __nccwpck_require__(4742)
-const { getResolveErrorBodyCallback } = __nccwpck_require__(6253)
+const { Readable } = __nccwpck_require__(9927)
+const { InvalidArgumentError, RequestAbortedError } = __nccwpck_require__(8707)
+const util = __nccwpck_require__(3440)
+const { getResolveErrorBodyCallback } = __nccwpck_require__(7655)
 const { AsyncResource } = __nccwpck_require__(6698)
 
 class RequestHandler extends AsyncResource {
@@ -2892,7 +2892,7 @@ module.exports.RequestHandler = RequestHandler
 
 /***/ }),
 
-/***/ 4318:
+/***/ 3560:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -2900,11 +2900,11 @@ module.exports.RequestHandler = RequestHandler
 
 const assert = __nccwpck_require__(4589)
 const { finished, PassThrough } = __nccwpck_require__(7075)
-const { InvalidArgumentError, InvalidReturnValueError } = __nccwpck_require__(7013)
-const util = __nccwpck_require__(4742)
-const { getResolveErrorBodyCallback } = __nccwpck_require__(6253)
+const { InvalidArgumentError, InvalidReturnValueError } = __nccwpck_require__(8707)
+const util = __nccwpck_require__(3440)
+const { getResolveErrorBodyCallback } = __nccwpck_require__(7655)
 const { AsyncResource } = __nccwpck_require__(6698)
-const { addSignal, removeSignal } = __nccwpck_require__(5532)
+const { addSignal, removeSignal } = __nccwpck_require__(158)
 
 class StreamHandler extends AsyncResource {
   constructor (opts, factory, callback) {
@@ -3120,16 +3120,16 @@ module.exports = stream
 
 /***/ }),
 
-/***/ 8892:
+/***/ 1882:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { InvalidArgumentError, SocketError } = __nccwpck_require__(7013)
+const { InvalidArgumentError, SocketError } = __nccwpck_require__(8707)
 const { AsyncResource } = __nccwpck_require__(6698)
-const util = __nccwpck_require__(4742)
-const { addSignal, removeSignal } = __nccwpck_require__(5532)
+const util = __nccwpck_require__(3440)
+const { addSignal, removeSignal } = __nccwpck_require__(158)
 const assert = __nccwpck_require__(4589)
 
 class UpgradeHandler extends AsyncResource {
@@ -3236,22 +3236,22 @@ module.exports = upgrade
 
 /***/ }),
 
-/***/ 477:
+/***/ 6615:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-module.exports.request = __nccwpck_require__(1725)
-module.exports.stream = __nccwpck_require__(4318)
-module.exports.pipeline = __nccwpck_require__(4280)
-module.exports.upgrade = __nccwpck_require__(8892)
-module.exports.connect = __nccwpck_require__(9826)
+module.exports.request = __nccwpck_require__(4043)
+module.exports.stream = __nccwpck_require__(3560)
+module.exports.pipeline = __nccwpck_require__(6862)
+module.exports.upgrade = __nccwpck_require__(1882)
+module.exports.connect = __nccwpck_require__(2279)
 
 
 /***/ }),
 
-/***/ 4501:
+/***/ 9927:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -3261,9 +3261,9 @@ module.exports.connect = __nccwpck_require__(9826)
 
 const assert = __nccwpck_require__(4589)
 const { Readable } = __nccwpck_require__(7075)
-const { RequestAbortedError, NotSupportedError, InvalidArgumentError, AbortError } = __nccwpck_require__(7013)
-const util = __nccwpck_require__(4742)
-const { ReadableStreamFrom } = __nccwpck_require__(4742)
+const { RequestAbortedError, NotSupportedError, InvalidArgumentError, AbortError } = __nccwpck_require__(8707)
+const util = __nccwpck_require__(3440)
+const { ReadableStreamFrom } = __nccwpck_require__(3440)
 
 const kConsume = Symbol('kConsume')
 const kReading = Symbol('kReading')
@@ -3644,15 +3644,15 @@ module.exports = { Readable: BodyReadable, chunksDecode }
 
 /***/ }),
 
-/***/ 6253:
+/***/ 7655:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 const assert = __nccwpck_require__(4589)
 const {
   ResponseStatusCodeError
-} = __nccwpck_require__(7013)
+} = __nccwpck_require__(8707)
 
-const { chunksDecode } = __nccwpck_require__(4501)
+const { chunksDecode } = __nccwpck_require__(9927)
 const CHUNK_LIMIT = 128 * 1024
 
 async function getResolveErrorBodyCallback ({ callback, body, contentType, statusCode, statusMessage, headers }) {
@@ -3744,7 +3744,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 4278:
+/***/ 9136:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -3752,9 +3752,9 @@ module.exports = {
 
 const net = __nccwpck_require__(7030)
 const assert = __nccwpck_require__(4589)
-const util = __nccwpck_require__(4742)
-const { InvalidArgumentError, ConnectTimeoutError } = __nccwpck_require__(7013)
-const timers = __nccwpck_require__(3325)
+const util = __nccwpck_require__(3440)
+const { InvalidArgumentError, ConnectTimeoutError } = __nccwpck_require__(8707)
+const timers = __nccwpck_require__(6603)
 
 function noop () {}
 
@@ -3992,7 +3992,7 @@ module.exports = buildConnector
 
 /***/ }),
 
-/***/ 2041:
+/***/ 735:
 /***/ ((module) => {
 
 "use strict";
@@ -4118,7 +4118,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 8664:
+/***/ 2414:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -4328,7 +4328,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 7013:
+/***/ 8707:
 /***/ ((module) => {
 
 "use strict";
@@ -4761,7 +4761,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 1241:
+/***/ 4655:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -4770,7 +4770,7 @@ module.exports = {
 const {
   InvalidArgumentError,
   NotSupportedError
-} = __nccwpck_require__(7013)
+} = __nccwpck_require__(8707)
 const assert = __nccwpck_require__(4589)
 const {
   isValidHTTPToken,
@@ -4785,9 +4785,9 @@ const {
   validateHandler,
   getServerName,
   normalizedMethodRecords
-} = __nccwpck_require__(4742)
-const { channels } = __nccwpck_require__(8664)
-const { headerNameLowerCasedRecord } = __nccwpck_require__(2041)
+} = __nccwpck_require__(3440)
+const { channels } = __nccwpck_require__(2414)
+const { headerNameLowerCasedRecord } = __nccwpck_require__(735)
 
 // Verifies that a given path is valid does not contain control chars \x00 to \x20
 const invalidPathRegex = /[^\u0021-\u00ff]/
@@ -5174,7 +5174,7 @@ module.exports = Request
 
 /***/ }),
 
-/***/ 7573:
+/***/ 6443:
 /***/ ((module) => {
 
 module.exports = {
@@ -5248,7 +5248,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 5322:
+/***/ 7752:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -5257,7 +5257,7 @@ module.exports = {
 const {
   wellknownHeaderNames,
   headerNameLowerCasedRecord
-} = __nccwpck_require__(2041)
+} = __nccwpck_require__(735)
 
 class TstNode {
   /** @type {any} */
@@ -5408,14 +5408,14 @@ module.exports = {
 
 /***/ }),
 
-/***/ 4742:
+/***/ 3440:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 const assert = __nccwpck_require__(4589)
-const { kDestroyed, kBodyUsed, kListeners, kBody } = __nccwpck_require__(7573)
+const { kDestroyed, kBodyUsed, kListeners, kBody } = __nccwpck_require__(6443)
 const { IncomingMessage } = __nccwpck_require__(7067)
 const stream = __nccwpck_require__(7075)
 const net = __nccwpck_require__(7030)
@@ -5423,9 +5423,9 @@ const { Blob } = __nccwpck_require__(4573)
 const nodeUtil = __nccwpck_require__(7975)
 const { stringify } = __nccwpck_require__(1792)
 const { EventEmitter: EE } = __nccwpck_require__(8474)
-const { InvalidArgumentError } = __nccwpck_require__(7013)
-const { headerNameLowerCasedRecord } = __nccwpck_require__(2041)
-const { tree } = __nccwpck_require__(5322)
+const { InvalidArgumentError } = __nccwpck_require__(8707)
+const { headerNameLowerCasedRecord } = __nccwpck_require__(735)
+const { tree } = __nccwpck_require__(7752)
 
 const [nodeMajor, nodeMinor] = process.versions.node.split('.').map(v => Number(v))
 
@@ -6135,19 +6135,19 @@ module.exports = {
 
 /***/ }),
 
-/***/ 8103:
+/***/ 7405:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { InvalidArgumentError } = __nccwpck_require__(7013)
-const { kClients, kRunning, kClose, kDestroy, kDispatch, kInterceptors } = __nccwpck_require__(7573)
-const DispatcherBase = __nccwpck_require__(9199)
-const Pool = __nccwpck_require__(2690)
-const Client = __nccwpck_require__(2539)
-const util = __nccwpck_require__(4742)
-const createRedirectInterceptor = __nccwpck_require__(5038)
+const { InvalidArgumentError } = __nccwpck_require__(8707)
+const { kClients, kRunning, kClose, kDestroy, kDispatch, kInterceptors } = __nccwpck_require__(6443)
+const DispatcherBase = __nccwpck_require__(1841)
+const Pool = __nccwpck_require__(628)
+const Client = __nccwpck_require__(3701)
+const util = __nccwpck_require__(3440)
+const createRedirectInterceptor = __nccwpck_require__(5092)
 
 const kOnConnect = Symbol('onConnect')
 const kOnDisconnect = Symbol('onDisconnect')
@@ -6272,7 +6272,7 @@ module.exports = Agent
 
 /***/ }),
 
-/***/ 1115:
+/***/ 837:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -6281,7 +6281,7 @@ module.exports = Agent
 const {
   BalancedPoolMissingUpstreamError,
   InvalidArgumentError
-} = __nccwpck_require__(7013)
+} = __nccwpck_require__(8707)
 const {
   PoolBase,
   kClients,
@@ -6289,10 +6289,10 @@ const {
   kAddClient,
   kRemoveClient,
   kGetDispatcher
-} = __nccwpck_require__(8122)
-const Pool = __nccwpck_require__(2690)
-const { kUrl, kInterceptors } = __nccwpck_require__(7573)
-const { parseOrigin } = __nccwpck_require__(4742)
+} = __nccwpck_require__(2128)
+const Pool = __nccwpck_require__(628)
+const { kUrl, kInterceptors } = __nccwpck_require__(6443)
+const { parseOrigin } = __nccwpck_require__(3440)
 const kFactory = Symbol('factory')
 
 const kOptions = Symbol('options')
@@ -6489,7 +6489,7 @@ module.exports = BalancedPool
 
 /***/ }),
 
-/***/ 3335:
+/***/ 637:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -6498,9 +6498,9 @@ module.exports = BalancedPool
 /* global WebAssembly */
 
 const assert = __nccwpck_require__(4589)
-const util = __nccwpck_require__(4742)
-const { channels } = __nccwpck_require__(8664)
-const timers = __nccwpck_require__(3325)
+const util = __nccwpck_require__(3440)
+const { channels } = __nccwpck_require__(2414)
+const timers = __nccwpck_require__(6603)
 const {
   RequestContentLengthMismatchError,
   ResponseContentLengthMismatchError,
@@ -6512,7 +6512,7 @@ const {
   BodyTimeoutError,
   HTTPParserError,
   ResponseExceededMaxSizeError
-} = __nccwpck_require__(7013)
+} = __nccwpck_require__(8707)
 const {
   kUrl,
   kReset,
@@ -6545,9 +6545,9 @@ const {
   kOnError,
   kResume,
   kHTTPContext
-} = __nccwpck_require__(7573)
+} = __nccwpck_require__(6443)
 
-const constants = __nccwpck_require__(4998)
+const constants = __nccwpck_require__(2824)
 const EMPTY_BUF = Buffer.alloc(0)
 const FastBuffer = Buffer[Symbol.species]
 const addListener = util.addListener
@@ -6556,11 +6556,11 @@ const removeAllListeners = util.removeAllListeners
 let extractBody
 
 async function lazyllhttp () {
-  const llhttpWasmData = process.env.JEST_WORKER_ID ? __nccwpck_require__(7724) : undefined
+  const llhttpWasmData = process.env.JEST_WORKER_ID ? __nccwpck_require__(3870) : undefined
 
   let mod
   try {
-    mod = await WebAssembly.compile(__nccwpck_require__(8772))
+    mod = await WebAssembly.compile(__nccwpck_require__(3434))
   } catch (e) {
     /* istanbul ignore next */
 
@@ -6568,7 +6568,7 @@ async function lazyllhttp () {
     // being enabled, but the occurring of this other error
     // * https://github.com/emscripten-core/emscripten/issues/11495
     // got me to remove that check to avoid breaking Node 12.
-    mod = await WebAssembly.compile(llhttpWasmData || __nccwpck_require__(7724))
+    mod = await WebAssembly.compile(llhttpWasmData || __nccwpck_require__(3870))
   }
 
   return await WebAssembly.instantiate(mod, {
@@ -7363,7 +7363,7 @@ function writeH1 (client, request) {
 
   if (util.isFormDataLike(body)) {
     if (!extractBody) {
-      extractBody = (__nccwpck_require__(1294).extractBody)
+      extractBody = (__nccwpck_require__(4492).extractBody)
     }
 
     const [bodyStream, contentType] = extractBody(body)
@@ -7867,7 +7867,7 @@ module.exports = connectH1
 
 /***/ }),
 
-/***/ 9610:
+/***/ 8788:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -7875,13 +7875,13 @@ module.exports = connectH1
 
 const assert = __nccwpck_require__(4589)
 const { pipeline } = __nccwpck_require__(7075)
-const util = __nccwpck_require__(4742)
+const util = __nccwpck_require__(3440)
 const {
   RequestContentLengthMismatchError,
   RequestAbortedError,
   SocketError,
   InformationalError
-} = __nccwpck_require__(7013)
+} = __nccwpck_require__(8707)
 const {
   kUrl,
   kReset,
@@ -7900,7 +7900,7 @@ const {
   kResume,
   kSize,
   kHTTPContext
-} = __nccwpck_require__(7573)
+} = __nccwpck_require__(6443)
 
 const kOpenStreams = Symbol('open streams')
 
@@ -8259,7 +8259,7 @@ function writeH2 (client, request) {
   let contentLength = util.bodyLength(body)
 
   if (util.isFormDataLike(body)) {
-    extractBody ??= (__nccwpck_require__(1294).extractBody)
+    extractBody ??= (__nccwpck_require__(4492).extractBody)
 
     const [bodyStream, contentType] = extractBody(body)
     headers['content-type'] = contentType
@@ -8619,7 +8619,7 @@ module.exports = connectH2
 
 /***/ }),
 
-/***/ 2539:
+/***/ 3701:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -8630,16 +8630,16 @@ module.exports = connectH2
 const assert = __nccwpck_require__(4589)
 const net = __nccwpck_require__(7030)
 const http = __nccwpck_require__(7067)
-const util = __nccwpck_require__(4742)
-const { channels } = __nccwpck_require__(8664)
-const Request = __nccwpck_require__(1241)
-const DispatcherBase = __nccwpck_require__(9199)
+const util = __nccwpck_require__(3440)
+const { channels } = __nccwpck_require__(2414)
+const Request = __nccwpck_require__(4655)
+const DispatcherBase = __nccwpck_require__(1841)
 const {
   InvalidArgumentError,
   InformationalError,
   ClientDestroyedError
-} = __nccwpck_require__(7013)
-const buildConnector = __nccwpck_require__(4278)
+} = __nccwpck_require__(8707)
+const buildConnector = __nccwpck_require__(9136)
 const {
   kUrl,
   kServerName,
@@ -8681,9 +8681,9 @@ const {
   kHTTPContext,
   kMaxConcurrentStreams,
   kResume
-} = __nccwpck_require__(7573)
-const connectH1 = __nccwpck_require__(3335)
-const connectH2 = __nccwpck_require__(9610)
+} = __nccwpck_require__(6443)
+const connectH1 = __nccwpck_require__(637)
+const connectH2 = __nccwpck_require__(8788)
 let deprecatedInterceptorWarned = false
 
 const kClosedResolve = Symbol('kClosedResolve')
@@ -8989,7 +8989,7 @@ class Client extends DispatcherBase {
   }
 }
 
-const createRedirectInterceptor = __nccwpck_require__(5038)
+const createRedirectInterceptor = __nccwpck_require__(5092)
 
 function onError (client, err) {
   if (
@@ -9249,19 +9249,19 @@ module.exports = Client
 
 /***/ }),
 
-/***/ 9199:
+/***/ 1841:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const Dispatcher = __nccwpck_require__(8989)
+const Dispatcher = __nccwpck_require__(883)
 const {
   ClientDestroyedError,
   ClientClosedError,
   InvalidArgumentError
-} = __nccwpck_require__(7013)
-const { kDestroy, kClose, kClosed, kDestroyed, kDispatch, kInterceptors } = __nccwpck_require__(7573)
+} = __nccwpck_require__(8707)
+const { kDestroy, kClose, kClosed, kDestroyed, kDispatch, kInterceptors } = __nccwpck_require__(6443)
 
 const kOnDestroyed = Symbol('onDestroyed')
 const kOnClosed = Symbol('onClosed')
@@ -9447,7 +9447,7 @@ module.exports = DispatcherBase
 
 /***/ }),
 
-/***/ 8989:
+/***/ 883:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -9520,16 +9520,16 @@ module.exports = Dispatcher
 
 /***/ }),
 
-/***/ 3535:
+/***/ 3137:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const DispatcherBase = __nccwpck_require__(9199)
-const { kClose, kDestroy, kClosed, kDestroyed, kDispatch, kNoProxyAgent, kHttpProxyAgent, kHttpsProxyAgent } = __nccwpck_require__(7573)
-const ProxyAgent = __nccwpck_require__(114)
-const Agent = __nccwpck_require__(8103)
+const DispatcherBase = __nccwpck_require__(1841)
+const { kClose, kDestroy, kClosed, kDestroyed, kDispatch, kNoProxyAgent, kHttpProxyAgent, kHttpsProxyAgent } = __nccwpck_require__(6443)
+const ProxyAgent = __nccwpck_require__(6672)
+const Agent = __nccwpck_require__(7405)
 
 const DEFAULT_PORTS = {
   'http:': 80,
@@ -9688,7 +9688,7 @@ module.exports = EnvHttpProxyAgent
 
 /***/ }),
 
-/***/ 7842:
+/***/ 4660:
 /***/ ((module) => {
 
 "use strict";
@@ -9813,16 +9813,16 @@ module.exports = class FixedQueue {
 
 /***/ }),
 
-/***/ 8122:
+/***/ 2128:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const DispatcherBase = __nccwpck_require__(9199)
-const FixedQueue = __nccwpck_require__(7842)
-const { kConnected, kSize, kRunning, kPending, kQueued, kBusy, kFree, kUrl, kClose, kDestroy, kDispatch } = __nccwpck_require__(7573)
-const PoolStats = __nccwpck_require__(7404)
+const DispatcherBase = __nccwpck_require__(1841)
+const FixedQueue = __nccwpck_require__(4660)
+const { kConnected, kSize, kRunning, kPending, kQueued, kBusy, kFree, kUrl, kClose, kDestroy, kDispatch } = __nccwpck_require__(6443)
+const PoolStats = __nccwpck_require__(3246)
 
 const kClients = Symbol('clients')
 const kNeedDrain = Symbol('needDrain')
@@ -10015,10 +10015,10 @@ module.exports = {
 
 /***/ }),
 
-/***/ 7404:
+/***/ 3246:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-const { kFree, kConnected, kPending, kQueued, kRunning, kSize } = __nccwpck_require__(7573)
+const { kFree, kConnected, kPending, kQueued, kRunning, kSize } = __nccwpck_require__(6443)
 const kPool = Symbol('pool')
 
 class PoolStats {
@@ -10056,7 +10056,7 @@ module.exports = PoolStats
 
 /***/ }),
 
-/***/ 2690:
+/***/ 628:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -10068,14 +10068,14 @@ const {
   kNeedDrain,
   kAddClient,
   kGetDispatcher
-} = __nccwpck_require__(8122)
-const Client = __nccwpck_require__(2539)
+} = __nccwpck_require__(2128)
+const Client = __nccwpck_require__(3701)
 const {
   InvalidArgumentError
-} = __nccwpck_require__(7013)
-const util = __nccwpck_require__(4742)
-const { kUrl, kInterceptors } = __nccwpck_require__(7573)
-const buildConnector = __nccwpck_require__(4278)
+} = __nccwpck_require__(8707)
+const util = __nccwpck_require__(3440)
+const { kUrl, kInterceptors } = __nccwpck_require__(6443)
+const buildConnector = __nccwpck_require__(9136)
 
 const kOptions = Symbol('options')
 const kConnections = Symbol('connections')
@@ -10171,20 +10171,20 @@ module.exports = Pool
 
 /***/ }),
 
-/***/ 114:
+/***/ 6672:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { kProxy, kClose, kDestroy, kDispatch, kInterceptors } = __nccwpck_require__(7573)
+const { kProxy, kClose, kDestroy, kDispatch, kInterceptors } = __nccwpck_require__(6443)
 const { URL } = __nccwpck_require__(3136)
-const Agent = __nccwpck_require__(8103)
-const Pool = __nccwpck_require__(2690)
-const DispatcherBase = __nccwpck_require__(9199)
-const { InvalidArgumentError, RequestAbortedError, SecureProxyConnectionError } = __nccwpck_require__(7013)
-const buildConnector = __nccwpck_require__(4278)
-const Client = __nccwpck_require__(2539)
+const Agent = __nccwpck_require__(7405)
+const Pool = __nccwpck_require__(628)
+const DispatcherBase = __nccwpck_require__(1841)
+const { InvalidArgumentError, RequestAbortedError, SecureProxyConnectionError } = __nccwpck_require__(8707)
+const buildConnector = __nccwpck_require__(9136)
+const Client = __nccwpck_require__(3701)
 
 const kAgent = Symbol('proxy agent')
 const kClient = Symbol('proxy client')
@@ -10453,14 +10453,14 @@ module.exports = ProxyAgent
 
 /***/ }),
 
-/***/ 2148:
+/***/ 50:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const Dispatcher = __nccwpck_require__(8989)
-const RetryHandler = __nccwpck_require__(9586)
+const Dispatcher = __nccwpck_require__(883)
+const RetryHandler = __nccwpck_require__(7816)
 
 class RetryAgent extends Dispatcher {
   #agent = null
@@ -10496,7 +10496,7 @@ module.exports = RetryAgent
 
 /***/ }),
 
-/***/ 3723:
+/***/ 2581:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -10505,8 +10505,8 @@ module.exports = RetryAgent
 // We include a version number for the Dispatcher API. In case of breaking changes,
 // this version number must be increased to avoid conflicts.
 const globalDispatcher = Symbol.for('undici.globalDispatcher.1')
-const { InvalidArgumentError } = __nccwpck_require__(7013)
-const Agent = __nccwpck_require__(8103)
+const { InvalidArgumentError } = __nccwpck_require__(8707)
+const Agent = __nccwpck_require__(7405)
 
 if (getGlobalDispatcher() === undefined) {
   setGlobalDispatcher(new Agent())
@@ -10536,7 +10536,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 1881:
+/***/ 8155:
 /***/ ((module) => {
 
 "use strict";
@@ -10588,16 +10588,16 @@ module.exports = class DecoratorHandler {
 
 /***/ }),
 
-/***/ 8276:
+/***/ 8754:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const util = __nccwpck_require__(4742)
-const { kBodyUsed } = __nccwpck_require__(7573)
+const util = __nccwpck_require__(3440)
+const { kBodyUsed } = __nccwpck_require__(6443)
 const assert = __nccwpck_require__(4589)
-const { InvalidArgumentError } = __nccwpck_require__(7013)
+const { InvalidArgumentError } = __nccwpck_require__(8707)
 const EE = __nccwpck_require__(8474)
 
 const redirectableStatusCodes = [300, 301, 302, 303, 307, 308]
@@ -10828,21 +10828,21 @@ module.exports = RedirectHandler
 
 /***/ }),
 
-/***/ 9586:
+/***/ 7816:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 const assert = __nccwpck_require__(4589)
 
-const { kRetryHandlerDefaultRetry } = __nccwpck_require__(7573)
-const { RequestRetryError } = __nccwpck_require__(7013)
+const { kRetryHandlerDefaultRetry } = __nccwpck_require__(6443)
+const { RequestRetryError } = __nccwpck_require__(8707)
 const {
   isDisturbed,
   parseHeaders,
   parseRangeHeader,
   wrapRequestBody
-} = __nccwpck_require__(4742)
+} = __nccwpck_require__(3440)
 
 function calculateRetryAfterHeader (retryAfter) {
   const current = Date.now()
@@ -11210,15 +11210,15 @@ module.exports = RetryHandler
 
 /***/ }),
 
-/***/ 3241:
+/***/ 379:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 const { isIP } = __nccwpck_require__(7030)
 const { lookup } = __nccwpck_require__(610)
-const DecoratorHandler = __nccwpck_require__(1881)
-const { InvalidArgumentError, InformationalError } = __nccwpck_require__(7013)
+const DecoratorHandler = __nccwpck_require__(8155)
+const { InvalidArgumentError, InformationalError } = __nccwpck_require__(8707)
 const maxInt = Math.pow(2, 31) - 1
 
 class DNSInstance {
@@ -11593,15 +11593,15 @@ module.exports = interceptorOpts => {
 
 /***/ }),
 
-/***/ 7278:
+/***/ 8060:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const util = __nccwpck_require__(4742)
-const { InvalidArgumentError, RequestAbortedError } = __nccwpck_require__(7013)
-const DecoratorHandler = __nccwpck_require__(1881)
+const util = __nccwpck_require__(3440)
+const { InvalidArgumentError, RequestAbortedError } = __nccwpck_require__(8707)
+const DecoratorHandler = __nccwpck_require__(8155)
 
 class DumpHandler extends DecoratorHandler {
   #maxSize = 1024 * 1024
@@ -11724,13 +11724,13 @@ module.exports = createDumpInterceptor
 
 /***/ }),
 
-/***/ 5038:
+/***/ 5092:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const RedirectHandler = __nccwpck_require__(8276)
+const RedirectHandler = __nccwpck_require__(8754)
 
 function createRedirectInterceptor ({ maxRedirections: defaultMaxRedirections }) {
   return (dispatch) => {
@@ -11753,12 +11753,12 @@ module.exports = createRedirectInterceptor
 
 /***/ }),
 
-/***/ 9704:
+/***/ 1514:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
-const RedirectHandler = __nccwpck_require__(8276)
+const RedirectHandler = __nccwpck_require__(8754)
 
 module.exports = opts => {
   const globalMaxRedirections = opts?.maxRedirections
@@ -11785,12 +11785,12 @@ module.exports = opts => {
 
 /***/ }),
 
-/***/ 7400:
+/***/ 2026:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
-const RetryHandler = __nccwpck_require__(9586)
+const RetryHandler = __nccwpck_require__(7816)
 
 module.exports = globalOpts => {
   return dispatch => {
@@ -11812,14 +11812,14 @@ module.exports = globalOpts => {
 
 /***/ }),
 
-/***/ 4998:
+/***/ 2824:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.SPECIAL_HEADERS = exports.HEADER_STATE = exports.MINOR = exports.MAJOR = exports.CONNECTION_TOKEN_CHARS = exports.HEADER_CHARS = exports.TOKEN = exports.STRICT_TOKEN = exports.HEX = exports.URL_CHAR = exports.STRICT_URL_CHAR = exports.USERINFO_CHARS = exports.MARK = exports.ALPHANUM = exports.NUM = exports.HEX_MAP = exports.NUM_MAP = exports.ALPHA = exports.FINISH = exports.H_METHOD_MAP = exports.METHOD_MAP = exports.METHODS_RTSP = exports.METHODS_ICE = exports.METHODS_HTTP = exports.METHODS = exports.LENIENT_FLAGS = exports.FLAGS = exports.TYPE = exports.ERROR = void 0;
-const utils_1 = __nccwpck_require__(4094);
+const utils_1 = __nccwpck_require__(172);
 // C headers
 var ERROR;
 (function (ERROR) {
@@ -12097,7 +12097,7 @@ exports.SPECIAL_HEADERS = {
 
 /***/ }),
 
-/***/ 7724:
+/***/ 3870:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -12110,7 +12110,7 @@ module.exports = Buffer.from('AGFzbQEAAAABJwdgAX8Bf2ADf39/AX9gAX8AYAJ/fwBgBH9/f3
 
 /***/ }),
 
-/***/ 8772:
+/***/ 3434:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -12123,7 +12123,7 @@ module.exports = Buffer.from('AGFzbQEAAAABJwdgAX8Bf2ADf39/AX9gAX8AYAJ/fwBgBH9/f3
 
 /***/ }),
 
-/***/ 4094:
+/***/ 172:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -12145,14 +12145,14 @@ exports.enumToMap = enumToMap;
 
 /***/ }),
 
-/***/ 7319:
+/***/ 7501:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { kClients } = __nccwpck_require__(7573)
-const Agent = __nccwpck_require__(8103)
+const { kClients } = __nccwpck_require__(6443)
+const Agent = __nccwpck_require__(7405)
 const {
   kAgent,
   kMockAgentSet,
@@ -12163,14 +12163,14 @@ const {
   kGetNetConnect,
   kOptions,
   kFactory
-} = __nccwpck_require__(4847)
-const MockClient = __nccwpck_require__(8747)
-const MockPool = __nccwpck_require__(706)
-const { matchValue, buildMockOptions } = __nccwpck_require__(9763)
-const { InvalidArgumentError, UndiciError } = __nccwpck_require__(7013)
-const Dispatcher = __nccwpck_require__(8989)
-const Pluralizer = __nccwpck_require__(5403)
-const PendingInterceptorsFormatter = __nccwpck_require__(7456)
+} = __nccwpck_require__(1117)
+const MockClient = __nccwpck_require__(7365)
+const MockPool = __nccwpck_require__(4004)
+const { matchValue, buildMockOptions } = __nccwpck_require__(3397)
+const { InvalidArgumentError, UndiciError } = __nccwpck_require__(8707)
+const Dispatcher = __nccwpck_require__(883)
+const Pluralizer = __nccwpck_require__(1529)
+const PendingInterceptorsFormatter = __nccwpck_require__(6142)
 
 class MockAgent extends Dispatcher {
   constructor (opts) {
@@ -12313,15 +12313,15 @@ module.exports = MockAgent
 
 /***/ }),
 
-/***/ 8747:
+/***/ 7365:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 const { promisify } = __nccwpck_require__(7975)
-const Client = __nccwpck_require__(2539)
-const { buildMockDispatch } = __nccwpck_require__(9763)
+const Client = __nccwpck_require__(3701)
+const { buildMockDispatch } = __nccwpck_require__(3397)
 const {
   kDispatches,
   kMockAgent,
@@ -12330,10 +12330,10 @@ const {
   kOrigin,
   kOriginalDispatch,
   kConnected
-} = __nccwpck_require__(4847)
-const { MockInterceptor } = __nccwpck_require__(5437)
-const Symbols = __nccwpck_require__(7573)
-const { InvalidArgumentError } = __nccwpck_require__(7013)
+} = __nccwpck_require__(1117)
+const { MockInterceptor } = __nccwpck_require__(1511)
+const Symbols = __nccwpck_require__(6443)
+const { InvalidArgumentError } = __nccwpck_require__(8707)
 
 /**
  * MockClient provides an API that extends the Client to influence the mockDispatches.
@@ -12380,13 +12380,13 @@ module.exports = MockClient
 
 /***/ }),
 
-/***/ 3559:
+/***/ 2429:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { UndiciError } = __nccwpck_require__(7013)
+const { UndiciError } = __nccwpck_require__(8707)
 
 const kMockNotMatchedError = Symbol.for('undici.error.UND_MOCK_ERR_MOCK_NOT_MATCHED')
 
@@ -12416,13 +12416,13 @@ module.exports = {
 
 /***/ }),
 
-/***/ 5437:
+/***/ 1511:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { getResponseData, buildKey, addMockDispatch } = __nccwpck_require__(9763)
+const { getResponseData, buildKey, addMockDispatch } = __nccwpck_require__(3397)
 const {
   kDispatches,
   kDispatchKey,
@@ -12430,9 +12430,9 @@ const {
   kDefaultTrailers,
   kContentLength,
   kMockDispatch
-} = __nccwpck_require__(4847)
-const { InvalidArgumentError } = __nccwpck_require__(7013)
-const { buildURL } = __nccwpck_require__(4742)
+} = __nccwpck_require__(1117)
+const { InvalidArgumentError } = __nccwpck_require__(8707)
+const { buildURL } = __nccwpck_require__(3440)
 
 /**
  * Defines the scope API for an interceptor reply
@@ -12631,15 +12631,15 @@ module.exports.MockScope = MockScope
 
 /***/ }),
 
-/***/ 706:
+/***/ 4004:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 const { promisify } = __nccwpck_require__(7975)
-const Pool = __nccwpck_require__(2690)
-const { buildMockDispatch } = __nccwpck_require__(9763)
+const Pool = __nccwpck_require__(628)
+const { buildMockDispatch } = __nccwpck_require__(3397)
 const {
   kDispatches,
   kMockAgent,
@@ -12648,10 +12648,10 @@ const {
   kOrigin,
   kOriginalDispatch,
   kConnected
-} = __nccwpck_require__(4847)
-const { MockInterceptor } = __nccwpck_require__(5437)
-const Symbols = __nccwpck_require__(7573)
-const { InvalidArgumentError } = __nccwpck_require__(7013)
+} = __nccwpck_require__(1117)
+const { MockInterceptor } = __nccwpck_require__(1511)
+const Symbols = __nccwpck_require__(6443)
+const { InvalidArgumentError } = __nccwpck_require__(8707)
 
 /**
  * MockPool provides an API that extends the Pool to influence the mockDispatches.
@@ -12698,7 +12698,7 @@ module.exports = MockPool
 
 /***/ }),
 
-/***/ 4847:
+/***/ 1117:
 /***/ ((module) => {
 
 "use strict";
@@ -12729,21 +12729,21 @@ module.exports = {
 
 /***/ }),
 
-/***/ 9763:
+/***/ 3397:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { MockNotMatchedError } = __nccwpck_require__(3559)
+const { MockNotMatchedError } = __nccwpck_require__(2429)
 const {
   kDispatches,
   kMockAgent,
   kOriginalDispatch,
   kOrigin,
   kGetNetConnect
-} = __nccwpck_require__(4847)
-const { buildURL } = __nccwpck_require__(4742)
+} = __nccwpck_require__(1117)
+const { buildURL } = __nccwpck_require__(3440)
 const { STATUS_CODES } = __nccwpck_require__(7067)
 const {
   types: {
@@ -13104,7 +13104,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 7456:
+/***/ 6142:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -13155,7 +13155,7 @@ module.exports = class PendingInterceptorsFormatter {
 
 /***/ }),
 
-/***/ 5403:
+/***/ 1529:
 /***/ ((module) => {
 
 "use strict";
@@ -13192,7 +13192,7 @@ module.exports = class Pluralizer {
 
 /***/ }),
 
-/***/ 3325:
+/***/ 6603:
 /***/ ((module) => {
 
 "use strict";
@@ -13623,21 +13623,21 @@ module.exports = {
 
 /***/ }),
 
-/***/ 1440:
+/***/ 9634:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { kConstruct } = __nccwpck_require__(6123)
-const { urlEquals, getFieldValues } = __nccwpck_require__(8848)
-const { kEnumerableProperty, isDisturbed } = __nccwpck_require__(4742)
-const { webidl } = __nccwpck_require__(735)
-const { Response, cloneResponse, fromInnerResponse } = __nccwpck_require__(2929)
-const { Request, fromInnerRequest } = __nccwpck_require__(4309)
-const { kState } = __nccwpck_require__(5785)
-const { fetching } = __nccwpck_require__(2104)
-const { urlIsHttpHttpsScheme, createDeferredPromise, readAllBytes } = __nccwpck_require__(18)
+const { kConstruct } = __nccwpck_require__(109)
+const { urlEquals, getFieldValues } = __nccwpck_require__(6798)
+const { kEnumerableProperty, isDisturbed } = __nccwpck_require__(3440)
+const { webidl } = __nccwpck_require__(5893)
+const { Response, cloneResponse, fromInnerResponse } = __nccwpck_require__(9051)
+const { Request, fromInnerRequest } = __nccwpck_require__(9967)
+const { kState } = __nccwpck_require__(3627)
+const { fetching } = __nccwpck_require__(4398)
+const { urlIsHttpHttpsScheme, createDeferredPromise, readAllBytes } = __nccwpck_require__(3168)
 const assert = __nccwpck_require__(4589)
 
 /**
@@ -14490,16 +14490,16 @@ module.exports = {
 
 /***/ }),
 
-/***/ 1823:
+/***/ 3245:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { kConstruct } = __nccwpck_require__(6123)
-const { Cache } = __nccwpck_require__(1440)
-const { webidl } = __nccwpck_require__(735)
-const { kEnumerableProperty } = __nccwpck_require__(4742)
+const { kConstruct } = __nccwpck_require__(109)
+const { Cache } = __nccwpck_require__(9634)
+const { webidl } = __nccwpck_require__(5893)
+const { kEnumerableProperty } = __nccwpck_require__(3440)
 
 class CacheStorage {
   /**
@@ -14650,28 +14650,28 @@ module.exports = {
 
 /***/ }),
 
-/***/ 6123:
+/***/ 109:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 module.exports = {
-  kConstruct: (__nccwpck_require__(7573).kConstruct)
+  kConstruct: (__nccwpck_require__(6443).kConstruct)
 }
 
 
 /***/ }),
 
-/***/ 8848:
+/***/ 6798:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 const assert = __nccwpck_require__(4589)
-const { URLSerializer } = __nccwpck_require__(9634)
-const { isValidHeaderName } = __nccwpck_require__(18)
+const { URLSerializer } = __nccwpck_require__(1900)
+const { isValidHeaderName } = __nccwpck_require__(3168)
 
 /**
  * @see https://url.spec.whatwg.org/#concept-url-equals
@@ -14716,7 +14716,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 8542:
+/***/ 1276:
 /***/ ((module) => {
 
 "use strict";
@@ -14736,16 +14736,16 @@ module.exports = {
 
 /***/ }),
 
-/***/ 107:
+/***/ 9061:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { parseSetCookie } = __nccwpck_require__(916)
-const { stringify } = __nccwpck_require__(3667)
-const { webidl } = __nccwpck_require__(735)
-const { Headers } = __nccwpck_require__(7386)
+const { parseSetCookie } = __nccwpck_require__(1978)
+const { stringify } = __nccwpck_require__(7797)
+const { webidl } = __nccwpck_require__(5893)
+const { Headers } = __nccwpck_require__(660)
 
 /**
  * @typedef {Object} Cookie
@@ -14928,15 +14928,15 @@ module.exports = {
 
 /***/ }),
 
-/***/ 916:
+/***/ 1978:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { maxNameValuePairSize, maxAttributeValueSize } = __nccwpck_require__(8542)
-const { isCTLExcludingHtab } = __nccwpck_require__(3667)
-const { collectASequenceOfCodePointsFast } = __nccwpck_require__(9634)
+const { maxNameValuePairSize, maxAttributeValueSize } = __nccwpck_require__(1276)
+const { isCTLExcludingHtab } = __nccwpck_require__(7797)
+const { collectASequenceOfCodePointsFast } = __nccwpck_require__(1900)
 const assert = __nccwpck_require__(4589)
 
 /**
@@ -15253,7 +15253,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 3667:
+/***/ 7797:
 /***/ ((module) => {
 
 "use strict";
@@ -15543,13 +15543,13 @@ module.exports = {
 
 /***/ }),
 
-/***/ 1009:
+/***/ 4031:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 const { Transform } = __nccwpck_require__(7075)
-const { isASCIINumber, isValidLastEventId } = __nccwpck_require__(2893)
+const { isASCIINumber, isValidLastEventId } = __nccwpck_require__(4811)
 
 /**
  * @type {number[]} BOM
@@ -15949,23 +15949,23 @@ module.exports = {
 
 /***/ }),
 
-/***/ 5108:
+/***/ 1238:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 const { pipeline } = __nccwpck_require__(7075)
-const { fetching } = __nccwpck_require__(2104)
-const { makeRequest } = __nccwpck_require__(4309)
-const { webidl } = __nccwpck_require__(735)
-const { EventSourceStream } = __nccwpck_require__(1009)
-const { parseMIMEType } = __nccwpck_require__(9634)
-const { createFastMessageEvent } = __nccwpck_require__(4194)
-const { isNetworkError } = __nccwpck_require__(2929)
-const { delay } = __nccwpck_require__(2893)
-const { kEnumerableProperty } = __nccwpck_require__(4742)
-const { environmentSettingsObject } = __nccwpck_require__(18)
+const { fetching } = __nccwpck_require__(4398)
+const { makeRequest } = __nccwpck_require__(9967)
+const { webidl } = __nccwpck_require__(5893)
+const { EventSourceStream } = __nccwpck_require__(4031)
+const { parseMIMEType } = __nccwpck_require__(1900)
+const { createFastMessageEvent } = __nccwpck_require__(5188)
+const { isNetworkError } = __nccwpck_require__(9051)
+const { delay } = __nccwpck_require__(4811)
+const { kEnumerableProperty } = __nccwpck_require__(3440)
+const { environmentSettingsObject } = __nccwpck_require__(3168)
 
 let experimentalWarned = false
 
@@ -16437,7 +16437,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 2893:
+/***/ 4811:
 /***/ ((module) => {
 
 "use strict";
@@ -16482,13 +16482,13 @@ module.exports = {
 
 /***/ }),
 
-/***/ 1294:
+/***/ 4492:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const util = __nccwpck_require__(4742)
+const util = __nccwpck_require__(3440)
 const {
   ReadableStreamFrom,
   isBlobLike,
@@ -16498,16 +16498,16 @@ const {
   fullyReadBody,
   extractMimeType,
   utf8DecodeBytes
-} = __nccwpck_require__(18)
-const { FormData } = __nccwpck_require__(6124)
-const { kState } = __nccwpck_require__(5785)
-const { webidl } = __nccwpck_require__(735)
+} = __nccwpck_require__(3168)
+const { FormData } = __nccwpck_require__(5910)
+const { kState } = __nccwpck_require__(3627)
+const { webidl } = __nccwpck_require__(5893)
 const { Blob } = __nccwpck_require__(4573)
 const assert = __nccwpck_require__(4589)
 const { isErrored, isDisturbed } = __nccwpck_require__(7075)
 const { isArrayBuffer } = __nccwpck_require__(3429)
-const { serializeAMimeType } = __nccwpck_require__(9634)
-const { multipartFormDataParser } = __nccwpck_require__(8850)
+const { serializeAMimeType } = __nccwpck_require__(1900)
+const { multipartFormDataParser } = __nccwpck_require__(116)
 let random
 
 try {
@@ -17019,7 +17019,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 7997:
+/***/ 4495:
 /***/ ((module) => {
 
 "use strict";
@@ -17151,7 +17151,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 9634:
+/***/ 1900:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -17903,13 +17903,13 @@ module.exports = {
 
 /***/ }),
 
-/***/ 6547:
+/***/ 6653:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { kConnected, kSize } = __nccwpck_require__(7573)
+const { kConnected, kSize } = __nccwpck_require__(6443)
 
 class CompatWeakRef {
   constructor (value) {
@@ -17957,15 +17957,15 @@ module.exports = function () {
 
 /***/ }),
 
-/***/ 5336:
+/***/ 7114:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 const { Blob, File } = __nccwpck_require__(4573)
-const { kState } = __nccwpck_require__(5785)
-const { webidl } = __nccwpck_require__(735)
+const { kState } = __nccwpck_require__(3627)
+const { webidl } = __nccwpck_require__(5893)
 
 // TODO(@KhafraDev): remove
 class FileLike {
@@ -18091,17 +18091,17 @@ module.exports = { FileLike, isFileLike }
 
 /***/ }),
 
-/***/ 8850:
+/***/ 116:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { isUSVString, bufferToLowerCasedHeaderName } = __nccwpck_require__(4742)
-const { utf8DecodeBytes } = __nccwpck_require__(18)
-const { HTTP_TOKEN_CODEPOINTS, isomorphicDecode } = __nccwpck_require__(9634)
-const { isFileLike } = __nccwpck_require__(5336)
-const { makeEntry } = __nccwpck_require__(6124)
+const { isUSVString, bufferToLowerCasedHeaderName } = __nccwpck_require__(3440)
+const { utf8DecodeBytes } = __nccwpck_require__(3168)
+const { HTTP_TOKEN_CODEPOINTS, isomorphicDecode } = __nccwpck_require__(1900)
+const { isFileLike } = __nccwpck_require__(7114)
+const { makeEntry } = __nccwpck_require__(5910)
 const assert = __nccwpck_require__(4589)
 const { File: NodeFile } = __nccwpck_require__(4573)
 
@@ -18573,17 +18573,17 @@ module.exports = {
 
 /***/ }),
 
-/***/ 6124:
+/***/ 5910:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { isBlobLike, iteratorMixin } = __nccwpck_require__(18)
-const { kState } = __nccwpck_require__(5785)
-const { kEnumerableProperty } = __nccwpck_require__(4742)
-const { FileLike, isFileLike } = __nccwpck_require__(5336)
-const { webidl } = __nccwpck_require__(735)
+const { isBlobLike, iteratorMixin } = __nccwpck_require__(3168)
+const { kState } = __nccwpck_require__(3627)
+const { kEnumerableProperty } = __nccwpck_require__(3440)
+const { FileLike, isFileLike } = __nccwpck_require__(7114)
+const { webidl } = __nccwpck_require__(5893)
 const { File: NativeFile } = __nccwpck_require__(4573)
 const nodeUtil = __nccwpck_require__(7975)
 
@@ -18833,7 +18833,7 @@ module.exports = { FormData, makeEntry }
 
 /***/ }),
 
-/***/ 9553:
+/***/ 1059:
 /***/ ((module) => {
 
 "use strict";
@@ -18881,7 +18881,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 7386:
+/***/ 660:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -18889,14 +18889,14 @@ module.exports = {
 
 
 
-const { kConstruct } = __nccwpck_require__(7573)
-const { kEnumerableProperty } = __nccwpck_require__(4742)
+const { kConstruct } = __nccwpck_require__(6443)
+const { kEnumerableProperty } = __nccwpck_require__(3440)
 const {
   iteratorMixin,
   isValidHeaderName,
   isValidHeaderValue
-} = __nccwpck_require__(18)
-const { webidl } = __nccwpck_require__(735)
+} = __nccwpck_require__(3168)
+const { webidl } = __nccwpck_require__(5893)
 const assert = __nccwpck_require__(4589)
 const util = __nccwpck_require__(7975)
 
@@ -19576,7 +19576,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 2104:
+/***/ 4398:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -19590,9 +19590,9 @@ const {
   filterResponse,
   makeResponse,
   fromInnerResponse
-} = __nccwpck_require__(2929)
-const { HeadersList } = __nccwpck_require__(7386)
-const { Request, cloneRequest } = __nccwpck_require__(4309)
+} = __nccwpck_require__(9051)
+const { HeadersList } = __nccwpck_require__(660)
+const { Request, cloneRequest } = __nccwpck_require__(9967)
 const zlib = __nccwpck_require__(8522)
 const {
   bytesMatch,
@@ -19628,23 +19628,23 @@ const {
   buildContentRange,
   createInflate,
   extractMimeType
-} = __nccwpck_require__(18)
-const { kState, kDispatcher } = __nccwpck_require__(5785)
+} = __nccwpck_require__(3168)
+const { kState, kDispatcher } = __nccwpck_require__(3627)
 const assert = __nccwpck_require__(4589)
-const { safelyExtractBody, extractBody } = __nccwpck_require__(1294)
+const { safelyExtractBody, extractBody } = __nccwpck_require__(4492)
 const {
   redirectStatusSet,
   nullBodyStatus,
   safeMethodsSet,
   requestBodyHeader,
   subresourceSet
-} = __nccwpck_require__(7997)
+} = __nccwpck_require__(4495)
 const EE = __nccwpck_require__(8474)
 const { Readable, pipeline, finished } = __nccwpck_require__(7075)
-const { addAbortListener, isErrored, isReadable, bufferToLowerCasedHeaderName } = __nccwpck_require__(4742)
-const { dataURLProcessor, serializeAMimeType, minimizeSupportedMimeType } = __nccwpck_require__(9634)
-const { getGlobalDispatcher } = __nccwpck_require__(3723)
-const { webidl } = __nccwpck_require__(735)
+const { addAbortListener, isErrored, isReadable, bufferToLowerCasedHeaderName } = __nccwpck_require__(3440)
+const { dataURLProcessor, serializeAMimeType, minimizeSupportedMimeType } = __nccwpck_require__(1900)
+const { getGlobalDispatcher } = __nccwpck_require__(2581)
+const { webidl } = __nccwpck_require__(5893)
 const { STATUS_CODES } = __nccwpck_require__(7067)
 const GET_OR_HEAD = ['GET', 'HEAD']
 
@@ -21856,7 +21856,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 4309:
+/***/ 9967:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -21864,16 +21864,16 @@ module.exports = {
 
 
 
-const { extractBody, mixinBody, cloneBody, bodyUnusable } = __nccwpck_require__(1294)
-const { Headers, fill: fillHeaders, HeadersList, setHeadersGuard, getHeadersGuard, setHeadersList, getHeadersList } = __nccwpck_require__(7386)
-const { FinalizationRegistry } = __nccwpck_require__(6547)()
-const util = __nccwpck_require__(4742)
+const { extractBody, mixinBody, cloneBody, bodyUnusable } = __nccwpck_require__(4492)
+const { Headers, fill: fillHeaders, HeadersList, setHeadersGuard, getHeadersGuard, setHeadersList, getHeadersList } = __nccwpck_require__(660)
+const { FinalizationRegistry } = __nccwpck_require__(6653)()
+const util = __nccwpck_require__(3440)
 const nodeUtil = __nccwpck_require__(7975)
 const {
   isValidHTTPToken,
   sameOrigin,
   environmentSettingsObject
-} = __nccwpck_require__(18)
+} = __nccwpck_require__(3168)
 const {
   forbiddenMethodsSet,
   corsSafeListedMethodsSet,
@@ -21883,12 +21883,12 @@ const {
   requestCredentials,
   requestCache,
   requestDuplex
-} = __nccwpck_require__(7997)
+} = __nccwpck_require__(4495)
 const { kEnumerableProperty, normalizedMethodRecordsBase, normalizedMethodRecords } = util
-const { kHeaders, kSignal, kState, kDispatcher } = __nccwpck_require__(5785)
-const { webidl } = __nccwpck_require__(735)
-const { URLSerializer } = __nccwpck_require__(9634)
-const { kConstruct } = __nccwpck_require__(7573)
+const { kHeaders, kSignal, kState, kDispatcher } = __nccwpck_require__(3627)
+const { webidl } = __nccwpck_require__(5893)
+const { URLSerializer } = __nccwpck_require__(1900)
+const { kConstruct } = __nccwpck_require__(6443)
 const assert = __nccwpck_require__(4589)
 const { getMaxListeners, setMaxListeners, getEventListeners, defaultMaxListeners } = __nccwpck_require__(8474)
 
@@ -22901,15 +22901,15 @@ module.exports = { Request, makeRequest, fromInnerRequest, cloneRequest }
 
 /***/ }),
 
-/***/ 2929:
+/***/ 9051:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { Headers, HeadersList, fill, getHeadersGuard, setHeadersGuard, setHeadersList } = __nccwpck_require__(7386)
-const { extractBody, cloneBody, mixinBody, hasFinalizationRegistry, streamRegistry, bodyUnusable } = __nccwpck_require__(1294)
-const util = __nccwpck_require__(4742)
+const { Headers, HeadersList, fill, getHeadersGuard, setHeadersGuard, setHeadersList } = __nccwpck_require__(660)
+const { extractBody, cloneBody, mixinBody, hasFinalizationRegistry, streamRegistry, bodyUnusable } = __nccwpck_require__(4492)
+const util = __nccwpck_require__(3440)
 const nodeUtil = __nccwpck_require__(7975)
 const { kEnumerableProperty } = util
 const {
@@ -22921,16 +22921,16 @@ const {
   isErrorLike,
   isomorphicEncode,
   environmentSettingsObject: relevantRealm
-} = __nccwpck_require__(18)
+} = __nccwpck_require__(3168)
 const {
   redirectStatusSet,
   nullBodyStatus
-} = __nccwpck_require__(7997)
-const { kState, kHeaders } = __nccwpck_require__(5785)
-const { webidl } = __nccwpck_require__(735)
-const { FormData } = __nccwpck_require__(6124)
-const { URLSerializer } = __nccwpck_require__(9634)
-const { kConstruct } = __nccwpck_require__(7573)
+} = __nccwpck_require__(4495)
+const { kState, kHeaders } = __nccwpck_require__(3627)
+const { webidl } = __nccwpck_require__(5893)
+const { FormData } = __nccwpck_require__(5910)
+const { URLSerializer } = __nccwpck_require__(1900)
+const { kConstruct } = __nccwpck_require__(6443)
 const assert = __nccwpck_require__(4589)
 const { types } = __nccwpck_require__(7975)
 
@@ -23519,7 +23519,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 5785:
+/***/ 3627:
 /***/ ((module) => {
 
 "use strict";
@@ -23536,7 +23536,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 18:
+/***/ 3168:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -23544,14 +23544,14 @@ module.exports = {
 
 const { Transform } = __nccwpck_require__(7075)
 const zlib = __nccwpck_require__(8522)
-const { redirectStatusSet, referrerPolicySet: referrerPolicyTokens, badPortsSet } = __nccwpck_require__(7997)
-const { getGlobalOrigin } = __nccwpck_require__(9553)
-const { collectASequenceOfCodePoints, collectAnHTTPQuotedString, removeChars, parseMIMEType } = __nccwpck_require__(9634)
+const { redirectStatusSet, referrerPolicySet: referrerPolicyTokens, badPortsSet } = __nccwpck_require__(4495)
+const { getGlobalOrigin } = __nccwpck_require__(1059)
+const { collectASequenceOfCodePoints, collectAnHTTPQuotedString, removeChars, parseMIMEType } = __nccwpck_require__(1900)
 const { performance } = __nccwpck_require__(643)
-const { isBlobLike, ReadableStreamFrom, isValidHTTPToken, normalizedMethodRecordsBase } = __nccwpck_require__(4742)
+const { isBlobLike, ReadableStreamFrom, isValidHTTPToken, normalizedMethodRecordsBase } = __nccwpck_require__(3440)
 const assert = __nccwpck_require__(4589)
 const { isUint8Array } = __nccwpck_require__(3429)
-const { webidl } = __nccwpck_require__(735)
+const { webidl } = __nccwpck_require__(5893)
 
 let supportedHashes = []
 
@@ -25176,7 +25176,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 735:
+/***/ 5893:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -25184,7 +25184,7 @@ module.exports = {
 
 const { types, inspect } = __nccwpck_require__(7975)
 const { markAsUncloneable } = __nccwpck_require__(5919)
-const { toUSVString } = __nccwpck_require__(4742)
+const { toUSVString } = __nccwpck_require__(3440)
 
 /** @type {import('../../../types/webidl').Webidl} */
 const webidl = {}
@@ -25879,7 +25879,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 4281:
+/***/ 2607:
 /***/ ((module) => {
 
 "use strict";
@@ -26177,7 +26177,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 6413:
+/***/ 8355:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -26187,16 +26187,16 @@ const {
   staticPropertyDescriptors,
   readOperation,
   fireAProgressEvent
-} = __nccwpck_require__(4968)
+} = __nccwpck_require__(3610)
 const {
   kState,
   kError,
   kResult,
   kEvents,
   kAborted
-} = __nccwpck_require__(227)
-const { webidl } = __nccwpck_require__(735)
-const { kEnumerableProperty } = __nccwpck_require__(4742)
+} = __nccwpck_require__(961)
+const { webidl } = __nccwpck_require__(5893)
+const { kEnumerableProperty } = __nccwpck_require__(3440)
 
 class FileReader extends EventTarget {
   constructor () {
@@ -26529,13 +26529,13 @@ module.exports = {
 
 /***/ }),
 
-/***/ 1519:
+/***/ 8573:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { webidl } = __nccwpck_require__(735)
+const { webidl } = __nccwpck_require__(5893)
 
 const kState = Symbol('ProgressEvent state')
 
@@ -26615,7 +26615,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 227:
+/***/ 961:
 /***/ ((module) => {
 
 "use strict";
@@ -26633,7 +26633,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 4968:
+/***/ 3610:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -26645,10 +26645,10 @@ const {
   kResult,
   kAborted,
   kLastProgressEventFired
-} = __nccwpck_require__(227)
-const { ProgressEvent } = __nccwpck_require__(1519)
-const { getEncoding } = __nccwpck_require__(4281)
-const { serializeAMimeType, parseMIMEType } = __nccwpck_require__(9634)
+} = __nccwpck_require__(961)
+const { ProgressEvent } = __nccwpck_require__(8573)
+const { getEncoding } = __nccwpck_require__(2607)
+const { serializeAMimeType, parseMIMEType } = __nccwpck_require__(1900)
 const { types } = __nccwpck_require__(7975)
 const { StringDecoder } = __nccwpck_require__(3193)
 const { btoa } = __nccwpck_require__(4573)
@@ -27032,28 +27032,28 @@ module.exports = {
 
 /***/ }),
 
-/***/ 8863:
+/***/ 6897:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { uid, states, sentCloseFrameState, emptyBuffer, opcodes } = __nccwpck_require__(8742)
+const { uid, states, sentCloseFrameState, emptyBuffer, opcodes } = __nccwpck_require__(736)
 const {
   kReadyState,
   kSentClose,
   kByteParser,
   kReceivedClose,
   kResponse
-} = __nccwpck_require__(358)
-const { fireEvent, failWebsocketConnection, isClosing, isClosed, isEstablished, parseExtensions } = __nccwpck_require__(5259)
-const { channels } = __nccwpck_require__(8664)
-const { CloseEvent } = __nccwpck_require__(4194)
-const { makeRequest } = __nccwpck_require__(4309)
-const { fetching } = __nccwpck_require__(2104)
-const { Headers, getHeadersList } = __nccwpck_require__(7386)
-const { getDecodeSplit } = __nccwpck_require__(18)
-const { WebsocketFrameSend } = __nccwpck_require__(6062)
+} = __nccwpck_require__(1216)
+const { fireEvent, failWebsocketConnection, isClosing, isClosed, isEstablished, parseExtensions } = __nccwpck_require__(8625)
+const { channels } = __nccwpck_require__(2414)
+const { CloseEvent } = __nccwpck_require__(5188)
+const { makeRequest } = __nccwpck_require__(9967)
+const { fetching } = __nccwpck_require__(4398)
+const { Headers, getHeadersList } = __nccwpck_require__(660)
+const { getDecodeSplit } = __nccwpck_require__(3168)
+const { WebsocketFrameSend } = __nccwpck_require__(3264)
 
 /** @type {import('crypto')} */
 let crypto
@@ -27411,7 +27411,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 8742:
+/***/ 736:
 /***/ ((module) => {
 
 "use strict";
@@ -27485,15 +27485,15 @@ module.exports = {
 
 /***/ }),
 
-/***/ 4194:
+/***/ 5188:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { webidl } = __nccwpck_require__(735)
-const { kEnumerableProperty } = __nccwpck_require__(4742)
-const { kConstruct } = __nccwpck_require__(7573)
+const { webidl } = __nccwpck_require__(5893)
+const { kEnumerableProperty } = __nccwpck_require__(3440)
+const { kConstruct } = __nccwpck_require__(6443)
 const { MessagePort } = __nccwpck_require__(5919)
 
 /**
@@ -27822,13 +27822,13 @@ module.exports = {
 
 /***/ }),
 
-/***/ 6062:
+/***/ 3264:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { maxUnsigned16Bit } = __nccwpck_require__(8742)
+const { maxUnsigned16Bit } = __nccwpck_require__(736)
 
 const BUFFER_SIZE = 16386
 
@@ -27926,15 +27926,15 @@ module.exports = {
 
 /***/ }),
 
-/***/ 5275:
+/***/ 9469:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 const { createInflateRaw, Z_DEFAULT_WINDOWBITS } = __nccwpck_require__(8522)
-const { isValidClientWindowBits } = __nccwpck_require__(5259)
-const { MessageSizeExceededError } = __nccwpck_require__(7013)
+const { isValidClientWindowBits } = __nccwpck_require__(8625)
+const { MessageSizeExceededError } = __nccwpck_require__(8707)
 
 const tail = Buffer.from([0x00, 0x00, 0xff, 0xff])
 const kBuffer = Symbol('kBuffer')
@@ -28052,7 +28052,7 @@ module.exports = { PerMessageDeflate }
 
 /***/ }),
 
-/***/ 9646:
+/***/ 1652:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -28060,9 +28060,9 @@ module.exports = { PerMessageDeflate }
 
 const { Writable } = __nccwpck_require__(7075)
 const assert = __nccwpck_require__(4589)
-const { parserStates, opcodes, states, emptyBuffer, sentCloseFrameState } = __nccwpck_require__(8742)
-const { kReadyState, kSentClose, kResponse, kReceivedClose } = __nccwpck_require__(358)
-const { channels } = __nccwpck_require__(8664)
+const { parserStates, opcodes, states, emptyBuffer, sentCloseFrameState } = __nccwpck_require__(736)
+const { kReadyState, kSentClose, kResponse, kReceivedClose } = __nccwpck_require__(1216)
+const { channels } = __nccwpck_require__(2414)
 const {
   isValidStatusCode,
   isValidOpcode,
@@ -28072,10 +28072,10 @@ const {
   isControlFrame,
   isTextBinaryFrame,
   isContinuationFrame
-} = __nccwpck_require__(5259)
-const { WebsocketFrameSend } = __nccwpck_require__(6062)
-const { closeWebSocketConnection } = __nccwpck_require__(8863)
-const { PerMessageDeflate } = __nccwpck_require__(5275)
+} = __nccwpck_require__(8625)
+const { WebsocketFrameSend } = __nccwpck_require__(3264)
+const { closeWebSocketConnection } = __nccwpck_require__(6897)
+const { PerMessageDeflate } = __nccwpck_require__(9469)
 
 // This code was influenced by ws released under the MIT license.
 // Copyright (c) 2011 Einar Otto Stangvik <einaros@gmail.com>
@@ -28487,15 +28487,15 @@ module.exports = {
 
 /***/ }),
 
-/***/ 8002:
+/***/ 3900:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { WebsocketFrameSend } = __nccwpck_require__(6062)
-const { opcodes, sendHints } = __nccwpck_require__(8742)
-const FixedQueue = __nccwpck_require__(7842)
+const { WebsocketFrameSend } = __nccwpck_require__(3264)
+const { opcodes, sendHints } = __nccwpck_require__(736)
+const FixedQueue = __nccwpck_require__(4660)
 
 /** @type {typeof Uint8Array} */
 const FastBuffer = Buffer[Symbol.species]
@@ -28599,7 +28599,7 @@ module.exports = { SendQueue }
 
 /***/ }),
 
-/***/ 358:
+/***/ 1216:
 /***/ ((module) => {
 
 "use strict";
@@ -28619,17 +28619,17 @@ module.exports = {
 
 /***/ }),
 
-/***/ 5259:
+/***/ 8625:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { kReadyState, kController, kResponse, kBinaryType, kWebSocketURL } = __nccwpck_require__(358)
-const { states, opcodes } = __nccwpck_require__(8742)
-const { ErrorEvent, createFastMessageEvent } = __nccwpck_require__(4194)
+const { kReadyState, kController, kResponse, kBinaryType, kWebSocketURL } = __nccwpck_require__(1216)
+const { states, opcodes } = __nccwpck_require__(736)
+const { ErrorEvent, createFastMessageEvent } = __nccwpck_require__(5188)
 const { isUtf8 } = __nccwpck_require__(4573)
-const { collectASequenceOfCodePointsFast, removeHTTPWhitespace } = __nccwpck_require__(9634)
+const { collectASequenceOfCodePointsFast, removeHTTPWhitespace } = __nccwpck_require__(1900)
 
 /* globals Blob */
 
@@ -28949,16 +28949,16 @@ module.exports = {
 
 /***/ }),
 
-/***/ 564:
+/***/ 3726:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { webidl } = __nccwpck_require__(735)
-const { URLSerializer } = __nccwpck_require__(9634)
-const { environmentSettingsObject } = __nccwpck_require__(18)
-const { staticPropertyDescriptors, states, sentCloseFrameState, sendHints } = __nccwpck_require__(8742)
+const { webidl } = __nccwpck_require__(5893)
+const { URLSerializer } = __nccwpck_require__(1900)
+const { environmentSettingsObject } = __nccwpck_require__(3168)
+const { staticPropertyDescriptors, states, sentCloseFrameState, sendHints } = __nccwpck_require__(736)
 const {
   kWebSocketURL,
   kReadyState,
@@ -28967,21 +28967,21 @@ const {
   kResponse,
   kSentClose,
   kByteParser
-} = __nccwpck_require__(358)
+} = __nccwpck_require__(1216)
 const {
   isConnecting,
   isEstablished,
   isClosing,
   isValidSubprotocol,
   fireEvent
-} = __nccwpck_require__(5259)
-const { establishWebSocketConnection, closeWebSocketConnection } = __nccwpck_require__(8863)
-const { ByteParser } = __nccwpck_require__(9646)
-const { kEnumerableProperty, isBlobLike } = __nccwpck_require__(4742)
-const { getGlobalDispatcher } = __nccwpck_require__(3723)
+} = __nccwpck_require__(8625)
+const { establishWebSocketConnection, closeWebSocketConnection } = __nccwpck_require__(6897)
+const { ByteParser } = __nccwpck_require__(1652)
+const { kEnumerableProperty, isBlobLike } = __nccwpck_require__(3440)
+const { getGlobalDispatcher } = __nccwpck_require__(2581)
 const { types } = __nccwpck_require__(7975)
-const { ErrorEvent, CloseEvent } = __nccwpck_require__(4194)
-const { SendQueue } = __nccwpck_require__(8002)
+const { ErrorEvent, CloseEvent } = __nccwpck_require__(5188)
+const { SendQueue } = __nccwpck_require__(3900)
 
 // https://websockets.spec.whatwg.org/#interface-definition
 class WebSocket extends EventTarget {
@@ -29545,7 +29545,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 430:
+/***/ 9665:
 /***/ ((module) => {
 
 module.exports = eval("require")("./swc.android-arm-eabi.node");
@@ -29553,7 +29553,7 @@ module.exports = eval("require")("./swc.android-arm-eabi.node");
 
 /***/ }),
 
-/***/ 4528:
+/***/ 8685:
 /***/ ((module) => {
 
 module.exports = eval("require")("./swc.android-arm64.node");
@@ -29561,7 +29561,7 @@ module.exports = eval("require")("./swc.android-arm64.node");
 
 /***/ }),
 
-/***/ 4000:
+/***/ 475:
 /***/ ((module) => {
 
 module.exports = eval("require")("./swc.darwin-arm64.node");
@@ -29569,7 +29569,7 @@ module.exports = eval("require")("./swc.darwin-arm64.node");
 
 /***/ }),
 
-/***/ 8533:
+/***/ 8818:
 /***/ ((module) => {
 
 module.exports = eval("require")("./swc.darwin-universal.node");
@@ -29577,7 +29577,7 @@ module.exports = eval("require")("./swc.darwin-universal.node");
 
 /***/ }),
 
-/***/ 3530:
+/***/ 8009:
 /***/ ((module) => {
 
 module.exports = eval("require")("./swc.darwin-x64.node");
@@ -29585,7 +29585,7 @@ module.exports = eval("require")("./swc.darwin-x64.node");
 
 /***/ }),
 
-/***/ 3588:
+/***/ 3873:
 /***/ ((module) => {
 
 module.exports = eval("require")("./swc.freebsd-arm64.node");
@@ -29593,7 +29593,7 @@ module.exports = eval("require")("./swc.freebsd-arm64.node");
 
 /***/ }),
 
-/***/ 9638:
+/***/ 3291:
 /***/ ((module) => {
 
 module.exports = eval("require")("./swc.freebsd-x64.node");
@@ -29601,7 +29601,7 @@ module.exports = eval("require")("./swc.freebsd-x64.node");
 
 /***/ }),
 
-/***/ 91:
+/***/ 7222:
 /***/ ((module) => {
 
 module.exports = eval("require")("./swc.linux-arm-gnueabihf.node");
@@ -29609,7 +29609,7 @@ module.exports = eval("require")("./swc.linux-arm-gnueabihf.node");
 
 /***/ }),
 
-/***/ 1464:
+/***/ 8337:
 /***/ ((module) => {
 
 module.exports = eval("require")("./swc.linux-arm64-gnu.node");
@@ -29617,7 +29617,7 @@ module.exports = eval("require")("./swc.linux-arm64-gnu.node");
 
 /***/ }),
 
-/***/ 4073:
+/***/ 7602:
 /***/ ((module) => {
 
 module.exports = eval("require")("./swc.linux-arm64-musl.node");
@@ -29625,7 +29625,7 @@ module.exports = eval("require")("./swc.linux-arm64-musl.node");
 
 /***/ }),
 
-/***/ 1887:
+/***/ 1446:
 /***/ ((module) => {
 
 module.exports = eval("require")("./swc.linux-ppc64-gnu.node");
@@ -29633,7 +29633,7 @@ module.exports = eval("require")("./swc.linux-ppc64-gnu.node");
 
 /***/ }),
 
-/***/ 1553:
+/***/ 9312:
 /***/ ((module) => {
 
 module.exports = eval("require")("./swc.linux-riscv64-gnu.node");
@@ -29641,7 +29641,7 @@ module.exports = eval("require")("./swc.linux-riscv64-gnu.node");
 
 /***/ }),
 
-/***/ 6786:
+/***/ 8593:
 /***/ ((module) => {
 
 module.exports = eval("require")("./swc.linux-riscv64-musl.node");
@@ -29649,7 +29649,7 @@ module.exports = eval("require")("./swc.linux-riscv64-musl.node");
 
 /***/ }),
 
-/***/ 5217:
+/***/ 2644:
 /***/ ((module) => {
 
 module.exports = eval("require")("./swc.linux-s390x-gnu.node");
@@ -29657,7 +29657,7 @@ module.exports = eval("require")("./swc.linux-s390x-gnu.node");
 
 /***/ }),
 
-/***/ 5146:
+/***/ 4675:
 /***/ ((module) => {
 
 module.exports = eval("require")("./swc.linux-x64-gnu.node");
@@ -29665,7 +29665,7 @@ module.exports = eval("require")("./swc.linux-x64-gnu.node");
 
 /***/ }),
 
-/***/ 3795:
+/***/ 2356:
 /***/ ((module) => {
 
 module.exports = eval("require")("./swc.linux-x64-musl.node");
@@ -29673,7 +29673,7 @@ module.exports = eval("require")("./swc.linux-x64-musl.node");
 
 /***/ }),
 
-/***/ 300:
+/***/ 6681:
 /***/ ((module) => {
 
 module.exports = eval("require")("./swc.wasi.cjs");
@@ -29681,7 +29681,7 @@ module.exports = eval("require")("./swc.wasi.cjs");
 
 /***/ }),
 
-/***/ 6640:
+/***/ 3535:
 /***/ ((module) => {
 
 module.exports = eval("require")("./swc.win32-arm64-msvc.node");
@@ -29689,7 +29689,7 @@ module.exports = eval("require")("./swc.win32-arm64-msvc.node");
 
 /***/ }),
 
-/***/ 5017:
+/***/ 8152:
 /***/ ((module) => {
 
 module.exports = eval("require")("./swc.win32-ia32-msvc.node");
@@ -29697,7 +29697,7 @@ module.exports = eval("require")("./swc.win32-ia32-msvc.node");
 
 /***/ }),
 
-/***/ 802:
+/***/ 2665:
 /***/ ((module) => {
 
 module.exports = eval("require")("./swc.win32-x64-msvc.node");
@@ -29705,7 +29705,7 @@ module.exports = eval("require")("./swc.win32-x64-msvc.node");
 
 /***/ }),
 
-/***/ 694:
+/***/ 727:
 /***/ ((module) => {
 
 module.exports = eval("require")("@swc/core-android-arm-eabi");
@@ -29713,7 +29713,7 @@ module.exports = eval("require")("@swc/core-android-arm-eabi");
 
 /***/ }),
 
-/***/ 6212:
+/***/ 607:
 /***/ ((module) => {
 
 module.exports = eval("require")("@swc/core-android-arm64");
@@ -29721,7 +29721,7 @@ module.exports = eval("require")("@swc/core-android-arm64");
 
 /***/ }),
 
-/***/ 2560:
+/***/ 5049:
 /***/ ((module) => {
 
 module.exports = eval("require")("@swc/core-darwin-arm64");
@@ -29729,7 +29729,7 @@ module.exports = eval("require")("@swc/core-darwin-arm64");
 
 /***/ }),
 
-/***/ 9963:
+/***/ 3890:
 /***/ ((module) => {
 
 module.exports = eval("require")("@swc/core-darwin-universal");
@@ -29737,7 +29737,7 @@ module.exports = eval("require")("@swc/core-darwin-universal");
 
 /***/ }),
 
-/***/ 2766:
+/***/ 8139:
 /***/ ((module) => {
 
 module.exports = eval("require")("@swc/core-darwin-x64");
@@ -29745,7 +29745,7 @@ module.exports = eval("require")("@swc/core-darwin-x64");
 
 /***/ }),
 
-/***/ 7860:
+/***/ 5367:
 /***/ ((module) => {
 
 module.exports = eval("require")("@swc/core-freebsd-arm64");
@@ -29753,7 +29753,7 @@ module.exports = eval("require")("@swc/core-freebsd-arm64");
 
 /***/ }),
 
-/***/ 3242:
+/***/ 6229:
 /***/ ((module) => {
 
 module.exports = eval("require")("@swc/core-freebsd-x64");
@@ -29761,7 +29761,7 @@ module.exports = eval("require")("@swc/core-freebsd-x64");
 
 /***/ }),
 
-/***/ 1225:
+/***/ 1638:
 /***/ ((module) => {
 
 module.exports = eval("require")("@swc/core-linux-arm-gnueabihf");
@@ -29769,7 +29769,7 @@ module.exports = eval("require")("@swc/core-linux-arm-gnueabihf");
 
 /***/ }),
 
-/***/ 6244:
+/***/ 6571:
 /***/ ((module) => {
 
 module.exports = eval("require")("@swc/core-linux-arm64-gnu");
@@ -29777,7 +29777,7 @@ module.exports = eval("require")("@swc/core-linux-arm64-gnu");
 
 /***/ }),
 
-/***/ 7915:
+/***/ 5254:
 /***/ ((module) => {
 
 module.exports = eval("require")("@swc/core-linux-arm64-musl");
@@ -29785,7 +29785,7 @@ module.exports = eval("require")("@swc/core-linux-arm64-musl");
 
 /***/ }),
 
-/***/ 1329:
+/***/ 3586:
 /***/ ((module) => {
 
 module.exports = eval("require")("@swc/core-linux-ppc64-gnu");
@@ -29793,7 +29793,7 @@ module.exports = eval("require")("@swc/core-linux-ppc64-gnu");
 
 /***/ }),
 
-/***/ 8199:
+/***/ 9008:
 /***/ ((module) => {
 
 module.exports = eval("require")("@swc/core-linux-riscv64-gnu");
@@ -29801,7 +29801,7 @@ module.exports = eval("require")("@swc/core-linux-riscv64-gnu");
 
 /***/ }),
 
-/***/ 5930:
+/***/ 8879:
 /***/ ((module) => {
 
 module.exports = eval("require")("@swc/core-linux-riscv64-musl");
@@ -29809,7 +29809,7 @@ module.exports = eval("require")("@swc/core-linux-riscv64-musl");
 
 /***/ }),
 
-/***/ 6635:
+/***/ 8600:
 /***/ ((module) => {
 
 module.exports = eval("require")("@swc/core-linux-s390x-gnu");
@@ -29817,7 +29817,7 @@ module.exports = eval("require")("@swc/core-linux-s390x-gnu");
 
 /***/ }),
 
-/***/ 746:
+/***/ 7793:
 /***/ ((module) => {
 
 module.exports = eval("require")("@swc/core-linux-x64-gnu");
@@ -29825,7 +29825,7 @@ module.exports = eval("require")("@swc/core-linux-x64-gnu");
 
 /***/ }),
 
-/***/ 5169:
+/***/ 6900:
 /***/ ((module) => {
 
 module.exports = eval("require")("@swc/core-linux-x64-musl");
@@ -29833,7 +29833,7 @@ module.exports = eval("require")("@swc/core-linux-x64-musl");
 
 /***/ }),
 
-/***/ 7722:
+/***/ 9301:
 /***/ ((module) => {
 
 module.exports = eval("require")("@swc/core-wasm32-wasi");
@@ -29841,7 +29841,7 @@ module.exports = eval("require")("@swc/core-wasm32-wasi");
 
 /***/ }),
 
-/***/ 6200:
+/***/ 293:
 /***/ ((module) => {
 
 module.exports = eval("require")("@swc/core-win32-arm64-msvc");
@@ -29849,7 +29849,7 @@ module.exports = eval("require")("@swc/core-win32-arm64-msvc");
 
 /***/ }),
 
-/***/ 7411:
+/***/ 1612:
 /***/ ((module) => {
 
 module.exports = eval("require")("@swc/core-win32-ia32-msvc");
@@ -29857,7 +29857,7 @@ module.exports = eval("require")("@swc/core-win32-ia32-msvc");
 
 /***/ }),
 
-/***/ 4196:
+/***/ 5855:
 /***/ ((module) => {
 
 module.exports = eval("require")("@swc/wasm");
@@ -30113,7 +30113,7 @@ module.exports = require("util");
 
 /***/ }),
 
-/***/ 2602:
+/***/ 1120:
 /***/ ((module) => {
 
 "use strict";
@@ -30291,7 +30291,7 @@ __webpack_unused_export__ = defaultContentType
 
 /***/ }),
 
-/***/ 6662:
+/***/ 155:
 /***/ ((module) => {
 
 "use strict";
@@ -30373,7 +30373,7 @@ var __webpack_exports__ = {};
 
 ;// CONCATENATED MODULE: external "os"
 const external_os_namespaceObject = require("os");
-;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/@actions/core/lib/utils.js
+;// CONCATENATED MODULE: ./node_modules/@actions/core/lib/utils.js
 // We use any as a valid input type
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /**
@@ -30409,7 +30409,7 @@ function utils_toCommandProperties(annotationProperties) {
     };
 }
 //# sourceMappingURL=utils.js.map
-;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/@actions/core/lib/command.js
+;// CONCATENATED MODULE: ./node_modules/@actions/core/lib/command.js
 
 
 /**
@@ -30505,7 +30505,7 @@ function escapeProperty(s) {
 const external_crypto_namespaceObject = require("crypto");
 // EXTERNAL MODULE: external "fs"
 var external_fs_ = __nccwpck_require__(9896);
-;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/@actions/core/lib/file-command.js
+;// CONCATENATED MODULE: ./node_modules/@actions/core/lib/file-command.js
 // For internal use, subject to change.
 // We use any as a valid input type
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -30546,7 +30546,7 @@ var external_path_ = __nccwpck_require__(6928);
 var external_http_ = __nccwpck_require__(8611);
 // EXTERNAL MODULE: external "https"
 var external_https_ = __nccwpck_require__(5692);
-;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/@actions/core/node_modules/@actions/http-client/lib/proxy.js
+;// CONCATENATED MODULE: ./node_modules/@actions/core/node_modules/@actions/http-client/lib/proxy.js
 function getProxyUrl(reqUrl) {
     const usingSsl = reqUrl.protocol === 'https:';
     if (checkBypass(reqUrl)) {
@@ -30637,11 +30637,11 @@ class DecodedURL extends URL {
     }
 }
 //# sourceMappingURL=proxy.js.map
-// EXTERNAL MODULE: ../../Users/david/Projects/trailhead/node_modules/tunnel/index.js
-var node_modules_tunnel = __nccwpck_require__(6628);
-// EXTERNAL MODULE: ../../Users/david/Projects/trailhead/node_modules/undici/index.js
-var undici = __nccwpck_require__(4258);
-;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/@actions/core/node_modules/@actions/http-client/lib/index.js
+// EXTERNAL MODULE: ./node_modules/tunnel/index.js
+var node_modules_tunnel = __nccwpck_require__(770);
+// EXTERNAL MODULE: ./node_modules/undici/index.js
+var undici = __nccwpck_require__(6752);
+;// CONCATENATED MODULE: ./node_modules/@actions/core/node_modules/@actions/http-client/lib/index.js
 /* eslint-disable @typescript-eslint/no-explicit-any */
 var __awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
@@ -31338,7 +31338,7 @@ class lib_HttpClient {
 }
 const lowercaseKeys = (obj) => Object.keys(obj).reduce((c, k) => ((c[k.toLowerCase()] = obj[k]), c), {});
 //# sourceMappingURL=index.js.map
-;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/@actions/core/node_modules/@actions/http-client/lib/auth.js
+;// CONCATENATED MODULE: ./node_modules/@actions/core/node_modules/@actions/http-client/lib/auth.js
 var auth_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -31414,7 +31414,7 @@ class PersonalAccessTokenCredentialHandler {
     }
 }
 //# sourceMappingURL=auth.js.map
-;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/@actions/core/lib/oidc-utils.js
+;// CONCATENATED MODULE: ./node_modules/@actions/core/lib/oidc-utils.js
 var oidc_utils_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -31488,7 +31488,7 @@ class oidc_utils_OidcClient {
     }
 }
 //# sourceMappingURL=oidc-utils.js.map
-;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/@actions/core/lib/summary.js
+;// CONCATENATED MODULE: ./node_modules/@actions/core/lib/summary.js
 var summary_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -31769,7 +31769,7 @@ const _summary = new Summary();
 const markdownSummary = (/* unused pure expression or super */ null && (_summary));
 const summary = _summary;
 //# sourceMappingURL=summary.js.map
-;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/@actions/core/lib/path-utils.js
+;// CONCATENATED MODULE: ./node_modules/@actions/core/lib/path-utils.js
 
 /**
  * toPosixPath converts the given path to the posix form. On Windows, \\ will be
@@ -31811,7 +31811,7 @@ var external_events_ = __nccwpck_require__(4434);
 var external_child_process_ = __nccwpck_require__(5317);
 // EXTERNAL MODULE: external "assert"
 var external_assert_ = __nccwpck_require__(2613);
-;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/@actions/io/lib/io-util.js
+;// CONCATENATED MODULE: ./node_modules/@actions/io/lib/io-util.js
 var io_util_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -31991,7 +31991,7 @@ function getCmdPath() {
     return (_a = process.env['COMSPEC']) !== null && _a !== void 0 ? _a : `cmd.exe`;
 }
 //# sourceMappingURL=io-util.js.map
-;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/@actions/io/lib/io.js
+;// CONCATENATED MODULE: ./node_modules/@actions/io/lib/io.js
 var io_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -32265,7 +32265,7 @@ function io_copyFile(srcFile, destFile, force) {
 //# sourceMappingURL=io.js.map
 ;// CONCATENATED MODULE: external "timers"
 const external_timers_namespaceObject = require("timers");
-;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/@actions/exec/lib/toolrunner.js
+;// CONCATENATED MODULE: ./node_modules/@actions/exec/lib/toolrunner.js
 var toolrunner_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -32853,7 +32853,7 @@ class ExecState extends external_events_.EventEmitter {
     }
 }
 //# sourceMappingURL=toolrunner.js.map
-;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/@actions/exec/lib/exec.js
+;// CONCATENATED MODULE: ./node_modules/@actions/exec/lib/exec.js
 var exec_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -32933,7 +32933,7 @@ function getExecOutput(commandLine, args, options) {
     });
 }
 //# sourceMappingURL=exec.js.map
-;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/@actions/core/lib/platform.js
+;// CONCATENATED MODULE: ./node_modules/@actions/core/lib/platform.js
 var platform_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -32998,7 +32998,7 @@ function getDetails() {
     });
 }
 //# sourceMappingURL=platform.js.map
-;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/@actions/core/lib/core.js
+;// CONCATENATED MODULE: ./node_modules/@actions/core/lib/core.js
 var core_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -33316,7 +33316,7 @@ function getIDToken(aud) {
  */
 
 //# sourceMappingURL=core.js.map
-;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/@actions/github/lib/context.js
+;// CONCATENATED MODULE: ./node_modules/@actions/github/lib/context.js
 
 
 class Context {
@@ -33369,9 +33369,9 @@ class Context {
     }
 }
 //# sourceMappingURL=context.js.map
-// EXTERNAL MODULE: ../../Users/david/Projects/trailhead/node_modules/@actions/http-client/lib/index.js
-var lib = __nccwpck_require__(4866);
-;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/@actions/github/lib/internal/utils.js
+// EXTERNAL MODULE: ./node_modules/@actions/http-client/lib/index.js
+var lib = __nccwpck_require__(4844);
+;// CONCATENATED MODULE: ./node_modules/@actions/github/lib/internal/utils.js
 var utils_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -33424,7 +33424,7 @@ function getUserAgentWithOrchestrationId(baseUserAgent) {
     return baseUserAgent;
 }
 //# sourceMappingURL=utils.js.map
-;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/universal-user-agent/index.js
+;// CONCATENATED MODULE: ./node_modules/universal-user-agent/index.js
 function getUserAgent() {
   if (typeof navigator === "object" && "userAgent" in navigator) {
     return navigator.userAgent;
@@ -33439,7 +33439,7 @@ function getUserAgent() {
   return "<environment undetectable>";
 }
 
-;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/before-after-hook/lib/register.js
+;// CONCATENATED MODULE: ./node_modules/before-after-hook/lib/register.js
 // @ts-check
 
 function register(state, name, method, options) {
@@ -33468,7 +33468,7 @@ function register(state, name, method, options) {
   });
 }
 
-;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/before-after-hook/lib/add.js
+;// CONCATENATED MODULE: ./node_modules/before-after-hook/lib/add.js
 // @ts-check
 
 function addHook(state, kind, name, hook) {
@@ -33516,7 +33516,7 @@ function addHook(state, kind, name, hook) {
   });
 }
 
-;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/before-after-hook/lib/remove.js
+;// CONCATENATED MODULE: ./node_modules/before-after-hook/lib/remove.js
 // @ts-check
 
 function removeHook(state, name, method) {
@@ -33537,7 +33537,7 @@ function removeHook(state, name, method) {
   state.registry[name].splice(index, 1);
 }
 
-;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/before-after-hook/index.js
+;// CONCATENATED MODULE: ./node_modules/before-after-hook/index.js
 // @ts-check
 
 
@@ -33584,7 +33584,7 @@ function Collection() {
 
 /* harmony default export */ const before_after_hook = ({ Singular, Collection });
 
-;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/@octokit/endpoint/dist-bundle/index.js
+;// CONCATENATED MODULE: ./node_modules/@octokit/endpoint/dist-bundle/index.js
 // pkg/dist-src/defaults.js
 
 
@@ -33930,9 +33930,9 @@ function withDefaults(oldDefaults, newDefaults) {
 var endpoint = withDefaults(null, DEFAULTS);
 
 
-// EXTERNAL MODULE: ../../Users/david/Projects/trailhead/node_modules/fast-content-type-parse/index.js
-var fast_content_type_parse = __nccwpck_require__(2602);
-;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/json-with-bigint/json-with-bigint.js
+// EXTERNAL MODULE: ./node_modules/fast-content-type-parse/index.js
+var fast_content_type_parse = __nccwpck_require__(1120);
+;// CONCATENATED MODULE: ./node_modules/json-with-bigint/json-with-bigint.js
 const intRegex = /^-?\d+$/;
 const noiseValue = /^-?\d+n+$/; // Noise - strings that match the custom format before being converted to it
 const originalStringify = JSON.stringify;
@@ -34149,7 +34149,7 @@ const JSONParse = (text, reviver) => {
 
 
 
-;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/@octokit/request-error/dist-src/index.js
+;// CONCATENATED MODULE: ./node_modules/@octokit/request-error/dist-src/index.js
 class RequestError extends Error {
   name;
   /**
@@ -34190,7 +34190,7 @@ class RequestError extends Error {
 }
 
 
-;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/@octokit/request/dist-bundle/index.js
+;// CONCATENATED MODULE: ./node_modules/@octokit/request/dist-bundle/index.js
 // pkg/dist-src/index.js
 
 
@@ -34393,7 +34393,7 @@ var request = dist_bundle_withDefaults(endpoint, defaults_default);
 /* v8 ignore next -- @preserve */
 /* v8 ignore else -- @preserve */
 
-;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/@octokit/graphql/dist-bundle/index.js
+;// CONCATENATED MODULE: ./node_modules/@octokit/graphql/dist-bundle/index.js
 // pkg/dist-src/index.js
 
 
@@ -34520,7 +34520,7 @@ function withCustomRequest(customRequest) {
 }
 
 
-;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/@octokit/auth-token/dist-bundle/index.js
+;// CONCATENATED MODULE: ./node_modules/@octokit/auth-token/dist-bundle/index.js
 // pkg/dist-src/is-jwt.js
 var b64url = "(?:[a-zA-Z0-9_-]+)";
 var sep = "\\.";
@@ -34575,11 +34575,11 @@ var createTokenAuth = function createTokenAuth2(token) {
 };
 
 
-;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/@octokit/core/dist-src/version.js
+;// CONCATENATED MODULE: ./node_modules/@octokit/core/dist-src/version.js
 const version_VERSION = "7.0.6";
 
 
-;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/@octokit/core/dist-src/index.js
+;// CONCATENATED MODULE: ./node_modules/@octokit/core/dist-src/index.js
 
 
 
@@ -34720,12 +34720,12 @@ class Octokit {
 }
 
 
-;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/@octokit/plugin-rest-endpoint-methods/dist-src/version.js
+;// CONCATENATED MODULE: ./node_modules/@octokit/plugin-rest-endpoint-methods/dist-src/version.js
 const dist_src_version_VERSION = "17.0.0";
 
 //# sourceMappingURL=version.js.map
 
-;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/@octokit/plugin-rest-endpoint-methods/dist-src/generated/endpoints.js
+;// CONCATENATED MODULE: ./node_modules/@octokit/plugin-rest-endpoint-methods/dist-src/generated/endpoints.js
 const Endpoints = {
   actions: {
     addCustomLabelsToSelfHostedRunnerForOrg: [
@@ -37019,7 +37019,7 @@ var endpoints_default = Endpoints;
 
 //# sourceMappingURL=endpoints.js.map
 
-;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/@octokit/plugin-rest-endpoint-methods/dist-src/endpoints-to-methods.js
+;// CONCATENATED MODULE: ./node_modules/@octokit/plugin-rest-endpoint-methods/dist-src/endpoints-to-methods.js
 
 const endpointMethodsMap = /* @__PURE__ */ new Map();
 for (const [scope, endpoints] of Object.entries(endpoints_default)) {
@@ -37145,7 +37145,7 @@ function decorate(octokit, scope, methodName, defaults, decorations) {
 
 //# sourceMappingURL=endpoints-to-methods.js.map
 
-;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/@octokit/plugin-rest-endpoint-methods/dist-src/index.js
+;// CONCATENATED MODULE: ./node_modules/@octokit/plugin-rest-endpoint-methods/dist-src/index.js
 
 
 function restEndpointMethods(octokit) {
@@ -37166,7 +37166,7 @@ legacyRestEndpointMethods.VERSION = dist_src_version_VERSION;
 
 //# sourceMappingURL=index.js.map
 
-;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/@octokit/plugin-paginate-rest/dist-bundle/index.js
+;// CONCATENATED MODULE: ./node_modules/@octokit/plugin-paginate-rest/dist-bundle/index.js
 // pkg/dist-src/version.js
 var plugin_paginate_rest_dist_bundle_VERSION = "0.0.0-development";
 
@@ -37578,7 +37578,7 @@ function paginateRest(octokit) {
 paginateRest.VERSION = plugin_paginate_rest_dist_bundle_VERSION;
 
 
-;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/@actions/github/lib/utils.js
+;// CONCATENATED MODULE: ./node_modules/@actions/github/lib/utils.js
 
 
 // octokit + plugins
@@ -37617,7 +37617,7 @@ function getOctokitOptions(token, options) {
     return opts;
 }
 //# sourceMappingURL=utils.js.map
-;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/@actions/github/lib/github.js
+;// CONCATENATED MODULE: ./node_modules/@actions/github/lib/github.js
 
 
 const github_context = new Context();
@@ -37632,7 +37632,7 @@ function getOctokit(token, options, ...additionalPlugins) {
     return new GitHubWithPlugins(getOctokitOptions(token, options));
 }
 //# sourceMappingURL=github.js.map
-;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/zod/v3/helpers/util.js
+;// CONCATENATED MODULE: ./node_modules/zod/v3/helpers/util.js
 var util;
 (function (util) {
     util.assertEqual = (_) => { };
@@ -37767,7 +37767,7 @@ const getParsedType = (data) => {
     }
 };
 
-;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/zod/v3/ZodError.js
+;// CONCATENATED MODULE: ./node_modules/zod/v3/ZodError.js
 
 const ZodIssueCode = util.arrayToEnum([
     "invalid_type",
@@ -37902,7 +37902,7 @@ ZodError.create = (issues) => {
     return error;
 };
 
-;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/zod/v3/locales/en.js
+;// CONCATENATED MODULE: ./node_modules/zod/v3/locales/en.js
 
 
 const errorMap = (issue, _ctx) => {
@@ -38013,7 +38013,7 @@ const errorMap = (issue, _ctx) => {
 };
 /* harmony default export */ const en = (errorMap);
 
-;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/zod/v3/errors.js
+;// CONCATENATED MODULE: ./node_modules/zod/v3/errors.js
 
 let overrideErrorMap = en;
 
@@ -38024,7 +38024,7 @@ function getErrorMap() {
     return overrideErrorMap;
 }
 
-;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/zod/v3/helpers/errorUtil.js
+;// CONCATENATED MODULE: ./node_modules/zod/v3/helpers/errorUtil.js
 var errorUtil;
 (function (errorUtil) {
     errorUtil.errToObj = (message) => typeof message === "string" ? { message } : message || {};
@@ -38032,7 +38032,7 @@ var errorUtil;
     errorUtil.toString = (message) => typeof message === "string" ? message : message?.message;
 })(errorUtil || (errorUtil = {}));
 
-;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/zod/v3/helpers/parseUtil.js
+;// CONCATENATED MODULE: ./node_modules/zod/v3/helpers/parseUtil.js
 
 
 const makeIssue = (params) => {
@@ -38143,7 +38143,7 @@ const isDirty = (x) => x.status === "dirty";
 const isValid = (x) => x.status === "valid";
 const isAsync = (x) => typeof Promise !== "undefined" && x instanceof Promise;
 
-;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/zod/v3/types.js
+;// CONCATENATED MODULE: ./node_modules/zod/v3/types.js
 
 
 
@@ -41893,12 +41893,30 @@ const CiCheckStatusEnum = enumType([
     "stale",
     "missing",
 ]);
+// ADR-011 §2 — input relevance. ADR-009's status says what a check DID; the
+// disposition says what it MEANS for this release decision. `missing_blocking`
+// is derived (ADR-009 `missing` on a blocking input), never configured.
+const InputDispositionKind = enumType([
+    "blocking",
+    "advisory",
+    "irrelevant",
+    "missing_blocking",
+]);
+const InputDisposition = objectType({
+    kind: InputDispositionKind,
+    reason: stringType().optional(),
+    /** `policy` = an input_relevance entry matched; `default` = required/optional fallback. */
+    source: enumType(["policy", "default"]),
+});
 const CiCheck = objectType({
     name: stringType(),
     status: CiCheckStatusEnum,
     conclusion: stringType().optional(),
     detailsUrl: stringType().url().optional(),
     required: booleanType(),
+    // Optional: summaries produced before dispositions are applied (and every
+    // pre-ADR-011 stored evaluation) carry none, and fall back to `required`.
+    disposition: InputDisposition.optional(),
 });
 const CiSummary = objectType({
     checks: arrayType(CiCheck),
@@ -42008,6 +42026,9 @@ const PolicyOverrideChanges = objectType({
     warnThreshold: numberType().min(0).max(100).optional(),
     releaseReady: literalType(true).optional(),
 });
+const OverrideScope = enumType(["full", "risk_only"]);
+// ADR-011 §3 renders the override record as {by, at, scope, rationale};
+// this schema carries by=owner, at=appliedAt, rationale=reason, plus scope.
 const PolicyOverrideAudit = objectType({
     source: enumType(["workflow", "label"]).default("workflow"),
     owner: stringType(),
@@ -42015,10 +42036,58 @@ const PolicyOverrideAudit = objectType({
     linkedTicket: stringType(),
     expiresAt: stringType(),
     appliedAt: stringType(),
+    // Optional, not defaulted: audits stored before ADR-011 carry no scope and
+    // must keep parsing as the pre-ADR-011 (full) override they actually were.
+    scope: OverrideScope.optional(),
     changes: PolicyOverrideChanges.default({}),
     preOverrideDecision: GateDecision.optional(),
     preOverrideReleaseReady: booleanType().optional(),
     preOverrideReasons: arrayType(stringType()).optional(),
+    /** Blocking reasons the override cleared (risk/policy driven). */
+    overriddenReasons: arrayType(stringType()).optional(),
+    /** Blocking reasons that survived the override (mechanical CI, ADR-011 §3). */
+    retainedReasons: arrayType(stringType()).optional(),
+});
+// ---------------------------------------------------------------------------
+// ADR-011 §1 — the Release Brief
+// ---------------------------------------------------------------------------
+const BriefVerdict = enumType(["allow", "warn", "block", "cannot_evaluate"]);
+const BriefFinding = objectType({
+    id: stringType(),
+    title: stringType(),
+    evidence: stringType().optional(),
+    severity: RemediationSeverity,
+});
+const BriefInput = objectType({
+    checkName: stringType(),
+    /** ADR-009 status, carried as a string so the renderer stays policy-agnostic. */
+    status: stringType(),
+    /** ADR-011 §2 disposition kind. */
+    disposition: stringType(),
+    reason: stringType().optional(),
+});
+const BriefAction = objectType({
+    kind: enumType(["fix", "override", "wait"]),
+    detail: stringType(),
+    link: stringType().optional(),
+});
+const BriefOverride = objectType({
+    by: stringType(),
+    at: stringType(),
+    scope: stringType(),
+    rationale: stringType(),
+});
+const ReleaseBrief = objectType({
+    verdict: BriefVerdict,
+    riskScore: numberType().optional(),
+    riskThreshold: numberType().optional(),
+    topMovers: arrayType(objectType({ factor: stringType(), score: numberType() })).optional(),
+    findings: arrayType(BriefFinding),
+    inputs: arrayType(BriefInput),
+    delta: stringType().optional(),
+    actions: arrayType(BriefAction),
+    override: BriefOverride.nullish(),
+    cannotEvaluateReason: stringType().optional(),
 });
 const CreditMeterResult = objectType({
     metered: booleanType(),
@@ -42049,6 +42118,10 @@ const GateEvaluation = objectType({
     environment: stringType().optional(),
     service: stringType().optional(),
     policyFindings: arrayType(stringType()).optional(),
+    // ADR-011 §1: "findings are enumerated, never counted". policyFindings keeps
+    // its count-strings for existing consumers; this is the enumeration.
+    enumeratedFindings: arrayType(BriefFinding).optional(),
+    releaseBrief: ReleaseBrief.optional(),
     pr: objectType({
         provenance: PrProvenance.optional(),
         headRef: stringType().optional(),
@@ -42173,6 +42246,18 @@ const ContextCiConfig = objectType({
     optional_checks: arrayType(stringType()).default([]),
     missing_required: enumType(["fail", "skip"]).default("fail"),
 });
+// ADR-011 §2 — one row of the branch-pair relevance table. `reason` is mandatory
+// for `irrelevant`, but that is enforced as a config *warning* (see
+// collectConfigWarnings in config-core.ts), not a parse failure: a hard refine
+// here would drop the whole repo config to defaults over one typo, which is how
+// parseRepoConfigContent degrades today.
+const InputRelevanceEntry = objectType({
+    pattern: stringType(),
+    disposition: enumType(["blocking", "advisory", "irrelevant"]),
+    reason: stringType().optional(),
+});
+/** ADR-011 §4 — per-branch-pair stance when the evaluation cannot run. */
+const AvailabilityStance = enumType(["fail_open", "fail_closed"]);
 const TrailheadContext = objectType({
     name: stringType(),
     match: ContextMatch,
@@ -42183,6 +42268,8 @@ const TrailheadContext = objectType({
     })
         .default({}),
     ci: ContextCiConfig.default({}),
+    input_relevance: arrayType(InputRelevanceEntry).default([]),
+    availability: AvailabilityStance.optional(),
 });
 const GateConfig = objectType({
     mode: GateMode.default("risk-only"),
@@ -42207,6 +42294,8 @@ const RiskPathProfileConfig = objectType({
 const OverrideConfig = objectType({
     enabled: booleanType().default(true),
     max_per_week: numberType().int().min(1).default(5),
+    // Defaults to "full" so repos that never set it keep pre-ADR-011 behavior.
+    scope: OverrideScope.default("full"),
 });
 const TuningConfig = objectType({
     auto_downgrade: booleanType().default(true),
@@ -42527,6 +42616,31 @@ function parseYaml(input) {
         stack.push({ indent, value: child });
     }
     return root;
+}
+/**
+ * Non-fatal config warnings, emitted by the loader after a successful parse.
+ *
+ * ADR-011 §2 makes `reason` mandatory for `disposition: irrelevant`, but this is
+ * deliberately NOT a Zod refine: `parseRepoConfigContent` returns null for ANY
+ * schema violation, which drops the entire repo config back to hardcoded
+ * defaults. Degrading a whole config over one missing reason string is worse
+ * than narrating it, so the entry still parses and the Release Brief prints a
+ * placeholder reason (see MISSING_IRRELEVANT_REASON in input-relevance.ts).
+ */
+function collectConfigWarnings(config) {
+    const warnings = [];
+    for (const context of config.contexts) {
+        for (const entry of context.input_relevance) {
+            if (entry.disposition !== "irrelevant")
+                continue;
+            if (entry.reason !== undefined && entry.reason.trim() !== "")
+                continue;
+            warnings.push(`contexts."${context.name}".input_relevance: pattern "${entry.pattern}" is ` +
+                `"disposition: irrelevant" with no reason. ADR-011 requires a reason for ` +
+                `irrelevant inputs; the Release Brief will show a placeholder until one is set.`);
+        }
+    }
+    return warnings;
 }
 function parseRepoConfigContent(content) {
     const raw = parseYaml(content);
@@ -43105,6 +43219,9 @@ function validateSchemaVersion(parsedConfig, configPath) {
     if (parsedConfig.schema_version > CURRENT_CONFIG_SCHEMA_VERSION) {
         core_warning(`${configPath}: schema_version=${parsedConfig.schema_version} is newer than ` +
             `supported ${CURRENT_CONFIG_SCHEMA_VERSION}. Some features may be ignored.`);
+    }
+    for (const warning of collectConfigWarnings(parsedConfig)) {
+        core_warning(`${configPath}: ${warning}`);
     }
     return parsedConfig;
 }
@@ -43718,6 +43835,19 @@ async function waitForChecks(options) {
 
 ;// CONCATENATED MODULE: ./src/release-ready.ts
 /**
+ * ADR-011 §2: the disposition, once resolved, is the axis that decides whether a
+ * red input blocks the release. Checks with no disposition — no `input_relevance`
+ * config, an externally-built CiSummary, or a stored pre-ADR-011 evaluation —
+ * fall back to `required`, which is byte-for-byte the pre-ADR-011 behavior
+ * (the default mapping is required -> blocking, non-required -> advisory).
+ */
+function checkCountsTowardBlocking(check) {
+    const kind = check.disposition?.kind;
+    if (kind === undefined)
+        return check.required;
+    return kind === "blocking" || kind === "missing_blocking";
+}
+/**
  * Composite release readiness decision (ADR-006).
  */
 function computeReleaseReady(input) {
@@ -43736,7 +43866,7 @@ function computeReleaseReady(input) {
     }
     if (input.ciSummary) {
         if (!input.ciSummary.allRequiredPassed) {
-            const failed = input.ciSummary.checks.filter((c) => c.required &&
+            const failed = input.ciSummary.checks.filter((c) => checkCountsTowardBlocking(c) &&
                 (c.status === "fail" || c.status === "missing" || c.status === "stale"));
             for (const check of failed) {
                 reasons.push(`Required CI check "${check.name}" is ${check.status.toUpperCase()}`);
@@ -43815,6 +43945,291 @@ function resolveCheckName(gateMode, configuredName) {
     if (gateMode === "risk-only")
         return "Trailhead";
     return configuredName ?? "Trailhead — Release Ready";
+}
+
+;// CONCATENATED MODULE: ./src/input-relevance.ts
+// ADR-011 §2 — input relevance policy (disposition engine).
+//
+// ADR-009's status enum (`pass|fail|skip|pending|stale|missing`) says what a check DID.
+// A disposition says what that MEANS for this release decision. This module is pure:
+// no octokit, no config loading, no I/O — callers resolve the policy entries for the
+// matched branch pair and hand them in.
+
+
+/**
+ * Reason substituted when config declares `irrelevant` without a reason. ADR-011 §2 makes the
+ * reason mandatory ("reason mandatory and shown in the brief"); the config schema layer rejects
+ * it too, so this is defense in depth for configs that reached us unvalidated.
+ */
+const MISSING_IRRELEVANT_REASON = "(no reason configured — reason is mandatory for irrelevant; fix .trailhead.yml)";
+/**
+ * Pattern matching precedence, per entry:
+ *   1. exact name match                      (checkNameMatches)
+ *   2. case-insensitive name match           (checkNameMatches)
+ *   3. configured-value-as-prefix match      (checkNameMatches)
+ *   4. glob match, case-insensitive          (matchesGlobs — lets "Deploy *" work)
+ * These are a union, not a ranking: an entry matches if ANY of them matches. Ranking between
+ * entries is positional only — entries are evaluated in declaration order and the FIRST
+ * matching entry wins, exactly like `contexts[]` resolution in context-matcher.ts.
+ */
+function entryMatches(entry, checkName) {
+    // A blank pattern would prefix-match every check name; treat it as matching nothing so a
+    // config typo cannot silently reclassify the whole input set.
+    if (entry.pattern.trim() === "")
+        return false;
+    if (checkNameMatches(entry.pattern, checkName))
+        return true;
+    return matchesGlobs(checkName, [entry.pattern]);
+}
+function hasText(value) {
+    return value !== undefined && value.trim() !== "";
+}
+/**
+ * Resolve one check to a disposition.
+ *
+ * - First matching entry wins; no match falls back to `required ? blocking : advisory`
+ *   with source `default`.
+ * - `missing_blocking` is DERIVED: ADR-009 status `missing` on a check that would otherwise
+ *   resolve to `blocking`. It is never configurable.
+ */
+function resolveDisposition(check, entries) {
+    const matched = entries.find((entry) => entryMatches(entry, check.name));
+    let kind;
+    let reason;
+    let source;
+    if (matched) {
+        kind = matched.disposition;
+        reason = hasText(matched.reason) ? matched.reason : undefined;
+        source = "policy";
+        if (kind === "irrelevant" && reason === undefined) {
+            reason = MISSING_IRRELEVANT_REASON;
+        }
+    }
+    else {
+        kind = check.required ? "blocking" : "advisory";
+        source = "default";
+    }
+    if (check.status === "missing" && kind === "blocking") {
+        kind = "missing_blocking";
+    }
+    return reason === undefined ? { kind, source } : { kind, reason, source };
+}
+/**
+ * Resolve a whole CI input set, keyed by check name. On duplicate check names the first
+ * occurrence wins, so the map is stable regardless of how many times a name appears.
+ */
+function resolveDispositions(checks, entries) {
+    const resolved = new Map();
+    for (const check of checks) {
+        if (resolved.has(check.name))
+            continue;
+        resolved.set(check.name, resolveDisposition(check, entries));
+    }
+    return resolved;
+}
+/** Only `blocking` and `missing_blocking` count against release readiness (ADR-011 §2 table). */
+function dispositionCountsTowardBlocking(d) {
+    return d.kind === "blocking" || d.kind === "missing_blocking";
+}
+
+;// CONCATENATED MODULE: ./src/release-brief.ts
+/**
+ * ADR-011 §1 — the Release Brief: the structured statement a human reads at the
+ * moment of a release decision, and its markdown renderer.
+ *
+ * This module is pure by design: no octokit, no GateEvaluation import, no
+ * dependency on the input-relevance policy. The integrator maps whatever it has
+ * onto `ReleaseBrief` and posts `renderReleaseBrief()`'s output.
+ */
+function countDiff(previous, current) {
+    const before = new Set(previous);
+    const after = new Set(current);
+    let resolved = 0;
+    for (const id of before)
+        if (!after.has(id))
+            resolved += 1;
+    let added = 0;
+    for (const id of after)
+        if (!before.has(id))
+            added += 1;
+    return { resolved, added };
+}
+function plural(count, noun) {
+    return `${count} ${noun}${count === 1 ? "" : "s"}`;
+}
+/**
+ * Render the one-line "vs previous" delta, e.g.
+ * `vs previous: block -> allow, risk 90 -> 42, 3 findings resolved, 1 new`.
+ *
+ * Returns undefined when the two snapshots share no comparable field — a missing
+ * or unreachable previous evaluation must omit the delta, never error (ADR-011 §1).
+ */
+function formatEvaluationDelta(previous, current) {
+    const parts = [];
+    let comparable = false;
+    if (previous.verdict !== undefined && current.verdict !== undefined) {
+        comparable = true;
+        if (previous.verdict !== current.verdict) {
+            parts.push(`${previous.verdict} -> ${current.verdict}`);
+        }
+    }
+    if (previous.riskScore !== undefined && current.riskScore !== undefined) {
+        comparable = true;
+        if (previous.riskScore !== current.riskScore) {
+            parts.push(`risk ${previous.riskScore} -> ${current.riskScore}`);
+        }
+    }
+    if (previous.findingIds !== undefined && current.findingIds !== undefined) {
+        comparable = true;
+        const { resolved, added } = countDiff(previous.findingIds, current.findingIds);
+        if (resolved > 0)
+            parts.push(`${plural(resolved, "finding")} resolved`);
+        if (added > 0)
+            parts.push(`${added} new`);
+    }
+    if (!comparable)
+        return undefined;
+    return `vs previous: ${parts.length > 0 ? parts.join(", ") : "no change"}`;
+}
+const DEFAULT_MAX_CHARS = 60000;
+const EVIDENCE_CAP_CHARS = 300;
+const EMPTY_CELL = "—";
+function escapePipes(value) {
+    return value.replace(/\|/g, "\\|");
+}
+/** Table cells must be single-line and must not break the column structure. */
+function cell(value) {
+    const flattened = value.replace(/\r?\n/g, " ").trim();
+    if (flattened.length === 0)
+        return EMPTY_CELL;
+    return escapePipes(flattened);
+}
+function verdictLabel(verdict) {
+    return verdict.replace(/_/g, " ").toUpperCase();
+}
+function verdictLine(brief) {
+    const segments = [];
+    if (brief.riskScore !== undefined) {
+        segments.push(brief.riskThreshold !== undefined
+            ? `risk ${brief.riskScore} (threshold ${brief.riskThreshold})`
+            : `risk ${brief.riskScore}`);
+    }
+    else if (brief.riskThreshold !== undefined) {
+        segments.push(`threshold ${brief.riskThreshold}`);
+    }
+    if (brief.topMovers && brief.topMovers.length > 0) {
+        const movers = brief.topMovers
+            .map((mover) => `${mover.factor} ${mover.score}`)
+            .join(", ");
+        segments.push(`top movers: ${movers}`);
+    }
+    const badge = `**${verdictLabel(brief.verdict)}**`;
+    return segments.length > 0 ? `${badge} — ${segments.join(" · ")}` : badge;
+}
+function capEvidence(evidence, cap) {
+    if (cap === undefined || evidence.length <= cap)
+        return evidence;
+    // Ellipsis included, so the capped evidence is exactly `cap` characters.
+    return `${evidence.slice(0, cap - 1)}…`;
+}
+function findingLines(finding, index, evidenceCap) {
+    const lines = [
+        `${index + 1}. **${escapePipes(finding.title)}** \`${finding.id}\` _(${finding.severity})_`,
+    ];
+    const evidence = finding.evidence?.trim();
+    if (evidence) {
+        for (const line of capEvidence(evidence, evidenceCap).split(/\r?\n/)) {
+            lines.push(`   > ${escapePipes(line)}`);
+        }
+    }
+    return lines;
+}
+function buildBrief(brief, keepFindings, evidenceCap, storedEvaluationUrl) {
+    const lines = ["## Release Brief", "", verdictLine(brief), ""];
+    // ADR-011 §1: "silence is a bug" — a cannot-evaluate brief must say why, up top.
+    if (brief.verdict === "cannot_evaluate" || brief.cannotEvaluateReason) {
+        const reason = brief.cannotEvaluateReason?.trim();
+        lines.push(`> ⚠️ **Cannot evaluate:** ${reason && reason.length > 0 ? reason : "no reason recorded"}`, "");
+    }
+    lines.push("### Findings", "");
+    if (brief.findings.length === 0) {
+        lines.push("No findings.", "");
+    }
+    else {
+        // ADR-011 §1: findings are enumerated, never counted.
+        const shown = brief.findings.slice(0, Math.max(0, keepFindings));
+        shown.forEach((finding, index) => {
+            lines.push(...findingLines(finding, index, evidenceCap));
+        });
+        const hidden = brief.findings.length - shown.length;
+        if (hidden > 0) {
+            const target = storedEvaluationUrl
+                ? `[stored evaluation](${storedEvaluationUrl})`
+                : "stored evaluation";
+            lines.push(`_…${hidden} more findings not shown inline — see the ${target}_`);
+        }
+        lines.push("");
+    }
+    lines.push("### Inputs", "");
+    if (brief.inputs.length === 0) {
+        lines.push("No inputs evaluated.", "");
+    }
+    else {
+        lines.push(`| Check | Status | Disposition | Reason |`, `|-------|--------|-------------|--------|`);
+        for (const input of brief.inputs) {
+            lines.push(`| ${cell(input.checkName)} | ${cell(input.status)} | ${cell(input.disposition)} | ${cell(input.reason ?? "")} |`);
+        }
+        lines.push("");
+    }
+    const delta = brief.delta?.trim();
+    if (delta) {
+        lines.push(`**Delta:** ${delta}`, "");
+    }
+    lines.push("### Actions", "");
+    if (brief.actions.length === 0) {
+        lines.push("No actions.", "");
+    }
+    else {
+        for (const action of brief.actions) {
+            const link = action.link ? ` ([link](${action.link}))` : "";
+            lines.push(`- **${action.kind}:** ${action.detail}${link}`);
+        }
+        lines.push("");
+    }
+    if (brief.override) {
+        const owner = brief.override.by.replace(/^@+/, "");
+        lines.push("### Override", "", `> Overridden by @${owner} at ${brief.override.at}, scope ${brief.override.scope} — ${brief.override.rationale}`, "");
+    }
+    return lines.join("\n").trimEnd();
+}
+/**
+ * Render a Release Brief as markdown suitable for a PR comment section.
+ *
+ * Truncation order (ADR-011 §1): drop findings from the end first (always
+ * keeping at least one plus a pointer to the stored evaluation), then cap
+ * evidence, and only then hard-clip. The result never exceeds `maxChars`.
+ */
+function renderReleaseBrief(brief, opts) {
+    const requested = opts?.maxChars ?? DEFAULT_MAX_CHARS;
+    const maxChars = Number.isFinite(requested) ? Math.floor(requested) : DEFAULT_MAX_CHARS;
+    if (maxChars <= 0)
+        return "";
+    const storedEvaluationUrl = opts?.storedEvaluationUrl;
+    const total = brief.findings.length;
+    let rendered = buildBrief(brief, total, undefined, storedEvaluationUrl);
+    if (rendered.length <= maxChars)
+        return rendered;
+    for (let keep = total - 1; keep >= 1; keep--) {
+        rendered = buildBrief(brief, keep, undefined, storedEvaluationUrl);
+        if (rendered.length <= maxChars)
+            return rendered;
+    }
+    const minKeep = total > 0 ? 1 : 0;
+    rendered = buildBrief(brief, minKeep, EVIDENCE_CAP_CHARS, storedEvaluationUrl);
+    if (rendered.length <= maxChars)
+        return rendered;
+    // Last resort: the length contract outranks markdown well-formedness.
+    return rendered.slice(0, maxChars);
 }
 
 ;// CONCATENATED MODULE: ./src/security.ts
@@ -44028,6 +44443,33 @@ function parseAgentIdFromHeadRef(headRef) {
     const match = headRef.match(/^agent\/([a-z0-9-]+)\//);
     return match?.[1] ?? null;
 }
+function pick(record, ...keys) {
+    for (const key of keys) {
+        const value = record[key];
+        if (value !== undefined && value !== null)
+            return value;
+    }
+    return undefined;
+}
+function readFindingIds(record) {
+    const direct = pick(record, "enumerated_findings", "enumeratedFindings");
+    const brief = pick(record, "release_brief", "releaseBrief");
+    const raw = direct ??
+        (brief && typeof brief === "object"
+            ? brief.findings
+            : undefined);
+    if (!Array.isArray(raw))
+        return undefined;
+    const ids = [];
+    for (const entry of raw) {
+        if (!entry || typeof entry !== "object")
+            continue;
+        const id = entry.id;
+        if (typeof id === "string")
+            ids.push(id);
+    }
+    return ids;
+}
 function parsePreviousEvaluationRow(row) {
     if (!row || typeof row !== "object")
         return null;
@@ -44039,7 +44481,24 @@ function parsePreviousEvaluationRow(row) {
     if (record.remediation && typeof record.remediation === "object") {
         remediation = record.remediation;
     }
-    return { id, remediation };
+    const snapshot = { id, remediation };
+    const riskScore = pick(record, "risk_score", "riskScore");
+    if (typeof riskScore === "number" && Number.isFinite(riskScore)) {
+        snapshot.riskScore = riskScore;
+    }
+    const gateDecision = pick(record, "gate_decision", "gateDecision");
+    if (gateDecision === "allow" || gateDecision === "warn" || gateDecision === "block") {
+        snapshot.gateDecision = gateDecision;
+    }
+    const releaseReady = pick(record, "release_ready", "releaseReady");
+    if (typeof releaseReady === "boolean") {
+        snapshot.releaseReady = releaseReady;
+    }
+    const findingIds = readFindingIds(record);
+    if (findingIds !== undefined) {
+        snapshot.findingIds = findingIds;
+    }
+    return snapshot;
 }
 function pickLatestPreviousEvaluation(rows, excludeEvaluationId) {
     for (const row of rows) {
@@ -44605,7 +45064,7 @@ function runPhase0Detectors(ctx) {
         .filter((check) => check !== null);
 }
 
-;// CONCATENATED MODULE: ../../Users/david/Projects/trailhead/node_modules/js-yaml/dist/js-yaml.mjs
+;// CONCATENATED MODULE: ./node_modules/js-yaml/dist/js-yaml.mjs
 
 /*! js-yaml 4.1.1 https://github.com/nodeca/js-yaml @license MIT */
 function isNothing(subject) {
@@ -48972,8 +49431,8 @@ function detectPromotionCoherence(ctx) {
     };
 }
 
-// EXTERNAL MODULE: ../../Users/david/Projects/trailhead/node_modules/@swc/core/index.js
-var _swc_core = __nccwpck_require__(5229);
+// EXTERNAL MODULE: ./node_modules/@swc/core/index.js
+var _swc_core = __nccwpck_require__(5971);
 ;// CONCATENATED MODULE: ./src/submission-checks/syntax-validity.ts
 // Real parse-based syntax validation for Gate 1 (no bracket-count fallback).
 // Parses full file content only — never a partial diff hunk (see submission-gate.md).
@@ -50391,17 +50850,22 @@ async function fetchFromKomatikStore(params) {
         return null;
     return fetchEvaluationList(listUrl, params);
 }
-async function fetchFromSupabase(params) {
-    const supabaseUrl = process.env.SUPABASE_URL;
-    const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
-    if (!supabaseUrl || !serviceRoleKey)
-        return null;
+/** Columns loop bookkeeping has always needed — guaranteed present in every store. */
+const SUPABASE_LOOP_SELECT = "id,remediation,loop_round,previous_evaluation_id,fixes_resolved,fixes_introduced,created_at";
+/**
+ * ADR-011 §1 adds the delta fields. `release_brief`/`enumerated_findings` land with the
+ * ADR-011 store migration, so a store that has not run it 400s on this select — hence the
+ * narrow-select retry below rather than one wide select that would take loop bookkeeping
+ * down with it.
+ */
+const SUPABASE_DELTA_SELECT = `${SUPABASE_LOOP_SELECT},risk_score,gate_decision,release_ready,enumerated_findings,release_brief`;
+async function fetchSupabaseRows(supabaseUrl, serviceRoleKey, params, select) {
     const url = new URL(`${supabaseUrl.replace(/\/$/, "")}/rest/v1/trailhead_evaluations`);
     url.searchParams.set("repo_id", `eq.${params.repoId}`);
     url.searchParams.set("pr_number", `eq.${params.prNumber}`);
     url.searchParams.set("order", "created_at.desc");
     url.searchParams.set("limit", "10");
-    url.searchParams.set("select", "id,remediation,loop_round,previous_evaluation_id,fixes_resolved,fixes_introduced,created_at");
+    url.searchParams.set("select", select);
     const response = await fetch(url.toString(), {
         method: "GET",
         headers: {
@@ -50414,7 +50878,18 @@ async function fetchFromSupabase(params) {
     if (!response.ok)
         return null;
     const rows = (await response.json());
-    if (!Array.isArray(rows))
+    return Array.isArray(rows) ? rows : null;
+}
+async function fetchFromSupabase(params) {
+    const supabaseUrl = process.env.SUPABASE_URL;
+    const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    if (!supabaseUrl || !serviceRoleKey)
+        return null;
+    let rows = await fetchSupabaseRows(supabaseUrl, serviceRoleKey, params, SUPABASE_DELTA_SELECT);
+    if (rows === null) {
+        rows = await fetchSupabaseRows(supabaseUrl, serviceRoleKey, params, SUPABASE_LOOP_SELECT);
+    }
+    if (rows === null)
         return null;
     return pickPreviousFromRows(rows, params.excludeEvaluationId);
 }
@@ -50506,6 +50981,7 @@ async function countRecentLabelOverrides(params) {
 }
 
 ;// CONCATENATED MODULE: ./src/override.ts
+
 const OVERRIDE_LABEL = "trailhead-override";
 const OVERRIDE_COMMENT_PATTERN = /^trailhead-override:\s*(.+)/im;
 function hasOverrideLabel(labels) {
@@ -50524,9 +51000,53 @@ function parseOverrideComment(comments) {
     }
     return null;
 }
+const CI_FAILING_STATUSES = new Set(["fail", "missing", "stale"]);
+const CI_REQUIRED_CHECK_REASON = /^Required CI check "/;
+const CI_PENDING_REASON = /required CI check\(s\) still pending$/i;
+/**
+ * True when a computeReleaseReady() reason came from mechanical CI rather than
+ * risk/policy. ADR-011 §3: a `risk_only` override never clears these — getting
+ * past a red required check stays an admin-merge.
+ *
+ * Structural first: a reason naming a blocking check that CiSummary reports as
+ * fail/missing/stale is mechanical regardless of phrasing. The phrasing fallback
+ * fails closed — a reason that still reads as a CI reason but cannot be matched
+ * to a check (no CiSummary, renamed check, external CI manifest) keeps blocking.
+ *
+ * ADR-011 §2 composition: "blocking" is the check's disposition, not its
+ * `required` flag, so an input dispositioned `irrelevant`/`advisory` never
+ * produces a reason to retain, and a non-required input dispositioned `blocking`
+ * survives a risk_only override.
+ */
+function isMechanicalCiReason(reason, ci) {
+    const structural = ci?.checks.some((check) => checkCountsTowardBlocking(check) &&
+        CI_FAILING_STATUSES.has(check.status) &&
+        reason.includes(`"${check.name}"`));
+    if (structural)
+        return true;
+    if (ci && ci.pendingCount > 0 && CI_PENDING_REASON.test(reason))
+        return true;
+    return CI_REQUIRED_CHECK_REASON.test(reason) || CI_PENDING_REASON.test(reason);
+}
+function partitionOverrideReasons(reasons, ci) {
+    const overridden = [];
+    const retained = [];
+    for (const reason of reasons) {
+        if (isMechanicalCiReason(reason, ci))
+            retained.push(reason);
+        else
+            overridden.push(reason);
+    }
+    return { overridden, retained };
+}
 function buildLabelOverrideAudit(input) {
     const appliedAt = new Date().toISOString();
     const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+    const scope = input.scope ?? "full";
+    const reasons = [...input.releaseResult.reasons];
+    const { overridden, retained } = scope === "risk_only"
+        ? partitionOverrideReasons(reasons, input.ci)
+        : { overridden: reasons, retained: [] };
     return {
         source: "label",
         owner: input.parsed.author,
@@ -50534,12 +51054,13 @@ function buildLabelOverrideAudit(input) {
         linkedTicket: `override:pr#${input.prNumber}`,
         expiresAt,
         appliedAt,
-        changes: { releaseReady: true },
+        scope,
+        changes: retained.length === 0 ? { releaseReady: true } : {},
         preOverrideDecision: input.gateDecision,
         preOverrideReleaseReady: input.releaseResult.releaseReady,
-        preOverrideReasons: input.releaseResult.reasons.length > 0
-            ? [...input.releaseResult.reasons]
-            : undefined,
+        preOverrideReasons: reasons.length > 0 ? reasons : undefined,
+        overriddenReasons: overridden.length > 0 ? overridden : undefined,
+        retainedReasons: retained.length > 0 ? retained : undefined,
     };
 }
 function formatOverrideRejectionMessage(code) {
@@ -50601,15 +51122,38 @@ function resolveLabelOverride(input) {
             prNumber: input.prNumber,
             releaseResult: input.releaseResult,
             gateDecision: input.gateDecision,
+            scope: input.config.scope,
+            ci: input.ci,
         }),
     };
 }
 function applyLabelOverrideToEvaluation(evaluation, audit) {
+    if ((audit.scope ?? "full") !== "risk_only") {
+        return {
+            ...evaluation,
+            releaseReady: true,
+            releaseReadyReasons: undefined,
+            policyOverride: audit,
+        };
+    }
+    // Re-partition against the evaluation's own CiSummary: it is the authoritative
+    // structural signal, and the audit may have been built without one.
+    const reasons = evaluation.releaseReadyReasons ?? audit.preOverrideReasons ?? [];
+    const { overridden, retained } = partitionOverrideReasons(reasons, evaluation.ci);
+    const releaseReady = retained.length === 0;
+    const { releaseReady: _clearedFlag, ...changesWithoutReleaseReady } = audit.changes;
     return {
         ...evaluation,
-        releaseReady: true,
-        releaseReadyReasons: undefined,
-        policyOverride: audit,
+        releaseReady,
+        releaseReadyReasons: retained.length > 0 ? retained : undefined,
+        policyOverride: {
+            ...audit,
+            changes: releaseReady
+                ? { ...audit.changes, releaseReady: true }
+                : changesWithoutReleaseReady,
+            overriddenReasons: overridden.length > 0 ? overridden : undefined,
+            retainedReasons: retained.length > 0 ? retained : undefined,
+        },
     };
 }
 
@@ -51064,6 +51608,8 @@ async function fetchGitHubJsonPages(url, init, options = {}) {
 
 
 
+
+
 // Re-export sensitivityWeight with the RepoConfig-compatible signature
 function gate_sensitivityWeight(filename, repoConfig) {
     return sensitivityWeightShared(filename, repoConfig ?? null);
@@ -51490,7 +52036,7 @@ async function detectPrProvenance(prNumber, token) {
 function detectCiIntegrityRisk(files) {
     const { score, blockingPatterns, warningSignals } = detectCiIntegrity(files);
     if (score === 0) {
-        return { factor: null, blockingPatterns: [] };
+        return { factor: null, blockingPatterns: [], warningSignals: [] };
     }
     const factor = {
         type: "ci_integrity",
@@ -51501,7 +52047,7 @@ function detectCiIntegrityRisk(files) {
             description: "CI confidence and workflow integrity signals",
         },
     };
-    return { factor, blockingPatterns };
+    return { factor, blockingPatterns, warningSignals };
 }
 function detectWorkflowSecurityRisk(files, allowUnpinnedActions) {
     const blockingPatterns = [];
@@ -52158,6 +52704,7 @@ async function applyLabelOverrideIfNeeded(input) {
     const overrideSettings = input.repoConfig?.override ?? {
         enabled: true,
         max_per_week: 5,
+        scope: "full",
     };
     const comments = await fetchPrCommentsForOverride(input.prNumber, input.githubToken);
     const recentOverrideCount = await countRecentLabelOverrides({
@@ -52174,19 +52721,29 @@ async function applyLabelOverrideIfNeeded(input) {
         config: {
             enabled: overrideSettings.enabled,
             maxPerWeek: overrideSettings.max_per_week,
+            scope: overrideSettings.scope,
         },
         recentOverrideCount,
         releaseResult: input.releaseResult,
         gateDecision: input.gateDecision,
         prNumber: input.prNumber,
+        ci: input.evaluation.ci,
     });
     if (outcome.kind === "applied") {
-        core_warning(`Label override applied by ${outcome.audit.owner}: ${outcome.audit.reason}`);
+        const applied = applyLabelOverrideToEvaluation(input.evaluation, outcome.audit);
+        const retained = applied.policyOverride?.retainedReasons ?? [];
+        // ADR-011 §3: a risk_only override never clears mechanical blocking inputs —
+        // say so, otherwise the warning reads as a full bypass that it is not.
+        const retainedNote = retained.length > 0
+            ? ` — ${retained.length} mechanical CI reason(s) still blocking`
+            : "";
+        core_warning(`Label override applied by ${outcome.audit.owner} (scope ${outcome.audit.scope ?? "full"}): ` +
+            `${outcome.audit.reason}${retainedNote}`);
         return {
-            ...applyLabelOverrideToEvaluation(input.evaluation, outcome.audit),
+            ...applied,
             labelOverrideFeedback: {
                 status: "applied",
-                message: `Release override applied by \`${outcome.audit.owner}\`.`,
+                message: `Release override applied by \`${outcome.audit.owner}\`${retainedNote}.`,
             },
         };
     }
@@ -52205,10 +52762,266 @@ async function applyLabelOverrideIfNeeded(input) {
     return input.evaluation;
 }
 // ---------------------------------------------------------------------------
+// ADR-011 — input relevance, enumerated findings, Release Brief
+// ---------------------------------------------------------------------------
+/**
+ * Annotate every CI input with its ADR-011 §2 disposition and re-roll the
+ * summary counts against the *blocking* set rather than the `required` flag.
+ *
+ * With no `input_relevance` entries the default mapping is required -> blocking
+ * and non-required -> advisory, so the blocking set is exactly the required set
+ * and every count below reproduces `evaluateRequiredChecks` verbatim. Semantics
+ * only move when a policy entry matches.
+ */
+/** Budget for the brief inside a report that also becomes a check-run summary. */
+const BRIEF_MAX_CHARS = 20000;
+function applyInputRelevance(summary, entries) {
+    const resolved = resolveDispositions(summary.checks, entries);
+    const checks = summary.checks.map((check) => {
+        const disposition = resolved.get(check.name);
+        return disposition ? { ...check, disposition } : check;
+    });
+    const blocking = checks.filter((check) => check.disposition !== undefined &&
+        dispositionCountsTowardBlocking(check.disposition));
+    return {
+        checks,
+        allRequiredPassed: blocking.every((check) => check.status === "pass" || check.status === "skip"),
+        pendingCount: blocking.filter((check) => check.status === "pending").length,
+        failedCount: blocking.filter((check) => check.status === "fail" || check.status === "missing" || check.status === "stale").length,
+        missingCount: blocking.filter((check) => check.status === "missing").length,
+    };
+}
+/**
+ * Detector messages are authored as `<file>: <message>`. Split them so the brief
+ * can carry the file as evidence; anything that does not look like a path prefix
+ * stays a whole title (never guess evidence that is not there).
+ */
+function splitDetectorMessage(message) {
+    const separator = message.indexOf(": ");
+    if (separator > 0) {
+        const head = message.slice(0, separator);
+        if (/[/.]/.test(head) && !/\s/.test(head)) {
+            return { title: message.slice(separator + 2).trim(), evidence: head };
+        }
+    }
+    return { title: message };
+}
+/**
+ * ADR-011 §1: "findings are enumerated, never counted" — the Case A fix. Every
+ * detector already returns its patterns as strings; this turns them into
+ * addressable findings instead of a `.length`.
+ */
+function enumerateDetectorFindings(idPrefix, messages, severity) {
+    return messages.map((message, index) => {
+        const { title, evidence } = splitDetectorMessage(message);
+        return {
+            id: `${idPrefix}/${index + 1}`,
+            title,
+            severity,
+            ...(evidence ? { evidence } : {}),
+        };
+    });
+}
+function briefVerdict(evaluation) {
+    const mode = evaluation.gateMode ?? "risk-only";
+    if (mode === "release-ready" || mode === "advisory") {
+        if (evaluation.releaseReady === false)
+            return "block";
+        return evaluation.gateDecision === "warn" ? "warn" : "allow";
+    }
+    return evaluation.gateDecision;
+}
+function briefTopMovers(factors) {
+    const movers = [...factors]
+        .filter((factor) => factor.score > 0)
+        .sort((a, b) => b.score - a.score)
+        .slice(0, 3)
+        .map((factor) => ({ factor: factor.type, score: factor.score }));
+    return movers.length > 0 ? movers : undefined;
+}
+/**
+ * ADR-011 §1's `delta`. Two independent sources, either of which may be absent:
+ * the id-diff against the previous stored evaluation (verdict/risk/findings), and
+ * the remediation loop's own fix bookkeeping. A missing or unreachable previous
+ * evaluation omits the delta — it never errors.
+ */
+function briefDelta(evaluation, previous) {
+    const parts = [
+        previous
+            ? formatEvaluationDelta({
+                ...(previous.gateDecision !== undefined
+                    ? { verdict: previous.gateDecision }
+                    : {}),
+                ...(previous.riskScore !== undefined
+                    ? { riskScore: previous.riskScore }
+                    : {}),
+                ...(previous.findingIds !== undefined
+                    ? { findingIds: previous.findingIds }
+                    : {}),
+            }, {
+                verdict: evaluation.gateDecision,
+                riskScore: evaluation.riskScore,
+                ...(evaluation.enumeratedFindings !== undefined
+                    ? { findingIds: evaluation.enumeratedFindings.map((f) => f.id) }
+                    : {}),
+            })
+            : undefined,
+        briefRemediationDelta(evaluation),
+    ].filter((part) => part !== undefined);
+    return parts.length > 0 ? parts.join(" · ") : undefined;
+}
+function briefRemediationDelta(evaluation) {
+    const remediation = evaluation.remediation;
+    if (!remediation?.previous_evaluation_id)
+        return undefined;
+    const parts = [];
+    if (remediation.fixes_resolved.length > 0) {
+        parts.push(`resolved: ${remediation.fixes_resolved.join(", ")}`);
+    }
+    if (remediation.fixes_introduced.length > 0) {
+        parts.push(`introduced: ${remediation.fixes_introduced.join(", ")}`);
+    }
+    if (parts.length === 0)
+        parts.push("no change in findings");
+    return `round ${remediation.loop_round} vs previous evaluation — ${parts.join("; ")}`;
+}
+function briefActions(evaluation, findings, riskThreshold) {
+    const actions = [];
+    for (const check of evaluation.ci?.checks ?? []) {
+        if (!checkCountsTowardBlocking(check))
+            continue;
+        if (check.status !== "fail" &&
+            check.status !== "missing" &&
+            check.status !== "stale") {
+            continue;
+        }
+        actions.push({
+            kind: "fix",
+            detail: `CI input "${check.name}" is ${check.status.toUpperCase()} — fix it, or ` +
+                `classify it under \`contexts[].input_relevance\` if it is irrelevant to this branch pair.`,
+            ...(check.detailsUrl ? { link: check.detailsUrl } : {}),
+        });
+    }
+    for (const finding of findings) {
+        if (finding.severity !== "blocking")
+            continue;
+        actions.push({ kind: "fix", detail: `${finding.title} (\`${finding.id}\`)` });
+    }
+    const pending = evaluation.ci?.pendingCount ?? 0;
+    if (pending > 0) {
+        actions.push({
+            kind: "wait",
+            detail: `${pending} blocking CI check(s) still pending — the gate re-evaluates when they finish.`,
+        });
+    }
+    if (riskThreshold !== undefined &&
+        evaluation.riskScore > riskThreshold &&
+        !evaluation.policyOverride) {
+        actions.push({
+            kind: "override",
+            detail: `Risk ${evaluation.riskScore} exceeds threshold ${riskThreshold}. To accept it on ` +
+                `the record, add the \`${OVERRIDE_LABEL}\` label and comment ` +
+                `\`${OVERRIDE_LABEL}: <rationale>\` on this PR.`,
+        });
+    }
+    return actions;
+}
+/**
+ * Project a GateEvaluation onto ADR-011 §1's Release Brief. Pure — no I/O, no
+ * mutation — so it can be rebuilt from any stored evaluation.
+ */
+function buildReleaseBrief(evaluation, riskThreshold, cannotEvaluateReason, previous) {
+    const findings = evaluation.enumeratedFindings ?? [];
+    const override = evaluation.policyOverride;
+    const delta = briefDelta(evaluation, previous);
+    return {
+        verdict: cannotEvaluateReason ? "cannot_evaluate" : briefVerdict(evaluation),
+        riskScore: evaluation.riskScore,
+        ...(riskThreshold !== undefined ? { riskThreshold } : {}),
+        ...(briefTopMovers(evaluation.riskFactors)
+            ? { topMovers: briefTopMovers(evaluation.riskFactors) }
+            : {}),
+        findings,
+        // Every input gets a row, including the ones that did not count (ADR-011 §1).
+        inputs: (evaluation.ci?.checks ?? []).map((check) => ({
+            checkName: check.name,
+            status: check.status,
+            disposition: check.disposition?.kind ?? (check.required ? "blocking" : "advisory"),
+            ...(check.disposition?.reason ? { reason: check.disposition.reason } : {}),
+        })),
+        ...(delta ? { delta } : {}),
+        actions: briefActions(evaluation, findings, riskThreshold),
+        // ADR-011 §3 maps the audit's {owner, appliedAt, reason} onto {by, at, rationale}.
+        override: override
+            ? {
+                by: override.owner,
+                at: override.appliedAt,
+                scope: override.scope ?? "full",
+                rationale: override.reason,
+            }
+            : null,
+        ...(cannotEvaluateReason ? { cannotEvaluateReason } : {}),
+    };
+}
+// ---------------------------------------------------------------------------
+// ADR-011 §4 — availability stance
+// ---------------------------------------------------------------------------
+// The stance belongs to the matched context, which is only known *inside*
+// evaluateGate — but it has to be readable by main.ts's top-level catch, i.e.
+// after evaluateGate has already thrown. Stashing it here avoids loading and
+// re-matching the repo config a second time just to answer "open or closed?".
+let lastAvailabilityStance = null;
+/**
+ * The availability stance of the context the most recent evaluation matched, or
+ * null when no context matched (or the run failed before matching). Null means
+ * "no per-context stance" — the caller keeps its action-input fail-mode.
+ */
+function getResolvedAvailabilityStance() {
+    return lastAvailabilityStance;
+}
+/** Test seam, and the reset evaluateGate performs on entry. */
+function setResolvedAvailabilityStance(stance) {
+    lastAvailabilityStance = stance;
+}
+/**
+ * ADR-011 §1: "silence is a bug." When the evaluation could not run at all there is
+ * no GateEvaluation to project, so the brief is built from the failure itself.
+ */
+function buildCannotEvaluateBrief(reason, stance) {
+    const actions = [
+        {
+            kind: "fix",
+            detail: "Resolve the failure above and re-run the Trailhead job. Until it runs, no " +
+                "risk score, no input dispositions and no findings exist for this commit.",
+        },
+        stance === "fail_closed"
+            ? {
+                kind: "wait",
+                detail: "Availability stance is fail_closed: no verdict means no merge. Break-glass " +
+                    "is a GitHub admin merge — visible and extraordinary, and it records nothing.",
+            }
+            : {
+                kind: "wait",
+                detail: "Availability stance is fail_open: this run did not block the merge, but no " +
+                    "Trailhead verdict was recorded for this commit.",
+            },
+    ];
+    return {
+        verdict: "cannot_evaluate",
+        findings: [],
+        inputs: [],
+        actions,
+        override: null,
+        cannotEvaluateReason: reason,
+    };
+}
+// ---------------------------------------------------------------------------
 // Main evaluation entry point
 // ---------------------------------------------------------------------------
 async function evaluateGate(config, commitSha, prNumber) {
     const start = Date.now();
+    // Nothing is known about this run's availability stance until a context matches.
+    setResolvedAvailabilityStance(null);
     const isMergeQueue = github_context.eventName === "merge_group" ||
         github_context.payload?.pull_request?.labels?.some((l) => l.name === "queue" || l.name.includes("merge-queue")) === true;
     if (isMergeQueue) {
@@ -52255,6 +53068,12 @@ async function evaluateGate(config, commitSha, prNumber) {
         : null;
     if (matchedContext) {
         info(`Matched context "${matchedContext.matched.name}" for base=${prMatchCtx.baseRef}`);
+    }
+    // ADR-011 §4 — a per-branch-pair stance overrides the action-input fail-mode.
+    const availabilityStance = matchedContext?.context.availability ?? null;
+    setResolvedAvailabilityStance(availabilityStance);
+    if (availabilityStance) {
+        info(`Availability stance: ${availabilityStance} (context "${matchedContext?.matched.name}")`);
     }
     const effectiveEnvironment = config.environment ?? matchedContext?.matched.environment ?? undefined;
     const envConfig = effectiveEnvironment
@@ -52304,7 +53123,7 @@ async function evaluateGate(config, commitSha, prNumber) {
     }
     const ciIntegrityConfig = repoConfig?.policies?.ci_integrity;
     const ciIntegrity = ciIntegrityConfig?.enabled === false
-        ? { factor: null, blockingPatterns: [] }
+        ? { factor: null, blockingPatterns: [], warningSignals: [] }
         : detectCiIntegrityRisk(files);
     if (ciIntegrity.factor) {
         riskFactors.push(ciIntegrity.factor);
@@ -52480,13 +53299,17 @@ async function evaluateGate(config, commitSha, prNumber) {
         repoConfig,
     });
     const sessionCfg = repoConfig?.policies?.session_correlation;
+    // Kept as its own list so ADR-011 §1 can enumerate the burst instead of
+    // burying it in the undifferentiated policyFindings prose.
+    const sessionCorrelationFindings = [];
     if (sessionCorrelation && sessionCfg) {
         const threshold = sessionCfg.threshold;
         if (sessionCorrelation.burstCount >= threshold) {
-            policyFindings.push(`Rapid-fire merge burst detected: ${sessionCorrelation.burstCount} merged PRs in ${sessionCorrelation.windowMinutes} minutes.`);
+            sessionCorrelationFindings.push(`Rapid-fire merge burst detected: ${sessionCorrelation.burstCount} merged PRs in ${sessionCorrelation.windowMinutes} minutes.`);
             if (sessionCfg.mode === "block") {
-                policyFindings.push("Session correlation policy is configured to block.");
+                sessionCorrelationFindings.push("Session correlation policy is configured to block.");
             }
+            policyFindings.push(...sessionCorrelationFindings);
         }
     }
     const healthChecks = [...httpHealthChecks];
@@ -52505,6 +53328,12 @@ async function evaluateGate(config, commitSha, prNumber) {
     const sensitiveEscalation = decideSensitiveFilesEscalation(riskFactors, repoConfig?.policies?.sensitive_files);
     if (sensitiveEscalation.reason)
         policyFindings.push(sensitiveEscalation.reason);
+    const sessionCorrelationBlocks = sessionCorrelation !== null &&
+        sessionCfg !== undefined &&
+        sessionCorrelation.burstCount >= sessionCfg.threshold &&
+        sessionCfg.mode === "block";
+    const submissionBlocks = submissionChecks.length > 0 &&
+        submissionGateShouldBlock(submissionChecks, submissionMode);
     const gateDecision = agentPolicy?.forceBlock === true ||
         sensitiveEscalation.block ||
         (ciIntegrity.blockingPatterns.length > 0 &&
@@ -52520,16 +53349,54 @@ async function evaluateGate(config, commitSha, prNumber) {
             (duplicateLogicConfig?.mode ?? "warn") === "block") ||
         ((crossRepoImpact.factor?.score ?? 0) >= 60 &&
             (repoConfig?.policies?.cross_repo_impact?.mode ?? "warn") === "block") ||
-        (sessionCorrelation &&
-            sessionCfg &&
-            sessionCorrelation.burstCount >= sessionCfg.threshold &&
-            sessionCfg.mode === "block") ||
-        (submissionChecks.length > 0 &&
-            submissionGateShouldBlock(submissionChecks, submissionMode))
+        sessionCorrelationBlocks ||
+        submissionBlocks
         ? "block"
         : sensitiveEscalation.warn && baselineDecision === "allow"
             ? "warn"
             : baselineDecision;
+    // ADR-011 §1 (Case A): the count-strings below stay for existing consumers, but
+    // the individual patterns are now carried through to the evaluation so the
+    // Release Brief can enumerate them instead of printing a bare number.
+    const enumeratedFindings = [
+        ...enumerateDetectorFindings("ci_integrity", ciIntegrity.blockingPatterns, "blocking"),
+        ...enumerateDetectorFindings("ci_integrity_warning", ciIntegrity.warningSignals, "warn"),
+        ...enumerateDetectorFindings("workflow_security", workflowSecurity.blockingPatterns, "blocking"),
+        ...enumerateDetectorFindings("workflow_security_warning", workflowSecurity.warnings, "warn"),
+        ...enumerateDetectorFindings("prompt_injection", promptInjection.blockingPatterns, "blocking"),
+        ...enumerateDetectorFindings("prompt_injection_warning", promptInjection.warnings, "warn"),
+        ...enumerateDetectorFindings("supply_chain", supplyChain.blockingPatterns, "blocking"),
+        ...enumerateDetectorFindings("supply_chain_warning", supplyChain.warnings, "warn"),
+        ...enumerateDetectorFindings("pr_scope", prScope.findings, "advisory"),
+        ...enumerateDetectorFindings("duplicate_logic", duplicateLogic.findings, "advisory"),
+        ...enumerateDetectorFindings("cross_repo_impact", crossRepoImpact.findings, "advisory"),
+        // The four block-capable sources below are not detector pattern lists, so
+        // they used to reach the evaluation as prose in `policyFindings` only. A
+        // BLOCK caused by any of them would then render as "No findings." — the
+        // exact silence ADR-011 §1 forbids.
+        ...enumerateDetectorFindings("agent_policy", agentPolicy?.findings ?? [], agentPolicy?.forceBlock === true ? "blocking" : "warn"),
+        // A single escalation verdict, so its id is fixed rather than enumerated.
+        ...(sensitiveEscalation.reason
+            ? [
+                {
+                    id: "sensitive_files/0",
+                    title: sensitiveEscalation.reason,
+                    severity: sensitiveEscalation.block
+                        ? "blocking"
+                        : "warn",
+                },
+            ]
+            : []),
+        ...enumerateDetectorFindings("session_correlation", sessionCorrelationFindings, sessionCorrelationBlocks ? "blocking" : "warn"),
+        // `policyFindings` only ever carried the submission count; the per-check
+        // code/title/detail/severity is what a human actually needs.
+        ...submissionChecks.map((check, index) => ({
+            id: `submission/${check.code}/${index + 1}`,
+            title: check.title,
+            evidence: check.detail,
+            severity: check.severity,
+        })),
+    ];
     if (ciIntegrity.blockingPatterns.length > 0) {
         policyFindings.push(`CI integrity blocking patterns detected (${ciIntegrity.blockingPatterns.length}).`);
     }
@@ -52616,6 +53483,7 @@ async function evaluateGate(config, commitSha, prNumber) {
         evaluationMs: Date.now() - start,
         environment: effectiveEnvironment,
         policyFindings: policyFindings.length > 0 ? policyFindings : undefined,
+        enumeratedFindings: enumeratedFindings.length > 0 ? enumeratedFindings : undefined,
         pr: prNumber
             ? {
                 provenance: provenance ??
@@ -52690,6 +53558,9 @@ async function evaluateGate(config, commitSha, prNumber) {
                 });
                 ciSummary = evaluateRequiredChecks(checks, ciConfig, ciManifest);
             }
+            // ADR-011 §2 — resolve each input's disposition before anything reads the
+            // summary. With no input_relevance config this is a pure annotation pass.
+            ciSummary = applyInputRelevance(ciSummary, matchedContext?.context.input_relevance ?? []);
             localEvaluation.ci = ciSummary;
         }
         catch (error) {
@@ -52753,23 +53624,25 @@ async function evaluateGate(config, commitSha, prNumber) {
         provenanceType: localEvaluation.pr?.provenance?.type,
     });
     localEvaluation.agentBriefMode = agentBriefMode;
+    // Fetched once, outside the remediation branch: ADR-011 §1's delta needs the
+    // previous evaluation even in repos that have remediation turned off.
+    let previousEvaluation = null;
+    if (prNumber && (config.evaluationStoreUrl || process.env.SUPABASE_URL)) {
+        try {
+            previousEvaluation = await fetchPreviousEvaluationForPr({
+                repoId: localEvaluation.repoId,
+                prNumber,
+                excludeEvaluationId: localEvaluation.id,
+                storeUrl: config.evaluationStoreUrl,
+                apiKey: config.trailheadApiKey,
+            });
+        }
+        catch (error) {
+            core_debug(`Previous evaluation lookup failed: ${error}`);
+        }
+    }
     const remediationEnabled = remediationSettings?.enabled !== false;
     if (remediationEnabled) {
-        let previousEvaluation = null;
-        if (prNumber && (config.evaluationStoreUrl || process.env.SUPABASE_URL)) {
-            try {
-                previousEvaluation = await fetchPreviousEvaluationForPr({
-                    repoId: localEvaluation.repoId,
-                    prNumber,
-                    excludeEvaluationId: localEvaluation.id,
-                    storeUrl: config.evaluationStoreUrl,
-                    apiKey: config.trailheadApiKey,
-                });
-            }
-            catch (error) {
-                core_debug(`Previous evaluation lookup failed: ${error}`);
-            }
-        }
         localEvaluation.remediation = buildRemediation({
             evaluation: {
                 id: localEvaluation.id,
@@ -52786,11 +53659,57 @@ async function evaluateGate(config, commitSha, prNumber) {
             submissionChecks,
         });
     }
+    // ADR-011 §1 — built last so it sees release-readiness, the override outcome
+    // and the remediation delta.
+    localEvaluation.releaseBrief = buildReleaseBrief(localEvaluation, adjustedRiskThreshold, undefined, previousEvaluation);
     return localEvaluation;
 }
 // ---------------------------------------------------------------------------
 // PR comment posting
 // ---------------------------------------------------------------------------
+/**
+ * Safety bound for anything handed to GitHub as a report body. Issue comments
+ * cap at 65536 characters and a check run's `output.summary` at 65535; one
+ * number under both leaves room for the comment marker.
+ */
+const MAX_GATE_REPORT_CHARS = 65000;
+const BRIEF_HEADING = "## Release Brief";
+const BRIEF_SEPARATOR = "\n\n---\n\n";
+/** Cut points that leave the surviving markdown structurally intact. */
+const SECTION_BOUNDARIES = ["\n\n#", "\n\n<details>", "\n\n"];
+/**
+ * Clamp a gate report to what GitHub will actually accept.
+ *
+ * `renderReleaseBrief` already caps the brief itself, but the legacy report
+ * appended below it is unbounded (the files-changed list alone grows with the
+ * PR). Only that tail is trimmed — the brief is the decision, so it survives
+ * intact — and the reader is told where the full detail still lives.
+ */
+function clampGateReport(report, maxChars = MAX_GATE_REPORT_CHARS) {
+    if (report.length <= maxChars)
+        return report;
+    const notice = `\n\n_…report truncated (${report.length - maxChars} chars over GitHub's ` +
+        `comment limit) — full detail in the stored evaluation / job summary._`;
+    const budget = maxChars - notice.length;
+    if (budget <= 0)
+        return report.slice(0, maxChars);
+    // Never cut into the brief: keep everything up to its trailing separator.
+    const briefStart = report.indexOf(BRIEF_HEADING);
+    const separator = briefStart >= 0 ? report.indexOf(BRIEF_SEPARATOR, briefStart) : -1;
+    const floor = separator >= 0 ? separator + BRIEF_SEPARATOR.length : 0;
+    if (floor >= budget)
+        return `${report.slice(0, budget)}${notice}`;
+    const head = report.slice(0, budget);
+    let cut = budget;
+    for (const boundary of SECTION_BOUNDARIES) {
+        const index = head.lastIndexOf(boundary);
+        if (index > floor) {
+            cut = index;
+            break;
+        }
+    }
+    return `${report.slice(0, cut).trimEnd()}${notice}`;
+}
 async function postOverrideRejectionComment(prNumber, message, token) {
     try {
         const octokit = getOctokit(token);
@@ -52838,7 +53757,7 @@ async function postPrComment(report, prNumber, token) {
             per_page: 100,
         });
         const MARKER = "<!-- trailhead-gate-report -->";
-        const body = `${MARKER}\n${report}`;
+        const body = clampGateReport(`${MARKER}\n${report}`);
         const existing = comments.find((c) => c.body?.includes(MARKER));
         if (existing) {
             await octokit.rest.issues.updateComment({
@@ -52858,7 +53777,9 @@ async function postPrComment(report, prNumber, token) {
         }
     }
     catch (error) {
-        core_debug(`Failed to post PR comment: ${error}`);
+        // Fail-soft, but never silent: a missing gate comment is a visible gap in
+        // the record, so it belongs in the run log rather than in debug output.
+        core_warning(`Failed to post PR comment: ${error}`);
     }
 }
 // ---------------------------------------------------------------------------
@@ -52885,7 +53806,7 @@ async function createCheckRun(evaluation, report, token, checkName) {
             conclusion,
             output: {
                 title: `${name}: ${titleSuffix}`,
-                summary: report,
+                summary: clampGateReport(report),
                 ...(evaluation.storePersisted === false
                     ? { text: "Evaluation not persisted — dashboard incomplete." }
                     : {}),
@@ -52893,7 +53814,8 @@ async function createCheckRun(evaluation, report, token, checkName) {
         });
     }
     catch (error) {
-        core_debug(`Failed to create check run: ${error}`);
+        // Fail-soft, but never silent — see postPrComment.
+        core_warning(`Failed to create check run: ${error}`);
     }
 }
 // ---------------------------------------------------------------------------
@@ -53226,10 +54148,18 @@ function formatGateReport(evaluation, riskThreshold) {
             ? "RELEASE READY"
             : "NOT RELEASE READY"
         : evaluation.gateDecision.toUpperCase();
-    const lines = [
-        `## ${icon} Trailhead — ${headline}${envLabel}${contextLabel}`,
-        ``,
-    ];
+    const lines = [];
+    // ADR-011 §1 — the brief leads; the pre-existing report stays below it so the
+    // same `<!-- trailhead-gate-report -->` comment upgrades in place.
+    if (evaluation.releaseBrief) {
+        lines.push(renderReleaseBrief(evaluation.releaseBrief, {
+            // The same markdown becomes a check run's output.summary, which GitHub
+            // caps at 65535 characters; leave room for the report below.
+            maxChars: BRIEF_MAX_CHARS,
+            ...(evaluation.reportUrl ? { storedEvaluationUrl: evaluation.reportUrl } : {}),
+        }), ``, `---`, ``);
+    }
+    lines.push(`## ${icon} Trailhead — ${headline}${envLabel}${contextLabel}`, ``);
     if (mode === "release-ready" || mode === "advisory") {
         lines.push(`| Dimension | Status |`, `|-----------|--------|`, `| **Release Ready** | **${evaluation.releaseReady ? "YES" : "NO"}** |`, `| Risk | ${evaluation.riskScore}/100 (threshold ${threshold}) |`, ...(evaluation.sizeScore !== undefined
             ? [`| Size / blast radius | ${evaluation.sizeScore}/100 (reported separately) |`]
@@ -53922,15 +54852,50 @@ async function storeViaApi(url, evaluation, maxRetries = 3) {
     }
     return notStored;
 }
-async function storeViaSupabase(evaluation) {
-    const supabaseUrl = process.env.SUPABASE_URL;
-    const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
-    if (!supabaseUrl || !serviceRoleKey) {
-        return false;
+/**
+ * Columns introduced by the ADR-011 store migration. A store that has not run it
+ * rejects the whole insert, so `storeViaSupabase` strips these and retries once
+ * rather than losing the evaluation over a narration-only column.
+ */
+const ADR011_STORE_COLUMNS = ["release_brief", "enumerated_findings"];
+/** PostgREST's schema-cache miss: `{"code":"PGRST204","message":"Could not find …"}`. */
+const UNKNOWN_COLUMN_CODE = "PGRST204";
+const UNKNOWN_COLUMN_MESSAGE = /could not find the '([^']+)' column/i;
+/**
+ * True only for PostgREST's column-not-found signature naming an ADR-011 column.
+ *
+ * A bare substring match would strip-and-retry on any 400 that happened to
+ * mention `release_brief` — a permission error, a constraint violation, a
+ * validation message — turning an unrelated failure into a silent data loss.
+ */
+function mentionsUnknownAdr011Column(body) {
+    const columns = ADR011_STORE_COLUMNS;
+    let code;
+    let message = body;
+    try {
+        const parsed = JSON.parse(body);
+        if (parsed !== null && typeof parsed === "object") {
+            const record = parsed;
+            if (typeof record.code === "string")
+                code = record.code;
+            if (typeof record.message === "string")
+                message = record.message;
+        }
     }
-    const restUrl = `${supabaseUrl.replace(/\/$/, "")}/rest/v1/trailhead_evaluations`;
-    const row = buildEvaluationStoreRow(evaluation);
-    const response = await fetch(restUrl, {
+    catch {
+        // Not JSON — the textual signature below is all there is to go on.
+    }
+    // A different PostgREST code is a different failure, whatever it mentions.
+    if (code !== undefined && code !== UNKNOWN_COLUMN_CODE)
+        return false;
+    const named = UNKNOWN_COLUMN_MESSAGE.exec(message)?.[1];
+    if (named !== undefined)
+        return columns.includes(named);
+    // No recognisable message shape: only a bare PGRST204 naming a column counts.
+    return code === UNKNOWN_COLUMN_CODE && columns.some((column) => body.includes(column));
+}
+async function insertSupabaseRow(restUrl, serviceRoleKey, row) {
+    return fetch(restUrl, {
         method: "POST",
         headers: {
             "Content-Type": "application/json",
@@ -53941,11 +54906,33 @@ async function storeViaSupabase(evaluation) {
         body: JSON.stringify(row),
         signal: AbortSignal.timeout(STORE_TIMEOUT_MS),
     });
+}
+async function storeViaSupabase(evaluation) {
+    const supabaseUrl = process.env.SUPABASE_URL;
+    const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    if (!supabaseUrl || !serviceRoleKey) {
+        return false;
+    }
+    const restUrl = `${supabaseUrl.replace(/\/$/, "")}/rest/v1/trailhead_evaluations`;
+    const row = buildEvaluationStoreRow(evaluation);
+    let response = await insertSupabaseRow(restUrl, serviceRoleKey, row);
     if (response.ok || response.status === 201) {
         info("Evaluation stored via direct Supabase insert");
         return true;
     }
-    const body = await response.text().catch(() => "");
+    let body = await response.text().catch(() => "");
+    if (response.status === 400 && mentionsUnknownAdr011Column(body)) {
+        const legacyRow = Object.fromEntries(Object.entries(row).filter(([key]) => !ADR011_STORE_COLUMNS.includes(key)));
+        core_warning("Evaluation store is missing the ADR-011 columns " +
+            `(${ADR011_STORE_COLUMNS.join(", ")}) — storing without the release brief. ` +
+            "Apply cloud/migrations/006_release_brief.sql to persist it.");
+        response = await insertSupabaseRow(restUrl, serviceRoleKey, legacyRow);
+        if (response.ok || response.status === 201) {
+            info("Evaluation stored via direct Supabase insert");
+            return true;
+        }
+        body = await response.text().catch(() => "");
+    }
     core_warning(`Supabase direct insert failed (HTTP ${response.status}): ${body}`);
     return false;
 }
@@ -53979,7 +54966,16 @@ function buildEvaluationStoreRow(evaluation) {
         fixes_resolved: remediation?.fixes_resolved ?? [],
         fixes_introduced: remediation?.fixes_introduced ?? [],
         pr: evaluation.pr ?? null,
-        policy_override: evaluation.policyOverride ?? null,
+        // ADR-011 §3 — an audit written before the scope field existed WAS a full
+        // override; store that explicitly so consumers never have to infer it.
+        policy_override: evaluation.policyOverride
+            ? { ...evaluation.policyOverride, scope: evaluation.policyOverride.scope ?? "full" }
+            : null,
+        // ADR-011 §1. The Cloud/Komatik path POSTs the whole GateEvaluation, so these
+        // ride along there for free; the direct-Supabase path is column-explicit and
+        // needs them named. See cloud/migrations/006_release_brief.sql.
+        release_brief: evaluation.releaseBrief ?? null,
+        enumerated_findings: evaluation.enumeratedFindings ?? null,
         gate_mode: evaluation.gateMode ?? null,
         submission_checks: evaluation.submissionChecks ?? null,
         policy_findings: evaluation.policyFindings ?? null,
@@ -56528,6 +57524,7 @@ function resolveEvaluationTarget(context) {
 
 
 
+
 class PolicyOverrideError extends Error {
     constructor(message) {
         super(message);
@@ -56656,6 +57653,40 @@ async function runSelfHeal(config, prNumber) {
         }
     }
     return results;
+}
+/**
+ * ADR-011 §4 — the matched context's availability stance wins over the action-input
+ * fail-mode. Absent a stance (no context matched, or the run failed before matching)
+ * behaviour is exactly what it was before ADR-011.
+ */
+function resolveEffectiveFailMode(environment) {
+    const stance = getResolvedAvailabilityStance();
+    if (stance === "fail_open")
+        return "open";
+    if (stance === "fail_closed")
+        return "closed";
+    return resolveFailMode(getInput("fail-mode"), environment);
+}
+/**
+ * Post (or edit in place) the cannot-evaluate Release Brief on the PR. Deliberately
+ * swallows every failure of its own: the caller is already reporting a real error and
+ * must not have it replaced by "could not post a comment".
+ */
+async function postCannotEvaluateBrief(error, failMode) {
+    try {
+        const githubToken = getInput("github-token") || process.env.GITHUB_TOKEN || undefined;
+        // backfill/re-evaluation runs suppress PR comments (see evaluate-pr above).
+        const backfillMode = Boolean(getInput("evaluate-pr").trim());
+        const brief = buildCannotEvaluateBrief(String(error instanceof Error ? error.message : error), failMode === "open" ? "fail_open" : "fail_closed");
+        setOutput("release-brief-json", JSON.stringify(brief));
+        const { prNumber } = resolveEvaluationTarget(github_context);
+        if (!githubToken || !prNumber || backfillMode)
+            return;
+        await postPrComment(renderReleaseBrief(brief), prNumber, githubToken);
+    }
+    catch (postError) {
+        core_debug(`Cannot-evaluate brief could not be posted: ${postError}`);
+    }
 }
 async function run() {
     try {
@@ -56943,6 +57974,9 @@ async function run() {
         setOutput("gate-decision", evaluation.gateDecision);
         setOutput("release-ready", evaluation.releaseReady !== undefined ? String(evaluation.releaseReady) : "");
         setOutput("evaluation-json", JSON.stringify(evaluation));
+        if (evaluation.releaseBrief) {
+            setOutput("release-brief-json", JSON.stringify(evaluation.releaseBrief));
+        }
         const verdict = buildGateVerdict(evaluation, {
             trustRuntime: readTrustRuntime(),
             agentId: resolveAgentProvenanceId(evaluation),
@@ -57115,12 +58149,18 @@ async function run() {
         setFailed(blockReason);
     }
     catch (error) {
+        const environment = getInput("environment") || undefined;
+        const failMode = resolveEffectiveFailMode(environment);
         if (error instanceof PolicyOverrideError) {
+            // An unusable override is still a run that could not evaluate — ADR-011 §1
+            // owes the PR a brief here too, with the validation message as the reason.
+            await postCannotEvaluateBrief(error, failMode);
             setFailed(`Invalid policy override: ${error.message}`);
             return;
         }
-        const environment = getInput("environment") || undefined;
-        const failMode = resolveFailMode(getInput("fail-mode"), environment);
+        // ADR-011 §1: "silence is a bug." A run that could not evaluate still owes the
+        // PR a brief. Best-effort — a posting failure must never mask the real error.
+        await postCannotEvaluateBrief(error, failMode);
         if (failMode === "open") {
             core_warning(`Trailhead evaluation failed — proceeding with deployment (fail-open). Error: ${error}`);
         }

--- a/docs/README.md
+++ b/docs/README.md
@@ -278,6 +278,7 @@ Example:
 | [agents-submission-soak.md](./agents-submission-soak.md) | B4 agents dogfood — flip criterion + measurement |
 | [komatik-hosted-store.md](./komatik-hosted-store.md)     | Fleet warehouse at komatik.ai                    |
 | [agent-trust-metrics.md](./agent-trust-metrics.md)       | Trust loop implementers                          |
+| [release-brief.md](./release-brief.md)                   | Release owners — brief contract, input relevance |
 | [verdict.md](./verdict.md)                               | Collector integrators                            |
 | [migration-v3-to-v4.md](./migration-v3-to-v4.md)         | Upgrading from `@v3`                             |
 

--- a/docs/adr/010-architecture-lifecycle-gates.md
+++ b/docs/adr/010-architecture-lifecycle-gates.md
@@ -1,6 +1,6 @@
 # ADR-010: Architecture & Lifecycle Gates
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-06-01
 **Author:** Trailhead team
 

--- a/docs/adr/011-release-brief-and-input-relevance.md
+++ b/docs/adr/011-release-brief-and-input-relevance.md
@@ -1,6 +1,6 @@
 # ADR-011: Release Brief and Input Relevance Policy — closing the communication gap
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-08-09
 **Author:** Fable (Komatik keystone), from the 2026-08-09 Komatik promotion-train post-mortem
 **Builds on:** ADR-006 (Release Ready composite gate), ADR-008 (gate modes), ADR-009 (CI check classification)
@@ -27,7 +27,7 @@ was reviewed and accepted. The gate reasoned correctly and communicated a number
 **Case B — the input model has no concept of "failed but irrelevant."** On the staging→master PR (komatik
 #4034), GitHub's required-check bag blocked the merge on a red `Deploy Edge Functions` check. That red was a
 **staging-push infra failure** — `supabase link` on `SUPABASE_STAGING_PROJECT_REF`, a secret that
-*deliberately does not exist* (no staging Supabase project is provisioned; the sibling migrations workflow
+_deliberately does not exist_ (no staging Supabase project is provisioned; the sibling migrations workflow
 has carried a skip-guard comment saying exactly this since 2026-07-26). Under ADR-009's enum this is simply
 `fail`. There is no vocabulary for what it actually was: **a failed check that is irrelevant to THIS
 promotion decision, for a stateable reason**. Diagnosis and repair took a human an hour of log-spelunking
@@ -65,7 +65,7 @@ Contract rules:
 - **Every input gets a disposition with a reason** (see §2) — including the ones that did NOT count.
   Case B's line would have read:
   `Deploy Edge Functions: fail → irrelevant (staging target unconfigured by design; see
-  supabase-migrations.yml guard, 2026-07-26)`.
+supabase-migrations.yml guard, 2026-07-26)`.
 - **Silence is a bug.** If the evaluation cannot run (store unreachable, token missing), the brief says so
   and applies the availability stance (§4). A gate that fails to evaluate must still communicate.
 
@@ -74,12 +74,12 @@ Contract rules:
 ADR-009's status enum (`pass/fail/skip/pending/stale/missing`) describes what a check DID. This ADR adds a
 per-target-branch **disposition** describing what it MEANS for this decision:
 
-| Disposition | Meaning |
-| --- | --- |
-| `blocking` | red ⇒ release not ready |
-| `advisory` | feeds risk/warn, never blocks alone |
+| Disposition          | Meaning                                                                      |
+| -------------------- | ---------------------------------------------------------------------------- |
+| `blocking`           | red ⇒ release not ready                                                      |
+| `advisory`           | feeds risk/warn, never blocks alone                                          |
 | `irrelevant(reason)` | classified out for THIS branch pair, reason mandatory and shown in the brief |
-| `missing_blocking` | ADR-009 `missing` on a check policy requires |
+| `missing_blocking`   | ADR-009 `missing` on a check policy requires                                 |
 
 Policy lives in repo config (the ADR-007 config schema is the natural home) as a
 `branch-pair → check-pattern → disposition` table. Seed table for komatik (the dogfood consumer):
@@ -94,7 +94,7 @@ evaluation store `{by, at, scope, rationale}` and rendered in the brief. **Scope
 overrides the risk verdict and policy findings, never mechanical `blocking` inputs (red tests stay red).
 Getting past a red mechanical input remains a GitHub admin-merge — restored to what it should be: visible
 and extraordinary, not the routine override path. (Komatik's `BRANCHING.md` solo-maintainer section
-currently *instructs* configuring the bypass list for routine promotions — the exact pattern this replaces.)
+currently _instructs_ configuring the bypass list for routine promotions — the exact pattern this replaces.)
 
 ### 4. Availability stance (per branch pair, written down)
 
@@ -109,6 +109,16 @@ Risk 90 on a train that was keystone-verified, corpus-validated, and 100%-review
 needs a promotion-shaped calibration analog to the branch-pair exemption the scope rule already applies
 (`pr_scope: branch pair dev -> staging matches an exempt rule — scope limits skipped`). Stage 1 below
 measures this before any consumer flips enforcement.
+
+## Implementation
+
+Stage 0 landed in `src/release-brief.ts` (brief data model, markdown renderer, delta
+formatter) and `src/input-relevance.ts` (disposition engine), wired through
+`src/gate.ts` (`applyInputRelevance`, `enumerateDetectorFindings`, `buildReleaseBrief`,
+`buildCannotEvaluateBrief`), `src/release-ready.ts` (`checkCountsTowardBlocking`),
+`src/override.ts` (`risk_only` scope), and `src/main.ts` (availability stance in the
+top-level catch, `release-brief-json` output). Config surface — `contexts[].input_relevance`
+and `contexts[].availability` — is documented in [docs/release-brief.md](../release-brief.md).
 
 ## Rollout
 

--- a/docs/adr/011-release-brief-and-input-relevance.md
+++ b/docs/adr/011-release-brief-and-input-relevance.md
@@ -1,0 +1,145 @@
+# ADR-011: Release Brief and Input Relevance Policy — closing the communication gap
+
+**Status:** Proposed
+**Date:** 2026-08-09
+**Author:** Fable (Komatik keystone), from the 2026-08-09 Komatik promotion-train post-mortem
+**Builds on:** ADR-006 (Release Ready composite gate), ADR-008 (gate modes), ADR-009 (CI check classification)
+**Decision owner:** David
+
+## Context
+
+ADR-006 already answers the authority question: Trailhead — Release Ready is designed to be **the single
+required check**, composing CI status, risk, policy, freeze, health, and security into one decision. ADR-009
+defines how CI inputs are read (`pass/fail/skip/pending/stale/missing`).
+
+The 2026-08-09 Komatik promotion train (dev → staging → master, first master promotion in ~110 PRs) showed
+what is still missing. Two gate failures in one night, neither a detection failure — **both were
+communication failures at the decision point**, and one exposed a hole in the input model:
+
+**Case A — the verdict that could not speak.** On the dev→staging PR (komatik #4033), the gate
+(`trailhead@v4.6.0`, `gate-mode: release-ready`) returned **BLOCK: risk 90, "CI integrity blocking patterns
+detected (4)"**. The four patterns were never enumerated anywhere a human could see — not on the PR, not in
+the job summary; the CI log carries only the count, and the full evaluation went to `/api/trailhead/store`
+and stayed there. Because Trailhead was not the required check in that repo, the human decision-owner's only
+path forward was a GitHub **admin-merge — a bypass of every gate at once**, recording nothing about what risk
+was reviewed and accepted. The gate reasoned correctly and communicated a number.
+
+**Case B — the input model has no concept of "failed but irrelevant."** On the staging→master PR (komatik
+#4034), GitHub's required-check bag blocked the merge on a red `Deploy Edge Functions` check. That red was a
+**staging-push infra failure** — `supabase link` on `SUPABASE_STAGING_PROJECT_REF`, a secret that
+*deliberately does not exist* (no staging Supabase project is provisioned; the sibling migrations workflow
+has carried a skip-guard comment saying exactly this since 2026-07-26). Under ADR-009's enum this is simply
+`fail`. There is no vocabulary for what it actually was: **a failed check that is irrelevant to THIS
+promotion decision, for a stateable reason**. Diagnosis and repair took a human an hour of log-spelunking
+plus a workflow patch (komatik #4035); a reasoning gate with a relevance policy would have classified it in
+milliseconds and said so on the PR.
+
+The shared diagnosis: **the release brief — what a human needs at the moment of decision — is owned by
+nobody.** GitHub can enforce but cannot reason or narrate. Trailhead reasons, but its reasoning today
+surfaces as a check conclusion plus a stored evaluation nobody is looking at.
+
+## Decision
+
+Three additions to the release-ready gate, in priority order. Narration first — it ships value with zero
+enforcement change and would have answered both cases by itself.
+
+### 1. The Release Brief (the communication contract)
+
+Every evaluation — allow, warn, block, or **cannot-evaluate** — posts a structured comment on the PR (edited
+in place on re-evaluation; the check's summary links to it):
+
+```
+verdict: allow | warn | block | cannot_evaluate
+risk_score: <int>                 # with effective threshold and top movers
+findings: [ { id, title, evidence, severity } ]     # ENUMERATED — a bare count is a bug
+inputs:   [ { check_name, adr9_status, disposition, reason } ]
+delta:    <string>                # vs previous evaluation of this PR/head
+actions:  [ { kind: fix | override | wait, detail, link } ]
+override: { by, at, scope, rationale } | null
+```
+
+Contract rules:
+
+- **Findings are enumerated, never counted.** "CI integrity blocking patterns detected (4)" is a violation
+  of this contract. Each pattern gets id, evidence, severity.
+- **Every input gets a disposition with a reason** (see §2) — including the ones that did NOT count.
+  Case B's line would have read:
+  `Deploy Edge Functions: fail → irrelevant (staging target unconfigured by design; see
+  supabase-migrations.yml guard, 2026-07-26)`.
+- **Silence is a bug.** If the evaluation cannot run (store unreachable, token missing), the brief says so
+  and applies the availability stance (§4). A gate that fails to evaluate must still communicate.
+
+### 2. Input relevance policy (extends ADR-009)
+
+ADR-009's status enum (`pass/fail/skip/pending/stale/missing`) describes what a check DID. This ADR adds a
+per-target-branch **disposition** describing what it MEANS for this decision:
+
+| Disposition | Meaning |
+| --- | --- |
+| `blocking` | red ⇒ release not ready |
+| `advisory` | feeds risk/warn, never blocks alone |
+| `irrelevant(reason)` | classified out for THIS branch pair, reason mandatory and shown in the brief |
+| `missing_blocking` | ADR-009 `missing` on a check policy requires |
+
+Policy lives in repo config (the ADR-007 config schema is the natural home) as a
+`branch-pair → check-pattern → disposition` table. Seed table for komatik (the dogfood consumer):
+CI Gate / type-check / test suites / certification legs / migration lint ⇒ `blocking` on both staging and
+master pairs; push-triggered staging-target deploy checks ⇒ `irrelevant(unconfigured-by-design)` on
+master pairs; agent-author Vercel checks ⇒ `irrelevant(documented non-blocking)`.
+
+### 3. Scoped, recorded override
+
+A human override becomes a first-class Trailhead action (comment command or dashboard), recorded in the
+evaluation store `{by, at, scope, rationale}` and rendered in the brief. **Scope is `risk_only`**: it
+overrides the risk verdict and policy findings, never mechanical `blocking` inputs (red tests stay red).
+Getting past a red mechanical input remains a GitHub admin-merge — restored to what it should be: visible
+and extraordinary, not the routine override path. (Komatik's `BRANCHING.md` solo-maintainer section
+currently *instructs* configuring the bypass list for routine promotions — the exact pattern this replaces.)
+
+### 4. Availability stance (per branch pair, written down)
+
+Proposed defaults for the dogfood consumer: master pairs **fail closed** (no evaluation ⇒ no verdict ⇒ no
+merge; break-glass = admin-merge, already extraordinary per §3); staging pairs **fail open with a
+cannot-evaluate brief**. Consumers set their own in config; the requirement this ADR imposes is only that
+it is explicit.
+
+## Calibration note (carried from Case A, feeds ADR-006's threshold model)
+
+Risk 90 on a train that was keystone-verified, corpus-validated, and 100%-reviewed suggests the risk model
+needs a promotion-shaped calibration analog to the branch-pair exemption the scope rule already applies
+(`pr_scope: branch pair dev -> staging matches an exempt rule — scope limits skipped`). Stage 1 below
+measures this before any consumer flips enforcement.
+
+## Rollout
+
+- **Stage 0 — narrate only.** Ship the Release Brief with no enforcement change anywhere. Would have
+  resolved both 2026-08-09 cases on its own.
+- **Stage 1 — calibrate.** Track brief accuracy on real promotions (every block explainable? every
+  `irrelevant` classification correct?). Exit: N consecutive promotions with zero human corrections.
+- **Stage 2 — komatik flips staging** branch protection to require only `Trailhead — Release Ready`
+  (finally wiring what ADR-006 designed).
+- **Stage 3 — komatik flips master**, with fail-closed availability and recorded override live.
+  Admin-merge count becomes a tracked metric, expected value zero.
+
+## Consequences
+
+- The gate's value becomes legible exactly where decisions happen; time-to-diagnosis for a blocked
+  promotion drops from log access to reading one comment.
+- Accepted risk finally leaves a record (Case A's admin-merge left none).
+- New maintenance surface: the relevance policy table — deliberately small, in config, and self-auditing
+  (every `irrelevant` prints its reason on every PR, so a stale reason is visible daily).
+- Dogfood story: "Komatik's own production merges are governed by Trailhead" becomes a true product
+  sentence, with this ADR's gap list as the roadmap that made it true.
+
+## Source findings (2026-08-09, verified live during the train)
+
+1. The v4.6.0 action logs a BLOCK with a findings **count**; the enumeration exists only in the stored
+   evaluation, which is not linked from the check output. (§1 closes.)
+2. ADR-009 has no relevance axis; a deliberately-unconfigured staging deploy target surfaces as bare
+   `fail` and blocked a master promotion in a consumer whose required-check list included it. (§2 closes;
+   consumer-side symptom patched as komatik #4035.)
+3. The evaluation store and `warn,block` webhooks already exist — the substrate for the brief is built;
+   what is missing is the PR-surface narration and the disposition vocabulary.
+4. Consumer-side branch-protection guidance (komatik `BRANCHING.md`) normalizes admin-bypass for solo
+   maintainers — evidence that the override path this ADR specifies is currently filled by the most
+   dangerous available mechanism.

--- a/docs/komatik-migrations/20260808120000_trailhead_release_brief.sql
+++ b/docs/komatik-migrations/20260808120000_trailhead_release_brief.sql
@@ -1,0 +1,20 @@
+-- ADR-011 Release Brief columns for trailhead_evaluations (Aug 2026)
+-- Copy into Komatik/supabase/migrations/ via PR. Do NOT apply via MCP to prod.
+--
+-- Trailhead reference: cloud/migrations/006_release_brief.sql
+-- Update platform/web/lib/trailhead/evaluation-store.ts mapEvaluationStoreRow to persist these fields:
+--   release_brief:        pick(body, "releaseBrief", "release_brief") ?? null,
+--   enumerated_findings:  pick(body, "enumeratedFindings", "enumerated_findings") ?? null,
+--
+-- Until this lands, Trailhead degrades gracefully: the direct-Supabase store path
+-- retries the insert without these two columns, and the delta lookup falls back to
+-- its pre-ADR-011 narrow select.
+
+ALTER TABLE public.trailhead_evaluations
+  ADD COLUMN IF NOT EXISTS release_brief jsonb,
+  ADD COLUMN IF NOT EXISTS enumerated_findings jsonb;
+
+COMMENT ON COLUMN public.trailhead_evaluations.release_brief IS
+  'ADR-011 Release Brief: verdict, risk + top movers, enumerated findings, per-input dispositions, delta, actions, override.';
+COMMENT ON COLUMN public.trailhead_evaluations.enumerated_findings IS
+  'ADR-011 §1: findings as {id,title,evidence,severity} rows. policy_findings keeps the legacy count strings.';

--- a/docs/release-brief.md
+++ b/docs/release-brief.md
@@ -1,0 +1,237 @@
+# Release Brief (ADR-011)
+
+The Release Brief is what a human reads at the moment of a release decision. Every
+evaluation — allow, warn, block, or **cannot-evaluate** — posts one on the PR, edited
+in place on re-evaluation, and exposes the same object on the `release-brief-json`
+Action output.
+
+See [ADR-011](adr/011-release-brief-and-input-relevance.md) for the decision record.
+
+## The contract
+
+```jsonc
+{
+  "verdict": "allow | warn | block | cannot_evaluate",
+  "riskScore": 42,
+  "riskThreshold": 70,
+  "topMovers": [{ "factor": "code_churn", "score": 30 }], // top 3, descending
+  "findings": [
+    { "id": "ci_integrity/1", "title": "…", "evidence": "…", "severity": "blocking" },
+  ],
+  "inputs": [
+    {
+      "checkName": "CI Gate",
+      "status": "fail",
+      "disposition": "blocking",
+      "reason": "…",
+    },
+  ],
+  "delta": "vs previous: block -> allow, risk 90 -> 42, 3 findings resolved, 1 new",
+  "actions": [{ "kind": "fix | wait | override", "detail": "…", "link": "…" }],
+  "override": { "by": "dave", "at": "…", "scope": "risk_only", "rationale": "…" },
+}
+```
+
+Three rules the implementation enforces:
+
+1. **Findings are enumerated, never counted.** `"CI integrity blocking patterns detected (4)"`
+   is a contract violation. Every detector pattern becomes its own `{id, title, evidence, severity}`
+   row. (`policyFindings` keeps its legacy count strings for existing consumers;
+   `enumeratedFindings` is the enumeration.)
+2. **Every input gets a disposition with a reason — including the ones that did not count.**
+   A check classified out still gets a row saying so and why.
+3. **Silence is a bug.** If the evaluation cannot run at all, the brief says so, names the
+   failure, and applies the availability stance below.
+
+### Where it appears
+
+| Surface                              | Content                                                      |
+| ------------------------------------ | ------------------------------------------------------------ |
+| PR comment (`trailhead-gate-report`) | Brief first, then the existing gate report. Edited in place. |
+| Job summary / check-run summary      | The same markdown.                                           |
+| `release-brief-json` output          | The brief as JSON.                                           |
+| Evaluation store                     | `release_brief` + `enumerated_findings` columns.             |
+
+### Truncation
+
+Two independent caps, because GitHub rejects an oversized body outright (issue comments cap at
+65 536 characters, a check run's `output.summary` at 65 535).
+
+**1. The brief is capped at 20 000 characters inside the gate report.** Truncation order is
+deliberate: **drop findings from the end first**, always keeping at least one plus a pointer to
+the stored evaluation; then cap each finding's evidence at 300 characters; then, as a last
+resort, hard-clip. Inputs, delta, actions and override are never dropped — the input table is
+the part that answers "why is this blocked?".
+
+**2. The whole body is clamped to 65 000 characters at the two GitHub surfaces.** The legacy
+report appended below the brief is unbounded on its own (the files-changed list grows with the
+PR), so `postPrComment` and `createCheckRun` clamp what they send. Only the tail below the
+brief is trimmed — at a section boundary where one is available — and a visible
+`…report truncated (N chars over GitHub's comment limit)` notice replaces it. The brief itself
+is never cut by this pass. The job summary and the stored evaluation keep the full report, which
+is where the notice points.
+
+## Config reference
+
+### `contexts[].input_relevance` (ADR-011 §2)
+
+ADR-009's status enum (`pass|fail|skip|pending|stale|missing`) says what a check **did**.
+A disposition says what it **means for this decision**:
+
+| Disposition        | Meaning                                                            |
+| ------------------ | ------------------------------------------------------------------ |
+| `blocking`         | red ⇒ release not ready                                            |
+| `advisory`         | feeds risk/warn, never blocks alone                                |
+| `irrelevant`       | classified out for this branch pair — **reason mandatory**         |
+| `missing_blocking` | derived, never configured: ADR-009 `missing` on a `blocking` check |
+
+Resolution rules:
+
+- Entries are evaluated **in declaration order; the first match wins**, like `contexts[]` itself.
+- A pattern matches on exact name, case-insensitive name, configured-value-as-prefix, or glob.
+- No matching entry falls back to `required ? blocking : advisory` — so a config with no
+  `input_relevance` block behaves exactly as it did before ADR-011.
+- An `irrelevant` entry with no `reason` is a config error. It is **warned, not fatal**
+  (a hard failure would drop the whole repo config to defaults over one missing string) and
+  the brief prints a placeholder reason that is obviously wrong on sight.
+
+> **Glob caveat:** `*` compiles to `[^/]*`, so `"CI Gate *"` will **not** match
+> `"CI Gate / type-check"`. Check names containing `/` need `**` — `"CI Gate **"`.
+
+### `contexts[].availability` (ADR-011 §4)
+
+`fail_open` | `fail_closed`. When the evaluation itself fails, the matched context's stance
+**overrides the `fail-mode` action input**. Absent a stance (or when no context matched),
+behaviour is unchanged: the `fail-mode` input, defaulting to closed only for
+`environment: production`.
+
+Either way, a cannot-evaluate brief is posted to the PR before the run resolves.
+
+### `override.scope` (ADR-011 §3)
+
+The `trailhead-override` label + `trailhead-override: <rationale>` comment mechanism now
+carries a scope:
+
+- `full` (default, pre-ADR-011 behaviour) — flips release-readiness wholesale.
+- `risk_only` — overrides the risk verdict and policy findings, **never mechanical blocking
+  inputs**. Red tests stay red. Getting past a red mechanical input remains a GitHub
+  admin-merge: visible and extraordinary, not the routine override path.
+
+Under `risk_only`, reasons the override cleared are recorded as `overriddenReasons` and
+reasons that survived as `retainedReasons`, both on the stored `policy_override`.
+
+## Example `.trailhead.yml`
+
+This is ADR-011's seed table for the dogfood consumer (komatik), written out in full.
+
+```yaml
+schema_version: 2
+
+gate:
+  mode: release-ready
+  check_name: "Trailhead — Release Ready"
+
+thresholds:
+  risk: 90
+  warn: 50
+
+override:
+  enabled: true
+  max_per_week: 3
+
+contexts:
+  # dev -> staging: the promotion train's first leg.
+  - name: staging-promotion
+    match:
+      base_branch: [staging]
+      head_branch: [dev]
+    environment: staging
+    availability: fail_open
+    thresholds:
+      risk: 90
+      warn: 50
+    ci:
+      required_checks: [CI Gate, Security Guard, Migration Lint]
+      optional_checks: []
+      missing_required: fail
+    input_relevance:
+      - pattern: "CI Gate **"
+        disposition: blocking
+      - pattern: "Migration Lint"
+        disposition: blocking
+      - pattern: "vercel**"
+        disposition: irrelevant
+        reason: "agent-author Vercel preview — documented non-blocking"
+
+  # staging -> master: the promotion that ADR-011 Case B blocked.
+  - name: production-promotion
+    match:
+      base_branch: [master, main]
+      head_branch: [staging]
+    environment: production
+    availability: fail_closed
+    thresholds:
+      risk: 90
+      warn: 50
+    ci:
+      required_checks: [CI Gate, Security Guard, Migration Lint, Certification]
+      optional_checks: []
+      missing_required: fail
+    input_relevance:
+      - pattern: "CI Gate **"
+        disposition: blocking
+      - pattern: "Certification **"
+        disposition: blocking
+      - pattern: "Migration Lint"
+        disposition: blocking
+      - pattern: "Deploy Edge Functions"
+        disposition: irrelevant
+        reason: "staging target unconfigured by design — no staging Supabase project; see supabase-migrations.yml skip-guard (2026-07-26)"
+      - pattern: "vercel**"
+        disposition: irrelevant
+        reason: "agent-author Vercel preview — documented non-blocking"
+```
+
+With that table, ADR-011 Case B's line reads on the PR as:
+
+```
+| Deploy Edge Functions | fail | irrelevant | staging target unconfigured by design — … |
+```
+
+instead of an hour of log-spelunking.
+
+## Evaluation store
+
+`release_brief` and `enumerated_findings` are new `jsonb` columns:
+
+- Cloud / Komatik-hosted stores receive the whole `GateEvaluation` JSON, so both fields
+  ride along automatically — the hosted store just needs its row mapper updated.
+- The direct-Supabase path is column-explicit. Apply
+  [`cloud/migrations/006_release_brief.sql`](../cloud/migrations/006_release_brief.sql)
+  (Komatik fleet copy:
+  [`docs/komatik-migrations/20260808120000_trailhead_release_brief.sql`](komatik-migrations/20260808120000_trailhead_release_brief.sql)).
+- Until it is applied, Trailhead degrades rather than failing: the insert is retried without
+  the two columns (with a warning), and the delta lookup falls back to its pre-ADR-011 select
+  so remediation loop bookkeeping is unaffected. You simply get no `delta` line.
+
+## Rollout
+
+ADR-011 ships in four stages. **Stage 0 is what is implemented today.**
+
+| Stage | What                                                                             | Status  |
+| ----- | -------------------------------------------------------------------------------- | ------- |
+| 0     | Narrate only — brief, dispositions, scoped override, availability stance         | shipped |
+| 1     | Calibrate — track brief accuracy on real promotions                              | next    |
+| 2     | Komatik flips **staging** protection to require only `Trailhead — Release Ready` | pending |
+| 3     | Komatik flips **master**, fail-closed availability + recorded override live      | pending |
+
+> **Review caveat — `irrelevant` is narration-only until Stage 2.** A disposition only
+> changes Trailhead's own verdict. If GitHub branch protection still lists
+> `Deploy Edge Functions` in its required-check bag, GitHub keeps blocking the merge no
+> matter what the brief says. Dispositions become enforcement — not just narration — at the
+> moment Trailhead is the **sole** required check for that branch. Until then, treat an
+> `irrelevant` row as "Trailhead has classified this out and told you why", and expect the
+> merge button to still be red.
+
+Exit criterion for Stage 1: N consecutive promotions with zero human corrections — every
+block explainable from the brief alone, and every `irrelevant` classification correct.

--- a/mcp/dist/config-core.d.ts
+++ b/mcp/dist/config-core.d.ts
@@ -2,4 +2,15 @@ import type { RepoConfig as RepoConfigType } from "./types.js";
 export declare const SUPPORTED_CONFIG_SCHEMA_VERSIONS: Set<number>;
 export declare const CURRENT_CONFIG_SCHEMA_VERSION = 2;
 export declare function parseYaml(input: string): unknown;
+/**
+ * Non-fatal config warnings, emitted by the loader after a successful parse.
+ *
+ * ADR-011 §2 makes `reason` mandatory for `disposition: irrelevant`, but this is
+ * deliberately NOT a Zod refine: `parseRepoConfigContent` returns null for ANY
+ * schema violation, which drops the entire repo config back to hardcoded
+ * defaults. Degrading a whole config over one missing reason string is worse
+ * than narrating it, so the entry still parses and the Release Brief prints a
+ * placeholder reason (see MISSING_IRRELEVANT_REASON in input-relevance.ts).
+ */
+export declare function collectConfigWarnings(config: RepoConfigType): string[];
 export declare function parseRepoConfigContent(content: string): RepoConfigType | null;

--- a/mcp/dist/config-core.js
+++ b/mcp/dist/config-core.js
@@ -117,6 +117,31 @@ export function parseYaml(input) {
     }
     return root;
 }
+/**
+ * Non-fatal config warnings, emitted by the loader after a successful parse.
+ *
+ * ADR-011 §2 makes `reason` mandatory for `disposition: irrelevant`, but this is
+ * deliberately NOT a Zod refine: `parseRepoConfigContent` returns null for ANY
+ * schema violation, which drops the entire repo config back to hardcoded
+ * defaults. Degrading a whole config over one missing reason string is worse
+ * than narrating it, so the entry still parses and the Release Brief prints a
+ * placeholder reason (see MISSING_IRRELEVANT_REASON in input-relevance.ts).
+ */
+export function collectConfigWarnings(config) {
+    const warnings = [];
+    for (const context of config.contexts) {
+        for (const entry of context.input_relevance) {
+            if (entry.disposition !== "irrelevant")
+                continue;
+            if (entry.reason !== undefined && entry.reason.trim() !== "")
+                continue;
+            warnings.push(`contexts."${context.name}".input_relevance: pattern "${entry.pattern}" is ` +
+                `"disposition: irrelevant" with no reason. ADR-011 requires a reason for ` +
+                `irrelevant inputs; the Release Brief will show a placeholder until one is set.`);
+        }
+    }
+    return warnings;
+}
 export function parseRepoConfigContent(content) {
     const raw = parseYaml(content);
     const parsed = RepoConfig.safeParse(raw);

--- a/mcp/dist/loop-bookkeeping.d.ts
+++ b/mcp/dist/loop-bookkeeping.d.ts
@@ -1,5 +1,19 @@
-import type { GateEvaluation } from "./types.js";
-export type PreviousEvaluationSnapshot = Pick<GateEvaluation, "id" | "remediation">;
+import type { GateDecision, Remediation } from "./types.js";
+/**
+ * What the store returns about the previous evaluation of a PR. `id`/`remediation`
+ * drive loop bookkeeping; the rest is ADR-011 §1 delta material and is present only
+ * when the backend actually returned those columns — every consumer must treat the
+ * optional fields as "unknown", never as "unchanged".
+ */
+export interface PreviousEvaluationSnapshot {
+    id: string;
+    remediation?: Remediation;
+    riskScore?: number;
+    gateDecision?: GateDecision;
+    releaseReady?: boolean;
+    /** Ids of the previous evaluation's enumerated findings (ADR-011 §1). */
+    findingIds?: string[];
+}
 export declare function resolveLoopRound(previous: PreviousEvaluationSnapshot | null | undefined): number;
 export declare function parseAgentIdFromHeadRef(headRef: string | undefined): string | null;
 export declare function parsePreviousEvaluationRow(row: unknown): PreviousEvaluationSnapshot | null;

--- a/mcp/dist/loop-bookkeeping.js
+++ b/mcp/dist/loop-bookkeeping.js
@@ -10,6 +10,33 @@ export function parseAgentIdFromHeadRef(headRef) {
     const match = headRef.match(/^agent\/([a-z0-9-]+)\//);
     return match?.[1] ?? null;
 }
+function pick(record, ...keys) {
+    for (const key of keys) {
+        const value = record[key];
+        if (value !== undefined && value !== null)
+            return value;
+    }
+    return undefined;
+}
+function readFindingIds(record) {
+    const direct = pick(record, "enumerated_findings", "enumeratedFindings");
+    const brief = pick(record, "release_brief", "releaseBrief");
+    const raw = direct ??
+        (brief && typeof brief === "object"
+            ? brief.findings
+            : undefined);
+    if (!Array.isArray(raw))
+        return undefined;
+    const ids = [];
+    for (const entry of raw) {
+        if (!entry || typeof entry !== "object")
+            continue;
+        const id = entry.id;
+        if (typeof id === "string")
+            ids.push(id);
+    }
+    return ids;
+}
 export function parsePreviousEvaluationRow(row) {
     if (!row || typeof row !== "object")
         return null;
@@ -21,7 +48,24 @@ export function parsePreviousEvaluationRow(row) {
     if (record.remediation && typeof record.remediation === "object") {
         remediation = record.remediation;
     }
-    return { id, remediation };
+    const snapshot = { id, remediation };
+    const riskScore = pick(record, "risk_score", "riskScore");
+    if (typeof riskScore === "number" && Number.isFinite(riskScore)) {
+        snapshot.riskScore = riskScore;
+    }
+    const gateDecision = pick(record, "gate_decision", "gateDecision");
+    if (gateDecision === "allow" || gateDecision === "warn" || gateDecision === "block") {
+        snapshot.gateDecision = gateDecision;
+    }
+    const releaseReady = pick(record, "release_ready", "releaseReady");
+    if (typeof releaseReady === "boolean") {
+        snapshot.releaseReady = releaseReady;
+    }
+    const findingIds = readFindingIds(record);
+    if (findingIds !== undefined) {
+        snapshot.findingIds = findingIds;
+    }
+    return snapshot;
 }
 export function pickLatestPreviousEvaluation(rows, excludeEvaluationId) {
     for (const row of rows) {

--- a/mcp/dist/release-ready.d.ts
+++ b/mcp/dist/release-ready.d.ts
@@ -1,4 +1,12 @@
-import type { CiSummary, GateDecision, GateEvaluation, GateMode } from "./types.js";
+import type { CiCheck, CiSummary, GateDecision, GateEvaluation, GateMode } from "./types.js";
+/**
+ * ADR-011 §2: the disposition, once resolved, is the axis that decides whether a
+ * red input blocks the release. Checks with no disposition — no `input_relevance`
+ * config, an externally-built CiSummary, or a stored pre-ADR-011 evaluation —
+ * fall back to `required`, which is byte-for-byte the pre-ADR-011 behavior
+ * (the default mapping is required -> blocking, non-required -> advisory).
+ */
+export declare function checkCountsTowardBlocking(check: CiCheck): boolean;
 export interface ReleaseReadyInput {
     gateMode: GateMode;
     gateDecision: GateDecision;

--- a/mcp/dist/release-ready.js
+++ b/mcp/dist/release-ready.js
@@ -1,4 +1,17 @@
 /**
+ * ADR-011 §2: the disposition, once resolved, is the axis that decides whether a
+ * red input blocks the release. Checks with no disposition — no `input_relevance`
+ * config, an externally-built CiSummary, or a stored pre-ADR-011 evaluation —
+ * fall back to `required`, which is byte-for-byte the pre-ADR-011 behavior
+ * (the default mapping is required -> blocking, non-required -> advisory).
+ */
+export function checkCountsTowardBlocking(check) {
+    const kind = check.disposition?.kind;
+    if (kind === undefined)
+        return check.required;
+    return kind === "blocking" || kind === "missing_blocking";
+}
+/**
  * Composite release readiness decision (ADR-006).
  */
 export function computeReleaseReady(input) {
@@ -17,7 +30,7 @@ export function computeReleaseReady(input) {
     }
     if (input.ciSummary) {
         if (!input.ciSummary.allRequiredPassed) {
-            const failed = input.ciSummary.checks.filter((c) => c.required &&
+            const failed = input.ciSummary.checks.filter((c) => checkCountsTowardBlocking(c) &&
                 (c.status === "fail" || c.status === "missing" || c.status === "stale"));
             for (const check of failed) {
                 reasons.push(`Required CI check "${check.name}" is ${check.status.toUpperCase()}`);

--- a/mcp/dist/types.d.ts
+++ b/mcp/dist/types.d.ts
@@ -53,24 +53,65 @@ export declare const AgentBriefMode: z.ZodEnum<["off", "collapsed", "expanded"]>
 export type AgentBriefMode = z.infer<typeof AgentBriefMode>;
 export declare const CiCheckStatusEnum: z.ZodEnum<["pass", "fail", "skip", "pending", "stale", "missing"]>;
 export type CiCheckStatusEnum = z.infer<typeof CiCheckStatusEnum>;
+export declare const InputDispositionKind: z.ZodEnum<["blocking", "advisory", "irrelevant", "missing_blocking"]>;
+export type InputDispositionKind = z.infer<typeof InputDispositionKind>;
+export declare const InputDisposition: z.ZodObject<{
+    kind: z.ZodEnum<["blocking", "advisory", "irrelevant", "missing_blocking"]>;
+    reason: z.ZodOptional<z.ZodString>;
+    /** `policy` = an input_relevance entry matched; `default` = required/optional fallback. */
+    source: z.ZodEnum<["policy", "default"]>;
+}, "strip", z.ZodTypeAny, {
+    source: "policy" | "default";
+    kind: "advisory" | "blocking" | "irrelevant" | "missing_blocking";
+    reason?: string | undefined;
+}, {
+    source: "policy" | "default";
+    kind: "advisory" | "blocking" | "irrelevant" | "missing_blocking";
+    reason?: string | undefined;
+}>;
+export type InputDisposition = z.infer<typeof InputDisposition>;
 export declare const CiCheck: z.ZodObject<{
     name: z.ZodString;
     status: z.ZodEnum<["pass", "fail", "skip", "pending", "stale", "missing"]>;
     conclusion: z.ZodOptional<z.ZodString>;
     detailsUrl: z.ZodOptional<z.ZodString>;
     required: z.ZodBoolean;
+    disposition: z.ZodOptional<z.ZodObject<{
+        kind: z.ZodEnum<["blocking", "advisory", "irrelevant", "missing_blocking"]>;
+        reason: z.ZodOptional<z.ZodString>;
+        /** `policy` = an input_relevance entry matched; `default` = required/optional fallback. */
+        source: z.ZodEnum<["policy", "default"]>;
+    }, "strip", z.ZodTypeAny, {
+        source: "policy" | "default";
+        kind: "advisory" | "blocking" | "irrelevant" | "missing_blocking";
+        reason?: string | undefined;
+    }, {
+        source: "policy" | "default";
+        kind: "advisory" | "blocking" | "irrelevant" | "missing_blocking";
+        reason?: string | undefined;
+    }>>;
 }, "strip", z.ZodTypeAny, {
     status: "pending" | "pass" | "fail" | "skip" | "stale" | "missing";
     name: string;
     required: boolean;
     conclusion?: string | undefined;
     detailsUrl?: string | undefined;
+    disposition?: {
+        source: "policy" | "default";
+        kind: "advisory" | "blocking" | "irrelevant" | "missing_blocking";
+        reason?: string | undefined;
+    } | undefined;
 }, {
     status: "pending" | "pass" | "fail" | "skip" | "stale" | "missing";
     name: string;
     required: boolean;
     conclusion?: string | undefined;
     detailsUrl?: string | undefined;
+    disposition?: {
+        source: "policy" | "default";
+        kind: "advisory" | "blocking" | "irrelevant" | "missing_blocking";
+        reason?: string | undefined;
+    } | undefined;
 }>;
 export type CiCheck = z.infer<typeof CiCheck>;
 export declare const CiSummary: z.ZodObject<{
@@ -80,18 +121,42 @@ export declare const CiSummary: z.ZodObject<{
         conclusion: z.ZodOptional<z.ZodString>;
         detailsUrl: z.ZodOptional<z.ZodString>;
         required: z.ZodBoolean;
+        disposition: z.ZodOptional<z.ZodObject<{
+            kind: z.ZodEnum<["blocking", "advisory", "irrelevant", "missing_blocking"]>;
+            reason: z.ZodOptional<z.ZodString>;
+            /** `policy` = an input_relevance entry matched; `default` = required/optional fallback. */
+            source: z.ZodEnum<["policy", "default"]>;
+        }, "strip", z.ZodTypeAny, {
+            source: "policy" | "default";
+            kind: "advisory" | "blocking" | "irrelevant" | "missing_blocking";
+            reason?: string | undefined;
+        }, {
+            source: "policy" | "default";
+            kind: "advisory" | "blocking" | "irrelevant" | "missing_blocking";
+            reason?: string | undefined;
+        }>>;
     }, "strip", z.ZodTypeAny, {
         status: "pending" | "pass" | "fail" | "skip" | "stale" | "missing";
         name: string;
         required: boolean;
         conclusion?: string | undefined;
         detailsUrl?: string | undefined;
+        disposition?: {
+            source: "policy" | "default";
+            kind: "advisory" | "blocking" | "irrelevant" | "missing_blocking";
+            reason?: string | undefined;
+        } | undefined;
     }, {
         status: "pending" | "pass" | "fail" | "skip" | "stale" | "missing";
         name: string;
         required: boolean;
         conclusion?: string | undefined;
         detailsUrl?: string | undefined;
+        disposition?: {
+            source: "policy" | "default";
+            kind: "advisory" | "blocking" | "irrelevant" | "missing_blocking";
+            reason?: string | undefined;
+        } | undefined;
     }>, "many">;
     allRequiredPassed: z.ZodBoolean;
     pendingCount: z.ZodNumber;
@@ -104,6 +169,11 @@ export declare const CiSummary: z.ZodObject<{
         required: boolean;
         conclusion?: string | undefined;
         detailsUrl?: string | undefined;
+        disposition?: {
+            source: "policy" | "default";
+            kind: "advisory" | "blocking" | "irrelevant" | "missing_blocking";
+            reason?: string | undefined;
+        } | undefined;
     }[];
     allRequiredPassed: boolean;
     pendingCount: number;
@@ -116,6 +186,11 @@ export declare const CiSummary: z.ZodObject<{
         required: boolean;
         conclusion?: string | undefined;
         detailsUrl?: string | undefined;
+        disposition?: {
+            source: "policy" | "default";
+            kind: "advisory" | "blocking" | "irrelevant" | "missing_blocking";
+            reason?: string | undefined;
+        } | undefined;
     }[];
     allRequiredPassed: boolean;
     pendingCount: number;
@@ -319,6 +394,8 @@ export declare const PolicyOverrideChanges: z.ZodObject<{
     releaseReady?: true | undefined;
 }>;
 export type PolicyOverrideChanges = z.infer<typeof PolicyOverrideChanges>;
+export declare const OverrideScope: z.ZodEnum<["full", "risk_only"]>;
+export type OverrideScope = z.infer<typeof OverrideScope>;
 export declare const PolicyOverrideAudit: z.ZodObject<{
     source: z.ZodDefault<z.ZodEnum<["workflow", "label"]>>;
     owner: z.ZodString;
@@ -326,6 +403,7 @@ export declare const PolicyOverrideAudit: z.ZodObject<{
     linkedTicket: z.ZodString;
     expiresAt: z.ZodString;
     appliedAt: z.ZodString;
+    scope: z.ZodOptional<z.ZodEnum<["full", "risk_only"]>>;
     changes: z.ZodDefault<z.ZodObject<{
         failMode: z.ZodOptional<z.ZodEnum<["open", "closed"]>>;
         riskThreshold: z.ZodOptional<z.ZodNumber>;
@@ -345,6 +423,10 @@ export declare const PolicyOverrideAudit: z.ZodObject<{
     preOverrideDecision: z.ZodOptional<z.ZodEnum<["allow", "warn", "block"]>>;
     preOverrideReleaseReady: z.ZodOptional<z.ZodBoolean>;
     preOverrideReasons: z.ZodOptional<z.ZodArray<z.ZodString, "many">>;
+    /** Blocking reasons the override cleared (risk/policy driven). */
+    overriddenReasons: z.ZodOptional<z.ZodArray<z.ZodString, "many">>;
+    /** Blocking reasons that survived the override (mechanical CI, ADR-011 §3). */
+    retainedReasons: z.ZodOptional<z.ZodArray<z.ZodString, "many">>;
 }, "strip", z.ZodTypeAny, {
     reason: string;
     source: "workflow" | "label";
@@ -358,9 +440,12 @@ export declare const PolicyOverrideAudit: z.ZodObject<{
         warnThreshold?: number | undefined;
         releaseReady?: true | undefined;
     };
+    scope?: "full" | "risk_only" | undefined;
     preOverrideDecision?: "allow" | "warn" | "block" | undefined;
     preOverrideReleaseReady?: boolean | undefined;
     preOverrideReasons?: string[] | undefined;
+    overriddenReasons?: string[] | undefined;
+    retainedReasons?: string[] | undefined;
 }, {
     reason: string;
     owner: string;
@@ -368,6 +453,7 @@ export declare const PolicyOverrideAudit: z.ZodObject<{
     expiresAt: string;
     appliedAt: string;
     source?: "workflow" | "label" | undefined;
+    scope?: "full" | "risk_only" | undefined;
     changes?: {
         failMode?: "open" | "closed" | undefined;
         riskThreshold?: number | undefined;
@@ -377,8 +463,226 @@ export declare const PolicyOverrideAudit: z.ZodObject<{
     preOverrideDecision?: "allow" | "warn" | "block" | undefined;
     preOverrideReleaseReady?: boolean | undefined;
     preOverrideReasons?: string[] | undefined;
+    overriddenReasons?: string[] | undefined;
+    retainedReasons?: string[] | undefined;
 }>;
 export type PolicyOverrideAudit = z.infer<typeof PolicyOverrideAudit>;
+export declare const BriefVerdict: z.ZodEnum<["allow", "warn", "block", "cannot_evaluate"]>;
+export type BriefVerdict = z.infer<typeof BriefVerdict>;
+export declare const BriefFinding: z.ZodObject<{
+    id: z.ZodString;
+    title: z.ZodString;
+    evidence: z.ZodOptional<z.ZodString>;
+    severity: z.ZodEnum<["blocking", "warn", "advisory"]>;
+}, "strip", z.ZodTypeAny, {
+    severity: "warn" | "advisory" | "blocking";
+    title: string;
+    id: string;
+    evidence?: string | undefined;
+}, {
+    severity: "warn" | "advisory" | "blocking";
+    title: string;
+    id: string;
+    evidence?: string | undefined;
+}>;
+export type BriefFinding = z.infer<typeof BriefFinding>;
+export declare const BriefInput: z.ZodObject<{
+    checkName: z.ZodString;
+    /** ADR-009 status, carried as a string so the renderer stays policy-agnostic. */
+    status: z.ZodString;
+    /** ADR-011 §2 disposition kind. */
+    disposition: z.ZodString;
+    reason: z.ZodOptional<z.ZodString>;
+}, "strip", z.ZodTypeAny, {
+    status: string;
+    disposition: string;
+    checkName: string;
+    reason?: string | undefined;
+}, {
+    status: string;
+    disposition: string;
+    checkName: string;
+    reason?: string | undefined;
+}>;
+export type BriefInput = z.infer<typeof BriefInput>;
+export declare const BriefAction: z.ZodObject<{
+    kind: z.ZodEnum<["fix", "override", "wait"]>;
+    detail: z.ZodString;
+    link: z.ZodOptional<z.ZodString>;
+}, "strip", z.ZodTypeAny, {
+    detail: string;
+    kind: "fix" | "override" | "wait";
+    link?: string | undefined;
+}, {
+    detail: string;
+    kind: "fix" | "override" | "wait";
+    link?: string | undefined;
+}>;
+export type BriefAction = z.infer<typeof BriefAction>;
+export declare const BriefOverride: z.ZodObject<{
+    by: z.ZodString;
+    at: z.ZodString;
+    scope: z.ZodString;
+    rationale: z.ZodString;
+}, "strip", z.ZodTypeAny, {
+    at: string;
+    scope: string;
+    by: string;
+    rationale: string;
+}, {
+    at: string;
+    scope: string;
+    by: string;
+    rationale: string;
+}>;
+export type BriefOverride = z.infer<typeof BriefOverride>;
+export declare const ReleaseBrief: z.ZodObject<{
+    verdict: z.ZodEnum<["allow", "warn", "block", "cannot_evaluate"]>;
+    riskScore: z.ZodOptional<z.ZodNumber>;
+    riskThreshold: z.ZodOptional<z.ZodNumber>;
+    topMovers: z.ZodOptional<z.ZodArray<z.ZodObject<{
+        factor: z.ZodString;
+        score: z.ZodNumber;
+    }, "strip", z.ZodTypeAny, {
+        score: number;
+        factor: string;
+    }, {
+        score: number;
+        factor: string;
+    }>, "many">>;
+    findings: z.ZodArray<z.ZodObject<{
+        id: z.ZodString;
+        title: z.ZodString;
+        evidence: z.ZodOptional<z.ZodString>;
+        severity: z.ZodEnum<["blocking", "warn", "advisory"]>;
+    }, "strip", z.ZodTypeAny, {
+        severity: "warn" | "advisory" | "blocking";
+        title: string;
+        id: string;
+        evidence?: string | undefined;
+    }, {
+        severity: "warn" | "advisory" | "blocking";
+        title: string;
+        id: string;
+        evidence?: string | undefined;
+    }>, "many">;
+    inputs: z.ZodArray<z.ZodObject<{
+        checkName: z.ZodString;
+        /** ADR-009 status, carried as a string so the renderer stays policy-agnostic. */
+        status: z.ZodString;
+        /** ADR-011 §2 disposition kind. */
+        disposition: z.ZodString;
+        reason: z.ZodOptional<z.ZodString>;
+    }, "strip", z.ZodTypeAny, {
+        status: string;
+        disposition: string;
+        checkName: string;
+        reason?: string | undefined;
+    }, {
+        status: string;
+        disposition: string;
+        checkName: string;
+        reason?: string | undefined;
+    }>, "many">;
+    delta: z.ZodOptional<z.ZodString>;
+    actions: z.ZodArray<z.ZodObject<{
+        kind: z.ZodEnum<["fix", "override", "wait"]>;
+        detail: z.ZodString;
+        link: z.ZodOptional<z.ZodString>;
+    }, "strip", z.ZodTypeAny, {
+        detail: string;
+        kind: "fix" | "override" | "wait";
+        link?: string | undefined;
+    }, {
+        detail: string;
+        kind: "fix" | "override" | "wait";
+        link?: string | undefined;
+    }>, "many">;
+    override: z.ZodOptional<z.ZodNullable<z.ZodObject<{
+        by: z.ZodString;
+        at: z.ZodString;
+        scope: z.ZodString;
+        rationale: z.ZodString;
+    }, "strip", z.ZodTypeAny, {
+        at: string;
+        scope: string;
+        by: string;
+        rationale: string;
+    }, {
+        at: string;
+        scope: string;
+        by: string;
+        rationale: string;
+    }>>>;
+    cannotEvaluateReason: z.ZodOptional<z.ZodString>;
+}, "strip", z.ZodTypeAny, {
+    verdict: "allow" | "warn" | "block" | "cannot_evaluate";
+    findings: {
+        severity: "warn" | "advisory" | "blocking";
+        title: string;
+        id: string;
+        evidence?: string | undefined;
+    }[];
+    inputs: {
+        status: string;
+        disposition: string;
+        checkName: string;
+        reason?: string | undefined;
+    }[];
+    actions: {
+        detail: string;
+        kind: "fix" | "override" | "wait";
+        link?: string | undefined;
+    }[];
+    riskThreshold?: number | undefined;
+    override?: {
+        at: string;
+        scope: string;
+        by: string;
+        rationale: string;
+    } | null | undefined;
+    riskScore?: number | undefined;
+    topMovers?: {
+        score: number;
+        factor: string;
+    }[] | undefined;
+    delta?: string | undefined;
+    cannotEvaluateReason?: string | undefined;
+}, {
+    verdict: "allow" | "warn" | "block" | "cannot_evaluate";
+    findings: {
+        severity: "warn" | "advisory" | "blocking";
+        title: string;
+        id: string;
+        evidence?: string | undefined;
+    }[];
+    inputs: {
+        status: string;
+        disposition: string;
+        checkName: string;
+        reason?: string | undefined;
+    }[];
+    actions: {
+        detail: string;
+        kind: "fix" | "override" | "wait";
+        link?: string | undefined;
+    }[];
+    riskThreshold?: number | undefined;
+    override?: {
+        at: string;
+        scope: string;
+        by: string;
+        rationale: string;
+    } | null | undefined;
+    riskScore?: number | undefined;
+    topMovers?: {
+        score: number;
+        factor: string;
+    }[] | undefined;
+    delta?: string | undefined;
+    cannotEvaluateReason?: string | undefined;
+}>;
+export type ReleaseBrief = z.infer<typeof ReleaseBrief>;
 export declare const CreditMeterResult: z.ZodObject<{
     metered: z.ZodBoolean;
     skipped: z.ZodOptional<z.ZodBoolean>;
@@ -468,6 +772,168 @@ export declare const GateEvaluation: z.ZodObject<{
     environment: z.ZodOptional<z.ZodString>;
     service: z.ZodOptional<z.ZodString>;
     policyFindings: z.ZodOptional<z.ZodArray<z.ZodString, "many">>;
+    enumeratedFindings: z.ZodOptional<z.ZodArray<z.ZodObject<{
+        id: z.ZodString;
+        title: z.ZodString;
+        evidence: z.ZodOptional<z.ZodString>;
+        severity: z.ZodEnum<["blocking", "warn", "advisory"]>;
+    }, "strip", z.ZodTypeAny, {
+        severity: "warn" | "advisory" | "blocking";
+        title: string;
+        id: string;
+        evidence?: string | undefined;
+    }, {
+        severity: "warn" | "advisory" | "blocking";
+        title: string;
+        id: string;
+        evidence?: string | undefined;
+    }>, "many">>;
+    releaseBrief: z.ZodOptional<z.ZodObject<{
+        verdict: z.ZodEnum<["allow", "warn", "block", "cannot_evaluate"]>;
+        riskScore: z.ZodOptional<z.ZodNumber>;
+        riskThreshold: z.ZodOptional<z.ZodNumber>;
+        topMovers: z.ZodOptional<z.ZodArray<z.ZodObject<{
+            factor: z.ZodString;
+            score: z.ZodNumber;
+        }, "strip", z.ZodTypeAny, {
+            score: number;
+            factor: string;
+        }, {
+            score: number;
+            factor: string;
+        }>, "many">>;
+        findings: z.ZodArray<z.ZodObject<{
+            id: z.ZodString;
+            title: z.ZodString;
+            evidence: z.ZodOptional<z.ZodString>;
+            severity: z.ZodEnum<["blocking", "warn", "advisory"]>;
+        }, "strip", z.ZodTypeAny, {
+            severity: "warn" | "advisory" | "blocking";
+            title: string;
+            id: string;
+            evidence?: string | undefined;
+        }, {
+            severity: "warn" | "advisory" | "blocking";
+            title: string;
+            id: string;
+            evidence?: string | undefined;
+        }>, "many">;
+        inputs: z.ZodArray<z.ZodObject<{
+            checkName: z.ZodString;
+            /** ADR-009 status, carried as a string so the renderer stays policy-agnostic. */
+            status: z.ZodString;
+            /** ADR-011 §2 disposition kind. */
+            disposition: z.ZodString;
+            reason: z.ZodOptional<z.ZodString>;
+        }, "strip", z.ZodTypeAny, {
+            status: string;
+            disposition: string;
+            checkName: string;
+            reason?: string | undefined;
+        }, {
+            status: string;
+            disposition: string;
+            checkName: string;
+            reason?: string | undefined;
+        }>, "many">;
+        delta: z.ZodOptional<z.ZodString>;
+        actions: z.ZodArray<z.ZodObject<{
+            kind: z.ZodEnum<["fix", "override", "wait"]>;
+            detail: z.ZodString;
+            link: z.ZodOptional<z.ZodString>;
+        }, "strip", z.ZodTypeAny, {
+            detail: string;
+            kind: "fix" | "override" | "wait";
+            link?: string | undefined;
+        }, {
+            detail: string;
+            kind: "fix" | "override" | "wait";
+            link?: string | undefined;
+        }>, "many">;
+        override: z.ZodOptional<z.ZodNullable<z.ZodObject<{
+            by: z.ZodString;
+            at: z.ZodString;
+            scope: z.ZodString;
+            rationale: z.ZodString;
+        }, "strip", z.ZodTypeAny, {
+            at: string;
+            scope: string;
+            by: string;
+            rationale: string;
+        }, {
+            at: string;
+            scope: string;
+            by: string;
+            rationale: string;
+        }>>>;
+        cannotEvaluateReason: z.ZodOptional<z.ZodString>;
+    }, "strip", z.ZodTypeAny, {
+        verdict: "allow" | "warn" | "block" | "cannot_evaluate";
+        findings: {
+            severity: "warn" | "advisory" | "blocking";
+            title: string;
+            id: string;
+            evidence?: string | undefined;
+        }[];
+        inputs: {
+            status: string;
+            disposition: string;
+            checkName: string;
+            reason?: string | undefined;
+        }[];
+        actions: {
+            detail: string;
+            kind: "fix" | "override" | "wait";
+            link?: string | undefined;
+        }[];
+        riskThreshold?: number | undefined;
+        override?: {
+            at: string;
+            scope: string;
+            by: string;
+            rationale: string;
+        } | null | undefined;
+        riskScore?: number | undefined;
+        topMovers?: {
+            score: number;
+            factor: string;
+        }[] | undefined;
+        delta?: string | undefined;
+        cannotEvaluateReason?: string | undefined;
+    }, {
+        verdict: "allow" | "warn" | "block" | "cannot_evaluate";
+        findings: {
+            severity: "warn" | "advisory" | "blocking";
+            title: string;
+            id: string;
+            evidence?: string | undefined;
+        }[];
+        inputs: {
+            status: string;
+            disposition: string;
+            checkName: string;
+            reason?: string | undefined;
+        }[];
+        actions: {
+            detail: string;
+            kind: "fix" | "override" | "wait";
+            link?: string | undefined;
+        }[];
+        riskThreshold?: number | undefined;
+        override?: {
+            at: string;
+            scope: string;
+            by: string;
+            rationale: string;
+        } | null | undefined;
+        riskScore?: number | undefined;
+        topMovers?: {
+            score: number;
+            factor: string;
+        }[] | undefined;
+        delta?: string | undefined;
+        cannotEvaluateReason?: string | undefined;
+    }>>;
     pr: z.ZodOptional<z.ZodObject<{
         provenance: z.ZodOptional<z.ZodObject<{
             type: z.ZodEnum<["human", "dependabot", "copilot", "codex", "claude", "custom-bot", "unknown"]>;
@@ -550,6 +1016,7 @@ export declare const GateEvaluation: z.ZodObject<{
         linkedTicket: z.ZodString;
         expiresAt: z.ZodString;
         appliedAt: z.ZodString;
+        scope: z.ZodOptional<z.ZodEnum<["full", "risk_only"]>>;
         changes: z.ZodDefault<z.ZodObject<{
             failMode: z.ZodOptional<z.ZodEnum<["open", "closed"]>>;
             riskThreshold: z.ZodOptional<z.ZodNumber>;
@@ -569,6 +1036,10 @@ export declare const GateEvaluation: z.ZodObject<{
         preOverrideDecision: z.ZodOptional<z.ZodEnum<["allow", "warn", "block"]>>;
         preOverrideReleaseReady: z.ZodOptional<z.ZodBoolean>;
         preOverrideReasons: z.ZodOptional<z.ZodArray<z.ZodString, "many">>;
+        /** Blocking reasons the override cleared (risk/policy driven). */
+        overriddenReasons: z.ZodOptional<z.ZodArray<z.ZodString, "many">>;
+        /** Blocking reasons that survived the override (mechanical CI, ADR-011 §3). */
+        retainedReasons: z.ZodOptional<z.ZodArray<z.ZodString, "many">>;
     }, "strip", z.ZodTypeAny, {
         reason: string;
         source: "workflow" | "label";
@@ -582,9 +1053,12 @@ export declare const GateEvaluation: z.ZodObject<{
             warnThreshold?: number | undefined;
             releaseReady?: true | undefined;
         };
+        scope?: "full" | "risk_only" | undefined;
         preOverrideDecision?: "allow" | "warn" | "block" | undefined;
         preOverrideReleaseReady?: boolean | undefined;
         preOverrideReasons?: string[] | undefined;
+        overriddenReasons?: string[] | undefined;
+        retainedReasons?: string[] | undefined;
     }, {
         reason: string;
         owner: string;
@@ -592,6 +1066,7 @@ export declare const GateEvaluation: z.ZodObject<{
         expiresAt: string;
         appliedAt: string;
         source?: "workflow" | "label" | undefined;
+        scope?: "full" | "risk_only" | undefined;
         changes?: {
             failMode?: "open" | "closed" | undefined;
             riskThreshold?: number | undefined;
@@ -601,6 +1076,8 @@ export declare const GateEvaluation: z.ZodObject<{
         preOverrideDecision?: "allow" | "warn" | "block" | undefined;
         preOverrideReleaseReady?: boolean | undefined;
         preOverrideReasons?: string[] | undefined;
+        overriddenReasons?: string[] | undefined;
+        retainedReasons?: string[] | undefined;
     }>>;
     labelOverrideFeedback: z.ZodOptional<z.ZodObject<{
         status: z.ZodEnum<["applied", "rejected"]>;
@@ -621,18 +1098,42 @@ export declare const GateEvaluation: z.ZodObject<{
             conclusion: z.ZodOptional<z.ZodString>;
             detailsUrl: z.ZodOptional<z.ZodString>;
             required: z.ZodBoolean;
+            disposition: z.ZodOptional<z.ZodObject<{
+                kind: z.ZodEnum<["blocking", "advisory", "irrelevant", "missing_blocking"]>;
+                reason: z.ZodOptional<z.ZodString>;
+                /** `policy` = an input_relevance entry matched; `default` = required/optional fallback. */
+                source: z.ZodEnum<["policy", "default"]>;
+            }, "strip", z.ZodTypeAny, {
+                source: "policy" | "default";
+                kind: "advisory" | "blocking" | "irrelevant" | "missing_blocking";
+                reason?: string | undefined;
+            }, {
+                source: "policy" | "default";
+                kind: "advisory" | "blocking" | "irrelevant" | "missing_blocking";
+                reason?: string | undefined;
+            }>>;
         }, "strip", z.ZodTypeAny, {
             status: "pending" | "pass" | "fail" | "skip" | "stale" | "missing";
             name: string;
             required: boolean;
             conclusion?: string | undefined;
             detailsUrl?: string | undefined;
+            disposition?: {
+                source: "policy" | "default";
+                kind: "advisory" | "blocking" | "irrelevant" | "missing_blocking";
+                reason?: string | undefined;
+            } | undefined;
         }, {
             status: "pending" | "pass" | "fail" | "skip" | "stale" | "missing";
             name: string;
             required: boolean;
             conclusion?: string | undefined;
             detailsUrl?: string | undefined;
+            disposition?: {
+                source: "policy" | "default";
+                kind: "advisory" | "blocking" | "irrelevant" | "missing_blocking";
+                reason?: string | undefined;
+            } | undefined;
         }>, "many">;
         allRequiredPassed: z.ZodBoolean;
         pendingCount: z.ZodNumber;
@@ -645,6 +1146,11 @@ export declare const GateEvaluation: z.ZodObject<{
             required: boolean;
             conclusion?: string | undefined;
             detailsUrl?: string | undefined;
+            disposition?: {
+                source: "policy" | "default";
+                kind: "advisory" | "blocking" | "irrelevant" | "missing_blocking";
+                reason?: string | undefined;
+            } | undefined;
         }[];
         allRequiredPassed: boolean;
         pendingCount: number;
@@ -657,6 +1163,11 @@ export declare const GateEvaluation: z.ZodObject<{
             required: boolean;
             conclusion?: string | undefined;
             detailsUrl?: string | undefined;
+            disposition?: {
+                source: "policy" | "default";
+                kind: "advisory" | "blocking" | "irrelevant" | "missing_blocking";
+                reason?: string | undefined;
+            } | undefined;
         }[];
         allRequiredPassed: boolean;
         pendingCount: number;
@@ -892,10 +1403,10 @@ export declare const GateEvaluation: z.ZodObject<{
     }>>;
 }, "strip", z.ZodTypeAny, {
     id: string;
+    riskScore: number;
     repoId: string;
     commitSha: string;
     healthScore: number;
-    riskScore: number;
     gateDecision: "allow" | "warn" | "block";
     healthChecks: {
         status: "allow" | "warn" | "block";
@@ -934,6 +1445,46 @@ export declare const GateEvaluation: z.ZodObject<{
     reportUrl?: string | undefined;
     service?: string | undefined;
     policyFindings?: string[] | undefined;
+    enumeratedFindings?: {
+        severity: "warn" | "advisory" | "blocking";
+        title: string;
+        id: string;
+        evidence?: string | undefined;
+    }[] | undefined;
+    releaseBrief?: {
+        verdict: "allow" | "warn" | "block" | "cannot_evaluate";
+        findings: {
+            severity: "warn" | "advisory" | "blocking";
+            title: string;
+            id: string;
+            evidence?: string | undefined;
+        }[];
+        inputs: {
+            status: string;
+            disposition: string;
+            checkName: string;
+            reason?: string | undefined;
+        }[];
+        actions: {
+            detail: string;
+            kind: "fix" | "override" | "wait";
+            link?: string | undefined;
+        }[];
+        riskThreshold?: number | undefined;
+        override?: {
+            at: string;
+            scope: string;
+            by: string;
+            rationale: string;
+        } | null | undefined;
+        riskScore?: number | undefined;
+        topMovers?: {
+            score: number;
+            factor: string;
+        }[] | undefined;
+        delta?: string | undefined;
+        cannotEvaluateReason?: string | undefined;
+    } | undefined;
     pr?: {
         provenance?: {
             type: "unknown" | "human" | "dependabot" | "copilot" | "codex" | "claude" | "custom-bot";
@@ -972,9 +1523,12 @@ export declare const GateEvaluation: z.ZodObject<{
             warnThreshold?: number | undefined;
             releaseReady?: true | undefined;
         };
+        scope?: "full" | "risk_only" | undefined;
         preOverrideDecision?: "allow" | "warn" | "block" | undefined;
         preOverrideReleaseReady?: boolean | undefined;
         preOverrideReasons?: string[] | undefined;
+        overriddenReasons?: string[] | undefined;
+        retainedReasons?: string[] | undefined;
     } | undefined;
     labelOverrideFeedback?: {
         message: string;
@@ -988,6 +1542,11 @@ export declare const GateEvaluation: z.ZodObject<{
             required: boolean;
             conclusion?: string | undefined;
             detailsUrl?: string | undefined;
+            disposition?: {
+                source: "policy" | "default";
+                kind: "advisory" | "blocking" | "irrelevant" | "missing_blocking";
+                reason?: string | undefined;
+            } | undefined;
         }[];
         allRequiredPassed: boolean;
         pendingCount: number;
@@ -1049,10 +1608,10 @@ export declare const GateEvaluation: z.ZodObject<{
     }[] | undefined;
 }, {
     id: string;
+    riskScore: number;
     repoId: string;
     commitSha: string;
     healthScore: number;
-    riskScore: number;
     gateDecision: "allow" | "warn" | "block";
     healthChecks: {
         status: "allow" | "warn" | "block";
@@ -1091,6 +1650,46 @@ export declare const GateEvaluation: z.ZodObject<{
     reportUrl?: string | undefined;
     service?: string | undefined;
     policyFindings?: string[] | undefined;
+    enumeratedFindings?: {
+        severity: "warn" | "advisory" | "blocking";
+        title: string;
+        id: string;
+        evidence?: string | undefined;
+    }[] | undefined;
+    releaseBrief?: {
+        verdict: "allow" | "warn" | "block" | "cannot_evaluate";
+        findings: {
+            severity: "warn" | "advisory" | "blocking";
+            title: string;
+            id: string;
+            evidence?: string | undefined;
+        }[];
+        inputs: {
+            status: string;
+            disposition: string;
+            checkName: string;
+            reason?: string | undefined;
+        }[];
+        actions: {
+            detail: string;
+            kind: "fix" | "override" | "wait";
+            link?: string | undefined;
+        }[];
+        riskThreshold?: number | undefined;
+        override?: {
+            at: string;
+            scope: string;
+            by: string;
+            rationale: string;
+        } | null | undefined;
+        riskScore?: number | undefined;
+        topMovers?: {
+            score: number;
+            factor: string;
+        }[] | undefined;
+        delta?: string | undefined;
+        cannotEvaluateReason?: string | undefined;
+    } | undefined;
     pr?: {
         provenance?: {
             type: "unknown" | "human" | "dependabot" | "copilot" | "codex" | "claude" | "custom-bot";
@@ -1123,6 +1722,7 @@ export declare const GateEvaluation: z.ZodObject<{
         expiresAt: string;
         appliedAt: string;
         source?: "workflow" | "label" | undefined;
+        scope?: "full" | "risk_only" | undefined;
         changes?: {
             failMode?: "open" | "closed" | undefined;
             riskThreshold?: number | undefined;
@@ -1132,6 +1732,8 @@ export declare const GateEvaluation: z.ZodObject<{
         preOverrideDecision?: "allow" | "warn" | "block" | undefined;
         preOverrideReleaseReady?: boolean | undefined;
         preOverrideReasons?: string[] | undefined;
+        overriddenReasons?: string[] | undefined;
+        retainedReasons?: string[] | undefined;
     } | undefined;
     labelOverrideFeedback?: {
         message: string;
@@ -1145,6 +1747,11 @@ export declare const GateEvaluation: z.ZodObject<{
             required: boolean;
             conclusion?: string | undefined;
             detailsUrl?: string | undefined;
+            disposition?: {
+                source: "policy" | "default";
+                kind: "advisory" | "blocking" | "irrelevant" | "missing_blocking";
+                reason?: string | undefined;
+            } | undefined;
         }[];
         allRequiredPassed: boolean;
         pendingCount: number;
@@ -1257,8 +1864,8 @@ export declare const GateApiResponse: z.ZodObject<{
     }>, "many">>;
 }, "strip", z.ZodTypeAny, {
     id?: string | undefined;
-    healthScore?: number | undefined;
     riskScore?: number | undefined;
+    healthScore?: number | undefined;
     sizeScore?: number | undefined;
     gateDecision?: "allow" | "warn" | "block" | undefined;
     healthChecks?: {
@@ -1280,8 +1887,8 @@ export declare const GateApiResponse: z.ZodObject<{
     reportUrl?: string | undefined;
 }, {
     id?: string | undefined;
-    healthScore?: number | undefined;
     riskScore?: number | undefined;
+    healthScore?: number | undefined;
     sizeScore?: number | undefined;
     gateDecision?: "allow" | "warn" | "block" | undefined;
     healthChecks?: {
@@ -1544,6 +2151,23 @@ export declare const ContextCiConfig: z.ZodObject<{
     missing_required?: "fail" | "skip" | undefined;
 }>;
 export type ContextCiConfig = z.infer<typeof ContextCiConfig>;
+export declare const InputRelevanceEntry: z.ZodObject<{
+    pattern: z.ZodString;
+    disposition: z.ZodEnum<["blocking", "advisory", "irrelevant"]>;
+    reason: z.ZodOptional<z.ZodString>;
+}, "strip", z.ZodTypeAny, {
+    disposition: "advisory" | "blocking" | "irrelevant";
+    pattern: string;
+    reason?: string | undefined;
+}, {
+    disposition: "advisory" | "blocking" | "irrelevant";
+    pattern: string;
+    reason?: string | undefined;
+}>;
+export type InputRelevanceEntry = z.infer<typeof InputRelevanceEntry>;
+/** ADR-011 §4 — per-branch-pair stance when the evaluation cannot run. */
+export declare const AvailabilityStance: z.ZodEnum<["fail_open", "fail_closed"]>;
+export type AvailabilityStance = z.infer<typeof AvailabilityStance>;
 export declare const TrailheadContext: z.ZodObject<{
     name: z.ZodString;
     match: z.ZodObject<{
@@ -1583,6 +2207,20 @@ export declare const TrailheadContext: z.ZodObject<{
         optional_checks?: string[] | undefined;
         missing_required?: "fail" | "skip" | undefined;
     }>>;
+    input_relevance: z.ZodDefault<z.ZodArray<z.ZodObject<{
+        pattern: z.ZodString;
+        disposition: z.ZodEnum<["blocking", "advisory", "irrelevant"]>;
+        reason: z.ZodOptional<z.ZodString>;
+    }, "strip", z.ZodTypeAny, {
+        disposition: "advisory" | "blocking" | "irrelevant";
+        pattern: string;
+        reason?: string | undefined;
+    }, {
+        disposition: "advisory" | "blocking" | "irrelevant";
+        pattern: string;
+        reason?: string | undefined;
+    }>, "many">>;
+    availability: z.ZodOptional<z.ZodEnum<["fail_open", "fail_closed"]>>;
 }, "strip", z.ZodTypeAny, {
     name: string;
     match: {
@@ -1599,7 +2237,13 @@ export declare const TrailheadContext: z.ZodObject<{
         warn?: number | undefined;
         risk?: number | undefined;
     };
+    input_relevance: {
+        disposition: "advisory" | "blocking" | "irrelevant";
+        pattern: string;
+        reason?: string | undefined;
+    }[];
     environment?: string | undefined;
+    availability?: "fail_open" | "fail_closed" | undefined;
 }, {
     name: string;
     match: {
@@ -1617,6 +2261,12 @@ export declare const TrailheadContext: z.ZodObject<{
         warn?: number | undefined;
         risk?: number | undefined;
     } | undefined;
+    input_relevance?: {
+        disposition: "advisory" | "blocking" | "irrelevant";
+        pattern: string;
+        reason?: string | undefined;
+    }[] | undefined;
+    availability?: "fail_open" | "fail_closed" | undefined;
 }>;
 export type TrailheadContext = z.infer<typeof TrailheadContext>;
 export declare const GateConfig: z.ZodObject<{
@@ -1675,10 +2325,13 @@ export type RiskPathProfileConfig = z.infer<typeof RiskPathProfileConfig>;
 export declare const OverrideConfig: z.ZodObject<{
     enabled: z.ZodDefault<z.ZodBoolean>;
     max_per_week: z.ZodDefault<z.ZodNumber>;
+    scope: z.ZodDefault<z.ZodEnum<["full", "risk_only"]>>;
 }, "strip", z.ZodTypeAny, {
+    scope: "full" | "risk_only";
     enabled: boolean;
     max_per_week: number;
 }, {
+    scope?: "full" | "risk_only" | undefined;
     enabled?: boolean | undefined;
     max_per_week?: number | undefined;
 }>;
@@ -1967,10 +2620,13 @@ export declare const RepoConfig: z.ZodObject<{
     override: z.ZodOptional<z.ZodObject<{
         enabled: z.ZodDefault<z.ZodBoolean>;
         max_per_week: z.ZodDefault<z.ZodNumber>;
+        scope: z.ZodDefault<z.ZodEnum<["full", "risk_only"]>>;
     }, "strip", z.ZodTypeAny, {
+        scope: "full" | "risk_only";
         enabled: boolean;
         max_per_week: number;
     }, {
+        scope?: "full" | "risk_only" | undefined;
         enabled?: boolean | undefined;
         max_per_week?: number | undefined;
     }>>;
@@ -2209,6 +2865,20 @@ export declare const RepoConfig: z.ZodObject<{
             optional_checks?: string[] | undefined;
             missing_required?: "fail" | "skip" | undefined;
         }>>;
+        input_relevance: z.ZodDefault<z.ZodArray<z.ZodObject<{
+            pattern: z.ZodString;
+            disposition: z.ZodEnum<["blocking", "advisory", "irrelevant"]>;
+            reason: z.ZodOptional<z.ZodString>;
+        }, "strip", z.ZodTypeAny, {
+            disposition: "advisory" | "blocking" | "irrelevant";
+            pattern: string;
+            reason?: string | undefined;
+        }, {
+            disposition: "advisory" | "blocking" | "irrelevant";
+            pattern: string;
+            reason?: string | undefined;
+        }>, "many">>;
+        availability: z.ZodOptional<z.ZodEnum<["fail_open", "fail_closed"]>>;
     }, "strip", z.ZodTypeAny, {
         name: string;
         match: {
@@ -2225,7 +2895,13 @@ export declare const RepoConfig: z.ZodObject<{
             warn?: number | undefined;
             risk?: number | undefined;
         };
+        input_relevance: {
+            disposition: "advisory" | "blocking" | "irrelevant";
+            pattern: string;
+            reason?: string | undefined;
+        }[];
         environment?: string | undefined;
+        availability?: "fail_open" | "fail_closed" | undefined;
     }, {
         name: string;
         match: {
@@ -2243,6 +2919,12 @@ export declare const RepoConfig: z.ZodObject<{
             warn?: number | undefined;
             risk?: number | undefined;
         } | undefined;
+        input_relevance?: {
+            disposition: "advisory" | "blocking" | "irrelevant";
+            pattern: string;
+            reason?: string | undefined;
+        }[] | undefined;
+        availability?: "fail_open" | "fail_closed" | undefined;
     }>, "many">>;
     sensitivity: z.ZodDefault<z.ZodObject<{
         high: z.ZodDefault<z.ZodArray<z.ZodString, "many">>;
@@ -2796,7 +3478,13 @@ export declare const RepoConfig: z.ZodObject<{
             warn?: number | undefined;
             risk?: number | undefined;
         };
+        input_relevance: {
+            disposition: "advisory" | "blocking" | "irrelevant";
+            pattern: string;
+            reason?: string | undefined;
+        }[];
         environment?: string | undefined;
+        availability?: "fail_open" | "fail_closed" | undefined;
     }[];
     sensitivity: {
         high: string[];
@@ -2910,6 +3598,11 @@ export declare const RepoConfig: z.ZodObject<{
             critical?: number | undefined;
         } | undefined;
     };
+    override?: {
+        scope: "full" | "risk_only";
+        enabled: boolean;
+        max_per_week: number;
+    } | undefined;
     remediation?: {
         max_loop_rounds: number;
         enabled: boolean;
@@ -2920,10 +3613,6 @@ export declare const RepoConfig: z.ZodObject<{
             factors: ("code_churn" | "file_count")[];
             mode: "metadata" | "risk";
         };
-    } | undefined;
-    override?: {
-        enabled: boolean;
-        max_per_week: number;
     } | undefined;
     tuning?: {
         auto_downgrade: boolean;
@@ -2975,6 +3664,11 @@ export declare const RepoConfig: z.ZodObject<{
     } | undefined;
 }, {
     schema_version?: number | undefined;
+    override?: {
+        scope?: "full" | "risk_only" | undefined;
+        enabled?: boolean | undefined;
+        max_per_week?: number | undefined;
+    } | undefined;
     remediation?: {
         max_loop_rounds?: number | undefined;
         enabled?: boolean | undefined;
@@ -3007,10 +3701,6 @@ export declare const RepoConfig: z.ZodObject<{
         mode?: "release-ready" | "advisory" | "risk-only" | undefined;
         check_name?: string | undefined;
         agent_brief?: "off" | "collapsed" | "expanded" | undefined;
-    } | undefined;
-    override?: {
-        enabled?: boolean | undefined;
-        max_per_week?: number | undefined;
     } | undefined;
     tuning?: {
         auto_downgrade?: boolean | undefined;
@@ -3072,6 +3762,12 @@ export declare const RepoConfig: z.ZodObject<{
             warn?: number | undefined;
             risk?: number | undefined;
         } | undefined;
+        input_relevance?: {
+            disposition: "advisory" | "blocking" | "irrelevant";
+            pattern: string;
+            reason?: string | undefined;
+        }[] | undefined;
+        availability?: "fail_open" | "fail_closed" | undefined;
     }[] | undefined;
     sensitivity?: {
         high?: string[] | undefined;

--- a/mcp/dist/types.js
+++ b/mcp/dist/types.js
@@ -52,12 +52,30 @@ export const CiCheckStatusEnum = z.enum([
     "stale",
     "missing",
 ]);
+// ADR-011 §2 — input relevance. ADR-009's status says what a check DID; the
+// disposition says what it MEANS for this release decision. `missing_blocking`
+// is derived (ADR-009 `missing` on a blocking input), never configured.
+export const InputDispositionKind = z.enum([
+    "blocking",
+    "advisory",
+    "irrelevant",
+    "missing_blocking",
+]);
+export const InputDisposition = z.object({
+    kind: InputDispositionKind,
+    reason: z.string().optional(),
+    /** `policy` = an input_relevance entry matched; `default` = required/optional fallback. */
+    source: z.enum(["policy", "default"]),
+});
 export const CiCheck = z.object({
     name: z.string(),
     status: CiCheckStatusEnum,
     conclusion: z.string().optional(),
     detailsUrl: z.string().url().optional(),
     required: z.boolean(),
+    // Optional: summaries produced before dispositions are applied (and every
+    // pre-ADR-011 stored evaluation) carry none, and fall back to `required`.
+    disposition: InputDisposition.optional(),
 });
 export const CiSummary = z.object({
     checks: z.array(CiCheck),
@@ -167,6 +185,9 @@ export const PolicyOverrideChanges = z.object({
     warnThreshold: z.number().min(0).max(100).optional(),
     releaseReady: z.literal(true).optional(),
 });
+export const OverrideScope = z.enum(["full", "risk_only"]);
+// ADR-011 §3 renders the override record as {by, at, scope, rationale};
+// this schema carries by=owner, at=appliedAt, rationale=reason, plus scope.
 export const PolicyOverrideAudit = z.object({
     source: z.enum(["workflow", "label"]).default("workflow"),
     owner: z.string(),
@@ -174,10 +195,58 @@ export const PolicyOverrideAudit = z.object({
     linkedTicket: z.string(),
     expiresAt: z.string(),
     appliedAt: z.string(),
+    // Optional, not defaulted: audits stored before ADR-011 carry no scope and
+    // must keep parsing as the pre-ADR-011 (full) override they actually were.
+    scope: OverrideScope.optional(),
     changes: PolicyOverrideChanges.default({}),
     preOverrideDecision: GateDecision.optional(),
     preOverrideReleaseReady: z.boolean().optional(),
     preOverrideReasons: z.array(z.string()).optional(),
+    /** Blocking reasons the override cleared (risk/policy driven). */
+    overriddenReasons: z.array(z.string()).optional(),
+    /** Blocking reasons that survived the override (mechanical CI, ADR-011 §3). */
+    retainedReasons: z.array(z.string()).optional(),
+});
+// ---------------------------------------------------------------------------
+// ADR-011 §1 — the Release Brief
+// ---------------------------------------------------------------------------
+export const BriefVerdict = z.enum(["allow", "warn", "block", "cannot_evaluate"]);
+export const BriefFinding = z.object({
+    id: z.string(),
+    title: z.string(),
+    evidence: z.string().optional(),
+    severity: RemediationSeverity,
+});
+export const BriefInput = z.object({
+    checkName: z.string(),
+    /** ADR-009 status, carried as a string so the renderer stays policy-agnostic. */
+    status: z.string(),
+    /** ADR-011 §2 disposition kind. */
+    disposition: z.string(),
+    reason: z.string().optional(),
+});
+export const BriefAction = z.object({
+    kind: z.enum(["fix", "override", "wait"]),
+    detail: z.string(),
+    link: z.string().optional(),
+});
+export const BriefOverride = z.object({
+    by: z.string(),
+    at: z.string(),
+    scope: z.string(),
+    rationale: z.string(),
+});
+export const ReleaseBrief = z.object({
+    verdict: BriefVerdict,
+    riskScore: z.number().optional(),
+    riskThreshold: z.number().optional(),
+    topMovers: z.array(z.object({ factor: z.string(), score: z.number() })).optional(),
+    findings: z.array(BriefFinding),
+    inputs: z.array(BriefInput),
+    delta: z.string().optional(),
+    actions: z.array(BriefAction),
+    override: BriefOverride.nullish(),
+    cannotEvaluateReason: z.string().optional(),
 });
 export const CreditMeterResult = z.object({
     metered: z.boolean(),
@@ -208,6 +277,10 @@ export const GateEvaluation = z.object({
     environment: z.string().optional(),
     service: z.string().optional(),
     policyFindings: z.array(z.string()).optional(),
+    // ADR-011 §1: "findings are enumerated, never counted". policyFindings keeps
+    // its count-strings for existing consumers; this is the enumeration.
+    enumeratedFindings: z.array(BriefFinding).optional(),
+    releaseBrief: ReleaseBrief.optional(),
     pr: z
         .object({
         provenance: PrProvenance.optional(),
@@ -338,6 +411,18 @@ export const ContextCiConfig = z.object({
     optional_checks: z.array(z.string()).default([]),
     missing_required: z.enum(["fail", "skip"]).default("fail"),
 });
+// ADR-011 §2 — one row of the branch-pair relevance table. `reason` is mandatory
+// for `irrelevant`, but that is enforced as a config *warning* (see
+// collectConfigWarnings in config-core.ts), not a parse failure: a hard refine
+// here would drop the whole repo config to defaults over one typo, which is how
+// parseRepoConfigContent degrades today.
+export const InputRelevanceEntry = z.object({
+    pattern: z.string(),
+    disposition: z.enum(["blocking", "advisory", "irrelevant"]),
+    reason: z.string().optional(),
+});
+/** ADR-011 §4 — per-branch-pair stance when the evaluation cannot run. */
+export const AvailabilityStance = z.enum(["fail_open", "fail_closed"]);
 export const TrailheadContext = z.object({
     name: z.string(),
     match: ContextMatch,
@@ -349,6 +434,8 @@ export const TrailheadContext = z.object({
     })
         .default({}),
     ci: ContextCiConfig.default({}),
+    input_relevance: z.array(InputRelevanceEntry).default([]),
+    availability: AvailabilityStance.optional(),
 });
 export const GateConfig = z.object({
     mode: GateMode.default("risk-only"),
@@ -375,6 +462,8 @@ export const RiskPathProfileConfig = z.object({
 export const OverrideConfig = z.object({
     enabled: z.boolean().default(true),
     max_per_week: z.number().int().min(1).default(5),
+    // Defaults to "full" so repos that never set it keep pre-ADR-011 behavior.
+    scope: OverrideScope.default("full"),
 });
 export const TuningConfig = z.object({
     auto_downgrade: z.boolean().default(true),

--- a/mcp/dist/verdict.d.ts
+++ b/mcp/dist/verdict.d.ts
@@ -182,13 +182,13 @@ export declare const TrailheadVerdictSchema: z.ZodObject<{
         releaseReadyReasons: z.ZodOptional<z.ZodArray<z.ZodString, "many">>;
         policyFindings: z.ZodOptional<z.ZodArray<z.ZodString, "many">>;
     }, "strip", z.ZodTypeAny, {
-        healthScore: number;
         riskScore: number;
+        healthScore: number;
         policyFindings?: string[] | undefined;
         releaseReadyReasons?: string[] | undefined;
     }, {
-        healthScore: number;
         riskScore: number;
+        healthScore: number;
         policyFindings?: string[] | undefined;
         releaseReadyReasons?: string[] | undefined;
     }>>;
@@ -238,8 +238,8 @@ export declare const TrailheadVerdictSchema: z.ZodObject<{
     } | undefined;
     gate_mode?: "release-ready" | "advisory" | "risk-only" | undefined;
     _legacy?: {
-        healthScore: number;
         riskScore: number;
+        healthScore: number;
         policyFindings?: string[] | undefined;
         releaseReadyReasons?: string[] | undefined;
     } | undefined;
@@ -289,8 +289,8 @@ export declare const TrailheadVerdictSchema: z.ZodObject<{
     } | undefined;
     gate_mode?: "release-ready" | "advisory" | "risk-only" | undefined;
     _legacy?: {
-        healthScore: number;
         riskScore: number;
+        healthScore: number;
         policyFindings?: string[] | undefined;
         releaseReadyReasons?: string[] | undefined;
     } | undefined;

--- a/mcp/src/loop-bookkeeping.ts
+++ b/mcp/src/loop-bookkeeping.ts
@@ -1,8 +1,22 @@
 // Pure loop bookkeeping helpers — no framework dependencies.
 
-import type { GateEvaluation, Remediation } from "./types.js";
+import type { GateDecision, Remediation } from "./types.js";
 
-export type PreviousEvaluationSnapshot = Pick<GateEvaluation, "id" | "remediation">;
+/**
+ * What the store returns about the previous evaluation of a PR. `id`/`remediation`
+ * drive loop bookkeeping; the rest is ADR-011 §1 delta material and is present only
+ * when the backend actually returned those columns — every consumer must treat the
+ * optional fields as "unknown", never as "unchanged".
+ */
+export interface PreviousEvaluationSnapshot {
+  id: string;
+  remediation?: Remediation;
+  riskScore?: number;
+  gateDecision?: GateDecision;
+  releaseReady?: boolean;
+  /** Ids of the previous evaluation's enumerated findings (ADR-011 §1). */
+  findingIds?: string[];
+}
 
 export function resolveLoopRound(
   previous: PreviousEvaluationSnapshot | null | undefined,
@@ -15,6 +29,32 @@ export function parseAgentIdFromHeadRef(headRef: string | undefined): string | n
   if (!headRef) return null;
   const match = headRef.match(/^agent\/([a-z0-9-]+)\//);
   return match?.[1] ?? null;
+}
+
+function pick(record: Record<string, unknown>, ...keys: string[]): unknown {
+  for (const key of keys) {
+    const value = record[key];
+    if (value !== undefined && value !== null) return value;
+  }
+  return undefined;
+}
+
+function readFindingIds(record: Record<string, unknown>): string[] | undefined {
+  const direct = pick(record, "enumerated_findings", "enumeratedFindings");
+  const brief = pick(record, "release_brief", "releaseBrief");
+  const raw =
+    direct ??
+    (brief && typeof brief === "object"
+      ? (brief as Record<string, unknown>).findings
+      : undefined);
+  if (!Array.isArray(raw)) return undefined;
+  const ids: string[] = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== "object") continue;
+    const id = (entry as Record<string, unknown>).id;
+    if (typeof id === "string") ids.push(id);
+  }
+  return ids;
 }
 
 export function parsePreviousEvaluationRow(
@@ -30,7 +70,29 @@ export function parsePreviousEvaluationRow(
     remediation = record.remediation as Remediation;
   }
 
-  return { id, remediation };
+  const snapshot: PreviousEvaluationSnapshot = { id, remediation };
+
+  const riskScore = pick(record, "risk_score", "riskScore");
+  if (typeof riskScore === "number" && Number.isFinite(riskScore)) {
+    snapshot.riskScore = riskScore;
+  }
+
+  const gateDecision = pick(record, "gate_decision", "gateDecision");
+  if (gateDecision === "allow" || gateDecision === "warn" || gateDecision === "block") {
+    snapshot.gateDecision = gateDecision;
+  }
+
+  const releaseReady = pick(record, "release_ready", "releaseReady");
+  if (typeof releaseReady === "boolean") {
+    snapshot.releaseReady = releaseReady;
+  }
+
+  const findingIds = readFindingIds(record);
+  if (findingIds !== undefined) {
+    snapshot.findingIds = findingIds;
+  }
+
+  return snapshot;
 }
 
 export function pickLatestPreviousEvaluation(

--- a/src/__tests__/adr011-periphery.test.ts
+++ b/src/__tests__/adr011-periphery.test.ts
@@ -1,0 +1,483 @@
+/**
+ * ADR-011 periphery: availability stance (§4), the cannot-evaluate brief (§1),
+ * the store row (§3), and the delta (§1).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { formatEvaluationDelta } from "../release-brief.js";
+import { parsePreviousEvaluationRow } from "../loop-bookkeeping.js";
+import { fetchPreviousEvaluationForPr } from "../evaluation-history.js";
+import {
+  buildEvaluationStoreRow,
+  mentionsUnknownAdr011Column,
+  storeEvaluation,
+} from "../notify.js";
+import {
+  buildCannotEvaluateBrief,
+  buildReleaseBrief,
+  getResolvedAvailabilityStance,
+  setResolvedAvailabilityStance,
+} from "../gate.js";
+import type { GateEvaluation } from "../types.js";
+
+vi.mock("@actions/core", () => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warning: vi.fn(),
+  error: vi.fn(),
+  setFailed: vi.fn(),
+  setOutput: vi.fn(),
+  getInput: vi.fn().mockReturnValue(""),
+}));
+
+vi.mock("@actions/github", () => ({
+  context: {
+    repo: { owner: "test-owner", repo: "test-repo" },
+    payload: {},
+  },
+  getOctokit: () => ({ rest: {} }),
+}));
+
+function makeEvaluation(overrides: Partial<GateEvaluation> = {}): GateEvaluation {
+  return {
+    id: "dg-test",
+    repoId: "test-owner/test-repo",
+    commitSha: "abc1234567890",
+    healthScore: 100,
+    riskScore: 42,
+    gateDecision: "allow",
+    healthChecks: [],
+    riskFactors: [],
+    evaluationMs: 10,
+    prNumber: 7,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// formatEvaluationDelta (ADR-011 §1)
+// ---------------------------------------------------------------------------
+
+describe("formatEvaluationDelta", () => {
+  it("renders verdict, risk and finding movement in one line", () => {
+    expect(
+      formatEvaluationDelta(
+        { verdict: "block", riskScore: 90, findingIds: ["a", "b", "c", "d"] },
+        { verdict: "allow", riskScore: 42, findingIds: ["d", "e"] },
+      ),
+    ).toBe("vs previous: block -> allow, risk 90 -> 42, 3 findings resolved, 1 new");
+  });
+
+  it("uses the singular form for a single resolved finding", () => {
+    expect(formatEvaluationDelta({ findingIds: ["a"] }, { findingIds: [] })).toBe(
+      "vs previous: 1 finding resolved",
+    );
+  });
+
+  it("says 'no change' when comparable fields are all equal", () => {
+    expect(
+      formatEvaluationDelta(
+        { verdict: "allow", riskScore: 10, findingIds: ["a"] },
+        { verdict: "allow", riskScore: 10, findingIds: ["a"] },
+      ),
+    ).toBe("vs previous: no change");
+  });
+
+  it("omits fields the previous snapshot did not carry", () => {
+    expect(
+      formatEvaluationDelta({ riskScore: 80 }, { verdict: "allow", riskScore: 20 }),
+    ).toBe("vs previous: risk 80 -> 20");
+  });
+
+  it("returns undefined when nothing is comparable", () => {
+    expect(
+      formatEvaluationDelta({}, { verdict: "allow", riskScore: 20 }),
+    ).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parsePreviousEvaluationRow (widened snapshot)
+// ---------------------------------------------------------------------------
+
+describe("parsePreviousEvaluationRow — ADR-011 delta fields", () => {
+  it("reads snake_case store columns", () => {
+    const snapshot = parsePreviousEvaluationRow({
+      id: "eval-1",
+      risk_score: 90,
+      gate_decision: "block",
+      release_ready: false,
+      enumerated_findings: [{ id: "ci_integrity/1" }, { id: "ci_integrity/2" }],
+    });
+
+    expect(snapshot).toMatchObject({
+      id: "eval-1",
+      riskScore: 90,
+      gateDecision: "block",
+      releaseReady: false,
+      findingIds: ["ci_integrity/1", "ci_integrity/2"],
+    });
+  });
+
+  it("reads camelCase payloads from the cloud list API", () => {
+    const snapshot = parsePreviousEvaluationRow({
+      id: "eval-2",
+      riskScore: 12,
+      gateDecision: "allow",
+      releaseReady: true,
+    });
+
+    expect(snapshot?.riskScore).toBe(12);
+    expect(snapshot?.gateDecision).toBe("allow");
+    expect(snapshot?.releaseReady).toBe(true);
+  });
+
+  it("falls back to the stored release brief's findings", () => {
+    const snapshot = parsePreviousEvaluationRow({
+      id: "eval-3",
+      release_brief: { findings: [{ id: "supply_chain/1" }] },
+    });
+
+    expect(snapshot?.findingIds).toEqual(["supply_chain/1"]);
+  });
+
+  it("leaves delta fields undefined when the store did not return them", () => {
+    const snapshot = parsePreviousEvaluationRow({ id: "eval-4", remediation: {} });
+
+    expect(snapshot?.id).toBe("eval-4");
+    expect(snapshot?.riskScore).toBeUndefined();
+    expect(snapshot?.gateDecision).toBeUndefined();
+    expect(snapshot?.findingIds).toBeUndefined();
+  });
+
+  it("ignores an out-of-enum gate_decision", () => {
+    expect(
+      parsePreviousEvaluationRow({ id: "eval-5", gate_decision: "cannot_evaluate" })
+        ?.gateDecision,
+    ).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Supabase select widening + narrow retry
+// ---------------------------------------------------------------------------
+
+describe("fetchPreviousEvaluationForPr — Supabase delta select", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+    process.env.SUPABASE_URL = "https://db.example.com";
+    process.env.SUPABASE_SERVICE_ROLE_KEY = "service-role";
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete process.env.SUPABASE_URL;
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+  });
+
+  it("selects the delta columns and returns them on the snapshot", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(
+        JSON.stringify([{ id: "eval-prev", risk_score: 88, gate_decision: "block" }]),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    const snapshot = await fetchPreviousEvaluationForPr({
+      repoId: "test-owner/test-repo",
+      prNumber: 7,
+    });
+
+    const requestedUrl = vi.mocked(fetch).mock.calls[0]?.[0] as string;
+    expect(requestedUrl).toContain("risk_score");
+    expect(requestedUrl).toContain("release_brief");
+    expect(snapshot?.riskScore).toBe(88);
+    expect(snapshot?.gateDecision).toBe("block");
+  });
+
+  it("retries with the pre-ADR-011 narrow select when the store lacks the columns", async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(new Response("column does not exist", { status: 400 }))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify([{ id: "eval-prev", loop_round: 2 }]), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+    const snapshot = await fetchPreviousEvaluationForPr({
+      repoId: "test-owner/test-repo",
+      prNumber: 7,
+    });
+
+    expect(vi.mocked(fetch)).toHaveBeenCalledTimes(2);
+    const retryUrl = vi.mocked(fetch).mock.calls[1]?.[0] as string;
+    expect(retryUrl).not.toContain("release_brief");
+    expect(snapshot?.id).toBe("eval-prev");
+    // Loop bookkeeping still works — the whole point of the fallback.
+    expect(snapshot?.remediation?.loop_round).toBe(2);
+  });
+
+  it("returns null when both selects fail", async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(new Response("boom", { status: 500 }))
+      .mockResolvedValueOnce(new Response("boom", { status: 500 }));
+
+    await expect(
+      fetchPreviousEvaluationForPr({ repoId: "test-owner/test-repo", prNumber: 7 }),
+    ).resolves.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Store row (ADR-011 §1 + §3)
+// ---------------------------------------------------------------------------
+
+describe("buildEvaluationStoreRow — ADR-011 columns", () => {
+  it("carries the release brief and enumerated findings", () => {
+    const row = buildEvaluationStoreRow(
+      makeEvaluation({
+        enumeratedFindings: [
+          { id: "ci_integrity/1", title: "workflow bypass", severity: "blocking" },
+        ],
+        releaseBrief: {
+          verdict: "block",
+          findings: [],
+          inputs: [],
+          actions: [],
+        },
+      }),
+    );
+
+    expect(row.enumerated_findings).toEqual([
+      { id: "ci_integrity/1", title: "workflow bypass", severity: "blocking" },
+    ]);
+    expect(row.release_brief).toMatchObject({ verdict: "block" });
+  });
+
+  it("nulls both when the evaluation has neither", () => {
+    const row = buildEvaluationStoreRow(makeEvaluation());
+    expect(row.release_brief).toBeNull();
+    expect(row.enumerated_findings).toBeNull();
+  });
+
+  it("records the override scope explicitly, defaulting pre-ADR-011 audits to full", () => {
+    const row = buildEvaluationStoreRow(
+      makeEvaluation({
+        policyOverride: {
+          source: "label",
+          owner: "dave",
+          reason: "promotion train",
+          linkedTicket: "",
+          expiresAt: "",
+          appliedAt: "2026-08-08T00:00:00.000Z",
+          changes: {},
+        },
+      }),
+    );
+
+    expect(row.policy_override).toMatchObject({ scope: "full", owner: "dave" });
+  });
+
+  it("preserves an explicit risk_only scope", () => {
+    const row = buildEvaluationStoreRow(
+      makeEvaluation({
+        policyOverride: {
+          source: "label",
+          owner: "dave",
+          reason: "risk accepted",
+          linkedTicket: "",
+          expiresAt: "",
+          appliedAt: "2026-08-08T00:00:00.000Z",
+          scope: "risk_only",
+          changes: {},
+        },
+      }),
+    );
+
+    expect(row.policy_override).toMatchObject({ scope: "risk_only" });
+  });
+});
+
+describe("mentionsUnknownAdr011Column", () => {
+  it("recognises a PostgREST unknown-column body", () => {
+    expect(
+      mentionsUnknownAdr011Column(
+        `{"code":"PGRST204","message":"Could not find the 'release_brief' column"}`,
+      ),
+    ).toBe(true);
+  });
+
+  it("recognises the signature in a non-JSON body", () => {
+    expect(
+      mentionsUnknownAdr011Column(
+        "Could not find the 'enumerated_findings' column of 'trailhead_evaluations' in the schema cache",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not match unrelated failures", () => {
+    expect(mentionsUnknownAdr011Column(`{"code":"42501","message":"denied"}`)).toBe(
+      false,
+    );
+  });
+
+  it("does not match an unrelated 400 that merely names the column", () => {
+    expect(
+      mentionsUnknownAdr011Column(
+        `{"code":"42501","message":"permission denied for column release_brief"}`,
+      ),
+    ).toBe(false);
+    expect(
+      mentionsUnknownAdr011Column(
+        `{"code":"23514","message":"new row violates check constraint on enumerated_findings"}`,
+      ),
+    ).toBe(false);
+    expect(
+      mentionsUnknownAdr011Column("upstream connect error while writing release_brief"),
+    ).toBe(false);
+  });
+
+  it("does not match a schema-cache miss for some other column", () => {
+    expect(
+      mentionsUnknownAdr011Column(
+        `{"code":"PGRST204","message":"Could not find the 'trust_profile' column"}`,
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("storeEvaluation — Supabase fallback without the ADR-011 columns", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+    process.env.SUPABASE_URL = "https://db.example.com";
+    process.env.SUPABASE_SERVICE_ROLE_KEY = "service-role";
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete process.env.SUPABASE_URL;
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+  });
+
+  it("strips the new columns and retries once, rather than losing the evaluation", async () => {
+    vi.mocked(fetch)
+      // storeViaApi attempt (maxRetries: 0) — fails so the Supabase path runs.
+      .mockRejectedValueOnce(new Error("no cloud store"))
+      .mockResolvedValueOnce(
+        new Response(
+          `{"code":"PGRST204","message":"Could not find the 'release_brief' column"}`,
+          { status: 400 },
+        ),
+      )
+      .mockResolvedValueOnce(new Response("", { status: 201 }));
+
+    const stored = await storeEvaluation(
+      "https://store.example.com/v1/evaluations",
+      makeEvaluation({
+        releaseBrief: { verdict: "allow", findings: [], inputs: [], actions: [] },
+      }),
+      { maxRetries: 0 },
+    );
+
+    expect(stored).toBe(true);
+    expect(vi.mocked(fetch)).toHaveBeenCalledTimes(3);
+    const retryBody = JSON.parse(
+      vi.mocked(fetch).mock.calls[2]?.[1]?.body as string,
+    ) as Record<string, unknown>;
+    expect(retryBody).not.toHaveProperty("release_brief");
+    expect(retryBody).not.toHaveProperty("enumerated_findings");
+    expect(retryBody.id).toBe("dg-test");
+  });
+
+  it("does not retry for unrelated insert failures, even ones naming the column", async () => {
+    vi.mocked(fetch)
+      .mockRejectedValueOnce(new Error("no cloud store"))
+      .mockResolvedValueOnce(
+        new Response(
+          `{"code":"42501","message":"permission denied for column release_brief"}`,
+          { status: 400 },
+        ),
+      );
+
+    await expect(
+      storeEvaluation("https://store.example.com/v1/evaluations", makeEvaluation(), {
+        maxRetries: 0,
+      }),
+    ).resolves.toBe(false);
+    expect(vi.mocked(fetch)).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Availability stance + cannot-evaluate brief (ADR-011 §4 / §1)
+// ---------------------------------------------------------------------------
+
+describe("availability stance stash", () => {
+  afterEach(() => {
+    setResolvedAvailabilityStance(null);
+  });
+
+  it("defaults to null — no per-context stance means unchanged fail-mode behaviour", () => {
+    setResolvedAvailabilityStance(null);
+    expect(getResolvedAvailabilityStance()).toBeNull();
+  });
+
+  it("round-trips a resolved stance", () => {
+    setResolvedAvailabilityStance("fail_closed");
+    expect(getResolvedAvailabilityStance()).toBe("fail_closed");
+  });
+});
+
+describe("buildCannotEvaluateBrief", () => {
+  it("states the reason and the fail-closed consequence", () => {
+    const brief = buildCannotEvaluateBrief("store unreachable", "fail_closed");
+
+    expect(brief.verdict).toBe("cannot_evaluate");
+    expect(brief.cannotEvaluateReason).toBe("store unreachable");
+    expect(brief.findings).toEqual([]);
+    expect(brief.inputs).toEqual([]);
+    expect(brief.actions.map((a) => a.kind)).toEqual(["fix", "wait"]);
+    expect(brief.actions[1]?.detail).toContain("fail_closed");
+    expect(brief.actions[1]?.detail).toContain("admin merge");
+  });
+
+  it("states the fail-open consequence instead when the stance is open", () => {
+    const brief = buildCannotEvaluateBrief("token missing", "fail_open");
+    expect(brief.actions[1]?.detail).toContain("fail_open");
+    expect(brief.actions[1]?.detail).toContain("did not block");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildReleaseBrief delta wiring
+// ---------------------------------------------------------------------------
+
+describe("buildReleaseBrief — delta from the previous evaluation", () => {
+  it("sets the delta when a previous snapshot carries comparable fields", () => {
+    const brief = buildReleaseBrief(
+      makeEvaluation({
+        gateDecision: "allow",
+        riskScore: 42,
+        enumeratedFindings: [{ id: "b", title: "b", severity: "warn" }],
+      }),
+      70,
+      undefined,
+      { id: "prev", riskScore: 90, gateDecision: "block", findingIds: ["a", "b"] },
+    );
+
+    expect(brief.delta).toBe(
+      "vs previous: block -> allow, risk 90 -> 42, 1 finding resolved",
+    );
+  });
+
+  it("omits the delta when there is no previous evaluation", () => {
+    expect(buildReleaseBrief(makeEvaluation(), 70).delta).toBeUndefined();
+  });
+
+  it("omits the delta when the previous row carried no comparable fields", () => {
+    expect(
+      buildReleaseBrief(makeEvaluation(), 70, undefined, { id: "prev" }).delta,
+    ).toBeUndefined();
+  });
+});

--- a/src/__tests__/adr011-wiring.test.ts
+++ b/src/__tests__/adr011-wiring.test.ts
@@ -1,0 +1,663 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  applyInputRelevance,
+  buildReleaseBrief,
+  enumerateDetectorFindings,
+  formatGateReport,
+} from "../gate.js";
+import { computeReleaseReady, checkCountsTowardBlocking } from "../release-ready.js";
+import { partitionOverrideReasons } from "../override.js";
+import { collectConfigWarnings } from "../config-core.js";
+import { parseRepoConfigContent } from "../config-core.js";
+import type {
+  CiCheck,
+  CiSummary,
+  GateEvaluation,
+  InputRelevanceEntry,
+} from "../types.js";
+
+function check(overrides: Partial<CiCheck> & { name: string }): CiCheck {
+  return {
+    status: "pass",
+    required: false,
+    ...overrides,
+  };
+}
+
+function summary(checks: CiCheck[]): CiSummary {
+  const required = checks.filter((c) => c.required);
+  return {
+    checks,
+    allRequiredPassed: required.every((c) => c.status === "pass" || c.status === "skip"),
+    pendingCount: required.filter((c) => c.status === "pending").length,
+    failedCount: required.filter(
+      (c) => c.status === "fail" || c.status === "missing" || c.status === "stale",
+    ).length,
+    missingCount: required.filter((c) => c.status === "missing").length,
+  };
+}
+
+function evaluation(overrides: Partial<GateEvaluation> = {}): GateEvaluation {
+  return {
+    id: "dg-test",
+    repoId: "test-owner/test-repo",
+    commitSha: "abc1234",
+    healthScore: 100,
+    riskScore: 30,
+    gateDecision: "allow",
+    healthChecks: [],
+    riskFactors: [],
+    evaluationMs: 1,
+    gateMode: "release-ready",
+    releaseReady: true,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// applyInputRelevance
+// ---------------------------------------------------------------------------
+
+describe("applyInputRelevance", () => {
+  it("reproduces the pre-ADR-011 rollup byte-for-byte with no policy entries", () => {
+    const before = summary([
+      check({ name: "Build", status: "pass", required: true }),
+      check({ name: "Tests", status: "fail", required: true }),
+      check({ name: "Lint", status: "missing", required: true }),
+      check({ name: "Docs", status: "pending", required: true }),
+      check({ name: "Vercel", status: "fail", required: false }),
+    ]);
+
+    const after = applyInputRelevance(before, []);
+
+    expect(after.allRequiredPassed).toBe(before.allRequiredPassed);
+    expect(after.pendingCount).toBe(before.pendingCount);
+    expect(after.failedCount).toBe(before.failedCount);
+    expect(after.missingCount).toBe(before.missingCount);
+    expect(after.checks.map((c) => c.name)).toEqual(before.checks.map((c) => c.name));
+  });
+
+  it("maps required to blocking and non-required to advisory by default", () => {
+    const after = applyInputRelevance(
+      summary([
+        check({ name: "Build", status: "pass", required: true }),
+        check({ name: "Vercel", status: "fail", required: false }),
+      ]),
+      [],
+    );
+
+    expect(after.checks[0].disposition).toEqual({ kind: "blocking", source: "default" });
+    expect(after.checks[1].disposition).toEqual({ kind: "advisory", source: "default" });
+  });
+
+  it("derives missing_blocking for an absent required check", () => {
+    const after = applyInputRelevance(
+      summary([check({ name: "Build", status: "missing", required: true })]),
+      [],
+    );
+
+    expect(after.checks[0].disposition?.kind).toBe("missing_blocking");
+    expect(after.missingCount).toBe(1);
+    expect(after.failedCount).toBe(1);
+    expect(after.allRequiredPassed).toBe(false);
+  });
+
+  it("drops an irrelevant required failure out of the blocking rollup", () => {
+    const entries: InputRelevanceEntry[] = [
+      {
+        pattern: "Deploy Edge Functions",
+        disposition: "irrelevant",
+        reason: "staging target unconfigured by design",
+      },
+    ];
+
+    const after = applyInputRelevance(
+      summary([
+        check({ name: "Build", status: "pass", required: true }),
+        check({ name: "Deploy Edge Functions", status: "fail", required: true }),
+      ]),
+      entries,
+    );
+
+    expect(after.allRequiredPassed).toBe(true);
+    expect(after.failedCount).toBe(0);
+    expect(after.checks[1].disposition).toEqual({
+      kind: "irrelevant",
+      reason: "staging target unconfigured by design",
+      source: "policy",
+    });
+  });
+
+  it("drops an advisory required failure out of the blocking rollup", () => {
+    const after = applyInputRelevance(
+      summary([check({ name: "Flaky suite", status: "fail", required: true })]),
+      [{ pattern: "Flaky suite", disposition: "advisory" }],
+    );
+
+    expect(after.failedCount).toBe(0);
+    expect(after.allRequiredPassed).toBe(true);
+  });
+
+  it("promotes a non-required check to blocking when policy says so", () => {
+    const after = applyInputRelevance(
+      summary([check({ name: "Security scan", status: "fail", required: false })]),
+      [{ pattern: "Security scan", disposition: "blocking" }],
+    );
+
+    expect(after.failedCount).toBe(1);
+    expect(after.allRequiredPassed).toBe(false);
+  });
+
+  it("excludes an irrelevant pending check from pendingCount", () => {
+    const after = applyInputRelevance(
+      summary([check({ name: "Preview deploy", status: "pending", required: true })]),
+      [{ pattern: "Preview*", disposition: "irrelevant", reason: "not a gate input" }],
+    );
+
+    expect(after.pendingCount).toBe(0);
+    expect(after.allRequiredPassed).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeReleaseReady + dispositions (ADR-011 Case B)
+// ---------------------------------------------------------------------------
+
+describe("computeReleaseReady with dispositions", () => {
+  const base = {
+    gateMode: "release-ready" as const,
+    gateDecision: "allow" as const,
+    riskScore: 30,
+    riskThreshold: 70,
+    healthScore: 100,
+    healthChecksConfigured: false,
+    freezeActive: false,
+  };
+
+  it("Case B: a required fail dispositioned irrelevant no longer blocks", () => {
+    const ciSummary = applyInputRelevance(
+      summary([
+        check({ name: "CI Gate", status: "pass", required: true }),
+        check({ name: "Deploy Edge Functions", status: "fail", required: true }),
+      ]),
+      [
+        {
+          pattern: "Deploy Edge Functions",
+          disposition: "irrelevant",
+          reason: "staging target unconfigured by design",
+        },
+      ],
+    );
+
+    const result = computeReleaseReady({ ...base, ciSummary });
+
+    expect(result.releaseReady).toBe(true);
+    expect(result.reasons).toHaveLength(0);
+  });
+
+  it("still blocks the same input when no policy entry matches", () => {
+    const ciSummary = applyInputRelevance(
+      summary([check({ name: "Deploy Edge Functions", status: "fail", required: true })]),
+      [],
+    );
+
+    const result = computeReleaseReady({ ...base, ciSummary });
+
+    expect(result.releaseReady).toBe(false);
+    expect(result.reasons).toEqual(['Required CI check "Deploy Edge Functions" is FAIL']);
+  });
+
+  it("missing_blocking still produces the reason it produces today", () => {
+    const ciSummary = applyInputRelevance(
+      summary([check({ name: "Playwright", status: "missing", required: true })]),
+      [],
+    );
+
+    const result = computeReleaseReady({ ...base, ciSummary });
+
+    expect(ciSummary.checks[0].disposition?.kind).toBe("missing_blocking");
+    expect(result.reasons).toEqual(['Required CI check "Playwright" is MISSING']);
+  });
+
+  it("advisory failures produce no blocking reason", () => {
+    const ciSummary = applyInputRelevance(
+      summary([check({ name: "Bundle size", status: "fail", required: true })]),
+      [{ pattern: "Bundle size", disposition: "advisory" }],
+    );
+
+    expect(computeReleaseReady({ ...base, ciSummary }).releaseReady).toBe(true);
+  });
+});
+
+describe("checkCountsTowardBlocking", () => {
+  it("falls back to required when no disposition is attached", () => {
+    expect(checkCountsTowardBlocking(check({ name: "A", required: true }))).toBe(true);
+    expect(checkCountsTowardBlocking(check({ name: "B", required: false }))).toBe(false);
+  });
+
+  it("prefers the disposition over the required flag in both directions", () => {
+    expect(
+      checkCountsTowardBlocking(
+        check({
+          name: "A",
+          required: true,
+          disposition: { kind: "irrelevant", reason: "x", source: "policy" },
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      checkCountsTowardBlocking(
+        check({
+          name: "B",
+          required: false,
+          disposition: { kind: "blocking", source: "policy" },
+        }),
+      ),
+    ).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// risk_only override composition (ADR-011 §3 x §2)
+// ---------------------------------------------------------------------------
+
+describe("risk_only override composes with dispositions", () => {
+  it("retains reasons from checks whose disposition counts toward blocking", () => {
+    const ciSummary = applyInputRelevance(
+      summary([check({ name: "Security scan", status: "fail", required: false })]),
+      [{ pattern: "Security scan", disposition: "blocking" }],
+    );
+
+    const { overridden, retained } = partitionOverrideReasons(
+      ['Required CI check "Security scan" is FAIL', "Risk score 90 exceeds threshold 70"],
+      ciSummary,
+    );
+
+    expect(retained).toEqual(['Required CI check "Security scan" is FAIL']);
+    expect(overridden).toEqual(["Risk score 90 exceeds threshold 70"]);
+  });
+
+  it("has nothing to retain once an input is dispositioned irrelevant", () => {
+    const ciSummary = applyInputRelevance(
+      summary([check({ name: "Deploy Edge Functions", status: "fail", required: true })]),
+      [
+        {
+          pattern: "Deploy Edge Functions",
+          disposition: "irrelevant",
+          reason: "unconfigured by design",
+        },
+      ],
+    );
+
+    // computeReleaseReady never emits a reason for it, so the override has only
+    // risk/policy reasons left to clear.
+    const reasons = computeReleaseReady({
+      gateMode: "release-ready",
+      gateDecision: "block",
+      riskScore: 90,
+      riskThreshold: 70,
+      healthScore: 100,
+      healthChecksConfigured: false,
+      freezeActive: false,
+      ciSummary,
+    }).reasons;
+
+    const { retained } = partitionOverrideReasons(reasons, ciSummary);
+    expect(retained).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// enumerateDetectorFindings (ADR-011 Case A)
+// ---------------------------------------------------------------------------
+
+describe("enumerateDetectorFindings", () => {
+  it("gives every pattern a stable id, title and file evidence", () => {
+    const findings = enumerateDetectorFindings(
+      "ci_integrity",
+      [
+        '.github/workflows/ci.yml: workflow bypass pattern "|| true"',
+        '.github/workflows/ci.yml: introduced "continue-on-error: true"',
+      ],
+      "blocking",
+    );
+
+    expect(findings).toEqual([
+      {
+        id: "ci_integrity/1",
+        title: 'workflow bypass pattern "|| true"',
+        severity: "blocking",
+        evidence: ".github/workflows/ci.yml",
+      },
+      {
+        id: "ci_integrity/2",
+        title: 'introduced "continue-on-error: true"',
+        severity: "blocking",
+        evidence: ".github/workflows/ci.yml",
+      },
+    ]);
+  });
+
+  it("keeps prose messages whole rather than inventing evidence", () => {
+    const findings = enumerateDetectorFindings(
+      "pr_scope",
+      ["PR scope exceeds max_files (40 > 20)."],
+      "advisory",
+    );
+
+    expect(findings).toEqual([
+      {
+        id: "pr_scope/1",
+        title: "PR scope exceeds max_files (40 > 20).",
+        severity: "advisory",
+      },
+    ]);
+  });
+
+  it("returns nothing for an empty detector", () => {
+    expect(enumerateDetectorFindings("supply_chain", [], "warn")).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildReleaseBrief
+// ---------------------------------------------------------------------------
+
+describe("buildReleaseBrief", () => {
+  it("maps releaseReady=false to a block verdict with top movers", () => {
+    const brief = buildReleaseBrief(
+      evaluation({
+        releaseReady: false,
+        gateDecision: "block",
+        riskScore: 90,
+        riskFactors: [
+          { type: "ci_integrity", score: 40 },
+          { type: "code_churn", score: 25 },
+          { type: "file_count", score: 10 },
+          { type: "author_history", score: 5 },
+          { type: "pr_age", score: 0 },
+        ],
+      }),
+      70,
+    );
+
+    expect(brief.verdict).toBe("block");
+    expect(brief.riskScore).toBe(90);
+    expect(brief.riskThreshold).toBe(70);
+    expect(brief.topMovers).toEqual([
+      { factor: "ci_integrity", score: 40 },
+      { factor: "code_churn", score: 25 },
+      { factor: "file_count", score: 10 },
+    ]);
+  });
+
+  it("maps a warn gate decision on a ready release to warn", () => {
+    expect(buildReleaseBrief(evaluation({ gateDecision: "warn" }), 70).verdict).toBe(
+      "warn",
+    );
+  });
+
+  it("uses the raw gate decision in risk-only mode", () => {
+    const brief = buildReleaseBrief(
+      evaluation({ gateMode: "risk-only", gateDecision: "block", releaseReady: true }),
+      70,
+    );
+    expect(brief.verdict).toBe("block");
+  });
+
+  it("renders a cannot_evaluate verdict when a reason is supplied", () => {
+    const brief = buildReleaseBrief(evaluation(), 70, "evaluation store unreachable");
+    expect(brief.verdict).toBe("cannot_evaluate");
+    expect(brief.cannotEvaluateReason).toBe("evaluation store unreachable");
+  });
+
+  it("lists every input, including the ones that did not count", () => {
+    const ciSummary = applyInputRelevance(
+      summary([
+        check({ name: "CI Gate", status: "pass", required: true }),
+        check({ name: "Deploy Edge Functions", status: "fail", required: true }),
+        check({ name: "Vercel", status: "fail", required: false }),
+      ]),
+      [
+        {
+          pattern: "Deploy Edge Functions",
+          disposition: "irrelevant",
+          reason: "staging target unconfigured by design",
+        },
+      ],
+    );
+
+    const brief = buildReleaseBrief(evaluation({ ci: ciSummary }), 70);
+
+    expect(brief.inputs).toEqual([
+      { checkName: "CI Gate", status: "pass", disposition: "blocking" },
+      {
+        checkName: "Deploy Edge Functions",
+        status: "fail",
+        disposition: "irrelevant",
+        reason: "staging target unconfigured by design",
+      },
+      { checkName: "Vercel", status: "fail", disposition: "advisory" },
+    ]);
+  });
+
+  it("derives fix, wait and override actions", () => {
+    const ciSummary = applyInputRelevance(
+      summary([
+        check({
+          name: "Tests",
+          status: "fail",
+          required: true,
+          detailsUrl: "https://example.com/checks/1",
+        }),
+        check({ name: "Playwright", status: "pending", required: true }),
+      ]),
+      [],
+    );
+
+    const brief = buildReleaseBrief(
+      evaluation({
+        releaseReady: false,
+        gateDecision: "block",
+        riskScore: 90,
+        ci: ciSummary,
+        enumeratedFindings: [
+          { id: "ci_integrity/1", title: "bypass added", severity: "blocking" },
+          { id: "supply_chain_warning/1", title: "new dependency", severity: "warn" },
+        ],
+      }),
+      70,
+    );
+
+    expect(brief.actions).toEqual([
+      expect.objectContaining({ kind: "fix", link: "https://example.com/checks/1" }),
+      expect.objectContaining({ kind: "fix", detail: "bypass added (`ci_integrity/1`)" }),
+      expect.objectContaining({ kind: "wait" }),
+      expect.objectContaining({ kind: "override" }),
+    ]);
+  });
+
+  it("omits the override action once an override is already recorded", () => {
+    const brief = buildReleaseBrief(
+      evaluation({
+        riskScore: 90,
+        releaseReady: false,
+        policyOverride: {
+          source: "label",
+          owner: "david",
+          reason: "keystone-verified promotion train",
+          linkedTicket: "override:pr#4033",
+          expiresAt: "2026-08-16T00:00:00.000Z",
+          appliedAt: "2026-08-09T00:00:00.000Z",
+          scope: "risk_only",
+          changes: {},
+        },
+      }),
+      70,
+    );
+
+    expect(brief.actions.some((action) => action.kind === "override")).toBe(false);
+    expect(brief.override).toEqual({
+      by: "david",
+      at: "2026-08-09T00:00:00.000Z",
+      scope: "risk_only",
+      rationale: "keystone-verified promotion train",
+    });
+  });
+
+  it("reports override as null when there is none", () => {
+    expect(buildReleaseBrief(evaluation(), 70).override).toBeNull();
+  });
+
+  it("renders a delta only once a previous evaluation exists", () => {
+    expect(buildReleaseBrief(evaluation(), 70).delta).toBeUndefined();
+
+    const brief = buildReleaseBrief(
+      evaluation({
+        remediation: {
+          schema: "trailhead.remediation.v1",
+          release_ready: false,
+          fixes: [],
+          blocking_count: 0,
+          warn_count: 0,
+          advisory_count: 0,
+          autofix_eligible_count: 0,
+          loop_round: 2,
+          max_loop_rounds: 3,
+          previous_evaluation_id: "dg-prev",
+          fixes_resolved: ["ci_fail"],
+          fixes_introduced: [],
+          next_action: "fix_and_retry",
+        },
+      }),
+      70,
+    );
+
+    expect(brief.delta).toBe("round 2 vs previous evaluation — resolved: ci_fail");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatGateReport leads with the brief
+// ---------------------------------------------------------------------------
+
+describe("formatGateReport with a Release Brief", () => {
+  it("puts the brief first and keeps the existing report below it", () => {
+    const evaluated = evaluation({
+      releaseReady: false,
+      gateDecision: "block",
+      riskScore: 90,
+      enumeratedFindings: [
+        {
+          id: "ci_integrity/1",
+          title: 'workflow bypass pattern "|| true"',
+          severity: "blocking",
+          evidence: ".github/workflows/ci.yml",
+        },
+      ],
+      policyFindings: ["CI integrity blocking patterns detected (1)."],
+    });
+    evaluated.releaseBrief = buildReleaseBrief(evaluated, 70);
+
+    const report = formatGateReport(evaluated, 70);
+
+    expect(report.indexOf("## Release Brief")).toBe(0);
+    expect(report.indexOf("## Release Brief")).toBeLessThan(
+      report.indexOf("Trailhead — NOT RELEASE READY"),
+    );
+    // Case A: the pattern itself, not just the count.
+    expect(report).toContain('workflow bypass pattern "|| true"');
+    expect(report).toContain("`ci_integrity/1`");
+    // Existing consumers keep their count string.
+    expect(report).toContain("CI integrity blocking patterns detected (1).");
+  });
+
+  it("renders the pre-ADR-011 report unchanged when no brief is attached", () => {
+    const evaluated = evaluation();
+    const report = formatGateReport(evaluated, 70);
+    expect(report.startsWith("## ✅ Trailhead — RELEASE READY")).toBe(true);
+    expect(report).not.toContain("## Release Brief");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Config schema
+// ---------------------------------------------------------------------------
+
+describe("input_relevance config schema", () => {
+  const yaml = `schema_version: 2
+contexts:
+  - name: master-promotion
+    match:
+      base_branch: [master]
+      head_branch: [staging]
+    availability: fail_closed
+    ci:
+      required_checks: [CI Gate, Deploy Edge Functions]
+    input_relevance:
+      - pattern: "Deploy Edge Functions"
+        disposition: irrelevant
+        reason: "staging target unconfigured by design"
+      - pattern: "Vercel"
+        disposition: advisory
+`;
+
+  it("parses the nested branch-pair relevance table", () => {
+    const parsed = parseRepoConfigContent(yaml);
+    expect(parsed).not.toBeNull();
+    const context = parsed!.contexts[0];
+    expect(context.availability).toBe("fail_closed");
+    expect(context.input_relevance).toEqual([
+      {
+        pattern: "Deploy Edge Functions",
+        disposition: "irrelevant",
+        reason: "staging target unconfigured by design",
+      },
+      { pattern: "Vercel", disposition: "advisory" },
+    ]);
+  });
+
+  it("defaults input_relevance to [] and availability to undefined for old configs", () => {
+    const parsed = parseRepoConfigContent(`schema_version: 2
+contexts:
+  - name: main-pr
+    match:
+      base_branch: [main]
+    ci:
+      required_checks: [Lint]
+`);
+    expect(parsed!.contexts[0].input_relevance).toEqual([]);
+    expect(parsed!.contexts[0].availability).toBeUndefined();
+  });
+
+  it("warns — but does not drop the config — when irrelevant has no reason", () => {
+    const parsed = parseRepoConfigContent(`schema_version: 2
+contexts:
+  - name: main-pr
+    match:
+      base_branch: [main]
+    input_relevance:
+      - pattern: "Deploy Edge Functions"
+        disposition: irrelevant
+`);
+    expect(parsed).not.toBeNull();
+    const warnings = collectConfigWarnings(parsed!);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("Deploy Edge Functions");
+    expect(warnings[0]).toContain("irrelevant");
+  });
+
+  it("does not warn for blocking or advisory entries without a reason", () => {
+    const parsed = parseRepoConfigContent(`schema_version: 2
+contexts:
+  - name: main-pr
+    match:
+      base_branch: [main]
+    input_relevance:
+      - pattern: "Vercel"
+        disposition: advisory
+`);
+    expect(collectConfigWarnings(parsed!)).toEqual([]);
+  });
+});

--- a/src/__tests__/context-matcher.test.ts
+++ b/src/__tests__/context-matcher.test.ts
@@ -8,6 +8,7 @@ const contexts: TrailheadContext[] = [
     match: { base_branch: ["dev"], head_branch: [], labels: [] },
     thresholds: { risk: 70 },
     ci: { required_checks: ["Build"], optional_checks: [], missing_required: "fail" },
+    input_relevance: [],
   },
   {
     name: "promotion",
@@ -19,6 +20,7 @@ const contexts: TrailheadContext[] = [
       optional_checks: [],
       missing_required: "fail",
     },
+    input_relevance: [],
   },
 ];
 
@@ -59,6 +61,7 @@ describe("matchContext", () => {
         match: { base_branch: [], head_branch: [], labels: ["hotfix"] },
         thresholds: {},
         ci: { required_checks: [], optional_checks: [], missing_required: "fail" },
+        input_relevance: [],
       },
       ...contexts,
     ];

--- a/src/__tests__/evaluate-gate.test.ts
+++ b/src/__tests__/evaluate-gate.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 
 import { evaluateGate } from "../gate.js";
+import { GateEvaluation } from "../types.js";
 import type { TrailheadConfig } from "../types.js";
 import * as evaluationHistory from "../evaluation-history.js";
 
@@ -43,6 +44,10 @@ const githubMockState = vi.hoisted(() => ({
   }>,
   routeContents: {} as Record<string, string>,
   contentRequests: [] as string[],
+  closedPrs: [] as Array<{
+    merged_at: string | null;
+    user?: { login?: string };
+  }>,
 }));
 
 vi.mock("@actions/core", () => ({
@@ -104,6 +109,9 @@ vi.mock("@actions/github", () => ({
         })),
         listReviews: vi.fn().mockImplementation(async () => ({
           data: githubMockState.reviews,
+        })),
+        list: vi.fn().mockImplementation(async () => ({
+          data: githubMockState.closedPrs,
         })),
       },
       checks: {
@@ -193,6 +201,7 @@ describe("evaluateGate (integration)", () => {
     githubMockState.commitFiles = [];
     githubMockState.routeContents = {};
     githubMockState.contentRequests = [];
+    githubMockState.closedPrs = [];
     // Avoid loading repo .trailhead.yml on CI (GITHUB_WORKSPACE is set there).
     vi.stubEnv("GITHUB_WORKSPACE", "");
   });
@@ -574,5 +583,417 @@ policies:
 
     expect(result.remediation?.loop_round).toBe(2);
     expect(result.remediation?.previous_evaluation_id).toBe("eval-prev");
+  });
+
+  // -------------------------------------------------------------------------
+  // ADR-011 — Release Brief and input relevance
+  // -------------------------------------------------------------------------
+
+  it("Case B replay: an irrelevant required failure no longer blocks the release", async () => {
+    githubMockState.checkRuns = [
+      {
+        name: "Deploy Edge Functions",
+        status: "completed",
+        conclusion: "failure",
+        html_url: "https://example.com/checks/deploy-edge",
+      },
+      { name: "CI Gate", status: "completed", conclusion: "success" },
+    ];
+
+    const result = await withLocalTrailheadConfig(
+      `schema_version: 2
+gate:
+  mode: release-ready
+contexts:
+  - name: main-pr
+    match:
+      base_branch: [main]
+    ci:
+      required_checks: [CI Gate, Deploy Edge Functions]
+      optional_checks: []
+      missing_required: skip
+    input_relevance:
+      - pattern: "Deploy Edge Functions"
+        disposition: irrelevant
+        reason: "staging target unconfigured by design; see supabase-migrations.yml guard"`,
+      () =>
+        evaluateGate(
+          makeConfig({ githubToken: "ghp_test", securityGate: false }),
+          "pull-request-head-sha",
+          42,
+        ),
+    );
+
+    expect(result.releaseReady).toBe(true);
+    expect(result.releaseReadyReasons).toBeUndefined();
+    expect(result.ci?.failedCount).toBe(0);
+
+    const deployInput = result.releaseBrief?.inputs.find(
+      (input) => input.checkName === "Deploy Edge Functions",
+    );
+    expect(deployInput).toEqual({
+      checkName: "Deploy Edge Functions",
+      status: "fail",
+      disposition: "irrelevant",
+      reason: "staging target unconfigured by design; see supabase-migrations.yml guard",
+    });
+  });
+
+  it("blocks the same check when no input_relevance entry matches", async () => {
+    githubMockState.checkRuns = [
+      { name: "Deploy Edge Functions", status: "completed", conclusion: "failure" },
+    ];
+
+    const result = await withLocalTrailheadConfig(
+      `schema_version: 2
+gate:
+  mode: release-ready
+contexts:
+  - name: main-pr
+    match:
+      base_branch: [main]
+    ci:
+      required_checks: [Deploy Edge Functions]
+      optional_checks: []
+      missing_required: skip`,
+      () =>
+        evaluateGate(
+          makeConfig({ githubToken: "ghp_test", securityGate: false }),
+          "pull-request-head-sha",
+          42,
+        ),
+    );
+
+    expect(result.releaseReady).toBe(false);
+    expect(result.releaseReadyReasons).toContain(
+      'Required CI check "Deploy Edge Functions" is FAIL',
+    );
+    expect(result.releaseBrief?.verdict).toBe("block");
+  });
+
+  it("missing_blocking: an absent required check still blocks and is labelled", async () => {
+    githubMockState.checkRuns = [];
+
+    const result = await withLocalTrailheadConfig(
+      `schema_version: 2
+gate:
+  mode: release-ready
+contexts:
+  - name: main-pr
+    match:
+      base_branch: [main]
+    ci:
+      required_checks: [Playwright]
+      optional_checks: []
+      missing_required: fail`,
+      () =>
+        evaluateGate(
+          makeConfig({ githubToken: "ghp_test", securityGate: false }),
+          "pull-request-head-sha",
+          42,
+        ),
+    );
+
+    expect(result.releaseReady).toBe(false);
+    expect(result.releaseReadyReasons).toContain(
+      'Required CI check "Playwright" is MISSING',
+    );
+    expect(result.ci?.checks[0].disposition?.kind).toBe("missing_blocking");
+    expect(result.releaseBrief?.inputs[0].disposition).toBe("missing_blocking");
+  });
+
+  it("Case A replay: ci-integrity patterns are enumerated, not just counted", async () => {
+    githubMockState.filePages = {
+      1: [
+        {
+          filename: ".github/workflows/ci.yml",
+          additions: 2,
+          deletions: 0,
+          changes: 2,
+          status: "modified",
+          patch:
+            "@@ -1,1 +1,3 @@\n+      run: npm test || true\n+    continue-on-error: true\n",
+        },
+      ],
+    };
+
+    const result = await evaluateGate(
+      makeConfig({ githubToken: "ghp_test", securityGate: false }),
+      "pull-request-head-sha",
+      42,
+    );
+
+    expect(result.policyFindings).toContain(
+      "CI integrity blocking patterns detected (2).",
+    );
+
+    const enumerated = (result.enumeratedFindings ?? []).filter((finding) =>
+      finding.id.startsWith("ci_integrity/"),
+    );
+    expect(enumerated.map((finding) => finding.id)).toEqual([
+      "ci_integrity/1",
+      "ci_integrity/2",
+    ]);
+    expect(enumerated.every((finding) => finding.severity === "blocking")).toBe(true);
+    expect(
+      enumerated.every((finding) => finding.evidence === ".github/workflows/ci.yml"),
+    ).toBe(true);
+    expect(enumerated.map((finding) => finding.title)).toEqual([
+      'workflow bypass pattern "|| true"',
+      'introduced "continue-on-error: true"',
+    ]);
+
+    const briefFindings = result.releaseBrief?.findings ?? [];
+    expect(briefFindings.map((finding) => finding.id)).toEqual(
+      expect.arrayContaining(["ci_integrity/1", "ci_integrity/2"]),
+    );
+  });
+
+  it("attaches a Release Brief to every evaluation, with no config present", async () => {
+    githubMockState.checkRuns = [
+      { name: "CI Gate", status: "completed", conclusion: "success" },
+    ];
+
+    const result = await evaluateGate(
+      makeConfig({ githubToken: "ghp_test", securityGate: false }),
+      "pull-request-head-sha",
+      42,
+    );
+
+    const brief = result.releaseBrief;
+    expect(brief).toBeDefined();
+    expect(["allow", "warn", "block"]).toContain(brief!.verdict);
+    expect(brief!.riskScore).toBe(result.riskScore);
+    expect(Array.isArray(brief!.findings)).toBe(true);
+    expect(Array.isArray(brief!.inputs)).toBe(true);
+    expect(Array.isArray(brief!.actions)).toBe(true);
+    expect(brief!.override).toBeNull();
+    // Survives the GateEvaluation Zod schema (the store persists this object).
+    expect(GateEvaluation.safeParse(result).success).toBe(true);
+  });
+
+  it("no-config runs keep their pre-ADR-011 decisions and CI rollup", async () => {
+    githubMockState.checkRuns = [
+      { name: "CI Gate", status: "completed", conclusion: "failure" },
+      { name: "Vercel", status: "completed", conclusion: "failure" },
+    ];
+
+    const result = await withLocalTrailheadConfig(
+      `schema_version: 2
+gate:
+  mode: release-ready
+contexts:
+  - name: main-pr
+    match:
+      base_branch: [main]
+    ci:
+      required_checks: [CI Gate]
+      optional_checks: []
+      missing_required: skip`,
+      () =>
+        evaluateGate(
+          makeConfig({ githubToken: "ghp_test", securityGate: false }),
+          "pull-request-head-sha",
+          42,
+        ),
+    );
+
+    expect(result.releaseReady).toBe(false);
+    expect(result.releaseReadyReasons).toEqual(['Required CI check "CI Gate" is FAIL']);
+    expect(result.ci?.allRequiredPassed).toBe(false);
+    expect(result.ci?.failedCount).toBe(1);
+    expect(result.ci?.pendingCount).toBe(0);
+    expect(result.ci?.missingCount).toBe(0);
+    // The non-required red check is advisory by default and does not block.
+    expect(
+      result.ci?.checks.find((check) => check.name === "Vercel")?.disposition,
+    ).toEqual({ kind: "advisory", source: "default" });
+  });
+
+  // -------------------------------------------------------------------------
+  // ADR-011 §1 — a BLOCK never renders as "No findings."
+  //
+  // Four block-capable sources are not detector pattern lists, so each needs
+  // its own proof that the verdict it produced is also *named* in the brief.
+  // -------------------------------------------------------------------------
+
+  describe("every block-capable source reaches the Release Brief", () => {
+    function agentPr(): void {
+      githubMockState.pullRequest = {
+        user: { login: "test-author" },
+        base: { ref: "main" },
+        head: { ref: "claude/add-auth", sha: "pull-request-head-sha" },
+      };
+      githubMockState.payload = { pull_request: githubMockState.pullRequest };
+    }
+
+    it("names the agent PR policy that forced the block", async () => {
+      agentPr();
+      githubMockState.filePages = {
+        1: [
+          {
+            filename: "src/auth/session.ts",
+            additions: 10,
+            deletions: 0,
+            changes: 10,
+            status: "modified",
+          },
+        ],
+      };
+
+      const result = await withLocalTrailheadConfig(
+        `schema_version: 2
+policies:
+  agent_prs:
+    enabled: true
+    mode: block
+    required_approvals: 2
+`,
+        () =>
+          evaluateGate(
+            makeConfig({ githubToken: "ghp_test", securityGate: false }),
+            "pull-request-head-sha",
+            42,
+          ),
+      );
+
+      expect(result.gateDecision).toBe("block");
+      const findings = result.releaseBrief?.findings ?? [];
+      expect(findings.length).toBeGreaterThan(0);
+      const agentFindings = findings.filter((finding) =>
+        finding.id.startsWith("agent_policy/"),
+      );
+      expect(agentFindings.length).toBeGreaterThan(0);
+      expect(agentFindings.some((finding) => finding.severity === "blocking")).toBe(true);
+      expect(agentFindings.some((finding) => /approval/i.test(finding.title))).toBe(true);
+    });
+
+    it("names the sensitive-file escalation that forced the block", async () => {
+      githubMockState.filePages = {
+        1: [
+          {
+            filename: "supabase/migrations/0001_init.sql",
+            additions: 5,
+            deletions: 0,
+            changes: 5,
+            status: "added",
+          },
+        ],
+      };
+
+      const result = await withLocalTrailheadConfig(
+        `schema_version: 2
+policies:
+  sensitive_files:
+    enabled: true
+    mode: block
+    threshold: 25
+`,
+        () =>
+          evaluateGate(
+            makeConfig({ githubToken: "ghp_test", securityGate: false }),
+            "pull-request-head-sha",
+            42,
+          ),
+      );
+
+      expect(result.gateDecision).toBe("block");
+      const findings = result.releaseBrief?.findings ?? [];
+      expect(findings.length).toBeGreaterThan(0);
+      const escalation = findings.find((finding) => finding.id === "sensitive_files/0");
+      expect(escalation).toBeDefined();
+      expect(escalation!.severity).toBe("blocking");
+      expect(escalation!.title).toContain("sensitive_files score");
+    });
+
+    it("names the merge burst that forced the block", async () => {
+      agentPr();
+      const mergedAt = new Date().toISOString();
+      githubMockState.closedPrs = Array.from({ length: 3 }, () => ({
+        merged_at: mergedAt,
+        user: { login: "test-author" },
+      }));
+
+      const result = await withLocalTrailheadConfig(
+        `schema_version: 2
+policies:
+  session_correlation:
+    enabled: true
+    threshold: 3
+    window_minutes: 60
+    mode: block
+`,
+        () =>
+          evaluateGate(
+            makeConfig({ githubToken: "ghp_test", securityGate: false }),
+            "pull-request-head-sha",
+            42,
+          ),
+      );
+
+      expect(result.gateDecision).toBe("block");
+      const findings = result.releaseBrief?.findings ?? [];
+      expect(findings.length).toBeGreaterThan(0);
+      const burst = findings.filter((finding) =>
+        finding.id.startsWith("session_correlation/"),
+      );
+      expect(burst.map((finding) => finding.id)).toEqual([
+        "session_correlation/1",
+        "session_correlation/2",
+      ]);
+      expect(burst.every((finding) => finding.severity === "blocking")).toBe(true);
+      expect(burst[0].title).toContain("Rapid-fire merge burst detected: 3 merged PRs");
+    });
+
+    it("names each submission check instead of counting them", async () => {
+      githubMockState.filePages = {
+        1: [
+          {
+            filename: "src/rollout.ts",
+            additions: 2,
+            deletions: 0,
+            changes: 2,
+            status: "modified",
+            patch: "@@ -1,1 +1,3 @@\n+// TODO: implement rollout\n+export const x = 1;\n",
+          },
+        ],
+      };
+
+      const result = await withLocalTrailheadConfig(
+        `schema_version: 2
+submission:
+  enabled: true
+  mode: block
+`,
+        () =>
+          evaluateGate(
+            makeConfig({
+              githubToken: "ghp_test",
+              submissionGate: true,
+              securityGate: false,
+            }),
+            "pull-request-head-sha",
+            42,
+          ),
+      );
+
+      expect(result.gateDecision).toBe("block");
+      // The count string stays for existing consumers…
+      expect(result.policyFindings).toContain("Submission gate: 1 finding(s).");
+      // …but the brief names the check, its detail and its severity.
+      const findings = result.releaseBrief?.findings ?? [];
+      expect(findings.length).toBeGreaterThan(0);
+      const submission = findings.filter((finding) =>
+        finding.id.startsWith("submission/"),
+      );
+      expect(submission).toEqual([
+        {
+          id: "submission/mock_placeholder/1",
+          title: "Mock placeholder in production path",
+          evidence: expect.stringContaining("src/rollout.ts"),
+          severity: "blocking",
+        },
+      ]);
+    });
   });
 });

--- a/src/__tests__/gate.test.ts
+++ b/src/__tests__/gate.test.ts
@@ -16,6 +16,8 @@ import {
   managePrLabels,
   requestHighRiskReviewers,
   formatGateReport,
+  buildReleaseBrief,
+  MAX_GATE_REPORT_CHARS,
 } from "../gate.js";
 import { buildRemediation } from "../remediation.js";
 import type { GateEvaluation } from "../types.js";
@@ -1440,6 +1442,104 @@ describe("postPrComment", () => {
   it("handles API errors gracefully without throwing", async () => {
     mockListComments.mockRejectedValue(new Error("GitHub API error"));
     await expect(postPrComment("## Report", 42, "ghp_test")).resolves.toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Report clamping (ADR-011 §1) — GitHub rejects an oversized body outright, so
+// the brief cap alone is not enough: the legacy report below it is unbounded.
+// ---------------------------------------------------------------------------
+
+describe("gate report clamping", () => {
+  beforeEach(() => {
+    mockListComments.mockReset().mockResolvedValue({ data: [] });
+    mockCreateComment.mockReset().mockResolvedValue({});
+    mockUpdateComment.mockReset().mockResolvedValue({});
+    mockChecksCreate.mockReset().mockResolvedValue({});
+  });
+
+  function oversizedReport(): string {
+    const evaluation: GateEvaluation = {
+      id: "dg-huge",
+      repoId: "test-owner/test-repo",
+      commitSha: "abc1234567890",
+      healthScore: 100,
+      riskScore: 90,
+      gateDecision: "block",
+      healthChecks: [],
+      riskFactors: [{ type: "sensitive_files", score: 100 }],
+      evaluationMs: 10,
+      gateMode: "release-ready",
+      releaseReady: false,
+      files: Array.from(
+        { length: 3000 },
+        (_, index) => `src/generated/module-${index}/index.ts`,
+      ),
+      enumeratedFindings: Array.from({ length: 40 }, (_, index) => ({
+        id: `ci_integrity/${index + 1}`,
+        title: `workflow bypass pattern #${index + 1}`,
+        evidence: ".github/workflows/ci.yml",
+        severity: "blocking" as const,
+      })),
+      policyFindings: ["CI integrity blocking patterns detected (40)."],
+    };
+    evaluation.releaseBrief = buildReleaseBrief(evaluation, 70);
+
+    const report = formatGateReport(evaluation, 70);
+    expect(report.length).toBeGreaterThan(MAX_GATE_REPORT_CHARS);
+    return report;
+  }
+
+  it("clamps a new PR comment under the limit, keeping the brief", async () => {
+    await postPrComment(oversizedReport(), 42, "ghp_test");
+
+    const body = mockCreateComment.mock.calls[0]?.[0]?.body as string;
+    expect(body.length).toBeLessThanOrEqual(MAX_GATE_REPORT_CHARS);
+    expect(body).toContain("## Release Brief");
+    expect(body).toContain("workflow bypass pattern #1");
+    expect(body).toContain("report truncated");
+    expect(body).toContain("full detail in the stored evaluation / job summary");
+    // The unbounded tail is what gave way, not the brief.
+    expect(body).not.toContain("src/generated/module-2999/index.ts");
+  });
+
+  it("clamps an edited PR comment on the same path", async () => {
+    mockListComments.mockResolvedValue({
+      data: [{ id: 999, body: "<!-- trailhead-gate-report -->\nold report" }],
+    });
+    await postPrComment(oversizedReport(), 42, "ghp_test");
+
+    const body = mockUpdateComment.mock.calls[0]?.[0]?.body as string;
+    expect(body.length).toBeLessThanOrEqual(MAX_GATE_REPORT_CHARS);
+    expect(body).toContain("## Release Brief");
+    expect(body).toContain("report truncated");
+  });
+
+  it("clamps the check-run summary GitHub caps at 65535", async () => {
+    const evaluation: GateEvaluation = {
+      id: "dg-huge",
+      repoId: "test-owner/test-repo",
+      commitSha: "abc1234567890",
+      healthScore: 100,
+      riskScore: 90,
+      gateDecision: "block",
+      healthChecks: [],
+      riskFactors: [],
+      evaluationMs: 10,
+    };
+    await createCheckRun(evaluation, oversizedReport(), "ghp_test");
+
+    const summary = mockChecksCreate.mock.calls[0]?.[0]?.output?.summary as string;
+    expect(summary.length).toBeLessThanOrEqual(MAX_GATE_REPORT_CHARS);
+    expect(summary).toContain("## Release Brief");
+    expect(summary).toContain("report truncated");
+  });
+
+  it("leaves a report that already fits completely untouched", async () => {
+    await postPrComment("## Release Brief\n\nsmall", 42, "ghp_test");
+
+    const body = mockCreateComment.mock.calls[0]?.[0]?.body as string;
+    expect(body).toBe("<!-- trailhead-gate-report -->\n## Release Brief\n\nsmall");
   });
 });
 

--- a/src/__tests__/input-relevance.test.ts
+++ b/src/__tests__/input-relevance.test.ts
@@ -1,0 +1,387 @@
+import { describe, it, expect } from "vitest";
+import {
+  resolveDisposition,
+  resolveDispositions,
+  dispositionCountsTowardBlocking,
+  MISSING_IRRELEVANT_REASON,
+} from "../input-relevance.js";
+import type {
+  DispositionCheckInput,
+  InputRelevanceEntry,
+  ResolvedDisposition,
+} from "../input-relevance.js";
+
+const ALL_STATUSES: DispositionCheckInput["status"][] = [
+  "pass",
+  "fail",
+  "skip",
+  "pending",
+  "stale",
+  "missing",
+];
+
+function check(
+  name: string,
+  status: DispositionCheckInput["status"],
+  required = true,
+): DispositionCheckInput {
+  return { name, status, required };
+}
+
+describe("resolveDisposition — defaults (no entry matches)", () => {
+  it("required check with empty policy defaults to blocking", () => {
+    const result = resolveDisposition(check("CI Gate", "fail"), []);
+    expect(result).toEqual({ kind: "blocking", source: "default" });
+    expect(result.reason).toBeUndefined();
+  });
+
+  it("optional check with empty policy defaults to advisory", () => {
+    expect(resolveDisposition(check("Lint", "fail", false), [])).toEqual({
+      kind: "advisory",
+      source: "default",
+    });
+  });
+
+  it("falls back to default when entries exist but none match", () => {
+    const entries: InputRelevanceEntry[] = [
+      {
+        pattern: "Deploy *",
+        disposition: "irrelevant",
+        reason: "unconfigured by design",
+      },
+    ];
+    expect(resolveDisposition(check("type-check", "fail"), entries)).toEqual({
+      kind: "blocking",
+      source: "default",
+    });
+  });
+
+  it("defaults hold across every ADR-009 status", () => {
+    for (const status of ALL_STATUSES) {
+      const required = resolveDisposition(check("CI Gate", status), []);
+      const optional = resolveDisposition(check("CI Gate", status, false), []);
+      expect(required.source).toBe("default");
+      expect(optional.source).toBe("default");
+      expect(required.kind).toBe(status === "missing" ? "missing_blocking" : "blocking");
+      expect(optional.kind).toBe("advisory");
+    }
+  });
+});
+
+describe("resolveDisposition — entry ordering", () => {
+  const entries: InputRelevanceEntry[] = [
+    {
+      pattern: "Deploy Edge Functions",
+      disposition: "irrelevant",
+      reason: "staging unconfigured",
+    },
+    { pattern: "Deploy *", disposition: "advisory", reason: "deploys never block" },
+    { pattern: "*", disposition: "blocking", reason: "catch-all" },
+  ];
+
+  it("first matching entry wins even when later entries also match", () => {
+    expect(resolveDisposition(check("Deploy Edge Functions", "fail"), entries)).toEqual({
+      kind: "irrelevant",
+      reason: "staging unconfigured",
+      source: "policy",
+    });
+  });
+
+  it("falls through to the second entry when the first does not match", () => {
+    expect(resolveDisposition(check("Deploy Docs", "fail"), entries)).toEqual({
+      kind: "advisory",
+      reason: "deploys never block",
+      source: "policy",
+    });
+  });
+
+  it("a catch-all glob matches anything not claimed earlier", () => {
+    expect(resolveDisposition(check("type-check", "fail", false), entries)).toEqual({
+      kind: "blocking",
+      reason: "catch-all",
+      source: "policy",
+    });
+  });
+
+  it("reversing declaration order reverses the winner", () => {
+    const reversed = [...entries].reverse();
+    expect(
+      resolveDisposition(check("Deploy Edge Functions", "fail"), reversed).kind,
+    ).toBe("blocking");
+  });
+});
+
+describe("resolveDisposition — pattern matching semantics", () => {
+  function kindFor(pattern: string, name: string): string {
+    const entries: InputRelevanceEntry[] = [{ pattern, disposition: "advisory" }];
+    // required=true so a non-match is visibly "blocking"
+    return resolveDisposition(check(name, "fail"), entries).kind;
+  }
+
+  it("matches exactly", () => {
+    expect(kindFor("CI Gate", "CI Gate")).toBe("advisory");
+  });
+
+  it("matches case-insensitively", () => {
+    expect(kindFor("ci gate", "CI Gate")).toBe("advisory");
+    expect(kindFor("CI GATE", "CI Gate")).toBe("advisory");
+  });
+
+  it("matches a configured prefix (checkNameMatches semantics)", () => {
+    expect(kindFor("Deploy", "Deploy Edge Functions")).toBe("advisory");
+    expect(kindFor("deploy", "Deploy Edge Functions")).toBe("advisory");
+  });
+
+  it("does not match a suffix", () => {
+    expect(kindFor("Edge Functions", "Deploy Edge Functions")).toBe("blocking");
+  });
+
+  it("matches a trailing glob", () => {
+    expect(kindFor("Deploy *", "Deploy Edge Functions")).toBe("advisory");
+  });
+
+  it("matches a leading glob (glob-only — prefix matching cannot)", () => {
+    expect(kindFor("* Functions", "Deploy Edge Functions")).toBe("advisory");
+  });
+
+  it("matches a single-character glob", () => {
+    expect(kindFor("test-?", "test-1")).toBe("advisory");
+    expect(kindFor("test-?", "test-12")).toBe("blocking");
+  });
+
+  it("matches a globstar across slashes", () => {
+    expect(kindFor("CI Gate / **", "CI Gate / type-check")).toBe("advisory");
+  });
+
+  it("treats regex metacharacters in the pattern as literals", () => {
+    expect(kindFor("build(prod)", "build(prod)")).toBe("advisory");
+    expect(kindFor("build(prod)", "buildXprodY")).toBe("blocking");
+  });
+
+  it("does not match unrelated names", () => {
+    expect(kindFor("Deploy *", "type-check")).toBe("blocking");
+  });
+
+  it("ignores blank patterns instead of prefix-matching everything", () => {
+    expect(kindFor("", "anything at all")).toBe("blocking");
+    expect(kindFor("   ", "anything at all")).toBe("blocking");
+  });
+});
+
+describe("resolveDisposition — irrelevant reason handling", () => {
+  it("keeps a configured reason", () => {
+    const entries: InputRelevanceEntry[] = [
+      {
+        pattern: "Deploy *",
+        disposition: "irrelevant",
+        reason: "staging target unconfigured",
+      },
+    ];
+    expect(
+      resolveDisposition(check("Deploy Edge Functions", "fail"), entries).reason,
+    ).toBe("staging target unconfigured");
+  });
+
+  it("substitutes the placeholder when reason is absent", () => {
+    const entries: InputRelevanceEntry[] = [
+      { pattern: "Deploy *", disposition: "irrelevant" },
+    ];
+    expect(resolveDisposition(check("Deploy Edge Functions", "fail"), entries)).toEqual({
+      kind: "irrelevant",
+      reason: MISSING_IRRELEVANT_REASON,
+      source: "policy",
+    });
+  });
+
+  it("substitutes the placeholder for an empty or whitespace-only reason", () => {
+    for (const reason of ["", "   "]) {
+      const entries: InputRelevanceEntry[] = [
+        { pattern: "Deploy *", disposition: "irrelevant", reason },
+      ];
+      expect(
+        resolveDisposition(check("Deploy Edge Functions", "fail"), entries).reason,
+      ).toBe(MISSING_IRRELEVANT_REASON);
+    }
+  });
+
+  it("does not invent a reason for blocking or advisory entries", () => {
+    const entries: InputRelevanceEntry[] = [
+      { pattern: "Deploy *", disposition: "advisory" },
+      { pattern: "CI *", disposition: "blocking", reason: "   " },
+    ];
+    expect(resolveDisposition(check("Deploy Docs", "fail"), entries)).toEqual({
+      kind: "advisory",
+      source: "policy",
+    });
+    expect(resolveDisposition(check("CI Gate", "fail"), entries)).toEqual({
+      kind: "blocking",
+      source: "policy",
+    });
+  });
+});
+
+describe("resolveDisposition — missing_blocking derivation", () => {
+  it("derives missing_blocking from a policy blocking entry", () => {
+    const entries: InputRelevanceEntry[] = [
+      { pattern: "CI Gate", disposition: "blocking", reason: "core gate" },
+    ];
+    expect(resolveDisposition(check("CI Gate", "missing"), entries)).toEqual({
+      kind: "missing_blocking",
+      reason: "core gate",
+      source: "policy",
+    });
+  });
+
+  it("derives missing_blocking from the required default", () => {
+    expect(resolveDisposition(check("CI Gate", "missing"), [])).toEqual({
+      kind: "missing_blocking",
+      source: "default",
+    });
+  });
+
+  it("does not derive missing_blocking for advisory or irrelevant inputs", () => {
+    const entries: InputRelevanceEntry[] = [
+      { pattern: "Deploy *", disposition: "irrelevant", reason: "by design" },
+      { pattern: "Lint", disposition: "advisory" },
+    ];
+    expect(
+      resolveDisposition(check("Deploy Edge Functions", "missing"), entries).kind,
+    ).toBe("irrelevant");
+    expect(resolveDisposition(check("Lint", "missing"), entries).kind).toBe("advisory");
+    expect(resolveDisposition(check("Lint", "missing", false), []).kind).toBe("advisory");
+  });
+
+  it("only status=missing derives it — no other status does", () => {
+    for (const status of ALL_STATUSES) {
+      const kind = resolveDisposition(check("CI Gate", status), []).kind;
+      if (status === "missing") expect(kind).toBe("missing_blocking");
+      else expect(kind).toBe("blocking");
+    }
+  });
+
+  it("cannot be configured directly — configured blocking + non-missing stays blocking", () => {
+    const entries: InputRelevanceEntry[] = [
+      { pattern: "CI Gate", disposition: "blocking" },
+    ];
+    expect(resolveDisposition(check("CI Gate", "fail"), entries).kind).toBe("blocking");
+  });
+});
+
+describe("resolveDisposition — full status x disposition matrix", () => {
+  const dispositions: InputRelevanceEntry["disposition"][] = [
+    "blocking",
+    "advisory",
+    "irrelevant",
+  ];
+
+  it("resolves every combination as specified", () => {
+    for (const disposition of dispositions) {
+      for (const status of ALL_STATUSES) {
+        for (const required of [true, false]) {
+          const entries: InputRelevanceEntry[] = [
+            { pattern: "Any Check", disposition, reason: "because" },
+          ];
+          const result = resolveDisposition(
+            check("Any Check", status, required),
+            entries,
+          );
+          const expectedKind =
+            disposition === "blocking" && status === "missing"
+              ? "missing_blocking"
+              : disposition;
+          expect(result).toEqual({
+            kind: expectedKind,
+            reason: "because",
+            source: "policy",
+          });
+        }
+      }
+    }
+  });
+});
+
+describe("resolveDispositions", () => {
+  const entries: InputRelevanceEntry[] = [
+    {
+      pattern: "Deploy *",
+      disposition: "irrelevant",
+      reason: "staging unconfigured by design",
+    },
+    { pattern: "Lint", disposition: "advisory" },
+  ];
+
+  it("resolves each check, keyed by name", () => {
+    const map = resolveDispositions(
+      [
+        check("CI Gate", "pass"),
+        check("Deploy Edge Functions", "fail"),
+        check("Lint", "fail", false),
+        check("migration lint", "missing"),
+      ],
+      entries,
+    );
+    expect(map.size).toBe(4);
+    expect(map.get("CI Gate")).toEqual({ kind: "blocking", source: "default" });
+    expect(map.get("Deploy Edge Functions")).toEqual({
+      kind: "irrelevant",
+      reason: "staging unconfigured by design",
+      source: "policy",
+    });
+    expect(map.get("Lint")).toEqual({ kind: "advisory", source: "policy" });
+    expect(map.get("migration lint")).toEqual({
+      kind: "missing_blocking",
+      source: "default",
+    });
+  });
+
+  it("returns an empty map for no checks", () => {
+    expect(resolveDispositions([], entries).size).toBe(0);
+  });
+
+  it("works with an empty policy table", () => {
+    const map = resolveDispositions([check("CI Gate", "fail")], []);
+    expect(map.get("CI Gate")).toEqual({ kind: "blocking", source: "default" });
+  });
+
+  it("keeps the first occurrence on duplicate check names", () => {
+    const map = resolveDispositions(
+      [check("CI Gate", "fail", true), check("CI Gate", "pass", false)],
+      [],
+    );
+    expect(map.size).toBe(1);
+    expect(map.get("CI Gate")).toEqual({ kind: "blocking", source: "default" });
+  });
+
+  it("returns undefined for an unknown check name", () => {
+    expect(
+      resolveDispositions([check("CI Gate", "pass")], entries).get("nope"),
+    ).toBeUndefined();
+  });
+});
+
+describe("dispositionCountsTowardBlocking", () => {
+  const cases: Array<[ResolvedDisposition, boolean]> = [
+    [{ kind: "blocking", source: "default" }, true],
+    [{ kind: "missing_blocking", source: "default" }, true],
+    [{ kind: "advisory", source: "default" }, false],
+    [{ kind: "irrelevant", reason: "by design", source: "policy" }, false],
+  ];
+
+  it.each(cases)("%o -> %s", (resolved, expected) => {
+    expect(dispositionCountsTowardBlocking(resolved)).toBe(expected);
+  });
+
+  it("Case B: a red but irrelevant deploy check does not block", () => {
+    const entries: InputRelevanceEntry[] = [
+      {
+        pattern: "Deploy Edge Functions",
+        disposition: "irrelevant",
+        reason:
+          "staging target unconfigured by design; see supabase-migrations.yml guard",
+      },
+    ];
+    const resolved = resolveDisposition(check("Deploy Edge Functions", "fail"), entries);
+    expect(dispositionCountsTowardBlocking(resolved)).toBe(false);
+    expect(resolved.reason).toContain("unconfigured by design");
+  });
+});

--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -324,3 +324,146 @@ describe("run — cloud-upsell footer in the check summary", () => {
     expect(freshCore.setFailed).not.toHaveBeenCalled();
   });
 });
+
+/**
+ * ADR-011 §4 — availability stance, and §1's "silence is a bug": a run that could
+ * not evaluate must still post a cannot-evaluate brief on the PR.
+ */
+describe("run — cannot-evaluate path (ADR-011 §1/§4)", () => {
+  async function runFailedMain(options: {
+    inputs: Record<string, string>;
+    stance?: "fail_open" | "fail_closed" | null;
+  }): Promise<{
+    freshCore: typeof import("@actions/core");
+    postPrCommentSpy: ReturnType<typeof vi.spyOn>;
+  }> {
+    vi.resetModules();
+
+    const freshCore = await import("@actions/core");
+    const freshGithub = await import("@actions/github");
+    const freshGate = await import("../gate.js");
+    const freshHealers = await import("../healers/index.js");
+
+    vi.mocked(freshCore.getInput).mockImplementation(
+      (name: string) => options.inputs[name] ?? "",
+    );
+    (freshGithub.context as { payload: { pull_request?: { number: number } } }).payload =
+      {
+        pull_request: { number: 42 },
+      };
+
+    vi.spyOn(freshHealers, "registerHealer").mockImplementation(() => undefined);
+    vi.spyOn(freshGate, "evaluateGate").mockRejectedValue(
+      new Error("evaluation store unreachable"),
+    );
+    const postPrCommentSpy = vi.spyOn(freshGate, "postPrComment").mockResolvedValue();
+    freshGate.setResolvedAvailabilityStance(options.stance ?? null);
+
+    await import("../main.js");
+    await new Promise((r) => setTimeout(r, 0));
+
+    return { freshCore, postPrCommentSpy };
+  }
+
+  it("posts a cannot-evaluate brief and sets release-brief-json", async () => {
+    const { freshCore, postPrCommentSpy } = await runFailedMain({
+      inputs: { "github-token": "ghp_test", "fail-mode": "open" },
+    });
+
+    expect(postPrCommentSpy).toHaveBeenCalledTimes(1);
+    const body = postPrCommentSpy.mock.calls[0]?.[0] as string;
+    expect(body).toContain("CANNOT EVALUATE");
+    expect(body).toContain("evaluation store unreachable");
+    expect(freshCore.setOutput).toHaveBeenCalledWith(
+      "release-brief-json",
+      expect.stringContaining('"verdict":"cannot_evaluate"'),
+    );
+    expect(freshCore.setFailed).not.toHaveBeenCalled();
+  });
+
+  it("posts a cannot-evaluate brief when the policy override is unusable", async () => {
+    const { freshCore, postPrCommentSpy } = await runFailedMain({
+      // An override with no reason/owner/ticket/expiry throws PolicyOverrideError
+      // before evaluateGate is ever reached.
+      inputs: {
+        "github-token": "ghp_test",
+        "fail-mode": "open",
+        "override-risk-threshold": "90",
+      },
+    });
+
+    expect(postPrCommentSpy).toHaveBeenCalledTimes(1);
+    const body = postPrCommentSpy.mock.calls[0]?.[0] as string;
+    expect(body).toContain("CANNOT EVALUATE");
+    expect(body).toContain("Overrides require override-reason");
+    expect(freshCore.setOutput).toHaveBeenCalledWith(
+      "release-brief-json",
+      expect.stringContaining('"verdict":"cannot_evaluate"'),
+    );
+    // The distinct failure message survives the new brief-posting path.
+    expect(freshCore.setFailed).toHaveBeenCalledWith(
+      "Invalid policy override: Overrides require override-reason, override-owner, " +
+        "override-ticket, and override-expires-at",
+    );
+  });
+
+  it("a fail_closed context stance overrides a fail-open action input", async () => {
+    const { freshCore } = await runFailedMain({
+      inputs: { "github-token": "ghp_test", "fail-mode": "open" },
+      stance: "fail_closed",
+    });
+
+    expect(freshCore.setFailed).toHaveBeenCalledWith(
+      expect.stringContaining("fail-closed"),
+    );
+  });
+
+  it("a fail_open context stance overrides a fail-closed action input", async () => {
+    const { freshCore } = await runFailedMain({
+      inputs: { "github-token": "ghp_test", "fail-mode": "closed" },
+      stance: "fail_open",
+    });
+
+    expect(freshCore.setFailed).not.toHaveBeenCalled();
+    expect(freshCore.warning).toHaveBeenCalledWith(expect.stringContaining("fail-open"));
+  });
+
+  it("skips the PR comment in backfill mode but still sets the output", async () => {
+    const { freshCore, postPrCommentSpy } = await runFailedMain({
+      inputs: { "github-token": "ghp_test", "evaluate-pr": "99" },
+    });
+
+    expect(postPrCommentSpy).not.toHaveBeenCalled();
+    expect(freshCore.setOutput).toHaveBeenCalledWith(
+      "release-brief-json",
+      expect.stringContaining('"verdict":"cannot_evaluate"'),
+    );
+  });
+
+  it("never lets a comment-posting failure mask the original error", async () => {
+    vi.resetModules();
+    const freshCore = await import("@actions/core");
+    const freshGithub = await import("@actions/github");
+    const freshGate = await import("../gate.js");
+    const freshHealers = await import("../healers/index.js");
+
+    vi.mocked(freshCore.getInput).mockImplementation(
+      (name: string) =>
+        ({ "github-token": "ghp_test", "fail-mode": "closed" })[name] ?? "",
+    );
+    (freshGithub.context as { payload: { pull_request?: { number: number } } }).payload =
+      {
+        pull_request: { number: 42 },
+      };
+    vi.spyOn(freshHealers, "registerHealer").mockImplementation(() => undefined);
+    vi.spyOn(freshGate, "evaluateGate").mockRejectedValue(new Error("boom"));
+    vi.spyOn(freshGate, "postPrComment").mockRejectedValue(new Error("403 forbidden"));
+    freshGate.setResolvedAvailabilityStance(null);
+
+    await import("../main.js");
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(freshCore.setFailed).toHaveBeenCalledWith(expect.stringContaining("boom"));
+    expect(freshCore.setFailed).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/__tests__/override.test.ts
+++ b/src/__tests__/override.test.ts
@@ -4,8 +4,12 @@ import {
   parseOverrideComment,
   resolveLabelOverride,
   buildLabelOverrideAudit,
+  applyLabelOverrideToEvaluation,
+  partitionOverrideReasons,
   formatOverrideRejectionMessage,
 } from "../override.js";
+import { computeReleaseReady } from "../release-ready.js";
+import type { CiSummary, GateEvaluation, PolicyOverrideAudit } from "../types.js";
 
 describe("hasOverrideLabel", () => {
   it("matches trailhead-override case-insensitively", () => {
@@ -139,5 +143,365 @@ describe("buildLabelOverrideAudit", () => {
     expect(audit.linkedTicket).toBe("override:pr#99");
     expect(audit.preOverrideReleaseReady).toBe(false);
     expect(audit.preOverrideReasons).toEqual(["CI failed"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ADR-011 §3 — scoped override
+// ---------------------------------------------------------------------------
+
+const RED_CI: CiSummary = {
+  checks: [
+    { name: "type-check", status: "fail", required: true },
+    { name: "lint", status: "pass", required: true },
+    { name: "vercel-preview", status: "fail", required: false },
+  ],
+  allRequiredPassed: false,
+  pendingCount: 0,
+  failedCount: 2,
+  missingCount: 0,
+};
+
+const GREEN_CI: CiSummary = {
+  checks: [
+    { name: "type-check", status: "pass", required: true },
+    { name: "lint", status: "pass", required: true },
+  ],
+  allRequiredPassed: true,
+  pendingCount: 0,
+  failedCount: 0,
+  missingCount: 0,
+};
+
+function evaluationWith(overrides: Partial<GateEvaluation> = {}): GateEvaluation {
+  return {
+    id: "eval-1",
+    repoId: "KomatikAI/trailhead",
+    commitSha: "abc123",
+    prNumber: 4033,
+    healthScore: 90,
+    riskScore: 90,
+    gateDecision: "block",
+    healthChecks: [],
+    riskFactors: [],
+    evaluationMs: 12,
+    gateMode: "release-ready",
+    releaseReady: false,
+    ...overrides,
+  };
+}
+
+function auditWith(overrides: Partial<PolicyOverrideAudit> = {}): PolicyOverrideAudit {
+  return {
+    source: "label",
+    owner: "david",
+    reason: "reviewed and accepted",
+    linkedTicket: "override:pr#4033",
+    expiresAt: "2026-08-16T00:00:00.000Z",
+    appliedAt: "2026-08-09T00:00:00.000Z",
+    changes: { releaseReady: true },
+    ...overrides,
+  };
+}
+
+describe("partitionOverrideReasons", () => {
+  it("retains reasons naming a red required check and overrides the rest", () => {
+    const { overridden, retained } = partitionOverrideReasons(
+      [
+        'Required CI check "type-check" is FAIL',
+        "Risk score 90 exceeds threshold 70",
+        "Risk/policy gate decision is BLOCK",
+      ],
+      RED_CI,
+    );
+
+    expect(retained).toEqual(['Required CI check "type-check" is FAIL']);
+    expect(overridden).toEqual([
+      "Risk score 90 exceeds threshold 70",
+      "Risk/policy gate decision is BLOCK",
+    ]);
+  });
+
+  it("retains pending required checks", () => {
+    const { retained } = partitionOverrideReasons(
+      ["2 required CI check(s) still pending"],
+      { ...GREEN_CI, pendingCount: 2, allRequiredPassed: false },
+    );
+    expect(retained).toEqual(["2 required CI check(s) still pending"]);
+  });
+
+  it("fails closed on CI-shaped reasons when no CI summary is available", () => {
+    const { overridden, retained } = partitionOverrideReasons([
+      'Required CI check "deploy" is MISSING',
+      "Release freeze active",
+    ]);
+
+    expect(retained).toEqual(['Required CI check "deploy" is MISSING']);
+    expect(overridden).toEqual(["Release freeze active"]);
+  });
+
+  it("does not retain a CI reason for a check that is green", () => {
+    const { overridden, retained } = partitionOverrideReasons(
+      ["Security gate requires clearance — blocking alerts present"],
+      RED_CI,
+    );
+    expect(retained).toEqual([]);
+    expect(overridden).toHaveLength(1);
+  });
+});
+
+describe("scoped override — full (default)", () => {
+  it("defaults the audit scope to full and clears everything", () => {
+    const outcome = resolveLabelOverride({
+      labels: ["trailhead-override"],
+      comments: [{ body: "trailhead-override: approved by on-call", author: "david" }],
+      config: { enabled: true, maxPerWeek: 5 },
+      recentOverrideCount: 0,
+      releaseResult: {
+        releaseReady: false,
+        reasons: ['Required CI check "type-check" is FAIL'],
+      },
+      gateDecision: "block",
+      prNumber: 4033,
+      ci: RED_CI,
+    });
+
+    expect(outcome.kind).toBe("applied");
+    if (outcome.kind !== "applied") return;
+    expect(outcome.audit.scope).toBe("full");
+    expect(outcome.audit.changes.releaseReady).toBe(true);
+    expect(outcome.audit.retainedReasons).toBeUndefined();
+
+    const applied = applyLabelOverrideToEvaluation(
+      evaluationWith({
+        ci: RED_CI,
+        releaseReadyReasons: ['Required CI check "type-check" is FAIL'],
+      }),
+      outcome.audit,
+    );
+
+    expect(applied.releaseReady).toBe(true);
+    expect(applied.releaseReadyReasons).toBeUndefined();
+    expect(applied.policyOverride).toBe(outcome.audit);
+  });
+
+  it("treats a pre-ADR-011 audit with no scope as a full override", () => {
+    const applied = applyLabelOverrideToEvaluation(
+      evaluationWith({
+        ci: RED_CI,
+        releaseReadyReasons: ['Required CI check "type-check" is FAIL'],
+      }),
+      auditWith(),
+    );
+
+    expect(applied.releaseReady).toBe(true);
+    expect(applied.releaseReadyReasons).toBeUndefined();
+  });
+});
+
+describe("scoped override — risk_only", () => {
+  it("carries the scope onto the audit", () => {
+    const outcome = resolveLabelOverride({
+      labels: ["trailhead-override"],
+      comments: [
+        { body: "trailhead-override: keystone-verified train", author: "david" },
+      ],
+      config: { enabled: true, maxPerWeek: 5, scope: "risk_only" },
+      recentOverrideCount: 0,
+      releaseResult: {
+        releaseReady: false,
+        reasons: ["Risk score 90 exceeds threshold 70"],
+      },
+      gateDecision: "block",
+      prNumber: 4033,
+      ci: GREEN_CI,
+    });
+
+    expect(outcome.kind).toBe("applied");
+    if (outcome.kind !== "applied") return;
+    expect(outcome.audit.scope).toBe("risk_only");
+    expect(outcome.audit.reason).toBe("keystone-verified train");
+  });
+
+  it("leaves a red required check blocking (ADR-011 §3: red tests stay red)", () => {
+    const releaseResult = computeReleaseReady({
+      gateMode: "release-ready",
+      gateDecision: "block",
+      riskScore: 90,
+      riskThreshold: 70,
+      healthScore: 95,
+      healthChecksConfigured: true,
+      ciSummary: RED_CI,
+      freezeActive: false,
+    });
+    expect(releaseResult.releaseReady).toBe(false);
+
+    const outcome = resolveLabelOverride({
+      labels: ["trailhead-override"],
+      comments: [{ body: "trailhead-override: accepted risk", author: "david" }],
+      config: { enabled: true, maxPerWeek: 5, scope: "risk_only" },
+      recentOverrideCount: 0,
+      releaseResult,
+      gateDecision: "block",
+      prNumber: 4033,
+      ci: RED_CI,
+    });
+    expect(outcome.kind).toBe("applied");
+    if (outcome.kind !== "applied") return;
+
+    const applied = applyLabelOverrideToEvaluation(
+      evaluationWith({ ci: RED_CI, releaseReadyReasons: releaseResult.reasons }),
+      outcome.audit,
+    );
+
+    expect(applied.releaseReady).toBe(false);
+    expect(applied.releaseReadyReasons).toEqual([
+      'Required CI check "type-check" is FAIL',
+    ]);
+    expect(applied.policyOverride?.retainedReasons).toEqual([
+      'Required CI check "type-check" is FAIL',
+    ]);
+    expect(applied.policyOverride?.overriddenReasons).toEqual([
+      "Risk/policy gate decision is BLOCK",
+      "Risk score 90 exceeds threshold 70",
+    ]);
+    expect(applied.policyOverride?.changes.releaseReady).toBeUndefined();
+    expect(applied.policyOverride?.scope).toBe("risk_only");
+    expect(applied.policyOverride?.preOverrideReleaseReady).toBe(false);
+  });
+
+  it("clears a risk-over-threshold-only block", () => {
+    const releaseResult = computeReleaseReady({
+      gateMode: "release-ready",
+      gateDecision: "warn",
+      riskScore: 90,
+      riskThreshold: 70,
+      healthScore: 95,
+      healthChecksConfigured: true,
+      ciSummary: GREEN_CI,
+      freezeActive: false,
+    });
+    expect(releaseResult.reasons).toEqual(["Risk score 90 exceeds threshold 70"]);
+
+    const outcome = resolveLabelOverride({
+      labels: ["trailhead-override"],
+      comments: [{ body: "trailhead-override: promotion-shaped risk", author: "david" }],
+      config: { enabled: true, maxPerWeek: 5, scope: "risk_only" },
+      recentOverrideCount: 0,
+      releaseResult,
+      gateDecision: "warn",
+      prNumber: 4033,
+      ci: GREEN_CI,
+    });
+    expect(outcome.kind).toBe("applied");
+    if (outcome.kind !== "applied") return;
+
+    const applied = applyLabelOverrideToEvaluation(
+      evaluationWith({
+        ci: GREEN_CI,
+        gateDecision: "warn",
+        releaseReadyReasons: releaseResult.reasons,
+      }),
+      outcome.audit,
+    );
+
+    expect(applied.releaseReady).toBe(true);
+    expect(applied.releaseReadyReasons).toBeUndefined();
+    expect(applied.policyOverride?.changes.releaseReady).toBe(true);
+    expect(applied.policyOverride?.retainedReasons).toBeUndefined();
+    expect(applied.policyOverride?.overriddenReasons).toEqual([
+      "Risk score 90 exceeds threshold 70",
+    ]);
+  });
+
+  it("clears policy-finding-driven blocking", () => {
+    const releaseResult = computeReleaseReady({
+      gateMode: "release-ready",
+      gateDecision: "block",
+      riskScore: 10,
+      riskThreshold: 70,
+      healthScore: 95,
+      healthChecksConfigured: true,
+      ciSummary: GREEN_CI,
+      freezeActive: false,
+      policyFindings: ["CI integrity blocking patterns detected (4)"],
+    });
+
+    const applied = applyLabelOverrideToEvaluation(
+      evaluationWith({
+        ci: GREEN_CI,
+        releaseReadyReasons: releaseResult.reasons,
+      }),
+      buildLabelOverrideAudit({
+        parsed: { reason: "patterns reviewed", author: "david" },
+        prNumber: 4033,
+        releaseResult,
+        gateDecision: "block",
+        scope: "risk_only",
+        ci: GREEN_CI,
+      }),
+    );
+
+    expect(applied.releaseReady).toBe(true);
+    expect(applied.policyOverride?.overriddenReasons).toContain(
+      "CI integrity blocking patterns detected (4)",
+    );
+  });
+
+  it("keeps pending required checks blocking", () => {
+    const pendingCi: CiSummary = {
+      ...GREEN_CI,
+      allRequiredPassed: false,
+      pendingCount: 1,
+    };
+    const releaseResult = computeReleaseReady({
+      gateMode: "release-ready",
+      gateDecision: "block",
+      riskScore: 90,
+      riskThreshold: 70,
+      healthScore: 95,
+      healthChecksConfigured: true,
+      ciSummary: pendingCi,
+      freezeActive: false,
+    });
+
+    const applied = applyLabelOverrideToEvaluation(
+      evaluationWith({ ci: pendingCi, releaseReadyReasons: releaseResult.reasons }),
+      buildLabelOverrideAudit({
+        parsed: { reason: "accepted risk", author: "david" },
+        prNumber: 4033,
+        releaseResult,
+        gateDecision: "block",
+        scope: "risk_only",
+        ci: pendingCi,
+      }),
+    );
+
+    expect(applied.releaseReady).toBe(false);
+    expect(applied.releaseReadyReasons).toEqual(["1 required CI check(s) still pending"]);
+  });
+
+  it("re-partitions against the evaluation CI when the audit was built without one", () => {
+    const audit = buildLabelOverrideAudit({
+      parsed: { reason: "accepted risk", author: "david" },
+      prNumber: 4033,
+      releaseResult: {
+        releaseReady: false,
+        reasons: [
+          'Required CI check "type-check" is FAIL',
+          "Risk score 90 exceeds threshold 70",
+        ],
+      },
+      gateDecision: "block",
+      scope: "risk_only",
+    });
+    expect(audit.retainedReasons).toEqual(['Required CI check "type-check" is FAIL']);
+
+    const applied = applyLabelOverrideToEvaluation(evaluationWith({ ci: RED_CI }), audit);
+
+    expect(applied.releaseReady).toBe(false);
+    expect(applied.releaseReadyReasons).toEqual([
+      'Required CI check "type-check" is FAIL',
+    ]);
   });
 });

--- a/src/__tests__/release-brief.test.ts
+++ b/src/__tests__/release-brief.test.ts
@@ -369,6 +369,28 @@ describe("renderReleaseBrief — escaping", () => {
     expect(row?.replace(/\\\|/g, "")?.split("|").length).toBe(6);
   });
 
+  it("escapes backslashes so a trailing \\ cannot neutralize a pipe escape", () => {
+    const output = renderReleaseBrief(
+      brief({
+        inputs: [
+          input({
+            checkName: "build \\| windows",
+            status: "fail",
+            disposition: "blocking",
+            reason: "path C:\\ci\\logs|latest",
+          }),
+        ],
+      }),
+    );
+
+    const row = output.split("\n").find((line) => line.startsWith("| build"));
+    expect(row).toContain("build \\\\\\| windows");
+    expect(row).toContain("C:\\\\ci\\\\logs\\|latest");
+    // With backslashes escaped, no raw "\|" can survive to swallow a delimiter:
+    // 4 cells => 5 unescaped delimiters.
+    expect(row?.replace(/\\./g, "")?.split("|").length).toBe(6);
+  });
+
   it("escapes pipes in finding titles and evidence", () => {
     const output = renderReleaseBrief(
       brief({

--- a/src/__tests__/release-brief.test.ts
+++ b/src/__tests__/release-brief.test.ts
@@ -1,0 +1,398 @@
+import { describe, expect, it } from "vitest";
+import { renderReleaseBrief } from "../release-brief.js";
+import type { BriefFinding, BriefInput, ReleaseBrief } from "../release-brief.js";
+
+function brief(overrides: Partial<ReleaseBrief> = {}): ReleaseBrief {
+  return {
+    verdict: "allow",
+    findings: [],
+    inputs: [],
+    actions: [],
+    ...overrides,
+  };
+}
+
+function finding(overrides: Partial<BriefFinding> = {}): BriefFinding {
+  return {
+    id: "ci_integrity.bypass",
+    title: "Workflow bypass pattern introduced",
+    evidence: '.github/workflows/ci.yml: workflow bypass pattern "|| true"',
+    severity: "blocking",
+    ...overrides,
+  };
+}
+
+function input(overrides: Partial<BriefInput> = {}): BriefInput {
+  return {
+    checkName: "CI Gate",
+    status: "pass",
+    disposition: "blocking",
+    ...overrides,
+  };
+}
+
+describe("renderReleaseBrief — verdict shapes", () => {
+  it("renders an allow brief with no findings", () => {
+    const output = renderReleaseBrief(
+      brief({
+        verdict: "allow",
+        riskScore: 12,
+        riskThreshold: 70,
+        inputs: [input()],
+      }),
+    );
+
+    expect(output).toContain("## Release Brief");
+    expect(output).toContain("**ALLOW** — risk 12 (threshold 70)");
+    expect(output).toContain("No findings.");
+    expect(output).toContain("| CI Gate | pass | blocking | — |");
+    expect(output).toContain("No actions.");
+    expect(output).not.toContain("### Override");
+    expect(output).not.toContain("Cannot evaluate");
+  });
+
+  it("renders a warn brief with top movers, delta and actions", () => {
+    const output = renderReleaseBrief(
+      brief({
+        verdict: "warn",
+        riskScore: 55,
+        riskThreshold: 70,
+        topMovers: [
+          { factor: "churn", score: 25 },
+          { factor: "sensitivity", score: 15 },
+        ],
+        findings: [finding({ severity: "warn", id: "churn.large" })],
+        inputs: [input()],
+        delta: "risk 40 → 55 since the previous evaluation; 1 new finding",
+        actions: [
+          { kind: "fix", detail: "Split the PR", link: "https://example.test/split" },
+          { kind: "wait", detail: "Pending checks are still running" },
+        ],
+      }),
+    );
+
+    expect(output).toContain(
+      "**WARN** — risk 55 (threshold 70) · top movers: churn 25, sensitivity 15",
+    );
+    expect(output).toContain("**Delta:** risk 40 → 55 since the previous evaluation");
+    expect(output).toContain(
+      "- **fix:** Split the PR ([link](https://example.test/split))",
+    );
+    expect(output).toContain("- **wait:** Pending checks are still running");
+    expect(output).not.toContain("**wait:** Pending checks are still running (");
+  });
+
+  it("renders a block brief enumerating every finding, never a bare count", () => {
+    const findings = [
+      finding({ id: "ci_integrity.bypass", title: "Bypass pattern" }),
+      finding({
+        id: "ci_integrity.continue_on_error",
+        title: "continue-on-error introduced",
+        evidence: '.github/workflows/deploy.yml: introduced "continue-on-error: true"',
+      }),
+      finding({
+        id: "supply_chain.unpinned",
+        title: "Unpinned action",
+        evidence: undefined,
+        severity: "advisory",
+      }),
+    ];
+
+    const output = renderReleaseBrief(
+      brief({
+        verdict: "block",
+        riskScore: 90,
+        riskThreshold: 70,
+        topMovers: [{ factor: "ci_integrity", score: 40 }],
+        findings,
+        inputs: [input()],
+      }),
+    );
+
+    expect(output).toContain(
+      "**BLOCK** — risk 90 (threshold 70) · top movers: ci_integrity 40",
+    );
+    expect(output).toContain("1. **Bypass pattern** `ci_integrity.bypass` _(blocking)_");
+    expect(output).toContain(
+      "2. **continue-on-error introduced** `ci_integrity.continue_on_error` _(blocking)_",
+    );
+    expect(output).toContain(
+      "3. **Unpinned action** `supply_chain.unpinned` _(advisory)_",
+    );
+    expect(output).toContain("   > .github/workflows/deploy.yml");
+    // The Case A bug: a count standing in for the items.
+    expect(output).not.toMatch(/blocking patterns detected \(\d+\)/);
+    expect(output).not.toContain("more findings not shown inline");
+  });
+
+  it("renders a cannot_evaluate brief with the reason prominent plus inputs and actions", () => {
+    const output = renderReleaseBrief(
+      brief({
+        verdict: "cannot_evaluate",
+        cannotEvaluateReason: "evaluation store unreachable (HTTP 503)",
+        inputs: [input({ status: "pending", disposition: "blocking" })],
+        actions: [{ kind: "wait", detail: "Re-run once the store responds" }],
+      }),
+    );
+
+    const lines = output.split("\n");
+    expect(lines[0]).toBe("## Release Brief");
+    expect(lines[2]).toBe("**CANNOT EVALUATE**");
+    expect(lines[4]).toBe(
+      "> ⚠️ **Cannot evaluate:** evaluation store unreachable (HTTP 503)",
+    );
+    expect(output).toContain("| CI Gate | pending | blocking | — |");
+    expect(output).toContain("- **wait:** Re-run once the store responds");
+  });
+
+  it("states the omission when a cannot_evaluate brief carries no reason", () => {
+    const output = renderReleaseBrief(brief({ verdict: "cannot_evaluate" }));
+    expect(output).toContain("> ⚠️ **Cannot evaluate:** no reason recorded");
+  });
+
+  it("renders the override block and normalises a leading @", () => {
+    const output = renderReleaseBrief(
+      brief({
+        verdict: "block",
+        findings: [finding()],
+        override: {
+          by: "@david",
+          at: "2026-08-09T22:14:00Z",
+          scope: "risk_only",
+          rationale: "keystone-verified promotion train",
+        },
+      }),
+    );
+
+    expect(output).toContain("### Override");
+    expect(output).toContain(
+      "> Overridden by @david at 2026-08-09T22:14:00Z, scope risk_only — keystone-verified promotion train",
+    );
+  });
+
+  it("omits the override block when override is null", () => {
+    const output = renderReleaseBrief(brief({ override: null }));
+    expect(output).not.toContain("### Override");
+  });
+});
+
+describe("renderReleaseBrief — empty and partial data", () => {
+  it("renders a fully empty brief without dropping required sections", () => {
+    const output = renderReleaseBrief(brief());
+
+    expect(output).toContain("**ALLOW**");
+    expect(output).toContain("### Findings");
+    expect(output).toContain("No findings.");
+    expect(output).toContain("### Inputs");
+    expect(output).toContain("No inputs evaluated.");
+    expect(output).toContain("### Actions");
+    expect(output).toContain("No actions.");
+    expect(output).not.toContain("**Delta:**");
+    expect(output.endsWith("\n")).toBe(false);
+  });
+
+  it("renders every input row including passes and skips", () => {
+    const output = renderReleaseBrief(
+      brief({
+        inputs: [
+          input({ checkName: "type-check", status: "pass", disposition: "blocking" }),
+          input({ checkName: "Playwright", status: "skip", disposition: "advisory" }),
+          input({
+            checkName: "Deploy Edge Functions",
+            status: "fail",
+            disposition: "irrelevant",
+            reason: "staging target unconfigured by design",
+          }),
+        ],
+      }),
+    );
+
+    expect(output).toContain("| type-check | pass | blocking | — |");
+    expect(output).toContain("| Playwright | skip | advisory | — |");
+    expect(output).toContain(
+      "| Deploy Edge Functions | fail | irrelevant | staging target unconfigured by design |",
+    );
+  });
+
+  it("renders risk alone and threshold alone", () => {
+    expect(renderReleaseBrief(brief({ riskScore: 30 }))).toContain("**ALLOW** — risk 30");
+    expect(renderReleaseBrief(brief({ riskThreshold: 70 }))).toContain(
+      "**ALLOW** — threshold 70",
+    );
+    expect(renderReleaseBrief(brief({ topMovers: [] }))).toContain("**ALLOW**\n");
+  });
+
+  it("ignores a whitespace-only delta", () => {
+    expect(renderReleaseBrief(brief({ delta: "   " }))).not.toContain("**Delta:**");
+  });
+
+  it("renders multi-line evidence as multiple quoted lines", () => {
+    const output = renderReleaseBrief(
+      brief({
+        verdict: "block",
+        findings: [finding({ evidence: "first line\nsecond line" })],
+      }),
+    );
+
+    expect(output).toContain("   > first line\n   > second line");
+  });
+});
+
+describe("renderReleaseBrief — truncation", () => {
+  function manyFindings(count: number): BriefFinding[] {
+    return Array.from({ length: count }, (_, index) =>
+      finding({
+        id: `finding.${index}`,
+        title: `Finding number ${index}`,
+        evidence: `evidence body ${index} `.repeat(20),
+      }),
+    );
+  }
+
+  it("does not truncate a normal brief under the 60000 default", () => {
+    const output = renderReleaseBrief(
+      brief({ verdict: "block", findings: manyFindings(5), inputs: [input()] }),
+    );
+
+    expect(output.length).toBeLessThanOrEqual(60000);
+    expect(output).toContain("Finding number 4");
+    expect(output).not.toContain("more findings not shown inline");
+  });
+
+  it("drops findings from the end and appends the more-findings notice", () => {
+    const maxChars = 1200;
+    const output = renderReleaseBrief(
+      brief({ verdict: "block", findings: manyFindings(40), inputs: [input()] }),
+      { maxChars },
+    );
+
+    expect(output.length).toBeLessThanOrEqual(maxChars);
+    expect(output).toContain("1. **Finding number 0**");
+    expect(output).not.toContain("39. **Finding number 39**");
+    expect(output).toMatch(
+      /_…\d+ more findings not shown inline — see the stored evaluation_/,
+    );
+    expect(output).toContain("### Inputs");
+  });
+
+  it("links the stored evaluation in the notice when a url is given", () => {
+    const output = renderReleaseBrief(
+      brief({ verdict: "block", findings: manyFindings(40) }),
+      { maxChars: 1200, storedEvaluationUrl: "https://example.test/eval/9" },
+    );
+
+    expect(output.length).toBeLessThanOrEqual(1200);
+    expect(output).toContain(
+      "more findings not shown inline — see the [stored evaluation](https://example.test/eval/9)",
+    );
+  });
+
+  it("keeps at least one finding and caps evidence when a single finding is oversized", () => {
+    const output = renderReleaseBrief(
+      brief({
+        verdict: "block",
+        findings: [finding({ title: "Huge", evidence: "x".repeat(5000) })],
+        inputs: [input()],
+      }),
+      { maxChars: 900 },
+    );
+
+    expect(output.length).toBeLessThanOrEqual(900);
+    expect(output).toContain("1. **Huge**");
+    const evidenceLine = output.split("\n").find((line) => line.startsWith("   > x"));
+    expect(evidenceLine).toBeDefined();
+    // 300-char cap, ellipsis included, plus the "   > " prefix.
+    expect(evidenceLine?.length).toBe(305);
+    expect(evidenceLine?.endsWith("…")).toBe(true);
+  });
+
+  it("never exceeds maxChars even when nothing structural can be dropped", () => {
+    for (const maxChars of [1, 12, 40, 120]) {
+      const output = renderReleaseBrief(
+        brief({
+          verdict: "block",
+          findings: manyFindings(10),
+          inputs: [input(), input({ checkName: "Lint" })],
+          actions: [{ kind: "fix", detail: "do the thing" }],
+        }),
+        { maxChars },
+      );
+      expect(output.length).toBeLessThanOrEqual(maxChars);
+    }
+  });
+
+  it("hard-clips a findingless brief whose inputs alone overflow", () => {
+    const inputs = Array.from({ length: 50 }, (_, index) =>
+      input({ checkName: `check-${index}`, reason: `reason ${index}`.repeat(10) }),
+    );
+    const output = renderReleaseBrief(brief({ inputs }), { maxChars: 300 });
+
+    expect(output.length).toBeLessThanOrEqual(300);
+    expect(output).toContain("## Release Brief");
+  });
+
+  it("returns an empty string for a non-positive maxChars", () => {
+    expect(renderReleaseBrief(brief({ findings: [finding()] }), { maxChars: 0 })).toBe(
+      "",
+    );
+    expect(renderReleaseBrief(brief(), { maxChars: -5 })).toBe("");
+  });
+
+  it("falls back to the default when maxChars is not finite", () => {
+    const output = renderReleaseBrief(brief({ findings: manyFindings(3) }), {
+      maxChars: Number.NaN,
+    });
+    expect(output).toContain("Finding number 2");
+  });
+});
+
+describe("renderReleaseBrief — escaping", () => {
+  it("escapes pipes in check names, statuses, dispositions and reasons", () => {
+    const output = renderReleaseBrief(
+      brief({
+        inputs: [
+          input({
+            checkName: "build | linux",
+            status: "fail",
+            disposition: "irrelevant",
+            reason: "matrix leg a|b is not run on this pair",
+          }),
+        ],
+      }),
+    );
+
+    expect(output).toContain(
+      "| build \\| linux | fail | irrelevant | matrix leg a\\|b is not run on this pair |",
+    );
+    const row = output.split("\n").find((line) => line.startsWith("| build"));
+    // Escaped pipes must not add columns: 4 cells => 5 unescaped delimiters.
+    expect(row?.replace(/\\\|/g, "")?.split("|").length).toBe(6);
+  });
+
+  it("escapes pipes in finding titles and evidence", () => {
+    const output = renderReleaseBrief(
+      brief({
+        verdict: "block",
+        findings: [
+          finding({
+            title: "bypass a|b",
+            evidence: "ci.yml: `npm test || true` piped through a | b",
+          }),
+        ],
+      }),
+    );
+
+    expect(output).toContain("1. **bypass a\\|b** `ci_integrity.bypass` _(blocking)_");
+    expect(output).toContain("   > ci.yml: `npm test \\|\\| true` piped through a \\| b");
+  });
+
+  it("flattens newlines inside table cells", () => {
+    const output = renderReleaseBrief(
+      brief({
+        inputs: [input({ reason: "line one\nline two" })],
+      }),
+    );
+
+    expect(output).toContain("| CI Gate | pass | blocking | line one line two |");
+  });
+});

--- a/src/config-core.ts
+++ b/src/config-core.ts
@@ -133,6 +133,32 @@ export function parseYaml(input: string): unknown {
   return root;
 }
 
+/**
+ * Non-fatal config warnings, emitted by the loader after a successful parse.
+ *
+ * ADR-011 §2 makes `reason` mandatory for `disposition: irrelevant`, but this is
+ * deliberately NOT a Zod refine: `parseRepoConfigContent` returns null for ANY
+ * schema violation, which drops the entire repo config back to hardcoded
+ * defaults. Degrading a whole config over one missing reason string is worse
+ * than narrating it, so the entry still parses and the Release Brief prints a
+ * placeholder reason (see MISSING_IRRELEVANT_REASON in input-relevance.ts).
+ */
+export function collectConfigWarnings(config: RepoConfigType): string[] {
+  const warnings: string[] = [];
+  for (const context of config.contexts) {
+    for (const entry of context.input_relevance) {
+      if (entry.disposition !== "irrelevant") continue;
+      if (entry.reason !== undefined && entry.reason.trim() !== "") continue;
+      warnings.push(
+        `contexts."${context.name}".input_relevance: pattern "${entry.pattern}" is ` +
+          `"disposition: irrelevant" with no reason. ADR-011 requires a reason for ` +
+          `irrelevant inputs; the Release Brief will show a placeholder until one is set.`,
+      );
+    }
+  }
+  return warnings;
+}
+
 export function parseRepoConfigContent(content: string): RepoConfigType | null {
   const raw = parseYaml(content);
   const parsed = RepoConfig.safeParse(raw);

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,6 +3,7 @@ import * as github from "@actions/github";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import {
+  collectConfigWarnings,
   CURRENT_CONFIG_SCHEMA_VERSION,
   parseRepoConfigContent,
   parseYaml,
@@ -67,6 +68,10 @@ function validateSchemaVersion(
       `${configPath}: schema_version=${parsedConfig.schema_version} is newer than ` +
         `supported ${CURRENT_CONFIG_SCHEMA_VERSION}. Some features may be ignored.`,
     );
+  }
+
+  for (const warning of collectConfigWarnings(parsedConfig)) {
+    core.warning(`${configPath}: ${warning}`);
   }
 
   return parsedConfig;

--- a/src/evaluation-history.ts
+++ b/src/evaluation-history.ts
@@ -135,22 +135,30 @@ async function fetchFromKomatikStore(
   return fetchEvaluationList(listUrl, params);
 }
 
-async function fetchFromSupabase(
-  params: FetchPreviousEvaluationParams,
-): Promise<PreviousEvaluationSnapshot | null> {
-  const supabaseUrl = process.env.SUPABASE_URL;
-  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
-  if (!supabaseUrl || !serviceRoleKey) return null;
+/** Columns loop bookkeeping has always needed — guaranteed present in every store. */
+const SUPABASE_LOOP_SELECT =
+  "id,remediation,loop_round,previous_evaluation_id,fixes_resolved,fixes_introduced,created_at";
 
+/**
+ * ADR-011 §1 adds the delta fields. `release_brief`/`enumerated_findings` land with the
+ * ADR-011 store migration, so a store that has not run it 400s on this select — hence the
+ * narrow-select retry below rather than one wide select that would take loop bookkeeping
+ * down with it.
+ */
+const SUPABASE_DELTA_SELECT = `${SUPABASE_LOOP_SELECT},risk_score,gate_decision,release_ready,enumerated_findings,release_brief`;
+
+async function fetchSupabaseRows(
+  supabaseUrl: string,
+  serviceRoleKey: string,
+  params: FetchPreviousEvaluationParams,
+  select: string,
+): Promise<unknown[] | null> {
   const url = new URL(`${supabaseUrl.replace(/\/$/, "")}/rest/v1/trailhead_evaluations`);
   url.searchParams.set("repo_id", `eq.${params.repoId}`);
   url.searchParams.set("pr_number", `eq.${params.prNumber}`);
   url.searchParams.set("order", "created_at.desc");
   url.searchParams.set("limit", "10");
-  url.searchParams.set(
-    "select",
-    "id,remediation,loop_round,previous_evaluation_id,fixes_resolved,fixes_introduced,created_at",
-  );
+  url.searchParams.set("select", select);
 
   const response = await fetch(url.toString(), {
     method: "GET",
@@ -164,7 +172,31 @@ async function fetchFromSupabase(
 
   if (!response.ok) return null;
   const rows = (await response.json()) as unknown[];
-  if (!Array.isArray(rows)) return null;
+  return Array.isArray(rows) ? rows : null;
+}
+
+async function fetchFromSupabase(
+  params: FetchPreviousEvaluationParams,
+): Promise<PreviousEvaluationSnapshot | null> {
+  const supabaseUrl = process.env.SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceRoleKey) return null;
+
+  let rows = await fetchSupabaseRows(
+    supabaseUrl,
+    serviceRoleKey,
+    params,
+    SUPABASE_DELTA_SELECT,
+  );
+  if (rows === null) {
+    rows = await fetchSupabaseRows(
+      supabaseUrl,
+      serviceRoleKey,
+      params,
+      SUPABASE_LOOP_SELECT,
+    );
+  }
+  if (rows === null) return null;
   return pickPreviousFromRows(rows, params.excludeEvaluationId);
 }
 

--- a/src/gate.ts
+++ b/src/gate.ts
@@ -3,11 +3,18 @@ import * as github from "@actions/github";
 import { GateApiResponse as GateApiResponseSchema } from "./types.js";
 import type {
   TrailheadConfig,
+  AvailabilityStance,
+  BriefAction,
+  BriefFinding,
+  BriefVerdict,
   GateApiResponse,
   GateDecision,
   GateEvaluation,
   HealthCheckResult,
+  InputRelevanceEntry,
   PrProvenance,
+  ReleaseBrief,
+  RemediationSeverity,
   RepoConfig,
   RiskFactor,
   GateMode,
@@ -32,10 +39,16 @@ import {
 import {
   applyReleaseReadyToEvaluation,
   checkConclusionForEvaluation,
+  checkCountsTowardBlocking,
   computeReleaseReady,
   resolveCheckName,
   shouldBlockMerge,
 } from "./release-ready.js";
+import {
+  dispositionCountsTowardBlocking,
+  resolveDispositions,
+} from "./input-relevance.js";
+import { formatEvaluationDelta, renderReleaseBrief } from "./release-brief.js";
 import {
   computeRiskScore as computeRiskScoreShared,
   weightedAverageScores,
@@ -67,9 +80,11 @@ import {
   fetchPreviousEvaluationForPr,
   countRecentLabelOverrides,
 } from "./evaluation-history.js";
+import type { PreviousEvaluationSnapshot } from "./loop-bookkeeping.js";
 import {
   applyLabelOverrideToEvaluation,
   hasOverrideLabel,
+  OVERRIDE_LABEL,
   resolveLabelOverride,
 } from "./override.js";
 import {
@@ -627,13 +642,15 @@ async function detectPrProvenance(
 interface CiIntegrityDetection {
   factor: RiskFactor | null;
   blockingPatterns: string[];
+  /** Surfaced (not only buried in factor.detail) so ADR-011 can enumerate them. */
+  warningSignals: string[];
 }
 
 function detectCiIntegrityRisk(files: PrFileInfo[]): CiIntegrityDetection {
   const { score, blockingPatterns, warningSignals } = detectCiIntegrity(files);
 
   if (score === 0) {
-    return { factor: null, blockingPatterns: [] };
+    return { factor: null, blockingPatterns: [], warningSignals: [] };
   }
 
   const factor: RiskFactor = {
@@ -646,7 +663,7 @@ function detectCiIntegrityRisk(files: PrFileInfo[]): CiIntegrityDetection {
     },
   };
 
-  return { factor, blockingPatterns };
+  return { factor, blockingPatterns, warningSignals };
 }
 
 // ---------------------------------------------------------------------------
@@ -1548,6 +1565,7 @@ async function applyLabelOverrideIfNeeded(input: {
   const overrideSettings = input.repoConfig?.override ?? {
     enabled: true,
     max_per_week: 5,
+    scope: "full" as const,
   };
 
   const comments = await fetchPrCommentsForOverride(input.prNumber, input.githubToken);
@@ -1568,22 +1586,33 @@ async function applyLabelOverrideIfNeeded(input: {
     config: {
       enabled: overrideSettings.enabled,
       maxPerWeek: overrideSettings.max_per_week,
+      scope: overrideSettings.scope,
     },
     recentOverrideCount,
     releaseResult: input.releaseResult,
     gateDecision: input.gateDecision,
     prNumber: input.prNumber,
+    ci: input.evaluation.ci,
   });
 
   if (outcome.kind === "applied") {
+    const applied = applyLabelOverrideToEvaluation(input.evaluation, outcome.audit);
+    const retained = applied.policyOverride?.retainedReasons ?? [];
+    // ADR-011 §3: a risk_only override never clears mechanical blocking inputs —
+    // say so, otherwise the warning reads as a full bypass that it is not.
+    const retainedNote =
+      retained.length > 0
+        ? ` — ${retained.length} mechanical CI reason(s) still blocking`
+        : "";
     core.warning(
-      `Label override applied by ${outcome.audit.owner}: ${outcome.audit.reason}`,
+      `Label override applied by ${outcome.audit.owner} (scope ${outcome.audit.scope ?? "full"}): ` +
+        `${outcome.audit.reason}${retainedNote}`,
     );
     return {
-      ...applyLabelOverrideToEvaluation(input.evaluation, outcome.audit),
+      ...applied,
       labelOverrideFeedback: {
         status: "applied",
-        message: `Release override applied by \`${outcome.audit.owner}\`.`,
+        message: `Release override applied by \`${outcome.audit.owner}\`${retainedNote}.`,
       },
     };
   }
@@ -1609,6 +1638,324 @@ async function applyLabelOverrideIfNeeded(input: {
 }
 
 // ---------------------------------------------------------------------------
+// ADR-011 — input relevance, enumerated findings, Release Brief
+// ---------------------------------------------------------------------------
+
+/**
+ * Annotate every CI input with its ADR-011 §2 disposition and re-roll the
+ * summary counts against the *blocking* set rather than the `required` flag.
+ *
+ * With no `input_relevance` entries the default mapping is required -> blocking
+ * and non-required -> advisory, so the blocking set is exactly the required set
+ * and every count below reproduces `evaluateRequiredChecks` verbatim. Semantics
+ * only move when a policy entry matches.
+ */
+/** Budget for the brief inside a report that also becomes a check-run summary. */
+const BRIEF_MAX_CHARS = 20000;
+
+export function applyInputRelevance(
+  summary: CiSummary,
+  entries: InputRelevanceEntry[],
+): CiSummary {
+  const resolved = resolveDispositions(summary.checks, entries);
+  const checks: CiCheck[] = summary.checks.map((check) => {
+    const disposition = resolved.get(check.name);
+    return disposition ? { ...check, disposition } : check;
+  });
+  const blocking = checks.filter(
+    (check) =>
+      check.disposition !== undefined &&
+      dispositionCountsTowardBlocking(check.disposition),
+  );
+
+  return {
+    checks,
+    allRequiredPassed: blocking.every(
+      (check) => check.status === "pass" || check.status === "skip",
+    ),
+    pendingCount: blocking.filter((check) => check.status === "pending").length,
+    failedCount: blocking.filter(
+      (check) =>
+        check.status === "fail" || check.status === "missing" || check.status === "stale",
+    ).length,
+    missingCount: blocking.filter((check) => check.status === "missing").length,
+  };
+}
+
+/**
+ * Detector messages are authored as `<file>: <message>`. Split them so the brief
+ * can carry the file as evidence; anything that does not look like a path prefix
+ * stays a whole title (never guess evidence that is not there).
+ */
+function splitDetectorMessage(message: string): { title: string; evidence?: string } {
+  const separator = message.indexOf(": ");
+  if (separator > 0) {
+    const head = message.slice(0, separator);
+    if (/[/.]/.test(head) && !/\s/.test(head)) {
+      return { title: message.slice(separator + 2).trim(), evidence: head };
+    }
+  }
+  return { title: message };
+}
+
+/**
+ * ADR-011 §1: "findings are enumerated, never counted" — the Case A fix. Every
+ * detector already returns its patterns as strings; this turns them into
+ * addressable findings instead of a `.length`.
+ */
+export function enumerateDetectorFindings(
+  idPrefix: string,
+  messages: string[],
+  severity: RemediationSeverity,
+): BriefFinding[] {
+  return messages.map((message, index) => {
+    const { title, evidence } = splitDetectorMessage(message);
+    return {
+      id: `${idPrefix}/${index + 1}`,
+      title,
+      severity,
+      ...(evidence ? { evidence } : {}),
+    };
+  });
+}
+
+function briefVerdict(evaluation: GateEvaluation): BriefVerdict {
+  const mode = evaluation.gateMode ?? "risk-only";
+  if (mode === "release-ready" || mode === "advisory") {
+    if (evaluation.releaseReady === false) return "block";
+    return evaluation.gateDecision === "warn" ? "warn" : "allow";
+  }
+  return evaluation.gateDecision;
+}
+
+function briefTopMovers(
+  factors: RiskFactor[],
+): Array<{ factor: string; score: number }> | undefined {
+  const movers = [...factors]
+    .filter((factor) => factor.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, 3)
+    .map((factor) => ({ factor: factor.type, score: factor.score }));
+  return movers.length > 0 ? movers : undefined;
+}
+
+/**
+ * ADR-011 §1's `delta`. Two independent sources, either of which may be absent:
+ * the id-diff against the previous stored evaluation (verdict/risk/findings), and
+ * the remediation loop's own fix bookkeeping. A missing or unreachable previous
+ * evaluation omits the delta — it never errors.
+ */
+function briefDelta(
+  evaluation: GateEvaluation,
+  previous?: PreviousEvaluationSnapshot | null,
+): string | undefined {
+  const parts = [
+    previous
+      ? formatEvaluationDelta(
+          {
+            ...(previous.gateDecision !== undefined
+              ? { verdict: previous.gateDecision }
+              : {}),
+            ...(previous.riskScore !== undefined
+              ? { riskScore: previous.riskScore }
+              : {}),
+            ...(previous.findingIds !== undefined
+              ? { findingIds: previous.findingIds }
+              : {}),
+          },
+          {
+            verdict: evaluation.gateDecision,
+            riskScore: evaluation.riskScore,
+            ...(evaluation.enumeratedFindings !== undefined
+              ? { findingIds: evaluation.enumeratedFindings.map((f) => f.id) }
+              : {}),
+          },
+        )
+      : undefined,
+    briefRemediationDelta(evaluation),
+  ].filter((part): part is string => part !== undefined);
+
+  return parts.length > 0 ? parts.join(" · ") : undefined;
+}
+
+function briefRemediationDelta(evaluation: GateEvaluation): string | undefined {
+  const remediation = evaluation.remediation;
+  if (!remediation?.previous_evaluation_id) return undefined;
+  const parts: string[] = [];
+  if (remediation.fixes_resolved.length > 0) {
+    parts.push(`resolved: ${remediation.fixes_resolved.join(", ")}`);
+  }
+  if (remediation.fixes_introduced.length > 0) {
+    parts.push(`introduced: ${remediation.fixes_introduced.join(", ")}`);
+  }
+  if (parts.length === 0) parts.push("no change in findings");
+  return `round ${remediation.loop_round} vs previous evaluation — ${parts.join("; ")}`;
+}
+
+function briefActions(
+  evaluation: GateEvaluation,
+  findings: BriefFinding[],
+  riskThreshold?: number,
+): BriefAction[] {
+  const actions: BriefAction[] = [];
+
+  for (const check of evaluation.ci?.checks ?? []) {
+    if (!checkCountsTowardBlocking(check)) continue;
+    if (
+      check.status !== "fail" &&
+      check.status !== "missing" &&
+      check.status !== "stale"
+    ) {
+      continue;
+    }
+    actions.push({
+      kind: "fix",
+      detail:
+        `CI input "${check.name}" is ${check.status.toUpperCase()} — fix it, or ` +
+        `classify it under \`contexts[].input_relevance\` if it is irrelevant to this branch pair.`,
+      ...(check.detailsUrl ? { link: check.detailsUrl } : {}),
+    });
+  }
+
+  for (const finding of findings) {
+    if (finding.severity !== "blocking") continue;
+    actions.push({ kind: "fix", detail: `${finding.title} (\`${finding.id}\`)` });
+  }
+
+  const pending = evaluation.ci?.pendingCount ?? 0;
+  if (pending > 0) {
+    actions.push({
+      kind: "wait",
+      detail: `${pending} blocking CI check(s) still pending — the gate re-evaluates when they finish.`,
+    });
+  }
+
+  if (
+    riskThreshold !== undefined &&
+    evaluation.riskScore > riskThreshold &&
+    !evaluation.policyOverride
+  ) {
+    actions.push({
+      kind: "override",
+      detail:
+        `Risk ${evaluation.riskScore} exceeds threshold ${riskThreshold}. To accept it on ` +
+        `the record, add the \`${OVERRIDE_LABEL}\` label and comment ` +
+        `\`${OVERRIDE_LABEL}: <rationale>\` on this PR.`,
+    });
+  }
+
+  return actions;
+}
+
+/**
+ * Project a GateEvaluation onto ADR-011 §1's Release Brief. Pure — no I/O, no
+ * mutation — so it can be rebuilt from any stored evaluation.
+ */
+export function buildReleaseBrief(
+  evaluation: GateEvaluation,
+  riskThreshold?: number,
+  cannotEvaluateReason?: string,
+  previous?: PreviousEvaluationSnapshot | null,
+): ReleaseBrief {
+  const findings = evaluation.enumeratedFindings ?? [];
+  const override = evaluation.policyOverride;
+  const delta = briefDelta(evaluation, previous);
+
+  return {
+    verdict: cannotEvaluateReason ? "cannot_evaluate" : briefVerdict(evaluation),
+    riskScore: evaluation.riskScore,
+    ...(riskThreshold !== undefined ? { riskThreshold } : {}),
+    ...(briefTopMovers(evaluation.riskFactors)
+      ? { topMovers: briefTopMovers(evaluation.riskFactors) }
+      : {}),
+    findings,
+    // Every input gets a row, including the ones that did not count (ADR-011 §1).
+    inputs: (evaluation.ci?.checks ?? []).map((check) => ({
+      checkName: check.name,
+      status: check.status,
+      disposition: check.disposition?.kind ?? (check.required ? "blocking" : "advisory"),
+      ...(check.disposition?.reason ? { reason: check.disposition.reason } : {}),
+    })),
+    ...(delta ? { delta } : {}),
+    actions: briefActions(evaluation, findings, riskThreshold),
+    // ADR-011 §3 maps the audit's {owner, appliedAt, reason} onto {by, at, rationale}.
+    override: override
+      ? {
+          by: override.owner,
+          at: override.appliedAt,
+          scope: override.scope ?? "full",
+          rationale: override.reason,
+        }
+      : null,
+    ...(cannotEvaluateReason ? { cannotEvaluateReason } : {}),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// ADR-011 §4 — availability stance
+// ---------------------------------------------------------------------------
+
+// The stance belongs to the matched context, which is only known *inside*
+// evaluateGate — but it has to be readable by main.ts's top-level catch, i.e.
+// after evaluateGate has already thrown. Stashing it here avoids loading and
+// re-matching the repo config a second time just to answer "open or closed?".
+let lastAvailabilityStance: AvailabilityStance | null = null;
+
+/**
+ * The availability stance of the context the most recent evaluation matched, or
+ * null when no context matched (or the run failed before matching). Null means
+ * "no per-context stance" — the caller keeps its action-input fail-mode.
+ */
+export function getResolvedAvailabilityStance(): AvailabilityStance | null {
+  return lastAvailabilityStance;
+}
+
+/** Test seam, and the reset evaluateGate performs on entry. */
+export function setResolvedAvailabilityStance(stance: AvailabilityStance | null): void {
+  lastAvailabilityStance = stance;
+}
+
+/**
+ * ADR-011 §1: "silence is a bug." When the evaluation could not run at all there is
+ * no GateEvaluation to project, so the brief is built from the failure itself.
+ */
+export function buildCannotEvaluateBrief(
+  reason: string,
+  stance: AvailabilityStance,
+): ReleaseBrief {
+  const actions: BriefAction[] = [
+    {
+      kind: "fix",
+      detail:
+        "Resolve the failure above and re-run the Trailhead job. Until it runs, no " +
+        "risk score, no input dispositions and no findings exist for this commit.",
+    },
+    stance === "fail_closed"
+      ? {
+          kind: "wait",
+          detail:
+            "Availability stance is fail_closed: no verdict means no merge. Break-glass " +
+            "is a GitHub admin merge — visible and extraordinary, and it records nothing.",
+        }
+      : {
+          kind: "wait",
+          detail:
+            "Availability stance is fail_open: this run did not block the merge, but no " +
+            "Trailhead verdict was recorded for this commit.",
+        },
+  ];
+
+  return {
+    verdict: "cannot_evaluate",
+    findings: [],
+    inputs: [],
+    actions,
+    override: null,
+    cannotEvaluateReason: reason,
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Main evaluation entry point
 // ---------------------------------------------------------------------------
 
@@ -1618,6 +1965,8 @@ export async function evaluateGate(
   prNumber?: number,
 ): Promise<GateEvaluation> {
   const start = Date.now();
+  // Nothing is known about this run's availability stance until a context matches.
+  setResolvedAvailabilityStance(null);
 
   const isMergeQueue =
     github.context.eventName === "merge_group" ||
@@ -1692,6 +2041,15 @@ export async function evaluateGate(
     );
   }
 
+  // ADR-011 §4 — a per-branch-pair stance overrides the action-input fail-mode.
+  const availabilityStance = matchedContext?.context.availability ?? null;
+  setResolvedAvailabilityStance(availabilityStance);
+  if (availabilityStance) {
+    core.info(
+      `Availability stance: ${availabilityStance} (context "${matchedContext?.matched.name}")`,
+    );
+  }
+
   const effectiveEnvironment =
     config.environment ?? matchedContext?.matched.environment ?? undefined;
 
@@ -1758,7 +2116,7 @@ export async function evaluateGate(
   const ciIntegrityConfig = repoConfig?.policies?.ci_integrity;
   const ciIntegrity =
     ciIntegrityConfig?.enabled === false
-      ? { factor: null, blockingPatterns: [] }
+      ? { factor: null, blockingPatterns: [], warningSignals: [] }
       : detectCiIntegrityRisk(files);
   if (ciIntegrity.factor) {
     riskFactors.push(ciIntegrity.factor);
@@ -1970,15 +2328,21 @@ export async function evaluateGate(
     repoConfig,
   });
   const sessionCfg = repoConfig?.policies?.session_correlation;
+  // Kept as its own list so ADR-011 §1 can enumerate the burst instead of
+  // burying it in the undifferentiated policyFindings prose.
+  const sessionCorrelationFindings: string[] = [];
   if (sessionCorrelation && sessionCfg) {
     const threshold = sessionCfg.threshold;
     if (sessionCorrelation.burstCount >= threshold) {
-      policyFindings.push(
+      sessionCorrelationFindings.push(
         `Rapid-fire merge burst detected: ${sessionCorrelation.burstCount} merged PRs in ${sessionCorrelation.windowMinutes} minutes.`,
       );
       if (sessionCfg.mode === "block") {
-        policyFindings.push("Session correlation policy is configured to block.");
+        sessionCorrelationFindings.push(
+          "Session correlation policy is configured to block.",
+        );
       }
+      policyFindings.push(...sessionCorrelationFindings);
     }
   }
 
@@ -2004,6 +2368,15 @@ export async function evaluateGate(
   );
   if (sensitiveEscalation.reason) policyFindings.push(sensitiveEscalation.reason);
 
+  const sessionCorrelationBlocks =
+    sessionCorrelation !== null &&
+    sessionCfg !== undefined &&
+    sessionCorrelation.burstCount >= sessionCfg.threshold &&
+    sessionCfg.mode === "block";
+  const submissionBlocks =
+    submissionChecks.length > 0 &&
+    submissionGateShouldBlock(submissionChecks, submissionMode);
+
   const gateDecision =
     agentPolicy?.forceBlock === true ||
     sensitiveEscalation.block ||
@@ -2020,16 +2393,95 @@ export async function evaluateGate(
       (duplicateLogicConfig?.mode ?? "warn") === "block") ||
     ((crossRepoImpact.factor?.score ?? 0) >= 60 &&
       (repoConfig?.policies?.cross_repo_impact?.mode ?? "warn") === "block") ||
-    (sessionCorrelation &&
-      sessionCfg &&
-      sessionCorrelation.burstCount >= sessionCfg.threshold &&
-      sessionCfg.mode === "block") ||
-    (submissionChecks.length > 0 &&
-      submissionGateShouldBlock(submissionChecks, submissionMode))
+    sessionCorrelationBlocks ||
+    submissionBlocks
       ? ("block" as GateDecision)
       : sensitiveEscalation.warn && baselineDecision === "allow"
         ? ("warn" as GateDecision)
         : baselineDecision;
+
+  // ADR-011 §1 (Case A): the count-strings below stay for existing consumers, but
+  // the individual patterns are now carried through to the evaluation so the
+  // Release Brief can enumerate them instead of printing a bare number.
+  const enumeratedFindings: BriefFinding[] = [
+    ...enumerateDetectorFindings(
+      "ci_integrity",
+      ciIntegrity.blockingPatterns,
+      "blocking",
+    ),
+    ...enumerateDetectorFindings(
+      "ci_integrity_warning",
+      ciIntegrity.warningSignals,
+      "warn",
+    ),
+    ...enumerateDetectorFindings(
+      "workflow_security",
+      workflowSecurity.blockingPatterns,
+      "blocking",
+    ),
+    ...enumerateDetectorFindings(
+      "workflow_security_warning",
+      workflowSecurity.warnings,
+      "warn",
+    ),
+    ...enumerateDetectorFindings(
+      "prompt_injection",
+      promptInjection.blockingPatterns,
+      "blocking",
+    ),
+    ...enumerateDetectorFindings(
+      "prompt_injection_warning",
+      promptInjection.warnings,
+      "warn",
+    ),
+    ...enumerateDetectorFindings(
+      "supply_chain",
+      supplyChain.blockingPatterns,
+      "blocking",
+    ),
+    ...enumerateDetectorFindings("supply_chain_warning", supplyChain.warnings, "warn"),
+    ...enumerateDetectorFindings("pr_scope", prScope.findings, "advisory"),
+    ...enumerateDetectorFindings("duplicate_logic", duplicateLogic.findings, "advisory"),
+    ...enumerateDetectorFindings(
+      "cross_repo_impact",
+      crossRepoImpact.findings,
+      "advisory",
+    ),
+    // The four block-capable sources below are not detector pattern lists, so
+    // they used to reach the evaluation as prose in `policyFindings` only. A
+    // BLOCK caused by any of them would then render as "No findings." — the
+    // exact silence ADR-011 §1 forbids.
+    ...enumerateDetectorFindings(
+      "agent_policy",
+      agentPolicy?.findings ?? [],
+      agentPolicy?.forceBlock === true ? "blocking" : "warn",
+    ),
+    // A single escalation verdict, so its id is fixed rather than enumerated.
+    ...(sensitiveEscalation.reason
+      ? [
+          {
+            id: "sensitive_files/0",
+            title: sensitiveEscalation.reason,
+            severity: sensitiveEscalation.block
+              ? ("blocking" as const)
+              : ("warn" as const),
+          },
+        ]
+      : []),
+    ...enumerateDetectorFindings(
+      "session_correlation",
+      sessionCorrelationFindings,
+      sessionCorrelationBlocks ? "blocking" : "warn",
+    ),
+    // `policyFindings` only ever carried the submission count; the per-check
+    // code/title/detail/severity is what a human actually needs.
+    ...submissionChecks.map((check, index) => ({
+      id: `submission/${check.code}/${index + 1}`,
+      title: check.title,
+      evidence: check.detail,
+      severity: check.severity,
+    })),
+  ];
 
   if (ciIntegrity.blockingPatterns.length > 0) {
     policyFindings.push(
@@ -2149,6 +2601,7 @@ export async function evaluateGate(
     evaluationMs: Date.now() - start,
     environment: effectiveEnvironment,
     policyFindings: policyFindings.length > 0 ? policyFindings : undefined,
+    enumeratedFindings: enumeratedFindings.length > 0 ? enumeratedFindings : undefined,
     pr: prNumber
       ? {
           provenance:
@@ -2227,6 +2680,12 @@ export async function evaluateGate(
         });
         ciSummary = evaluateRequiredChecks(checks, ciConfig, ciManifest);
       }
+      // ADR-011 §2 — resolve each input's disposition before anything reads the
+      // summary. With no input_relevance config this is a pure annotation pass.
+      ciSummary = applyInputRelevance(
+        ciSummary,
+        matchedContext?.context.input_relevance ?? [],
+      );
       localEvaluation.ci = ciSummary;
     } catch (error) {
       core.warning(`CI orchestration failed (non-blocking): ${error}`);
@@ -2300,23 +2759,25 @@ export async function evaluateGate(
   });
   localEvaluation.agentBriefMode = agentBriefMode;
 
+  // Fetched once, outside the remediation branch: ADR-011 §1's delta needs the
+  // previous evaluation even in repos that have remediation turned off.
+  let previousEvaluation: PreviousEvaluationSnapshot | null = null;
+  if (prNumber && (config.evaluationStoreUrl || process.env.SUPABASE_URL)) {
+    try {
+      previousEvaluation = await fetchPreviousEvaluationForPr({
+        repoId: localEvaluation.repoId,
+        prNumber,
+        excludeEvaluationId: localEvaluation.id,
+        storeUrl: config.evaluationStoreUrl,
+        apiKey: config.trailheadApiKey,
+      });
+    } catch (error) {
+      core.debug(`Previous evaluation lookup failed: ${error}`);
+    }
+  }
+
   const remediationEnabled = remediationSettings?.enabled !== false;
   if (remediationEnabled) {
-    let previousEvaluation = null;
-    if (prNumber && (config.evaluationStoreUrl || process.env.SUPABASE_URL)) {
-      try {
-        previousEvaluation = await fetchPreviousEvaluationForPr({
-          repoId: localEvaluation.repoId,
-          prNumber,
-          excludeEvaluationId: localEvaluation.id,
-          storeUrl: config.evaluationStoreUrl,
-          apiKey: config.trailheadApiKey,
-        });
-      } catch (error) {
-        core.debug(`Previous evaluation lookup failed: ${error}`);
-      }
-    }
-
     localEvaluation.remediation = buildRemediation({
       evaluation: {
         id: localEvaluation.id,
@@ -2336,12 +2797,73 @@ export async function evaluateGate(
     });
   }
 
+  // ADR-011 §1 — built last so it sees release-readiness, the override outcome
+  // and the remediation delta.
+  localEvaluation.releaseBrief = buildReleaseBrief(
+    localEvaluation,
+    adjustedRiskThreshold,
+    undefined,
+    previousEvaluation,
+  );
+
   return localEvaluation;
 }
 
 // ---------------------------------------------------------------------------
 // PR comment posting
 // ---------------------------------------------------------------------------
+
+/**
+ * Safety bound for anything handed to GitHub as a report body. Issue comments
+ * cap at 65536 characters and a check run's `output.summary` at 65535; one
+ * number under both leaves room for the comment marker.
+ */
+export const MAX_GATE_REPORT_CHARS = 65000;
+
+const BRIEF_HEADING = "## Release Brief";
+const BRIEF_SEPARATOR = "\n\n---\n\n";
+
+/** Cut points that leave the surviving markdown structurally intact. */
+const SECTION_BOUNDARIES = ["\n\n#", "\n\n<details>", "\n\n"];
+
+/**
+ * Clamp a gate report to what GitHub will actually accept.
+ *
+ * `renderReleaseBrief` already caps the brief itself, but the legacy report
+ * appended below it is unbounded (the files-changed list alone grows with the
+ * PR). Only that tail is trimmed — the brief is the decision, so it survives
+ * intact — and the reader is told where the full detail still lives.
+ */
+export function clampGateReport(
+  report: string,
+  maxChars: number = MAX_GATE_REPORT_CHARS,
+): string {
+  if (report.length <= maxChars) return report;
+
+  const notice =
+    `\n\n_…report truncated (${report.length - maxChars} chars over GitHub's ` +
+    `comment limit) — full detail in the stored evaluation / job summary._`;
+  const budget = maxChars - notice.length;
+  if (budget <= 0) return report.slice(0, maxChars);
+
+  // Never cut into the brief: keep everything up to its trailing separator.
+  const briefStart = report.indexOf(BRIEF_HEADING);
+  const separator = briefStart >= 0 ? report.indexOf(BRIEF_SEPARATOR, briefStart) : -1;
+  const floor = separator >= 0 ? separator + BRIEF_SEPARATOR.length : 0;
+  if (floor >= budget) return `${report.slice(0, budget)}${notice}`;
+
+  const head = report.slice(0, budget);
+  let cut = budget;
+  for (const boundary of SECTION_BOUNDARIES) {
+    const index = head.lastIndexOf(boundary);
+    if (index > floor) {
+      cut = index;
+      break;
+    }
+  }
+
+  return `${report.slice(0, cut).trimEnd()}${notice}`;
+}
 
 export async function postOverrideRejectionComment(
   prNumber: number,
@@ -2403,7 +2925,7 @@ export async function postPrComment(
       per_page: 100,
     });
     const MARKER = "<!-- trailhead-gate-report -->";
-    const body = `${MARKER}\n${report}`;
+    const body = clampGateReport(`${MARKER}\n${report}`);
 
     const existing = comments.find((c) => c.body?.includes(MARKER));
 
@@ -2423,7 +2945,9 @@ export async function postPrComment(
       });
     }
   } catch (error) {
-    core.debug(`Failed to post PR comment: ${error}`);
+    // Fail-soft, but never silent: a missing gate comment is a visible gap in
+    // the record, so it belongs in the run log rather than in debug output.
+    core.warning(`Failed to post PR comment: ${error}`);
   }
 }
 
@@ -2461,14 +2985,15 @@ export async function createCheckRun(
       conclusion,
       output: {
         title: `${name}: ${titleSuffix}`,
-        summary: report,
+        summary: clampGateReport(report),
         ...(evaluation.storePersisted === false
           ? { text: "Evaluation not persisted — dashboard incomplete." }
           : {}),
       },
     });
   } catch (error) {
-    core.debug(`Failed to create check run: ${error}`);
+    // Fail-soft, but never silent — see postPrComment.
+    core.warning(`Failed to create check run: ${error}`);
   }
 }
 
@@ -2899,10 +3424,25 @@ export function formatGateReport(
         : "NOT RELEASE READY"
       : evaluation.gateDecision.toUpperCase();
 
-  const lines: string[] = [
-    `## ${icon} Trailhead — ${headline}${envLabel}${contextLabel}`,
-    ``,
-  ];
+  const lines: string[] = [];
+
+  // ADR-011 §1 — the brief leads; the pre-existing report stays below it so the
+  // same `<!-- trailhead-gate-report -->` comment upgrades in place.
+  if (evaluation.releaseBrief) {
+    lines.push(
+      renderReleaseBrief(evaluation.releaseBrief, {
+        // The same markdown becomes a check run's output.summary, which GitHub
+        // caps at 65535 characters; leave room for the report below.
+        maxChars: BRIEF_MAX_CHARS,
+        ...(evaluation.reportUrl ? { storedEvaluationUrl: evaluation.reportUrl } : {}),
+      }),
+      ``,
+      `---`,
+      ``,
+    );
+  }
+
+  lines.push(`## ${icon} Trailhead — ${headline}${envLabel}${contextLabel}`, ``);
 
   if (mode === "release-ready" || mode === "advisory") {
     lines.push(

--- a/src/input-relevance.ts
+++ b/src/input-relevance.ts
@@ -1,0 +1,120 @@
+// ADR-011 §2 — input relevance policy (disposition engine).
+//
+// ADR-009's status enum (`pass|fail|skip|pending|stale|missing`) says what a check DID.
+// A disposition says what that MEANS for this release decision. This module is pure:
+// no octokit, no config loading, no I/O — callers resolve the policy entries for the
+// matched branch pair and hand them in.
+
+import { checkNameMatches } from "./ci-core.js";
+import { matchesGlobs } from "./risk-engine.js";
+
+export type DispositionKind = "blocking" | "advisory" | "irrelevant" | "missing_blocking";
+
+/** One row of the branch-pair relevance table, as authored in repo config. */
+export interface InputRelevanceEntry {
+  pattern: string;
+  /** `missing_blocking` is derived, never configured — see resolveDisposition. */
+  disposition: "blocking" | "advisory" | "irrelevant";
+  reason?: string;
+}
+
+export interface ResolvedDisposition {
+  kind: DispositionKind;
+  reason?: string;
+  /** `policy` = an entry matched; `default` = fell through to the required/optional rule. */
+  source: "policy" | "default";
+}
+
+export interface DispositionCheckInput {
+  name: string;
+  status: "pass" | "fail" | "skip" | "pending" | "stale" | "missing";
+  required: boolean;
+}
+
+/**
+ * Reason substituted when config declares `irrelevant` without a reason. ADR-011 §2 makes the
+ * reason mandatory ("reason mandatory and shown in the brief"); the config schema layer rejects
+ * it too, so this is defense in depth for configs that reached us unvalidated.
+ */
+export const MISSING_IRRELEVANT_REASON =
+  "(no reason configured — reason is mandatory for irrelevant; fix .trailhead.yml)";
+
+/**
+ * Pattern matching precedence, per entry:
+ *   1. exact name match                      (checkNameMatches)
+ *   2. case-insensitive name match           (checkNameMatches)
+ *   3. configured-value-as-prefix match      (checkNameMatches)
+ *   4. glob match, case-insensitive          (matchesGlobs — lets "Deploy *" work)
+ * These are a union, not a ranking: an entry matches if ANY of them matches. Ranking between
+ * entries is positional only — entries are evaluated in declaration order and the FIRST
+ * matching entry wins, exactly like `contexts[]` resolution in context-matcher.ts.
+ */
+function entryMatches(entry: InputRelevanceEntry, checkName: string): boolean {
+  // A blank pattern would prefix-match every check name; treat it as matching nothing so a
+  // config typo cannot silently reclassify the whole input set.
+  if (entry.pattern.trim() === "") return false;
+  if (checkNameMatches(entry.pattern, checkName)) return true;
+  return matchesGlobs(checkName, [entry.pattern]);
+}
+
+function hasText(value: string | undefined): value is string {
+  return value !== undefined && value.trim() !== "";
+}
+
+/**
+ * Resolve one check to a disposition.
+ *
+ * - First matching entry wins; no match falls back to `required ? blocking : advisory`
+ *   with source `default`.
+ * - `missing_blocking` is DERIVED: ADR-009 status `missing` on a check that would otherwise
+ *   resolve to `blocking`. It is never configurable.
+ */
+export function resolveDisposition(
+  check: DispositionCheckInput,
+  entries: InputRelevanceEntry[],
+): ResolvedDisposition {
+  const matched = entries.find((entry) => entryMatches(entry, check.name));
+
+  let kind: DispositionKind;
+  let reason: string | undefined;
+  let source: "policy" | "default";
+
+  if (matched) {
+    kind = matched.disposition;
+    reason = hasText(matched.reason) ? matched.reason : undefined;
+    source = "policy";
+    if (kind === "irrelevant" && reason === undefined) {
+      reason = MISSING_IRRELEVANT_REASON;
+    }
+  } else {
+    kind = check.required ? "blocking" : "advisory";
+    source = "default";
+  }
+
+  if (check.status === "missing" && kind === "blocking") {
+    kind = "missing_blocking";
+  }
+
+  return reason === undefined ? { kind, source } : { kind, reason, source };
+}
+
+/**
+ * Resolve a whole CI input set, keyed by check name. On duplicate check names the first
+ * occurrence wins, so the map is stable regardless of how many times a name appears.
+ */
+export function resolveDispositions(
+  checks: DispositionCheckInput[],
+  entries: InputRelevanceEntry[],
+): Map<string, ResolvedDisposition> {
+  const resolved = new Map<string, ResolvedDisposition>();
+  for (const check of checks) {
+    if (resolved.has(check.name)) continue;
+    resolved.set(check.name, resolveDisposition(check, entries));
+  }
+  return resolved;
+}
+
+/** Only `blocking` and `missing_blocking` count against release readiness (ADR-011 §2 table). */
+export function dispositionCountsTowardBlocking(d: ResolvedDisposition): boolean {
+  return d.kind === "blocking" || d.kind === "missing_blocking";
+}

--- a/src/loop-bookkeeping.ts
+++ b/src/loop-bookkeeping.ts
@@ -1,8 +1,22 @@
 // Pure loop bookkeeping helpers — no framework dependencies.
 
-import type { GateEvaluation, Remediation } from "./types.js";
+import type { GateDecision, Remediation } from "./types.js";
 
-export type PreviousEvaluationSnapshot = Pick<GateEvaluation, "id" | "remediation">;
+/**
+ * What the store returns about the previous evaluation of a PR. `id`/`remediation`
+ * drive loop bookkeeping; the rest is ADR-011 §1 delta material and is present only
+ * when the backend actually returned those columns — every consumer must treat the
+ * optional fields as "unknown", never as "unchanged".
+ */
+export interface PreviousEvaluationSnapshot {
+  id: string;
+  remediation?: Remediation;
+  riskScore?: number;
+  gateDecision?: GateDecision;
+  releaseReady?: boolean;
+  /** Ids of the previous evaluation's enumerated findings (ADR-011 §1). */
+  findingIds?: string[];
+}
 
 export function resolveLoopRound(
   previous: PreviousEvaluationSnapshot | null | undefined,
@@ -15,6 +29,32 @@ export function parseAgentIdFromHeadRef(headRef: string | undefined): string | n
   if (!headRef) return null;
   const match = headRef.match(/^agent\/([a-z0-9-]+)\//);
   return match?.[1] ?? null;
+}
+
+function pick(record: Record<string, unknown>, ...keys: string[]): unknown {
+  for (const key of keys) {
+    const value = record[key];
+    if (value !== undefined && value !== null) return value;
+  }
+  return undefined;
+}
+
+function readFindingIds(record: Record<string, unknown>): string[] | undefined {
+  const direct = pick(record, "enumerated_findings", "enumeratedFindings");
+  const brief = pick(record, "release_brief", "releaseBrief");
+  const raw =
+    direct ??
+    (brief && typeof brief === "object"
+      ? (brief as Record<string, unknown>).findings
+      : undefined);
+  if (!Array.isArray(raw)) return undefined;
+  const ids: string[] = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== "object") continue;
+    const id = (entry as Record<string, unknown>).id;
+    if (typeof id === "string") ids.push(id);
+  }
+  return ids;
 }
 
 export function parsePreviousEvaluationRow(
@@ -30,7 +70,29 @@ export function parsePreviousEvaluationRow(
     remediation = record.remediation as Remediation;
   }
 
-  return { id, remediation };
+  const snapshot: PreviousEvaluationSnapshot = { id, remediation };
+
+  const riskScore = pick(record, "risk_score", "riskScore");
+  if (typeof riskScore === "number" && Number.isFinite(riskScore)) {
+    snapshot.riskScore = riskScore;
+  }
+
+  const gateDecision = pick(record, "gate_decision", "gateDecision");
+  if (gateDecision === "allow" || gateDecision === "warn" || gateDecision === "block") {
+    snapshot.gateDecision = gateDecision;
+  }
+
+  const releaseReady = pick(record, "release_ready", "releaseReady");
+  if (typeof releaseReady === "boolean") {
+    snapshot.releaseReady = releaseReady;
+  }
+
+  const findingIds = readFindingIds(record);
+  if (findingIds !== undefined) {
+    snapshot.findingIds = findingIds;
+  }
+
+  return snapshot;
 }
 
 export function pickLatestPreviousEvaluation(

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,10 @@
 import * as core from "@actions/core";
 import * as github from "@actions/github";
 import {
+  buildCannotEvaluateBrief,
   evaluateGate,
   formatGateReport,
+  getResolvedAvailabilityStance,
   postPrComment,
   createCheckRun,
   managePrLabels,
@@ -11,6 +13,7 @@ import {
   resolveCheckName,
   wrapCollapsibleSection,
 } from "./gate.js";
+import { renderReleaseBrief } from "./release-brief.js";
 import { deliverWebhooks, storeEvaluationDetailed } from "./notify.js";
 import { buildCloudFooterLine } from "./cloud-upsell.js";
 import {
@@ -193,6 +196,46 @@ async function runSelfHeal(
   }
 
   return results;
+}
+
+/**
+ * ADR-011 §4 — the matched context's availability stance wins over the action-input
+ * fail-mode. Absent a stance (no context matched, or the run failed before matching)
+ * behaviour is exactly what it was before ADR-011.
+ */
+function resolveEffectiveFailMode(environment: string | undefined): "open" | "closed" {
+  const stance = getResolvedAvailabilityStance();
+  if (stance === "fail_open") return "open";
+  if (stance === "fail_closed") return "closed";
+  return resolveFailMode(core.getInput("fail-mode"), environment);
+}
+
+/**
+ * Post (or edit in place) the cannot-evaluate Release Brief on the PR. Deliberately
+ * swallows every failure of its own: the caller is already reporting a real error and
+ * must not have it replaced by "could not post a comment".
+ */
+async function postCannotEvaluateBrief(
+  error: unknown,
+  failMode: "open" | "closed",
+): Promise<void> {
+  try {
+    const githubToken =
+      core.getInput("github-token") || process.env.GITHUB_TOKEN || undefined;
+    // backfill/re-evaluation runs suppress PR comments (see evaluate-pr above).
+    const backfillMode = Boolean(core.getInput("evaluate-pr").trim());
+    const brief = buildCannotEvaluateBrief(
+      String(error instanceof Error ? error.message : error),
+      failMode === "open" ? "fail_open" : "fail_closed",
+    );
+    core.setOutput("release-brief-json", JSON.stringify(brief));
+
+    const { prNumber } = resolveEvaluationTarget(github.context);
+    if (!githubToken || !prNumber || backfillMode) return;
+    await postPrComment(renderReleaseBrief(brief), prNumber, githubToken);
+  } catch (postError) {
+    core.debug(`Cannot-evaluate brief could not be posted: ${postError}`);
+  }
 }
 
 async function run(): Promise<void> {
@@ -543,6 +586,9 @@ async function run(): Promise<void> {
       evaluation.releaseReady !== undefined ? String(evaluation.releaseReady) : "",
     );
     core.setOutput("evaluation-json", JSON.stringify(evaluation));
+    if (evaluation.releaseBrief) {
+      core.setOutput("release-brief-json", JSON.stringify(evaluation.releaseBrief));
+    }
     const verdict = buildGateVerdict(evaluation, {
       trustRuntime: readTrustRuntime(),
       agentId: resolveAgentProvenanceId(evaluation),
@@ -771,13 +817,21 @@ async function run(): Promise<void> {
           `risk=${evaluation.riskScore} (threshold: ${config.riskThreshold})`;
     core.setFailed(blockReason);
   } catch (error) {
+    const environment = core.getInput("environment") || undefined;
+    const failMode = resolveEffectiveFailMode(environment);
+
     if (error instanceof PolicyOverrideError) {
+      // An unusable override is still a run that could not evaluate — ADR-011 §1
+      // owes the PR a brief here too, with the validation message as the reason.
+      await postCannotEvaluateBrief(error, failMode);
       core.setFailed(`Invalid policy override: ${error.message}`);
       return;
     }
 
-    const environment = core.getInput("environment") || undefined;
-    const failMode = resolveFailMode(core.getInput("fail-mode"), environment);
+    // ADR-011 §1: "silence is a bug." A run that could not evaluate still owes the
+    // PR a brief. Best-effort — a posting failure must never mask the real error.
+    await postCannotEvaluateBrief(error, failMode);
+
     if (failMode === "open") {
       core.warning(
         `Trailhead evaluation failed — proceeding with deployment (fail-open). Error: ${error}`,

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -367,6 +367,68 @@ async function storeViaApi(
   return notStored;
 }
 
+/**
+ * Columns introduced by the ADR-011 store migration. A store that has not run it
+ * rejects the whole insert, so `storeViaSupabase` strips these and retries once
+ * rather than losing the evaluation over a narration-only column.
+ */
+export const ADR011_STORE_COLUMNS = ["release_brief", "enumerated_findings"] as const;
+
+/** PostgREST's schema-cache miss: `{"code":"PGRST204","message":"Could not find …"}`. */
+const UNKNOWN_COLUMN_CODE = "PGRST204";
+const UNKNOWN_COLUMN_MESSAGE = /could not find the '([^']+)' column/i;
+
+/**
+ * True only for PostgREST's column-not-found signature naming an ADR-011 column.
+ *
+ * A bare substring match would strip-and-retry on any 400 that happened to
+ * mention `release_brief` — a permission error, a constraint violation, a
+ * validation message — turning an unrelated failure into a silent data loss.
+ */
+export function mentionsUnknownAdr011Column(body: string): boolean {
+  const columns = ADR011_STORE_COLUMNS as readonly string[];
+
+  let code: string | undefined;
+  let message = body;
+  try {
+    const parsed: unknown = JSON.parse(body);
+    if (parsed !== null && typeof parsed === "object") {
+      const record = parsed as { code?: unknown; message?: unknown };
+      if (typeof record.code === "string") code = record.code;
+      if (typeof record.message === "string") message = record.message;
+    }
+  } catch {
+    // Not JSON — the textual signature below is all there is to go on.
+  }
+
+  // A different PostgREST code is a different failure, whatever it mentions.
+  if (code !== undefined && code !== UNKNOWN_COLUMN_CODE) return false;
+
+  const named = UNKNOWN_COLUMN_MESSAGE.exec(message)?.[1];
+  if (named !== undefined) return columns.includes(named);
+
+  // No recognisable message shape: only a bare PGRST204 naming a column counts.
+  return code === UNKNOWN_COLUMN_CODE && columns.some((column) => body.includes(column));
+}
+
+async function insertSupabaseRow(
+  restUrl: string,
+  serviceRoleKey: string,
+  row: Record<string, unknown>,
+): Promise<Response> {
+  return fetch(restUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      apikey: serviceRoleKey,
+      Authorization: `Bearer ${serviceRoleKey}`,
+      Prefer: "resolution=merge-duplicates",
+    },
+    body: JSON.stringify(row),
+    signal: AbortSignal.timeout(STORE_TIMEOUT_MS),
+  });
+}
+
 async function storeViaSupabase(evaluation: GateEvaluation): Promise<boolean> {
   const supabaseUrl = process.env.SUPABASE_URL;
   const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
@@ -378,24 +440,34 @@ async function storeViaSupabase(evaluation: GateEvaluation): Promise<boolean> {
 
   const row = buildEvaluationStoreRow(evaluation);
 
-  const response = await fetch(restUrl, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      apikey: serviceRoleKey,
-      Authorization: `Bearer ${serviceRoleKey}`,
-      Prefer: "resolution=merge-duplicates",
-    },
-    body: JSON.stringify(row),
-    signal: AbortSignal.timeout(STORE_TIMEOUT_MS),
-  });
+  let response = await insertSupabaseRow(restUrl, serviceRoleKey, row);
 
   if (response.ok || response.status === 201) {
     core.info("Evaluation stored via direct Supabase insert");
     return true;
   }
 
-  const body = await response.text().catch(() => "");
+  let body = await response.text().catch(() => "");
+
+  if (response.status === 400 && mentionsUnknownAdr011Column(body)) {
+    const legacyRow = Object.fromEntries(
+      Object.entries(row).filter(
+        ([key]) => !(ADR011_STORE_COLUMNS as readonly string[]).includes(key),
+      ),
+    );
+    core.warning(
+      "Evaluation store is missing the ADR-011 columns " +
+        `(${ADR011_STORE_COLUMNS.join(", ")}) — storing without the release brief. ` +
+        "Apply cloud/migrations/006_release_brief.sql to persist it.",
+    );
+    response = await insertSupabaseRow(restUrl, serviceRoleKey, legacyRow);
+    if (response.ok || response.status === 201) {
+      core.info("Evaluation stored via direct Supabase insert");
+      return true;
+    }
+    body = await response.text().catch(() => "");
+  }
+
   core.warning(`Supabase direct insert failed (HTTP ${response.status}): ${body}`);
   return false;
 }
@@ -432,7 +504,16 @@ export function buildEvaluationStoreRow(
     fixes_resolved: remediation?.fixes_resolved ?? [],
     fixes_introduced: remediation?.fixes_introduced ?? [],
     pr: evaluation.pr ?? null,
-    policy_override: evaluation.policyOverride ?? null,
+    // ADR-011 §3 — an audit written before the scope field existed WAS a full
+    // override; store that explicitly so consumers never have to infer it.
+    policy_override: evaluation.policyOverride
+      ? { ...evaluation.policyOverride, scope: evaluation.policyOverride.scope ?? "full" }
+      : null,
+    // ADR-011 §1. The Cloud/Komatik path POSTs the whole GateEvaluation, so these
+    // ride along there for free; the direct-Supabase path is column-explicit and
+    // needs them named. See cloud/migrations/006_release_brief.sql.
+    release_brief: evaluation.releaseBrief ?? null,
+    enumerated_findings: evaluation.enumeratedFindings ?? null,
     gate_mode: evaluation.gateMode ?? null,
     submission_checks: evaluation.submissionChecks ?? null,
     policy_findings: evaluation.policyFindings ?? null,

--- a/src/override.ts
+++ b/src/override.ts
@@ -1,4 +1,11 @@
-import type { GateDecision, GateEvaluation, PolicyOverrideAudit } from "./types.js";
+import type {
+  CiSummary,
+  GateDecision,
+  GateEvaluation,
+  OverrideScope,
+  PolicyOverrideAudit,
+} from "./types.js";
+import { checkCountsTowardBlocking } from "./release-ready.js";
 import type { ReleaseReadyResult } from "./release-ready.js";
 
 export const OVERRIDE_LABEL = "trailhead-override";
@@ -12,6 +19,8 @@ export interface PrComment {
 export interface OverrideConfig {
   enabled: boolean;
   maxPerWeek: number;
+  /** ADR-011 §3 scope. Omitted is treated as "full" (pre-ADR-011 behavior). */
+  scope?: OverrideScope;
 }
 
 export interface ParsedOverrideComment {
@@ -49,14 +58,74 @@ export function parseOverrideComment(
   return null;
 }
 
+export interface OverrideReasonPartition {
+  /** Risk/policy-driven reasons a risk_only override clears. */
+  overridden: string[];
+  /** Mechanical CI reasons that survive a risk_only override. */
+  retained: string[];
+}
+
+const CI_FAILING_STATUSES = new Set<string>(["fail", "missing", "stale"]);
+const CI_REQUIRED_CHECK_REASON = /^Required CI check "/;
+const CI_PENDING_REASON = /required CI check\(s\) still pending$/i;
+
+/**
+ * True when a computeReleaseReady() reason came from mechanical CI rather than
+ * risk/policy. ADR-011 §3: a `risk_only` override never clears these — getting
+ * past a red required check stays an admin-merge.
+ *
+ * Structural first: a reason naming a blocking check that CiSummary reports as
+ * fail/missing/stale is mechanical regardless of phrasing. The phrasing fallback
+ * fails closed — a reason that still reads as a CI reason but cannot be matched
+ * to a check (no CiSummary, renamed check, external CI manifest) keeps blocking.
+ *
+ * ADR-011 §2 composition: "blocking" is the check's disposition, not its
+ * `required` flag, so an input dispositioned `irrelevant`/`advisory` never
+ * produces a reason to retain, and a non-required input dispositioned `blocking`
+ * survives a risk_only override.
+ */
+function isMechanicalCiReason(reason: string, ci?: CiSummary | null): boolean {
+  const structural = ci?.checks.some(
+    (check) =>
+      checkCountsTowardBlocking(check) &&
+      CI_FAILING_STATUSES.has(check.status) &&
+      reason.includes(`"${check.name}"`),
+  );
+  if (structural) return true;
+  if (ci && ci.pendingCount > 0 && CI_PENDING_REASON.test(reason)) return true;
+  return CI_REQUIRED_CHECK_REASON.test(reason) || CI_PENDING_REASON.test(reason);
+}
+
+export function partitionOverrideReasons(
+  reasons: readonly string[],
+  ci?: CiSummary | null,
+): OverrideReasonPartition {
+  const overridden: string[] = [];
+  const retained: string[] = [];
+  for (const reason of reasons) {
+    if (isMechanicalCiReason(reason, ci)) retained.push(reason);
+    else overridden.push(reason);
+  }
+  return { overridden, retained };
+}
+
 export function buildLabelOverrideAudit(input: {
   parsed: ParsedOverrideComment;
   prNumber: number;
   releaseResult: ReleaseReadyResult;
   gateDecision: GateDecision;
+  scope?: OverrideScope;
+  ci?: CiSummary | null;
 }): PolicyOverrideAudit {
   const appliedAt = new Date().toISOString();
   const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+  const scope: OverrideScope = input.scope ?? "full";
+  const reasons = [...input.releaseResult.reasons];
+
+  const { overridden, retained } =
+    scope === "risk_only"
+      ? partitionOverrideReasons(reasons, input.ci)
+      : { overridden: reasons, retained: [] as string[] };
 
   return {
     source: "label",
@@ -65,13 +134,13 @@ export function buildLabelOverrideAudit(input: {
     linkedTicket: `override:pr#${input.prNumber}`,
     expiresAt,
     appliedAt,
-    changes: { releaseReady: true },
+    scope,
+    changes: retained.length === 0 ? { releaseReady: true } : {},
     preOverrideDecision: input.gateDecision,
     preOverrideReleaseReady: input.releaseResult.releaseReady,
-    preOverrideReasons:
-      input.releaseResult.reasons.length > 0
-        ? [...input.releaseResult.reasons]
-        : undefined,
+    preOverrideReasons: reasons.length > 0 ? reasons : undefined,
+    overriddenReasons: overridden.length > 0 ? overridden : undefined,
+    retainedReasons: retained.length > 0 ? retained : undefined,
   };
 }
 
@@ -112,6 +181,8 @@ export function resolveLabelOverride(input: {
   releaseResult: ReleaseReadyResult;
   gateDecision: GateDecision;
   prNumber: number;
+  /** Structural CI signal used to scope a risk_only override. */
+  ci?: CiSummary | null;
 }): LabelOverrideOutcome {
   if (!hasOverrideLabel(input.labels)) {
     return { kind: "none" };
@@ -156,6 +227,8 @@ export function resolveLabelOverride(input: {
       prNumber: input.prNumber,
       releaseResult: input.releaseResult,
       gateDecision: input.gateDecision,
+      scope: input.config.scope,
+      ci: input.ci,
     }),
   };
 }
@@ -164,10 +237,33 @@ export function applyLabelOverrideToEvaluation(
   evaluation: GateEvaluation,
   audit: PolicyOverrideAudit,
 ): GateEvaluation {
+  if ((audit.scope ?? "full") !== "risk_only") {
+    return {
+      ...evaluation,
+      releaseReady: true,
+      releaseReadyReasons: undefined,
+      policyOverride: audit,
+    };
+  }
+
+  // Re-partition against the evaluation's own CiSummary: it is the authoritative
+  // structural signal, and the audit may have been built without one.
+  const reasons = evaluation.releaseReadyReasons ?? audit.preOverrideReasons ?? [];
+  const { overridden, retained } = partitionOverrideReasons(reasons, evaluation.ci);
+  const releaseReady = retained.length === 0;
+  const { releaseReady: _clearedFlag, ...changesWithoutReleaseReady } = audit.changes;
+
   return {
     ...evaluation,
-    releaseReady: true,
-    releaseReadyReasons: undefined,
-    policyOverride: audit,
+    releaseReady,
+    releaseReadyReasons: retained.length > 0 ? retained : undefined,
+    policyOverride: {
+      ...audit,
+      changes: releaseReady
+        ? { ...audit.changes, releaseReady: true }
+        : changesWithoutReleaseReady,
+      overriddenReasons: overridden.length > 0 ? overridden : undefined,
+      retainedReasons: retained.length > 0 ? retained : undefined,
+    },
   };
 }

--- a/src/release-brief.ts
+++ b/src/release-brief.ts
@@ -123,7 +123,9 @@ const EVIDENCE_CAP_CHARS = 300;
 const EMPTY_CELL = "—";
 
 function escapePipes(value: string): string {
-  return value.replace(/\|/g, "\\|");
+  // Backslashes first, or a pre-existing "\" would neutralize the pipe escape
+  // and break the cell structure (CodeQL js/incomplete-sanitization).
+  return value.replace(/\\/g, "\\\\").replace(/\|/g, "\\|");
 }
 
 /** Table cells must be single-line and must not break the column structure. */

--- a/src/release-brief.ts
+++ b/src/release-brief.ts
@@ -1,0 +1,299 @@
+/**
+ * ADR-011 §1 — the Release Brief: the structured statement a human reads at the
+ * moment of a release decision, and its markdown renderer.
+ *
+ * This module is pure by design: no octokit, no GateEvaluation import, no
+ * dependency on the input-relevance policy. The integrator maps whatever it has
+ * onto `ReleaseBrief` and posts `renderReleaseBrief()`'s output.
+ */
+
+export type BriefVerdict = "allow" | "warn" | "block" | "cannot_evaluate";
+
+export interface BriefFinding {
+  id: string;
+  title: string;
+  evidence?: string;
+  severity: "blocking" | "warn" | "advisory";
+}
+
+export interface BriefInput {
+  checkName: string;
+  /** ADR-009 status, carried as a string so this module stays policy-agnostic. */
+  status: string;
+  /** ADR-011 §2 disposition, likewise carried structurally. */
+  disposition: string;
+  reason?: string;
+}
+
+export interface BriefAction {
+  kind: "fix" | "override" | "wait";
+  detail: string;
+  link?: string;
+}
+
+export interface BriefOverride {
+  by: string;
+  at: string;
+  scope: string;
+  rationale: string;
+}
+
+export interface ReleaseBrief {
+  verdict: BriefVerdict;
+  riskScore?: number;
+  riskThreshold?: number;
+  topMovers?: Array<{ factor: string; score: number }>;
+  findings: BriefFinding[];
+  inputs: BriefInput[];
+  delta?: string;
+  actions: BriefAction[];
+  override?: BriefOverride | null;
+  cannotEvaluateReason?: string;
+}
+
+/**
+ * One side of the ADR-011 §1 `delta` comparison. Fields are optional because the
+ * evaluation store may not return them (older rows, narrow selects, backends that
+ * project a subset) — every absent field simply drops out of the sentence.
+ */
+export interface DeltaSnapshot {
+  verdict?: string;
+  riskScore?: number;
+  findingIds?: string[];
+}
+
+function countDiff(
+  previous: string[],
+  current: string[],
+): { resolved: number; added: number } {
+  const before = new Set(previous);
+  const after = new Set(current);
+  let resolved = 0;
+  for (const id of before) if (!after.has(id)) resolved += 1;
+  let added = 0;
+  for (const id of after) if (!before.has(id)) added += 1;
+  return { resolved, added };
+}
+
+function plural(count: number, noun: string): string {
+  return `${count} ${noun}${count === 1 ? "" : "s"}`;
+}
+
+/**
+ * Render the one-line "vs previous" delta, e.g.
+ * `vs previous: block -> allow, risk 90 -> 42, 3 findings resolved, 1 new`.
+ *
+ * Returns undefined when the two snapshots share no comparable field — a missing
+ * or unreachable previous evaluation must omit the delta, never error (ADR-011 §1).
+ */
+export function formatEvaluationDelta(
+  previous: DeltaSnapshot,
+  current: DeltaSnapshot,
+): string | undefined {
+  const parts: string[] = [];
+  let comparable = false;
+
+  if (previous.verdict !== undefined && current.verdict !== undefined) {
+    comparable = true;
+    if (previous.verdict !== current.verdict) {
+      parts.push(`${previous.verdict} -> ${current.verdict}`);
+    }
+  }
+
+  if (previous.riskScore !== undefined && current.riskScore !== undefined) {
+    comparable = true;
+    if (previous.riskScore !== current.riskScore) {
+      parts.push(`risk ${previous.riskScore} -> ${current.riskScore}`);
+    }
+  }
+
+  if (previous.findingIds !== undefined && current.findingIds !== undefined) {
+    comparable = true;
+    const { resolved, added } = countDiff(previous.findingIds, current.findingIds);
+    if (resolved > 0) parts.push(`${plural(resolved, "finding")} resolved`);
+    if (added > 0) parts.push(`${added} new`);
+  }
+
+  if (!comparable) return undefined;
+  return `vs previous: ${parts.length > 0 ? parts.join(", ") : "no change"}`;
+}
+
+const DEFAULT_MAX_CHARS = 60000;
+const EVIDENCE_CAP_CHARS = 300;
+const EMPTY_CELL = "—";
+
+function escapePipes(value: string): string {
+  return value.replace(/\|/g, "\\|");
+}
+
+/** Table cells must be single-line and must not break the column structure. */
+function cell(value: string): string {
+  const flattened = value.replace(/\r?\n/g, " ").trim();
+  if (flattened.length === 0) return EMPTY_CELL;
+  return escapePipes(flattened);
+}
+
+function verdictLabel(verdict: BriefVerdict): string {
+  return verdict.replace(/_/g, " ").toUpperCase();
+}
+
+function verdictLine(brief: ReleaseBrief): string {
+  const segments: string[] = [];
+
+  if (brief.riskScore !== undefined) {
+    segments.push(
+      brief.riskThreshold !== undefined
+        ? `risk ${brief.riskScore} (threshold ${brief.riskThreshold})`
+        : `risk ${brief.riskScore}`,
+    );
+  } else if (brief.riskThreshold !== undefined) {
+    segments.push(`threshold ${brief.riskThreshold}`);
+  }
+
+  if (brief.topMovers && brief.topMovers.length > 0) {
+    const movers = brief.topMovers
+      .map((mover) => `${mover.factor} ${mover.score}`)
+      .join(", ");
+    segments.push(`top movers: ${movers}`);
+  }
+
+  const badge = `**${verdictLabel(brief.verdict)}**`;
+  return segments.length > 0 ? `${badge} — ${segments.join(" · ")}` : badge;
+}
+
+function capEvidence(evidence: string, cap: number | undefined): string {
+  if (cap === undefined || evidence.length <= cap) return evidence;
+  // Ellipsis included, so the capped evidence is exactly `cap` characters.
+  return `${evidence.slice(0, cap - 1)}…`;
+}
+
+function findingLines(
+  finding: BriefFinding,
+  index: number,
+  evidenceCap: number | undefined,
+): string[] {
+  const lines = [
+    `${index + 1}. **${escapePipes(finding.title)}** \`${finding.id}\` _(${finding.severity})_`,
+  ];
+  const evidence = finding.evidence?.trim();
+  if (evidence) {
+    for (const line of capEvidence(evidence, evidenceCap).split(/\r?\n/)) {
+      lines.push(`   > ${escapePipes(line)}`);
+    }
+  }
+  return lines;
+}
+
+function buildBrief(
+  brief: ReleaseBrief,
+  keepFindings: number,
+  evidenceCap: number | undefined,
+  storedEvaluationUrl: string | undefined,
+): string {
+  const lines: string[] = ["## Release Brief", "", verdictLine(brief), ""];
+
+  // ADR-011 §1: "silence is a bug" — a cannot-evaluate brief must say why, up top.
+  if (brief.verdict === "cannot_evaluate" || brief.cannotEvaluateReason) {
+    const reason = brief.cannotEvaluateReason?.trim();
+    lines.push(
+      `> ⚠️ **Cannot evaluate:** ${reason && reason.length > 0 ? reason : "no reason recorded"}`,
+      "",
+    );
+  }
+
+  lines.push("### Findings", "");
+  if (brief.findings.length === 0) {
+    lines.push("No findings.", "");
+  } else {
+    // ADR-011 §1: findings are enumerated, never counted.
+    const shown = brief.findings.slice(0, Math.max(0, keepFindings));
+    shown.forEach((finding, index) => {
+      lines.push(...findingLines(finding, index, evidenceCap));
+    });
+    const hidden = brief.findings.length - shown.length;
+    if (hidden > 0) {
+      const target = storedEvaluationUrl
+        ? `[stored evaluation](${storedEvaluationUrl})`
+        : "stored evaluation";
+      lines.push(`_…${hidden} more findings not shown inline — see the ${target}_`);
+    }
+    lines.push("");
+  }
+
+  lines.push("### Inputs", "");
+  if (brief.inputs.length === 0) {
+    lines.push("No inputs evaluated.", "");
+  } else {
+    lines.push(
+      `| Check | Status | Disposition | Reason |`,
+      `|-------|--------|-------------|--------|`,
+    );
+    for (const input of brief.inputs) {
+      lines.push(
+        `| ${cell(input.checkName)} | ${cell(input.status)} | ${cell(input.disposition)} | ${cell(input.reason ?? "")} |`,
+      );
+    }
+    lines.push("");
+  }
+
+  const delta = brief.delta?.trim();
+  if (delta) {
+    lines.push(`**Delta:** ${delta}`, "");
+  }
+
+  lines.push("### Actions", "");
+  if (brief.actions.length === 0) {
+    lines.push("No actions.", "");
+  } else {
+    for (const action of brief.actions) {
+      const link = action.link ? ` ([link](${action.link}))` : "";
+      lines.push(`- **${action.kind}:** ${action.detail}${link}`);
+    }
+    lines.push("");
+  }
+
+  if (brief.override) {
+    const owner = brief.override.by.replace(/^@+/, "");
+    lines.push(
+      "### Override",
+      "",
+      `> Overridden by @${owner} at ${brief.override.at}, scope ${brief.override.scope} — ${brief.override.rationale}`,
+      "",
+    );
+  }
+
+  return lines.join("\n").trimEnd();
+}
+
+/**
+ * Render a Release Brief as markdown suitable for a PR comment section.
+ *
+ * Truncation order (ADR-011 §1): drop findings from the end first (always
+ * keeping at least one plus a pointer to the stored evaluation), then cap
+ * evidence, and only then hard-clip. The result never exceeds `maxChars`.
+ */
+export function renderReleaseBrief(
+  brief: ReleaseBrief,
+  opts?: { maxChars?: number; storedEvaluationUrl?: string },
+): string {
+  const requested = opts?.maxChars ?? DEFAULT_MAX_CHARS;
+  const maxChars = Number.isFinite(requested) ? Math.floor(requested) : DEFAULT_MAX_CHARS;
+  if (maxChars <= 0) return "";
+  const storedEvaluationUrl = opts?.storedEvaluationUrl;
+
+  const total = brief.findings.length;
+  let rendered = buildBrief(brief, total, undefined, storedEvaluationUrl);
+  if (rendered.length <= maxChars) return rendered;
+
+  for (let keep = total - 1; keep >= 1; keep--) {
+    rendered = buildBrief(brief, keep, undefined, storedEvaluationUrl);
+    if (rendered.length <= maxChars) return rendered;
+  }
+
+  const minKeep = total > 0 ? 1 : 0;
+  rendered = buildBrief(brief, minKeep, EVIDENCE_CAP_CHARS, storedEvaluationUrl);
+  if (rendered.length <= maxChars) return rendered;
+
+  // Last resort: the length contract outranks markdown well-formedness.
+  return rendered.slice(0, maxChars);
+}

--- a/src/release-ready.ts
+++ b/src/release-ready.ts
@@ -1,4 +1,23 @@
-import type { CiSummary, GateDecision, GateEvaluation, GateMode } from "./types.js";
+import type {
+  CiCheck,
+  CiSummary,
+  GateDecision,
+  GateEvaluation,
+  GateMode,
+} from "./types.js";
+
+/**
+ * ADR-011 §2: the disposition, once resolved, is the axis that decides whether a
+ * red input blocks the release. Checks with no disposition — no `input_relevance`
+ * config, an externally-built CiSummary, or a stored pre-ADR-011 evaluation —
+ * fall back to `required`, which is byte-for-byte the pre-ADR-011 behavior
+ * (the default mapping is required -> blocking, non-required -> advisory).
+ */
+export function checkCountsTowardBlocking(check: CiCheck): boolean {
+  const kind = check.disposition?.kind;
+  if (kind === undefined) return check.required;
+  return kind === "blocking" || kind === "missing_blocking";
+}
 
 export interface ReleaseReadyInput {
   gateMode: GateMode;
@@ -42,7 +61,7 @@ export function computeReleaseReady(input: ReleaseReadyInput): ReleaseReadyResul
     if (!input.ciSummary.allRequiredPassed) {
       const failed = input.ciSummary.checks.filter(
         (c) =>
-          c.required &&
+          checkCountsTowardBlocking(c) &&
           (c.status === "fail" || c.status === "missing" || c.status === "stale"),
       );
       for (const check of failed) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,12 +68,34 @@ export const CiCheckStatusEnum = z.enum([
 ]);
 export type CiCheckStatusEnum = z.infer<typeof CiCheckStatusEnum>;
 
+// ADR-011 §2 — input relevance. ADR-009's status says what a check DID; the
+// disposition says what it MEANS for this release decision. `missing_blocking`
+// is derived (ADR-009 `missing` on a blocking input), never configured.
+export const InputDispositionKind = z.enum([
+  "blocking",
+  "advisory",
+  "irrelevant",
+  "missing_blocking",
+]);
+export type InputDispositionKind = z.infer<typeof InputDispositionKind>;
+
+export const InputDisposition = z.object({
+  kind: InputDispositionKind,
+  reason: z.string().optional(),
+  /** `policy` = an input_relevance entry matched; `default` = required/optional fallback. */
+  source: z.enum(["policy", "default"]),
+});
+export type InputDisposition = z.infer<typeof InputDisposition>;
+
 export const CiCheck = z.object({
   name: z.string(),
   status: CiCheckStatusEnum,
   conclusion: z.string().optional(),
   detailsUrl: z.string().url().optional(),
   required: z.boolean(),
+  // Optional: summaries produced before dispositions are applied (and every
+  // pre-ADR-011 stored evaluation) carry none, and fall back to `required`.
+  disposition: InputDisposition.optional(),
 });
 export type CiCheck = z.infer<typeof CiCheck>;
 
@@ -205,6 +227,11 @@ export const PolicyOverrideChanges = z.object({
 });
 export type PolicyOverrideChanges = z.infer<typeof PolicyOverrideChanges>;
 
+export const OverrideScope = z.enum(["full", "risk_only"]);
+export type OverrideScope = z.infer<typeof OverrideScope>;
+
+// ADR-011 §3 renders the override record as {by, at, scope, rationale};
+// this schema carries by=owner, at=appliedAt, rationale=reason, plus scope.
 export const PolicyOverrideAudit = z.object({
   source: z.enum(["workflow", "label"]).default("workflow"),
   owner: z.string(),
@@ -212,12 +239,73 @@ export const PolicyOverrideAudit = z.object({
   linkedTicket: z.string(),
   expiresAt: z.string(),
   appliedAt: z.string(),
+  // Optional, not defaulted: audits stored before ADR-011 carry no scope and
+  // must keep parsing as the pre-ADR-011 (full) override they actually were.
+  scope: OverrideScope.optional(),
   changes: PolicyOverrideChanges.default({}),
   preOverrideDecision: GateDecision.optional(),
   preOverrideReleaseReady: z.boolean().optional(),
   preOverrideReasons: z.array(z.string()).optional(),
+  /** Blocking reasons the override cleared (risk/policy driven). */
+  overriddenReasons: z.array(z.string()).optional(),
+  /** Blocking reasons that survived the override (mechanical CI, ADR-011 §3). */
+  retainedReasons: z.array(z.string()).optional(),
 });
 export type PolicyOverrideAudit = z.infer<typeof PolicyOverrideAudit>;
+
+// ---------------------------------------------------------------------------
+// ADR-011 §1 — the Release Brief
+// ---------------------------------------------------------------------------
+
+export const BriefVerdict = z.enum(["allow", "warn", "block", "cannot_evaluate"]);
+export type BriefVerdict = z.infer<typeof BriefVerdict>;
+
+export const BriefFinding = z.object({
+  id: z.string(),
+  title: z.string(),
+  evidence: z.string().optional(),
+  severity: RemediationSeverity,
+});
+export type BriefFinding = z.infer<typeof BriefFinding>;
+
+export const BriefInput = z.object({
+  checkName: z.string(),
+  /** ADR-009 status, carried as a string so the renderer stays policy-agnostic. */
+  status: z.string(),
+  /** ADR-011 §2 disposition kind. */
+  disposition: z.string(),
+  reason: z.string().optional(),
+});
+export type BriefInput = z.infer<typeof BriefInput>;
+
+export const BriefAction = z.object({
+  kind: z.enum(["fix", "override", "wait"]),
+  detail: z.string(),
+  link: z.string().optional(),
+});
+export type BriefAction = z.infer<typeof BriefAction>;
+
+export const BriefOverride = z.object({
+  by: z.string(),
+  at: z.string(),
+  scope: z.string(),
+  rationale: z.string(),
+});
+export type BriefOverride = z.infer<typeof BriefOverride>;
+
+export const ReleaseBrief = z.object({
+  verdict: BriefVerdict,
+  riskScore: z.number().optional(),
+  riskThreshold: z.number().optional(),
+  topMovers: z.array(z.object({ factor: z.string(), score: z.number() })).optional(),
+  findings: z.array(BriefFinding),
+  inputs: z.array(BriefInput),
+  delta: z.string().optional(),
+  actions: z.array(BriefAction),
+  override: BriefOverride.nullish(),
+  cannotEvaluateReason: z.string().optional(),
+});
+export type ReleaseBrief = z.infer<typeof ReleaseBrief>;
 
 export const CreditMeterResult = z.object({
   metered: z.boolean(),
@@ -250,6 +338,10 @@ export const GateEvaluation = z.object({
   environment: z.string().optional(),
   service: z.string().optional(),
   policyFindings: z.array(z.string()).optional(),
+  // ADR-011 §1: "findings are enumerated, never counted". policyFindings keeps
+  // its count-strings for existing consumers; this is the enumeration.
+  enumeratedFindings: z.array(BriefFinding).optional(),
+  releaseBrief: ReleaseBrief.optional(),
   pr: z
     .object({
       provenance: PrProvenance.optional(),
@@ -411,6 +503,22 @@ export const ContextCiConfig = z.object({
 });
 export type ContextCiConfig = z.infer<typeof ContextCiConfig>;
 
+// ADR-011 §2 — one row of the branch-pair relevance table. `reason` is mandatory
+// for `irrelevant`, but that is enforced as a config *warning* (see
+// collectConfigWarnings in config-core.ts), not a parse failure: a hard refine
+// here would drop the whole repo config to defaults over one typo, which is how
+// parseRepoConfigContent degrades today.
+export const InputRelevanceEntry = z.object({
+  pattern: z.string(),
+  disposition: z.enum(["blocking", "advisory", "irrelevant"]),
+  reason: z.string().optional(),
+});
+export type InputRelevanceEntry = z.infer<typeof InputRelevanceEntry>;
+
+/** ADR-011 §4 — per-branch-pair stance when the evaluation cannot run. */
+export const AvailabilityStance = z.enum(["fail_open", "fail_closed"]);
+export type AvailabilityStance = z.infer<typeof AvailabilityStance>;
+
 export const TrailheadContext = z.object({
   name: z.string(),
   match: ContextMatch,
@@ -422,6 +530,8 @@ export const TrailheadContext = z.object({
     })
     .default({}),
   ci: ContextCiConfig.default({}),
+  input_relevance: z.array(InputRelevanceEntry).default([]),
+  availability: AvailabilityStance.optional(),
 });
 export type TrailheadContext = z.infer<typeof TrailheadContext>;
 
@@ -456,6 +566,8 @@ export type RiskPathProfileConfig = z.infer<typeof RiskPathProfileConfig>;
 export const OverrideConfig = z.object({
   enabled: z.boolean().default(true),
   max_per_week: z.number().int().min(1).default(5),
+  // Defaults to "full" so repos that never set it keep pre-ADR-011 behavior.
+  scope: OverrideScope.default("full"),
 });
 export type OverrideConfig = z.infer<typeof OverrideConfig>;
 


### PR DESCRIPTION
Written from tonight's komatik promotion-train post-mortem (komatik #4033/#4034), at David's request: *"in both cases there is a missing communication piece that trailhead should be handling."*

**What happened tonight, in one line each:**
- **Case A**: the gate returned `BLOCK: risk 90, CI integrity blocking patterns (4)` — and the four patterns were never enumerated anywhere a human could see; the only path forward was an admin-merge that bypassed everything and recorded nothing.
- **Case B**: a master promotion was blocked by a `fail` on a **staging**-target deploy check whose secrets *deliberately don't exist* — ADR-009's enum has no way to say "failed but irrelevant to this decision, here's why."

**What this ADR adds** (building on ADR-006's already-ratified single-check authority and ADR-009's status enum — deliberately NOT re-proposing what 006 decided):
1. **The Release Brief** — a structured, edited-in-place PR comment for every evaluation: enumerated findings (a bare count is a contract violation), per-input dispositions with reasons, delta, and available actions. Silence is a bug.
2. **Input relevance policy** — a per-branch-pair disposition axis over ADR-009 statuses: `blocking / advisory / irrelevant(reason) / missing_blocking`, config-schema-homed, self-auditing (every `irrelevant` prints its reason on every PR).
3. **Scoped recorded override** — `risk_only`, stored `{by, at, scope, rationale}`; red mechanical inputs stay unoverridable through Trailhead, restoring admin-merge to visible-and-extraordinary.
4. **Explicit availability stance** per branch pair (proposed: master fail-closed, staging fail-open-with-brief).

**Rollout is narrate-first**: stage 0 posts the brief with zero enforcement change anywhere — it would have resolved both of tonight's cases by itself — then calibration, then komatik flips staging, then master, per ADR-006's design.

Also carries a calibration note: risk 90 on a keystone-verified, corpus-validated train wants a promotion-shaped exemption analog to the existing `pr_scope` branch-pair rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HVYZ9VXGiKr8mVUQew53zq