### PR TITLE
fix(gate): read PR labels live so a trailhead-override survives a rerun

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Trailhead will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- **PR labels are read live, not from the event payload** — every label consumer in an evaluation (the `trailhead-override` label, `contexts[].match.labels`, and merge-queue detection) now reads the PR's current labels from the API at the start of the evaluation. `github.context.payload` is a snapshot of the event that created the run, so a **rerun** replays the original payload and could never see a label applied since. Because GitHub only turns a failed required check suite green by rerunning it, that made the sanctioned override unusable at the one moment it is needed: apply the label, rerun, and the rerun still could not see it — forcing an admin merge. Explicit `evaluate-pr` backfill metadata (already resolved live in `main.ts`) stays authoritative, and a failed live read warns and falls back to the payload labels. The action's own `add-risk-labels` writes run after the evaluation and cannot race the read.
+
 ## [4.7.0] - 2026-08-08
 
 ### Added

--- a/dist/index.js
+++ b/dist/index.js
@@ -51988,6 +51988,13 @@ async function callGateApi(config, localEvaluation) {
         return null;
     }
 }
+/**
+ * Branch/label context derived from the triggering event payload alone.
+ *
+ * The payload is a SNAPSHOT taken when the event was created. It is the
+ * correct source for base/head refs (they cannot change without a new event)
+ * but NOT for labels — see resolvePrMatchContext. Kept as the fallback layer.
+ */
 function getPrMatchContext(metadata) {
     const pr = github_context.payload?.pull_request;
     return {
@@ -52001,6 +52008,83 @@ function getPrMatchContext(metadata) {
             "main",
         labels: metadata?.labels ?? (pr?.labels ?? []).map((l) => l.name ?? "").filter(Boolean),
     };
+}
+/**
+ * Read the PR's CURRENT labels from the API.
+ *
+ * Returns null — never [] — when the labels could not be read, so the caller
+ * can distinguish "this PR genuinely has no labels" (a valid live answer that
+ * must be honored, otherwise removing a label would never be seen) from "the
+ * live read failed" (fall back to the payload).
+ */
+async function fetchLivePrLabels(prNumber, token) {
+    try {
+        const octokit = getOctokit(token);
+        const { owner, repo } = github_context.repo;
+        const { data: pr } = await octokit.rest.pulls.get({
+            owner,
+            repo,
+            pull_number: prNumber,
+        });
+        const labels = pr
+            .labels;
+        if (!Array.isArray(labels))
+            return null;
+        return labels
+            .map((label) => (typeof label === "string" ? label : (label?.name ?? "")))
+            .filter(Boolean);
+    }
+    catch (error) {
+        core_debug(`Failed to read live labels for PR #${prNumber}: ${error}`);
+        return null;
+    }
+}
+/**
+ * PR context for every label consumer in this evaluation — merge-queue
+ * detection, v4 context matching, and the label override.
+ *
+ * Labels are read LIVE from the API rather than taken from the triggering
+ * event payload. A rerun of an earlier run replays that run's ORIGINAL
+ * payload, so a label applied after the run was created is invisible to the
+ * rerun. That made the sanctioned `trailhead-override` label unusable as a
+ * remedy: GitHub requires every check suite bearing a required context name
+ * to end green, and a failed suite can only be made green by rerunning it —
+ * which is exactly the path that could never see the new label. Applying the
+ * override then still left the PR unmergeable without an admin merge.
+ *
+ * Resolved at the START of evaluateGate, which also keeps it clear of the
+ * action's own `add-risk-labels` writes — those run after the evaluation.
+ */
+async function resolvePrMatchContext(input) {
+    const payloadCtx = getPrMatchContext(input.metadata);
+    // Explicit metadata wins, unchanged: the `evaluate-pr` backfill path builds
+    // it in main.ts from its own live pulls.get, so it is already current.
+    if (input.metadata?.labels)
+        return payloadCtx;
+    if (!input.prNumber || !input.token) {
+        if (payloadCtx.labels.length > 0) {
+            core_debug("No PR number or github-token available — using event payload labels for PR context.");
+        }
+        return payloadCtx;
+    }
+    const liveLabels = await fetchLivePrLabels(input.prNumber, input.token);
+    if (!liveLabels) {
+        core_warning(`Could not read live labels for PR #${input.prNumber} — falling back to the ` +
+            `triggering event's payload labels ` +
+            `(${payloadCtx.labels.length > 0 ? payloadCtx.labels.join(", ") : "none"}). ` +
+            `A label applied after this run's event was created — including ` +
+            `\`${OVERRIDE_LABEL}\` — is not visible to this evaluation.`);
+        return payloadCtx;
+    }
+    const payloadLabels = payloadCtx.labels;
+    const drifted = liveLabels.length !== payloadLabels.length ||
+        liveLabels.some((label) => !payloadLabels.includes(label));
+    if (drifted) {
+        info(`PR #${input.prNumber} labels changed since this run's triggering event — ` +
+            `using live labels [${liveLabels.join(", ") || "none"}] ` +
+            `instead of payload labels [${payloadLabels.join(", ") || "none"}].`);
+    }
+    return { ...payloadCtx, labels: liveLabels };
 }
 async function fetchPrCommentsForOverride(prNumber, token) {
     try {
@@ -52329,7 +52413,14 @@ async function evaluateGate(config, commitSha, prNumber, prMetadata) {
     const start = Date.now();
     // Nothing is known about this run's availability stance until a context matches.
     setResolvedAvailabilityStance(null);
-    const prMatchCtx = getPrMatchContext(prMetadata);
+    // Labels are read live here, before anything consumes them, so merge-queue
+    // detection, context matching and the label override all see the same
+    // current truth rather than the triggering event's snapshot.
+    const prMatchCtx = await resolvePrMatchContext({
+        metadata: prMetadata,
+        prNumber,
+        token: config.githubToken,
+    });
     const isMergeQueue = github_context.eventName === "merge_group" ||
         prMatchCtx.labels.some((label) => label === "queue" || label.includes("merge-queue"));
     if (isMergeQueue) {

--- a/docs/release-brief.md
+++ b/docs/release-brief.md
@@ -120,6 +120,17 @@ carries a scope:
 Under `risk_only`, reasons the override cleared are recorded as `overriddenReasons` and
 reasons that survived as `retainedReasons`, both on the stored `policy_override`.
 
+#### Label liveness
+
+Labels are read **live** from the GitHub API at the start of every evaluation, not taken
+from the triggering event's payload. The payload is a snapshot: re-running a workflow
+replays the run's original event, so a label applied afterwards would never appear in it.
+Since GitHub only turns a failed check suite green by rerunning it, a payload-only read
+made the override unusable exactly where it is needed — apply the label, rerun, and the
+rerun could not see it. The same live read backs context matching and merge-queue
+detection, so every consumer sees one current set of labels. If the live read fails, the
+run warns and falls back to the payload labels for that evaluation.
+
 ## Example `.trailhead.yml`
 
 This is ADR-011's seed table for the dogfood consumer (komatik), written out in full.

--- a/src/__tests__/override-liveness.test.ts
+++ b/src/__tests__/override-liveness.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Label liveness.
+ *
+ * `github.context.payload` is a snapshot of the event that created the run.
+ * Re-running a workflow replays that ORIGINAL payload, so any label applied
+ * after the run was created is absent from it. That made the sanctioned
+ * `trailhead-override` label unusable as a remedy for a red required check:
+ * GitHub only turns a failed check suite green by rerunning it, and the rerun
+ * was the one path guaranteed never to see the new label.
+ *
+ * These tests pin the fix at the layer where it has to live — evaluateGate's
+ * single PR context — so the override, context matching and merge-queue
+ * detection all read the same live labels.
+ */
+import { vi } from "vitest";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import * as core from "@actions/core";
+
+import { evaluateGate } from "../gate.js";
+import type { TrailheadConfig } from "../types.js";
+
+const githubMockState = vi.hoisted(() => ({
+  /** Labels the API reports right now — what a live read sees. */
+  liveLabels: [] as Array<{ name: string }>,
+  /** Labels frozen into the triggering event's payload. */
+  payloadLabels: [] as Array<{ name: string }>,
+  comments: [] as Array<{ body: string; user?: { login: string } }>,
+  checkRuns: [] as Array<{ name: string; status: string; conclusion: string | null }>,
+  pullsGetFails: false,
+}));
+
+vi.mock("@actions/core", () => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warning: vi.fn(),
+  error: vi.fn(),
+  setFailed: vi.fn(),
+  setOutput: vi.fn(),
+  getInput: vi.fn().mockReturnValue(""),
+}));
+
+vi.mock("@actions/github", () => ({
+  context: {
+    repo: { owner: "test-owner", repo: "test-repo" },
+    sha: "pull-request-head-sha",
+    eventName: "pull_request",
+    get payload() {
+      return {
+        pull_request: {
+          user: { login: "release-bot[bot]" },
+          base: { ref: "main" },
+          head: { ref: "release/train-9", sha: "pull-request-head-sha" },
+          labels: githubMockState.payloadLabels,
+        },
+      };
+    },
+  },
+  getOctokit: (_token: string) => ({
+    rest: {
+      pulls: {
+        get: vi.fn().mockImplementation(async () => {
+          if (githubMockState.pullsGetFails) {
+            throw new Error("HttpError: 503 Service Unavailable");
+          }
+          return {
+            data: {
+              state: "open",
+              user: { login: "release-bot[bot]" },
+              created_at: new Date().toISOString(),
+              base: { ref: "main" },
+              head: { ref: "release/train-9", sha: "pull-request-head-sha" },
+              labels: githubMockState.liveLabels,
+              body: "## Plan\n- [x] tests",
+            },
+          };
+        }),
+        listFiles: vi.fn().mockResolvedValue({
+          data: [{ filename: "src/app.ts", additions: 4, deletions: 1, changes: 5 }],
+        }),
+        listCommits: vi.fn().mockResolvedValue({
+          data: [
+            {
+              sha: "pr-commit-1",
+              author: { login: "release-bot[bot]" },
+              commit: {
+                message: "chore: promote",
+                author: { name: "Release Bot", email: "bot@example.com" },
+              },
+            },
+          ],
+        }),
+        listReviews: vi.fn().mockResolvedValue({ data: [] }),
+        list: vi.fn().mockResolvedValue({ data: [] }),
+      },
+      issues: {
+        listComments: vi.fn().mockImplementation(async () => ({
+          data: githubMockState.comments,
+        })),
+      },
+      checks: {
+        listForRef: vi.fn().mockImplementation(async () => ({
+          data: { check_runs: githubMockState.checkRuns },
+        })),
+      },
+      repos: {
+        getCommit: vi.fn().mockResolvedValue({ data: { files: [] } }),
+        listCommits: vi.fn().mockResolvedValue({ data: [] }),
+        getContent: vi.fn().mockRejectedValue(new Error("not found")),
+      },
+    },
+  }),
+}));
+
+function makeConfig(overrides: Partial<TrailheadConfig> = {}): TrailheadConfig {
+  return {
+    apiKey: "",
+    apiUrl: "",
+    riskThreshold: 70,
+    failMode: "open",
+    selfHeal: false,
+    addRiskLabels: true,
+    reviewersOnRisk: [],
+    webhookEvents: ["warn", "block"],
+    healthCheckUrls: [],
+    githubToken: "ghp_test",
+    securityGate: false,
+    waitTimeoutMinutes: 0,
+    ...overrides,
+  };
+}
+
+async function withLocalTrailheadConfig<T>(
+  content: string,
+  run: () => Promise<T>,
+): Promise<T> {
+  const workspace = await mkdtemp(path.join(os.tmpdir(), "trailhead-liveness-"));
+  await writeFile(path.join(workspace, ".trailhead.yml"), content, "utf-8");
+  vi.stubEnv("GITHUB_WORKSPACE", workspace);
+  try {
+    return await run();
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
+}
+
+/** Release-ready gate with one required check, which is red below. */
+const RELEASE_READY_CONFIG = `schema_version: 2
+gate:
+  mode: release-ready
+contexts:
+  - name: main-pr
+    match:
+      base_branch: [main]
+    ci:
+      required_checks: [CI Gate]
+      optional_checks: []
+      missing_required: fail`;
+
+describe("PR label liveness", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")));
+    githubMockState.liveLabels = [];
+    githubMockState.payloadLabels = [];
+    githubMockState.comments = [];
+    githubMockState.checkRuns = [
+      { name: "CI Gate", status: "completed", conclusion: "failure" },
+    ];
+    githubMockState.pullsGetFails = false;
+    vi.stubEnv("GITHUB_WORKSPACE", "");
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  it("applies the override from a label added after the triggering event (the rerun case)", async () => {
+    // The operator applied the label AFTER the run that is now being rerun,
+    // so it exists on the PR but not in the replayed payload.
+    githubMockState.payloadLabels = [];
+    githubMockState.liveLabels = [{ name: "trailhead-override" }];
+    githubMockState.comments = [
+      {
+        body: "trailhead-override: release train blocked on a known-flaky suite",
+        user: { login: "dschirmer" },
+      },
+    ];
+
+    const result = await withLocalTrailheadConfig(RELEASE_READY_CONFIG, () =>
+      evaluateGate(makeConfig(), "pull-request-head-sha", 4929),
+    );
+
+    expect(result.policyOverride).toBeDefined();
+    expect(result.policyOverride?.source).toBe("label");
+    expect(result.policyOverride?.owner).toBe("dschirmer");
+    expect(result.policyOverride?.reason).toBe(
+      "release train blocked on a known-flaky suite",
+    );
+    expect(result.releaseReady).toBe(true);
+    // The label drift is narrated, not silently swallowed.
+    expect(core.info).toHaveBeenCalledWith(
+      expect.stringContaining("labels changed since this run's triggering event"),
+    );
+  });
+
+  it("honors a label removed since the triggering event", async () => {
+    // Payload still carries the override; the PR no longer does.
+    githubMockState.payloadLabels = [{ name: "trailhead-override" }];
+    githubMockState.liveLabels = [];
+    githubMockState.comments = [
+      { body: "trailhead-override: no longer needed", user: { login: "dschirmer" } },
+    ];
+
+    const result = await withLocalTrailheadConfig(RELEASE_READY_CONFIG, () =>
+      evaluateGate(makeConfig(), "pull-request-head-sha", 4929),
+    );
+
+    expect(result.policyOverride).toBeUndefined();
+    expect(result.releaseReady).toBe(false);
+  });
+
+  it("falls back to payload labels and warns when the live read fails", async () => {
+    githubMockState.pullsGetFails = true;
+    githubMockState.payloadLabels = [{ name: "trailhead-override" }];
+    githubMockState.liveLabels = [];
+    githubMockState.comments = [
+      { body: "trailhead-override: prod outage", user: { login: "dschirmer" } },
+    ];
+
+    const result = await withLocalTrailheadConfig(RELEASE_READY_CONFIG, () =>
+      evaluateGate(makeConfig(), "pull-request-head-sha", 4929),
+    );
+
+    expect(core.warning).toHaveBeenCalledWith(
+      expect.stringContaining("Could not read live labels for PR #4929"),
+    );
+    expect(core.warning).toHaveBeenCalledWith(
+      expect.stringContaining("falling back to the triggering event's payload labels"),
+    );
+    // Fallback is a degradation, not a regression: the payload label still works.
+    expect(result.policyOverride?.source).toBe("label");
+    expect(result.releaseReady).toBe(true);
+  });
+
+  it("keeps explicit backfill metadata authoritative over the live read", async () => {
+    // evaluate-pr builds metadata from its own live pulls.get in main.ts.
+    githubMockState.liveLabels = [{ name: "trailhead-override" }];
+    githubMockState.payloadLabels = [];
+    githubMockState.comments = [
+      { body: "trailhead-override: prod outage", user: { login: "dschirmer" } },
+    ];
+
+    const result = await withLocalTrailheadConfig(RELEASE_READY_CONFIG, () =>
+      evaluateGate(makeConfig(), "pull-request-head-sha", 4929, {
+        baseRef: "main",
+        headRef: "release/train-9",
+        labels: [],
+        authorLogin: "release-bot[bot]",
+      }),
+    );
+
+    expect(result.policyOverride).toBeUndefined();
+    expect(result.releaseReady).toBe(false);
+  });
+
+  it("matches a v4 context on a live label the payload never carried", async () => {
+    // Proves the live read lands ABOVE the override — every label consumer
+    // (context matching here, merge-queue detection, the override) reads it.
+    githubMockState.payloadLabels = [];
+    githubMockState.liveLabels = [{ name: "release-train" }];
+    githubMockState.checkRuns = [
+      { name: "CI Gate", status: "completed", conclusion: "success" },
+    ];
+
+    const result = await withLocalTrailheadConfig(
+      `schema_version: 2
+gate:
+  mode: release-ready
+contexts:
+  - name: release-train
+    match:
+      base_branch: [main]
+      labels: ["release-train"]
+    ci:
+      required_checks: [CI Gate]
+      optional_checks: []
+      missing_required: fail
+  - name: main-pr
+    match:
+      base_branch: [main]
+    ci:
+      required_checks: [CI Gate]
+      optional_checks: []
+      missing_required: fail`,
+      () => evaluateGate(makeConfig(), "pull-request-head-sha", 4929),
+    );
+
+    expect(result.context?.name).toBe("release-train");
+  });
+});

--- a/src/gate.ts
+++ b/src/gate.ts
@@ -1562,6 +1562,13 @@ export interface EvaluationPrMetadata {
   authorLogin?: string;
 }
 
+/**
+ * Branch/label context derived from the triggering event payload alone.
+ *
+ * The payload is a SNAPSHOT taken when the event was created. It is the
+ * correct source for base/head refs (they cannot change without a new event)
+ * but NOT for labels — see resolvePrMatchContext. Kept as the fallback layer.
+ */
 function getPrMatchContext(metadata?: EvaluationPrMetadata): PrMatchContext {
   const pr = github.context.payload?.pull_request as
     | {
@@ -1585,6 +1592,101 @@ function getPrMatchContext(metadata?: EvaluationPrMetadata): PrMatchContext {
     labels:
       metadata?.labels ?? (pr?.labels ?? []).map((l) => l.name ?? "").filter(Boolean),
   };
+}
+
+/**
+ * Read the PR's CURRENT labels from the API.
+ *
+ * Returns null — never [] — when the labels could not be read, so the caller
+ * can distinguish "this PR genuinely has no labels" (a valid live answer that
+ * must be honored, otherwise removing a label would never be seen) from "the
+ * live read failed" (fall back to the payload).
+ */
+async function fetchLivePrLabels(
+  prNumber: number,
+  token: string,
+): Promise<string[] | null> {
+  try {
+    const octokit = github.getOctokit(token);
+    const { owner, repo } = github.context.repo;
+    const { data: pr } = await octokit.rest.pulls.get({
+      owner,
+      repo,
+      pull_number: prNumber,
+    });
+    const labels = (pr as { labels?: Array<{ name?: string } | string> | undefined })
+      .labels;
+    if (!Array.isArray(labels)) return null;
+    return labels
+      .map((label) => (typeof label === "string" ? label : (label?.name ?? "")))
+      .filter(Boolean);
+  } catch (error) {
+    core.debug(`Failed to read live labels for PR #${prNumber}: ${error}`);
+    return null;
+  }
+}
+
+/**
+ * PR context for every label consumer in this evaluation — merge-queue
+ * detection, v4 context matching, and the label override.
+ *
+ * Labels are read LIVE from the API rather than taken from the triggering
+ * event payload. A rerun of an earlier run replays that run's ORIGINAL
+ * payload, so a label applied after the run was created is invisible to the
+ * rerun. That made the sanctioned `trailhead-override` label unusable as a
+ * remedy: GitHub requires every check suite bearing a required context name
+ * to end green, and a failed suite can only be made green by rerunning it —
+ * which is exactly the path that could never see the new label. Applying the
+ * override then still left the PR unmergeable without an admin merge.
+ *
+ * Resolved at the START of evaluateGate, which also keeps it clear of the
+ * action's own `add-risk-labels` writes — those run after the evaluation.
+ */
+async function resolvePrMatchContext(input: {
+  metadata?: EvaluationPrMetadata;
+  prNumber?: number;
+  token?: string;
+}): Promise<PrMatchContext> {
+  const payloadCtx = getPrMatchContext(input.metadata);
+
+  // Explicit metadata wins, unchanged: the `evaluate-pr` backfill path builds
+  // it in main.ts from its own live pulls.get, so it is already current.
+  if (input.metadata?.labels) return payloadCtx;
+
+  if (!input.prNumber || !input.token) {
+    if (payloadCtx.labels.length > 0) {
+      core.debug(
+        "No PR number or github-token available — using event payload labels for PR context.",
+      );
+    }
+    return payloadCtx;
+  }
+
+  const liveLabels = await fetchLivePrLabels(input.prNumber, input.token);
+  if (!liveLabels) {
+    core.warning(
+      `Could not read live labels for PR #${input.prNumber} — falling back to the ` +
+        `triggering event's payload labels ` +
+        `(${payloadCtx.labels.length > 0 ? payloadCtx.labels.join(", ") : "none"}). ` +
+        `A label applied after this run's event was created — including ` +
+        `\`${OVERRIDE_LABEL}\` — is not visible to this evaluation.`,
+    );
+    return payloadCtx;
+  }
+
+  const payloadLabels = payloadCtx.labels;
+  const drifted =
+    liveLabels.length !== payloadLabels.length ||
+    liveLabels.some((label) => !payloadLabels.includes(label));
+  if (drifted) {
+    core.info(
+      `PR #${input.prNumber} labels changed since this run's triggering event — ` +
+        `using live labels [${liveLabels.join(", ") || "none"}] ` +
+        `instead of payload labels [${payloadLabels.join(", ") || "none"}].`,
+    );
+  }
+
+  return { ...payloadCtx, labels: liveLabels };
 }
 
 async function fetchPrCommentsForOverride(
@@ -1999,7 +2101,14 @@ export async function evaluateGate(
   const start = Date.now();
   // Nothing is known about this run's availability stance until a context matches.
   setResolvedAvailabilityStance(null);
-  const prMatchCtx = getPrMatchContext(prMetadata);
+  // Labels are read live here, before anything consumes them, so merge-queue
+  // detection, context matching and the label override all see the same
+  // current truth rather than the triggering event's snapshot.
+  const prMatchCtx = await resolvePrMatchContext({
+    metadata: prMetadata,
+    prNumber,
+    token: config.githubToken,
+  });
 
   const isMergeQueue =
     github.context.eventName === "merge_group" ||


### PR DESCRIPTION
## The incident

On 2026-08-28 the komatik release train wedged. `KomatikAI/komatik` PRs #4929 and #4934 each had a required Trailhead check suite that had already ended red. An operator applied the sanctioned `trailhead-override` label and reran the failed suite — the only way GitHub turns a red check suite green, since every check suite bearing a required context name must end green for the branch protection to clear. The rerun replayed the run's **original** event payload, which predates the label, so Trailhead never saw the override and re-blocked. Each rerun reproduced the same verdict, the required context could not converge to green by any operator action, and the release train was landed by **admin merge** — the outcome the override exists to avoid.

## The bug

`getPrMatchContext` (src/gate.ts) read labels from `github.context.payload.pull_request.labels`, while PR comments (`fetchPrCommentsForOverride`) and formal review state were already fetched live from the API. `github.context.payload` is a snapshot of the event that created the run, so on a rerun it is by definition stale with respect to any label applied since. The override label was therefore the one input in the override decision that a rerun could not observe.

## The change

`evaluateGate` now resolves its PR context through a new `resolvePrMatchContext`, which reads the PR's **current** labels via `octokit.rest.pulls.get` before anything consumes them:

- **Live labels reach every consumer, not just the override.** The read happens at the top of `evaluateGate`, above `hasOverrideLabel`, above `matchContext` (`contexts[].match.labels`), and above merge-queue detection — one live set, no divergence between the override path and context matching.
- **Payload fallback with a named warning.** A failed live read logs `Could not read live labels for PR #N — falling back to the triggering event's payload labels (…)` and uses the payload labels. Fallback is a degradation, never a regression: a payload label still works.
- **`null` is not `[]`.** `fetchLivePrLabels` returns `null` on failure and `[]` only when the PR genuinely has no labels, so a *removed* label is honored rather than masked by the payload.
- **`prMetadata.labels` precedence is unchanged.** The `evaluate-pr` backfill path builds its metadata from its own live `pulls.get` in `main.ts`; explicit metadata stays authoritative and short-circuits the extra read.
- **No race with the action's own label writes.** `managePrLabels` (`add-risk-labels`) runs in `main.ts` *after* `evaluateGate` returns, so a read at evaluation start cannot observe or collide with them.
- Drift between live and payload labels is narrated via `core.info`, so the next time this happens the run log says so.

## Tests

New `src/__tests__/override-liveness.test.ts` drives the real `evaluateGate` against a release-ready gate with a red required check:

| Test | Proves |
| --- | --- |
| label added after the triggering event | override applies from a live label absent in the payload — the #4929/#4934 rerun case |
| label removed since the triggering event | a stale payload label does not resurrect a withdrawn override |
| live read fails | payload fallback **and** the warning naming it |
| explicit backfill metadata | `evaluate-pr` metadata still wins over the live read |
| context match on a live label | `contexts[].match.labels` sees live labels too — the fix is at the right layer, not bolted onto the override |

4 of the 5 fail against `dev` without the source change (the backfill test is a regression guard and passes both ways).

Full suite: **74 files, 1071 tests, all passing.** `npm run format:check`, `npm run lint` (ESLint + `tsc --noEmit`), and `node scripts/run-simulate.mjs --threshold 100` are clean.

## dist

`dist/` is committed and `action.yml` runs `dist/index.js`, so the bundle is rebuilt here with the repo's own `npm run build`. The `dist/index.js` delta is exactly this change: one line removed (`getPrMatchContext(prMetadata)` → the awaited resolver) plus the two new functions. `dist/licenses.txt` was reverted — its only delta was build-host churn from `@swc/core-linux-arm64-*` optional deps present on this machine, unrelated to the change.

## ⚠️ NOTE for downstream adopters — two places pin the SHA

Consumers pin this action **by commit SHA**, so merging here does not deliver the fix. `KomatikAI/komatik` currently pins `622c6e9` in **two** places, and adopting this fix requires updating **both in the same komatik PR** or CI will fail closed on the trust assertion:

1. `.github/workflows/trailhead.yml` — the `uses:` pin
2. `scripts/ci/validate-trace-workflow-trust.mjs` — asserts that exact SHA

That komatik change is intentionally **not** made in this PR.

## Relationship to `docs/adr-012-override-liveness`

The unmerged `docs/adr-012-override-liveness` branch (~10k lines) addresses override liveness more broadly: a GraphQL `fetchLiveOverrideState` reading labels *and* comments together, required-check lineage, and a `|| true` taxonomy. It fixes the override path itself — it drops the `hasOverrideLabel(prMatchCtx.labels)` call-site guard and refuses to authorize from unverified payload state at all.

The two are complementary rather than duplicative. ADR-012 leaves `getPrMatchContext` untouched, so `prMatchCtx.labels` — and therefore **merge-queue detection and `contexts[].match.labels`** — still read the frozen payload there. This PR fixes the label read at that shared layer and is small enough to pin immediately at `dev`'s tip while ADR-012 is still in review. If ADR-012 lands after this, `fetchLivePrLabels` and `fetchLiveOverrideState` should be reconciled into one read (ADR-012's stricter "never authorize from payload_fallback" stance should win for the override decision specifically); the live `prMatchCtx.labels` this PR introduces stays useful for the non-override consumers either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Puu253HREYAwUCLtKDp6Wy
