### PR TITLE
fix(ci-integrity): exempt || true inside trap cleanup handlers

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -50770,14 +50770,25 @@ function addedPatchLines(patch) {
         .filter((line) => line.startsWith("+") && !line.startsWith("+++"))
         .map((line) => line.slice(1));
 }
+const OR_TRUE_BYPASS = /\|\|\s*true/;
+/** A `|| true` on a `trap '…'` line is best-effort cleanup, not a CI bypass:
+ * the suppression applies only to the trap handler's own command (e.g.
+ * `trap 'docker rm --force "$c" >/dev/null 2>&1 || true' EXIT`), never to a
+ * test/build step's outcome. First hit: komatik release train #4864
+ * (2026-08-26), where teams-worker.yml's container-cleanup trap was flagged
+ * as a blocking bypass. The optional `run:` prefix keeps the inline YAML form
+ * (`run: trap '…' EXIT`) exempt too; a `|| true` on any other added line
+ * still blocks. */
+const TRAP_CLEANUP_LINE = /^\s*(?:-\s*)?(?:run:\s*)?trap\b/;
 /** Detect newly introduced CI bypasses, never unchanged or deleted context. */
 function detectCiIntegrity(files) {
     const blockingPatterns = [];
     const warningSignals = [];
     let score = 0;
     for (const file of files.filter((entry) => entry.filename.startsWith(".github/workflows/"))) {
-        const added = addedPatchLines(file.patch).join("\n");
-        if (/\|\|\s*true/.test(added)) {
+        const addedLines = addedPatchLines(file.patch);
+        const added = addedLines.join("\n");
+        if (addedLines.some((line) => OR_TRUE_BYPASS.test(line) && !TRAP_CLEANUP_LINE.test(line))) {
             blockingPatterns.push(`${file.filename}: workflow bypass pattern "|| true"`);
             score += 45;
         }

--- a/src/__tests__/ci-integrity-precision.test.ts
+++ b/src/__tests__/ci-integrity-precision.test.ts
@@ -30,4 +30,50 @@ describe("CI integrity diff precision", () => {
     expect(result.blockingPatterns).toHaveLength(1);
     expect(result.score).toBe(45);
   });
+
+  it("exempts || true inside a trap cleanup handler (komatik#4864)", () => {
+    const result = detectCiIntegrity([
+      {
+        filename: ".github/workflows/teams-worker.yml",
+        patch: [
+          "@@ -95,2 +95,3 @@",
+          "       - name: Boot Teams image and prove exact release identity",
+          "+          trap 'docker rm --force \"$container_id\" >/dev/null 2>&1 || true' EXIT",
+        ].join("\n"),
+      },
+    ]);
+
+    expect(result.blockingPatterns).toEqual([]);
+    expect(result.score).toBe(0);
+  });
+
+  it("exempts the inline run: trap form", () => {
+    const result = detectCiIntegrity([
+      {
+        filename: ".github/workflows/ci.yml",
+        patch: "@@ -1,1 +1,2 @@\n+        run: trap 'rm -rf \"$scratch\" || true' EXIT",
+      },
+    ]);
+
+    expect(result.blockingPatterns).toEqual([]);
+    expect(result.score).toBe(0);
+  });
+
+  it("still blocks a real bypass added alongside a trap cleanup line", () => {
+    const result = detectCiIntegrity([
+      {
+        filename: ".github/workflows/ci.yml",
+        patch: [
+          "@@ -1,2 +1,4 @@",
+          "+          trap 'docker rm --force \"$cid\" || true' EXIT",
+          "+          npm test || true",
+        ].join("\n"),
+      },
+    ]);
+
+    expect(result.blockingPatterns).toEqual([
+      '.github/workflows/ci.yml: workflow bypass pattern "|| true"',
+    ]);
+    expect(result.score).toBe(45);
+  });
 });

--- a/src/ci-integrity.ts
+++ b/src/ci-integrity.ts
@@ -19,6 +19,18 @@ function addedPatchLines(patch: string | undefined): string[] {
     .map((line) => line.slice(1));
 }
 
+const OR_TRUE_BYPASS = /\|\|\s*true/;
+
+/** A `|| true` on a `trap '…'` line is best-effort cleanup, not a CI bypass:
+ * the suppression applies only to the trap handler's own command (e.g.
+ * `trap 'docker rm --force "$c" >/dev/null 2>&1 || true' EXIT`), never to a
+ * test/build step's outcome. First hit: komatik release train #4864
+ * (2026-08-26), where teams-worker.yml's container-cleanup trap was flagged
+ * as a blocking bypass. The optional `run:` prefix keeps the inline YAML form
+ * (`run: trap '…' EXIT`) exempt too; a `|| true` on any other added line
+ * still blocks. */
+const TRAP_CLEANUP_LINE = /^\s*(?:-\s*)?(?:run:\s*)?trap\b/;
+
 /** Detect newly introduced CI bypasses, never unchanged or deleted context. */
 export function detectCiIntegrity(files: CiIntegrityFile[]): CiIntegrityResult {
   const blockingPatterns: string[] = [];
@@ -28,8 +40,13 @@ export function detectCiIntegrity(files: CiIntegrityFile[]): CiIntegrityResult {
   for (const file of files.filter((entry) =>
     entry.filename.startsWith(".github/workflows/"),
   )) {
-    const added = addedPatchLines(file.patch).join("\n");
-    if (/\|\|\s*true/.test(added)) {
+    const addedLines = addedPatchLines(file.patch);
+    const added = addedLines.join("\n");
+    if (
+      addedLines.some(
+        (line) => OR_TRUE_BYPASS.test(line) && !TRAP_CLEANUP_LINE.test(line),
+      )
+    ) {
       blockingPatterns.push(`${file.filename}: workflow bypass pattern "|| true"`);
       score += 45;
     }


### PR DESCRIPTION
## PROBLEM

`detectCiIntegrity` (src/ci-integrity.ts) flags any added workflow line matching `|| true` as a **blocking** `ci_integrity` bypass pattern. A `|| true` inside a `trap '…'` cleanup handler is not a bypass — it suppresses only the trap's own cleanup command's exit status, never a test/build step's outcome.

First real hit: **komatik release PR #4864** (2026-08-26). The train added this step to `.github/workflows/teams-worker.yml`:

```
trap 'docker rm --force "$container_id" >/dev/null 2>&1 || true' EXIT
```

Trailhead Gate returned `Release not ready: Risk/policy gate decision is BLOCK; CI integrity blocking patterns detected (1)` on an otherwise all-green release (risk 58, threshold 95 — the pattern alone forced BLOCK).

## FIX

The `|| true` check now evaluates per added line and exempts lines whose command is a `trap` invocation (including the inline `run: trap '…' EXIT` form). Every other added line carrying `|| true` still blocks, including a real bypass added alongside a trap line in the same patch (regression-tested). `continue-on-error` / `always()` checks unchanged.

## EXECUTED CHECKS (real output, not claims)

`npx vitest run src/__tests__/ci-integrity-precision.test.ts` (after clean `npm ci`):

```
 Test Files  1 passed (1)
      Tests  5 passed (5)
```

`npx tsc --noEmit` → exit 0.

**Corpus validation against the live false positive**: ran the patched `detectCiIntegrity` over the real GitHub API file list of komatik PR #4864 (498 files, 6 workflow files):

```
blockingPatterns: []
warningSignals: []
score: 0
```

The old code on the same input produces the one teams-worker.yml blocking finding the gate reported.

## NOTES

- `dist/index.js` rebuilt via `npm run build` from a clean `npm ci` of this branch's own lockfile; `dist/licenses.txt` untouched (no dependency changes — local rebuild-only churn reverted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Puu253HREYAwUCLtKDp6Wy
