### PR TITLE
ci(release): fix CLI publish checkout racing the dist retag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,14 @@ jobs:
     needs: release
 
     steps:
+      # Re-resolve the tag instead of taking checkout's default (github.sha,
+      # frozen at the commit the tag pointed to when the run triggered): the
+      # release job above may have force-moved the tag onto the CI-built dist
+      # commit, and checkout@v7 fails the run when ref and expected sha
+      # disagree (v4.7.0's CLI publish died here, twice).
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.ref_name }}
 
       - uses: actions/setup-node@v7
         with:


### PR DESCRIPTION
The release job force-moves the version tag onto the CI-built dist commit; since checkout@v7 (#335) the publish-cli job's bare checkout then fails validating the moved tag against the frozen github.sha. v4.7.0's CLI publish failed here on both attempts. Fix: checkout ref: github.ref_name to re-resolve the tag. Note this workflow runs from the tagged commit, so the fix protects v4.7.1+; publishing the 4.7.0 CLI needs the tag re-push dance or a manual publish (see conversation). Expect security-guard to block for the workflow edit — needs the security-reviewed label. 🤖 Generated with [Claude Code](https://claude.com/claude-code)