### PR TITLE
release: v4.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to Trailhead will be documented in this file.
 
-## [Unreleased]
+## [4.7.1] - 2026-08-28
 
 ### Fixed
 

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@komatikai/trailhead",
-  "version": "4.7.0",
+  "version": "4.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@komatikai/trailhead",
-      "version": "4.7.0",
+      "version": "4.7.1",
       "license": "MIT",
       "dependencies": {
         "@swc/core": "^1.15.40"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@komatikai/trailhead",
-  "version": "4.7.0",
+  "version": "4.7.1",
   "description": "Trailhead CLI — setup wizard and utilities for the Trailhead deployment gate",
   "bin": {
     "trailhead": "dist/index.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trailhead",
-  "version": "4.7.0",
+  "version": "4.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "trailhead",
-      "version": "4.7.0",
+      "version": "4.7.1",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trailhead",
-  "version": "4.7.0",
+  "version": "4.7.1",
   "private": true,
   "description": "Release readiness gate for GitHub PRs — waits for CI, scores code risk, checks production health, and blocks merges that are not release-ready.",
   "license": "MIT",


### PR DESCRIPTION
## [4.7.1] - 2026-08-28

### Fixed

- **PR labels are read live, not from the event payload** — every label consumer in an evaluation (the `trailhead-override` label, `contexts[].match.labels`, and merge-queue detection) now reads the PR's current labels from the API at the start of the evaluation. `github.context.payload` is a snapshot of the event that created the run, so a **rerun** replays the original payload and could never see a label applied since. Because GitHub only turns a failed required check suite green by rerunning it, that made the sanctioned override unusable at the one moment it is needed: apply the label, rerun, and the rerun still could not see it — forcing an admin merge. Explicit `evaluate-pr` backfill metadata (already resolved live in `main.ts`) stays authoritative, and a failed live read warns and falls back to the payload labels. The action's own `add-risk-labels` writes run after the evaluation and cannot race the read.

- **Split guidance no longer fabricates schema changes** — only true migrations directories (first two path segments) earn the `database/migrations` split label; every other path buckets by its literal two-segment prefix. `supabase/functions` was previously narrated as a migrations change.
- **One risk threshold per comment** — `formatGateReport` reads the brief's effective `riskThreshold` everywhere, and retires the legacy sections the brief already states (verdict/risk/gate rows, CI table, policy findings) when a brief is attached. Briefless evaluations render the full legacy report unchanged.
- **Honest remediation JSON** — per-finding severities come from the enumerated findings, so warn findings can no longer surface as severity `blocking`. Non-blocking policy tiers get additive codes (`policy.finding.warn`, `policy.finding.advisory`, routine lane); a new blocking `risk.over_threshold` fix (red lane) names the top risk movers and both real levers, and is suppressed after a recorded override. Wired end-to-end through `evaluateGate` — the fix was previously unreachable — with an integration test that discriminates the threaded path.
- **Disposition reasons always populated** — defaults self-describe (required check / not required), and an ADR-009 `skip` resolves to `irrelevant("skipped upstream (path filter or workflow condition)")` whatever its source. A policy-blocking check that was path-filtered no longer renders the self-contradiction "skip | blocking | —" (promotion-zero correction). Outcome-neutral for gate decisions, proven by neutrality tests.

