### PR TITLE
fix(submission): mock_placeholder skips attribute/class placeholder contexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ All notable changes to Trailhead will be documented in this file.
 
 - **`gate.check_name` now names the published check** — the effective Checks API context is `check-name` (action input) ?? `gate.check_name` (`.trailhead.yml`) ?? the mode default (`Trailhead` for `risk-only`, `Trailhead — Release Ready` otherwise), and it is resolved once in `evaluateGate` and reused by the catch path. **A repo that sets `gate.check_name` will see its published check renamed** to that value — previously `gate.check_name` was consulted by `trailhead doctor` and check-exclusion but never by the publisher, so such a repo published under the mode default. Update the required-status-check contexts in branch protection before upgrading, or the old context stays permanently pending. `gate.check_name` also lost its schema default, so a repo with a `gate:` block that does not set `check_name` now gets the mode default instead of `Trailhead — Release Ready` in every mode. Repos with no `gate:` block are unaffected.
 
+### Fixed
+
+- **`mock_placeholder` no longer flags standard frontend `placeholder` vocabulary** — the bare-word pattern now skips `placeholder` used as an HTML/JSX attribute (`placeholder="…"`), a Tailwind utility or variant (`placeholder-white/15`, `placeholder:text-sm`), a CSS pseudo-element (`::placeholder`), a property access (`input.placeholder`), or an object key (`placeholder: "…"`). Any frontend PR adding a form input previously blocked on the detector (first real-world hit: KomatikAI/sundog#517, which forced that repo to demote `mock_placeholder` to `severity: warn`). Bare-word stubs (`// placeholder until real API lands`) still block, and screaming-case constants like `PLACEHOLDER_RESPONSE` are now caught explicitly — the underscore removed the trailing word boundary the old pattern relied on, so they were never actually flagged.
+
 ## [4.7.1] - 2026-08-28
 
 ### Fixed

--- a/app/src/submission-checks/detectors.ts
+++ b/app/src/submission-checks/detectors.ts
@@ -37,7 +37,12 @@ const MOCK_PATTERNS = [
   /\bTODO:\s*implement\b/gi,
   /\bFIXME\b/g,
   /\bIn production,\s*use\b/i,
-  /\bplaceholder\b/gi,
+  /\bPLACEHOLDER_[A-Z0-9_]+\b/,
+  // Bare "placeholder" only — the word as an HTML/JSX attribute (placeholder="…"),
+  // a Tailwind utility/variant (placeholder-white/15, placeholder:text-sm), a CSS
+  // pseudo-element (::placeholder), a property access (input.placeholder), or an
+  // object key (placeholder: "…") is standard frontend vocabulary, not a stub.
+  /(?<![.:])\bplaceholder\b(?![=:-])/gi,
   /\blorem ipsum\b/gi,
 ];
 

--- a/mcp/dist/submission-checks/detectors.js
+++ b/mcp/dist/submission-checks/detectors.js
@@ -21,7 +21,12 @@ const MOCK_PATTERNS = [
     /\bTODO:\s*implement\b/gi,
     /\bFIXME\b/g,
     /\bIn production,\s*use\b/i,
-    /\bplaceholder\b/gi,
+    /\bPLACEHOLDER_[A-Z0-9_]+\b/,
+    // Bare "placeholder" only — the word as an HTML/JSX attribute (placeholder="…"),
+    // a Tailwind utility/variant (placeholder-white/15, placeholder:text-sm), a CSS
+    // pseudo-element (::placeholder), a property access (input.placeholder), or an
+    // object key (placeholder: "…") is standard frontend vocabulary, not a stub.
+    /(?<![.:])\bplaceholder\b(?![=:-])/gi,
     /\blorem ipsum\b/gi,
 ];
 const SECRET_PATTERNS = [

--- a/mcp/src/submission-checks/detectors.ts
+++ b/mcp/src/submission-checks/detectors.ts
@@ -37,7 +37,12 @@ const MOCK_PATTERNS = [
   /\bTODO:\s*implement\b/gi,
   /\bFIXME\b/g,
   /\bIn production,\s*use\b/i,
-  /\bplaceholder\b/gi,
+  /\bPLACEHOLDER_[A-Z0-9_]+\b/,
+  // Bare "placeholder" only — the word as an HTML/JSX attribute (placeholder="…"),
+  // a Tailwind utility/variant (placeholder-white/15, placeholder:text-sm), a CSS
+  // pseudo-element (::placeholder), a property access (input.placeholder), or an
+  // object key (placeholder: "…") is standard frontend vocabulary, not a stub.
+  /(?<![.:])\bplaceholder\b(?![=:-])/gi,
   /\blorem ipsum\b/gi,
 ];
 

--- a/src/__tests__/submission-detectors-precision.test.ts
+++ b/src/__tests__/submission-detectors-precision.test.ts
@@ -262,6 +262,87 @@ describe("mock_placeholder", () => {
     );
     expect(check?.code).toBe("mock_placeholder");
   });
+
+  it("ignores the JSX/HTML placeholder attribute", () => {
+    const check = detectMockPlaceholder(
+      ctx({
+        files: [
+          {
+            filename: "src/components/CheckpointTimeline.tsx",
+            patch: '@@\n+          placeholder="Game title"\n',
+          },
+        ],
+      }),
+    );
+    expect(check).toBeNull();
+  });
+
+  it("ignores Tailwind placeholder utilities and variants", () => {
+    const check = detectMockPlaceholder(
+      ctx({
+        files: [
+          {
+            filename: "src/components/CheckpointTimeline.tsx",
+            patch:
+              '@@\n+          className="placeholder-white/15 placeholder:text-zinc-500"\n',
+          },
+        ],
+      }),
+    );
+    expect(check).toBeNull();
+  });
+
+  it("ignores CSS ::placeholder and placeholder property access", () => {
+    const check = detectMockPlaceholder(
+      ctx({
+        files: [
+          {
+            filename: "src/styles/form.css",
+            patch: "@@\n+input::placeholder { color: gray; }\n",
+          },
+          {
+            filename: "src/form.ts",
+            patch: '@@\n+input.placeholder = "Search";\n',
+          },
+          {
+            filename: "src/config.ts",
+            patch: '@@\n+const field = { placeholder: "Enter name" };\n',
+          },
+        ],
+      }),
+    );
+    expect(check).toBeNull();
+  });
+
+  it("still flags a bare placeholder comment", () => {
+    const check = detectMockPlaceholder(
+      ctx({
+        files: [
+          {
+            filename: "src/api.ts",
+            patch: "@@\n+// placeholder until real API lands\n",
+          },
+        ],
+      }),
+    );
+    expect(check?.code).toBe("mock_placeholder");
+  });
+
+  it("flags SCREAMING_CASE PLACEHOLDER_ constants", () => {
+    // The word pattern alone can't catch these (the underscore removes the
+    // trailing word boundary), and MOCK_ only covers the MOCK_ prefix.
+    const check = detectMockPlaceholder(
+      ctx({
+        files: [
+          {
+            filename: "src/api.ts",
+            patch: "@@\n+const PLACEHOLDER_RESPONSE = { ok: true };\n",
+          },
+        ],
+      }),
+    );
+    expect(check?.code).toBe("mock_placeholder");
+  });
 });
 
 describe("secrets fixture precision", () => {

--- a/src/submission-checks/detectors.ts
+++ b/src/submission-checks/detectors.ts
@@ -37,7 +37,12 @@ const MOCK_PATTERNS = [
   /\bTODO:\s*implement\b/gi,
   /\bFIXME\b/g,
   /\bIn production,\s*use\b/i,
-  /\bplaceholder\b/gi,
+  /\bPLACEHOLDER_[A-Z0-9_]+\b/,
+  // Bare "placeholder" only — the word as an HTML/JSX attribute (placeholder="…"),
+  // a Tailwind utility/variant (placeholder-white/15, placeholder:text-sm), a CSS
+  // pseudo-element (::placeholder), a property access (input.placeholder), or an
+  // object key (placeholder: "…") is standard frontend vocabulary, not a stub.
+  /(?<![.:])\bplaceholder\b(?![=:-])/gi,
   /\blorem ipsum\b/gi,
 ];
 


### PR DESCRIPTION
## Problem

`MOCK_PATTERNS` includes `/\bplaceholder\b/gi`, which matches the standard HTML/JSX `placeholder=` attribute and Tailwind `placeholder-*` / `placeholder:*` utility classes. Any frontend PR that adds a form input trips the blocking `mock_placeholder` detector.

First real-world hit: KomatikAI/sundog#517 (`CheckpointTimeline.tsx` form inputs), which forced sundog to demote the detector to `severity: warn` in its `.trailhead.yml`.

## Fix

Replace the bare-word pattern with `/(?<![.:])\bplaceholder\b(?![=:-])/gi` — the word only counts as a stub when it stands bare:

| Context | Example | Before | After |
|---|---|---|---|
| JSX/HTML attribute | `placeholder="Game title"` | 🔴 block | ✅ pass |
| Tailwind utility/variant | `placeholder-white/15`, `placeholder:text-sm` | 🔴 block | ✅ pass |
| CSS pseudo-element | `input::placeholder { … }` | 🔴 block | ✅ pass |
| Property access | `input.placeholder = "…"` | 🔴 block | ✅ pass |
| Object key | `{ placeholder: "Enter name" }` | 🔴 block | ✅ pass |
| Bare comment stub | `// placeholder until real API lands` | 🔴 block | 🔴 block |
| Prose stub | `This is a placeholder implementation` | 🔴 block | 🔴 block |
| CI command | `run: deploy placeholder` | 🔴 block | 🔴 block |

Also adds `/\bPLACEHOLDER_[A-Z0-9_]+\b/` (mirroring the existing `MOCK_` pattern): verified that `const PLACEHOLDER_RESPONSE` was never actually caught before — the underscore removes the trailing word boundary the bare-word pattern relied on, and `MOCK_` only covers its own prefix. Replayed the exact sundog #517 lines through the new pattern: zero hits.

## Included

- `src/submission-checks/detectors.ts` — the pattern change
- `src/__tests__/submission-detectors-precision.test.ts` — 5 new regression tests covering the table above (all 3 pre-existing `mock_placeholder` tests unchanged and passing)
- `app/src` + `mcp/src` mirrors regenerated via `scripts/copy-shared-src.mjs`; `mcp/dist` rebuilt (CI parity gate)
- CHANGELOG `[Unreleased]` entry

## Verification

- Full suite: 1319/1319 tests pass (76 files)
- `npm run lint` (eslint + tsc), `app/` typecheck, `mcp/` build, `npm run format:check` all clean

## Follow-up (sundog, after release + re-pin)

Once this ships in a release and sundog's `.github/workflows/trailhead.yml` re-pins past `v4.5.4`, drop the `submission.detectors.mock_placeholder: severity: warn` override (currently on the `feat/komatik-publish-panel` branch, commit 6dd17c14) to re-promote the detector to blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)