### PR TITLE
release: v4.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to Trailhead will be documented in this file.
 
-## [Unreleased]
+## [4.7.0] - 2026-08-08
 
 ### Added
 

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@komatikai/trailhead",
-  "version": "4.6.1",
+  "version": "4.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@komatikai/trailhead",
-      "version": "4.6.1",
+      "version": "4.7.0",
       "license": "MIT",
       "dependencies": {
         "@swc/core": "^1.15.40"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@komatikai/trailhead",
-  "version": "4.6.1",
+  "version": "4.7.0",
   "description": "Trailhead CLI — setup wizard and utilities for the Trailhead deployment gate",
   "bin": {
     "trailhead": "dist/index.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trailhead",
-  "version": "4.6.1",
+  "version": "4.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "trailhead",
-      "version": "4.6.1",
+      "version": "4.7.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trailhead",
-  "version": "4.6.1",
+  "version": "4.7.0",
   "private": true,
   "description": "Release readiness gate for GitHub PRs — waits for CI, scores code risk, checks production health, and blocks merges that are not release-ready.",
   "license": "MIT",


### PR DESCRIPTION
Rolls `[Unreleased]` into **v4.7.0** — the ADR-011 release (Release Brief, input relevance dispositions, `risk_only` override scope, per-context availability, `release-brief-json` output, store columns), all merged in #348.

Version bumps via `npm version 4.7.0` (root + CLI through `sync-cli-version.mjs`). Suite green at 1032 tests; prettier clean.

**After merge** (maintainer steps, per the v4.6.1 flow): promote and push the `v4.7.0` tag — `release.yml` rebuilds/verifies `dist/`, retags the rolling `v4`, and publishes the CLI. The komatik Stage 1 calibration PR consumes `@v4.7.0` and is blocked until the tag exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
